### PR TITLE
Fix Filmic RGB on Intel Arc

### DIFF
--- a/data/kernels/filmic.cl
+++ b/data/kernels/filmic.cl
@@ -1038,7 +1038,7 @@ filmicrgb_chroma (read_only image2d_t in, write_only image2d_t out,
 kernel void
 filmic_mask_clipped_pixels(read_only image2d_t in, write_only image2d_t out,
                            int width, int height,
-                           const float normalize, const float feathering, write_only image2d_t is_clipped)
+                           const float normalize, const float feathering, global uint *is_clipped)
 {
   const unsigned int x = get_global_id(0);
   const unsigned int y = get_global_id(1);
@@ -1052,7 +1052,7 @@ filmic_mask_clipped_pixels(read_only image2d_t in, write_only image2d_t out,
   const float argument = -pix_max * normalize + feathering;
   const float weight = clamp(1.0f / ( 1.0f + native_exp2(argument)), 0.f, 1.f);
 
-  if(4.f > argument) write_imageui(is_clipped, (int2)(0, 0), 1);
+  if(4.f > argument) *is_clipped = 1;
 
   write_imagef(out, (int2)(x, y), weight);
 }

--- a/src/iop/filmicrgb.c
+++ b/src/iop/filmicrgb.c
@@ -2423,6 +2423,8 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
   dt_colorspaces_iccprofile_info_cl_t *profile_info_cl;
   cl_float *profile_lut_cl = NULL;
 
+  cl_mem clipped = NULL;
+
   err = dt_ioppr_build_iccprofile_params_cl(work_profile, devid, &profile_info_cl, &profile_lut_cl,
                                             &dev_profile_info, &dev_profile_lut);
   if(err != CL_SUCCESS) goto error;
@@ -2436,9 +2438,10 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
   // used to adjust noise level depending on size. Don't amplify noise if magnified > 100%
   const float scale = fmaxf(piece->iscale / roi_in->scale, 1.f);
 
-  // get the number of OpenCL threads
-  uint16_t is_clipped = 0;
-  cl_mem clipped = dt_opencl_alloc_device(devid, 1, 1, sizeof(uint16_t));
+  uint32_t is_clipped = 0;
+  clipped = dt_opencl_alloc_device_buffer(devid, sizeof(uint32_t));
+  err = dt_opencl_write_buffer_to_device(devid, &is_clipped, clipped, 0, sizeof(uint32_t), CL_TRUE);
+  if(err != CL_SUCCESS) goto error;
 
   // build a mask of clipped pixels
   mask = dt_opencl_alloc_device(devid, sizes[0], sizes[1], sizeof(float));
@@ -2452,8 +2455,9 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
   err = dt_opencl_enqueue_kernel_2d(devid, gd->kernel_filmic_mask, sizes);
   if(err != CL_SUCCESS) goto error;
 
-  // read the number of clipped pixels
-  dt_opencl_copy_device_to_host(devid, &is_clipped, clipped, 1, 1, sizeof(uint16_t));
+  // check for clipped pixels
+  err = dt_opencl_read_buffer_from_device(devid, &is_clipped, clipped, 0, sizeof(uint32_t), CL_TRUE);
+  if(err != CL_SUCCESS) goto error;
   dt_opencl_release_mem_object(clipped);
   clipped = NULL;
 
@@ -2648,6 +2652,7 @@ error:
   dt_opencl_release_mem_object(output_matrix_cl);
   dt_opencl_release_mem_object(export_input_matrix_cl);
   dt_opencl_release_mem_object(export_output_matrix_cl);
+  dt_opencl_release_mem_object(clipped);
   dt_print(DT_DEBUG_OPENCL, "[opencl_filmicrgb] couldn't enqueue kernel! %d\n", err);
   return FALSE;
 }


### PR DESCRIPTION
This PR fixes two issues in Filmic RGB's `process_cl()` function, one of them being major depending on the user's hardware platform.

The first one makes the filter yield a black image on Intel Arc GPUs (at least the A770 on my system, on Linux with `intel-compute-runtime` 23.13.26032.30).  The reason is that, when the filmic mask kernel is called, `clipped` is passed as a `cl_mem` (a pointer type), whereas it is a `uint16_t`.  The first commit fixes this.  (It might be worth to switch to a more type-safe API here--it looks like DT did so.)

The second issue is that `clipped` is not free'd on OpenCL errors, and that the copy operation from the device to the host is not checked for errors.  The second patch fixes this.

I also want to report that, otherwise, Ansel seems to work fine with OpenCL on Intel Arc GPUs.