### PR TITLE
Fix lensfun in AppImage (and other plugin dependencies)

### DIFF
--- a/.ci/ci-script-appimage.sh
+++ b/.ci/ci-script-appimage.sh
@@ -26,6 +26,11 @@ export DESTDIR=../AppDir
 cmake .. -DCMAKE_INSTALL_PREFIX=/usr -G Ninja -DCMAKE_BUILD_TYPE=Release -DBINARY_PACKAGE_BUILD=1 -DCMAKE_INSTALL_LIBDIR=lib64
 cmake --build . --target install
 
+# Grab lensfun database. You should run `sudo lensfun-update-data` before making
+# AppImage, we did this in CI.
+mkdir -p ../AppDir/usr/share/lensfun
+cp -a /var/lib/lensfun-updates/* ../AppDir/usr/share/lensfun
+
 ## Replace relative pathes to executable in ansel.desktop
 ## The pathes will be handled by AppImage.
 sed -i 's/\/usr\/bin\///' ../AppDir/usr/share/applications/photos.ansel.app.desktop

--- a/.ci/ci-script-appimage.sh
+++ b/.ci/ci-script-appimage.sh
@@ -38,4 +38,12 @@ chmod +x linuxdeploy-x86_64.AppImage linuxdeploy-plugin-gtk.sh
 export DEPLOY_GTK_VERSION="3"
 export VERSION=$(sh ../tools/get_git_version_string.sh)
 
-./linuxdeploy-x86_64.AppImage --appdir ../AppDir --plugin gtk --output appimage
+# Our plugins link against libansel, it's not in system, so tell linuxdeploy
+# where to find it. Don't use LD_PRELOAD here, linuxdeploy cannot see preloaded
+# libraries.
+export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:../AppDir/usr/lib64/ansel/"
+# Using `--deploy-deps-only` to tell linuxdeploy also collect dependencies for
+# libraries in this dir, but don't copy those libraries. On the contrary,
+# `--library` will copy both libraries and their dependencies, which is not what
+# we want, we already installed our plugins.
+./linuxdeploy-x86_64.AppImage --appdir ../AppDir --plugin gtk --deploy-deps-only ../AppDir/usr/lib64/ansel/plugins --output appimage

--- a/.github/workflows/lin-nightly.yml
+++ b/.github/workflows/lin-nightly.yml
@@ -23,7 +23,7 @@ jobs:
         generator:
           - Ninja
         branch:
-          - { code: master, label: stable }
+          - { code: "${{ github.ref_name }}", label: stable }
     env:
       CC: ${{ matrix.compiler.CC }}
       CXX: ${{ matrix.compiler.CXX }}

--- a/.github/workflows/lin-nightly.yml
+++ b/.github/workflows/lin-nightly.yml
@@ -109,14 +109,16 @@ jobs:
             gstreamer1.0-tools \
             debianutils;
       # squashfs, libfuse2, gstreamer are deps of AppImage builder, not Ansel
-      - uses: actions/checkout@v3
+      - name: Checkout ansel source
+        uses: actions/checkout@v3
         with:
           ref: ${{ env.BRANCH }}
           fetch-depth: 0
           submodules: true
           path: src
       # Fetch exiv2 source, because the version in Ubuntu 20.04 is tooooooo old.
-      - uses: actions/checkout@v3
+      - name: Checkout exiv2 source
+        uses: actions/checkout@v3
         with:
           repository: 'Exiv2/exiv2'
           # Exiv2 replaces AutoPtr with UniquePtr, before we update the base
@@ -126,15 +128,22 @@ jobs:
           fetch-depth: 1
       # Install manually compiled dependencies into system, so ansel will link
       # against it and AppImage will grab it.
-      - name: Manually build dependencies
+      - name: Manually build exiv2 dependency
         run: |
           cd exiv2-src
-          cmake -B build -GNinja -DCMAKE_INSTALL_PREFIX=/usr -DEXIV2_ENABLE_VIDEO=ON -DEXIV2_ENABLE_NLS=ON -DEXIV2_ENABLE_XMP=ON -DEXIV2_ENABLE_CURL=ON -DEXIV2_ENABLE_WEBREADY=ON -DEXIV2_ENABLE_BMFF=ON
+          cmake -B build -GNinja \
+          -DCMAKE_INSTALL_PREFIX=/usr \
+          -DEXIV2_ENABLE_VIDEO=ON \
+          -DEXIV2_ENABLE_NLS=ON \
+          -DEXIV2_ENABLE_XMP=ON \
+          -DEXIV2_ENABLE_CURL=ON \
+          -DEXIV2_ENABLE_WEBREADY=ON \
+          -DEXIV2_ENABLE_BMFF=ON
           ninja -C build
           sudo ninja -C build install
           cd ..
       - name: Update lensfun data for root
-        if: ${{ false }} #${{ success() }} re-enable when lensfun servers renew the SSL certificate
+        if: ${{ success() }}
         run: |
           sudo lensfun-update-data
       - name: Build and Install


### PR DESCRIPTION
linuxdeploy tries to resolve all linked libraries and collect them,
however, we don't link plugins, but load them with `dlopen()`, so
linuxdeploy cannot see them and resolve their dependencies.

This commit tells linuxdeploy the plugin dir so it will resolve and
collect dependencies of plugins.

Fixes <https://github.com/aurelienpierreeng/ansel/issues/54>.

This PR also enable `lensfun-update-data` because it works now.

This PR also make nightly Linux build checkout triggered branch, instead of master.