### PR TITLE
Diffuse or Sharpen : maximum Edge Sensitivity increased

### DIFF
--- a/src/iop/diffuse.c
+++ b/src/iop/diffuse.c
@@ -58,7 +58,7 @@ typedef struct dt_iop_diffuse_params_t
   int iterations;           // $MIN: 0    $MAX: 500  $DEFAULT: 1  $DESCRIPTION: "iterations"
   float sharpness;          // $MIN: -1.  $MAX: 1.   $DEFAULT: 0. $DESCRIPTION: "sharpness"
   int radius;               // $MIN: 0    $MAX: 2048 $DEFAULT: 8  $DESCRIPTION: "radius span"
-  float regularization;     // $MIN: 0.   $MAX: 4.   $DEFAULT: 0. $DESCRIPTION: "edge sensitivity"
+  float regularization;     // $MIN: 0.   $MAX: 6.   $DEFAULT: 0. $DESCRIPTION: "edge sensitivity"
   float variance_threshold; // $MIN: -2.  $MAX: 2.   $DEFAULT: 0. $DESCRIPTION: "edge threshold"
 
   float anisotropy_first;   // $MIN: -10. $MAX: 10.  $DEFAULT: 0. $DESCRIPTION: "1st order anisotropy"


### PR DESCRIPTION
### What does this PR ?

This PR sets the maximum Edge Sensitivity to 6 in the Diffuse or Sharpen module.


### What is this PR about ?

@pedrorrodriguez asked if the Edge Sensitivity couldn't be increased to 5 or more.
It happened that it actually gives good result in the case of denoising to preserve more edges.

Some example on a zoomed part from a picture (800%).
This is without Diffuse or Sharpen:
![Capture d’écran du 2023-06-29 00-15-14](https://github.com/aurelienpierreeng/ansel/assets/75432524/18d924ab-9ad1-4f5a-8da9-826a632dc7b2)

This is with Diffuse or Sharpen with some settings to remove noise and Edge Sensitivity at 4 (current max):
![Capture d’écran du 2023-06-29 00-15-21](https://github.com/aurelienpierreeng/ansel/assets/75432524/82cdc432-b67b-4dab-8923-77681101082e)

This is with Diffuse or Sharpen with the same settings but Edge Sensitivity at 5:
![Capture d’écran du 2023-06-29 00-15-29](https://github.com/aurelienpierreeng/ansel/assets/75432524/6b15462c-d32d-4c16-a5bf-19a57ef32c00)
