### PR TITLE
Fix libxmp2 deprecated function

### DIFF
--- a/src/develop/lightroom.c
+++ b/src/develop/lightroom.c
@@ -1091,7 +1091,7 @@ gboolean dt_lightroom_import(int imgid, dt_develop_t *dev, gboolean iauto)
 
   // Parse xml document
 
-  doc = xmlParseEntity(pathname);
+  doc = xmlReadFile(pathname, NULL, 0);
 
   if(doc == NULL)
   {


### PR DESCRIPTION
### What this PR do ?

It fix #181. `xmlParseEntity()` is remplaced by `xmlReadFile(,,)` .

Works on windows 11 and Ubuntu 22.04.