### PR TITLE
Increase Highlight Correction's max laplacian iterations

### DIFF
--- a/src/iop/highlights.c
+++ b/src/iop/highlights.c
@@ -100,7 +100,7 @@ typedef struct dt_iop_highlights_params_t
   float clip; // $MIN: 0.0 $MAX: 2.0 $DEFAULT: 1.0 $DESCRIPTION: "clipping threshold"
   // params of v3
   float noise_level; // $MIN: 0. $MAX: 0.5 $DEFAULT: 0.00 $DESCRIPTION: "noise level"
-  int iterations; // $MIN: 1 $MAX: 256 $DEFAULT: 30 $DESCRIPTION: "iterations"
+  int iterations; // $MIN: 1 $MAX: 512 $DEFAULT: 30 $DESCRIPTION: "iterations"
   dt_atrous_wavelets_scales_t scales; // $DEFAULT: 8 $DESCRIPTION: "diameter of reconstruction"
   float reconstructing;    // $MIN: 0.0 $MAX: 1.0  $DEFAULT: 0.4 $DESCRIPTION: "cast balance"
   float combine;           // $MIN: 0.0 $MAX: 10.0 $DEFAULT: 2.0 $DESCRIPTION: "combine segments"
@@ -2272,6 +2272,7 @@ void gui_init(struct dt_iop_module_t *self)
                                                 "into the rest of the noisy image. useful at high ISO."));
 
   g->iterations = dt_bauhaus_slider_from_params(self, "iterations");
+  dt_bauhaus_slider_set_soft_range(g->iterations, 1, 256);
   gtk_widget_set_tooltip_text(g->iterations, _("increase if magenta highlights don't get fully corrected\n"
                                                "each new iteration brings a performance penalty."));
 


### PR DESCRIPTION
### What this PR does ?
Discretely set maximum iterations number to 512 instead of 256. You'll have to right-clic and type a number greater than 256.
fix #133

### Why ?

In some cases, one still have magenta in the corrected area even if the iterations number is set to the current maximum (256 iterations).
This change could help those situations. (need more test) 