### PR TITLE
Warn user when too many masks × too many history steps are going to be written in DB/XMP

### DIFF
--- a/src/common/exif.cc
+++ b/src/common/exif.cc
@@ -3889,7 +3889,7 @@ char *dt_exif_xmp_read_string(const int imgid)
   {
     char input_filename[PATH_MAX] = { 0 };
     gboolean from_cache = FALSE;
-    dt_image_full_path(imgid, input_filename, sizeof(input_filename), &from_cache);
+    dt_image_full_path(imgid,  input_filename,  sizeof(input_filename),  &from_cache, __FUNCTION__);
 
     // first take over the data from the source image
     Exiv2::XmpData xmpData;
@@ -4015,7 +4015,7 @@ int dt_exif_xmp_attach_export(const int imgid, const char *filename, void *metad
   {
     char input_filename[PATH_MAX] = { 0 };
     gboolean from_cache = TRUE;
-    dt_image_full_path(imgid, input_filename, sizeof(input_filename), &from_cache);
+    dt_image_full_path(imgid,  input_filename,  sizeof(input_filename),  &from_cache, __FUNCTION__);
 
     std::unique_ptr<Exiv2::Image> img(Exiv2::ImageFactory::open(WIDEN(filename)));
     // unfortunately it seems we have to read the metadata, to not erase the exif (which we just wrote).
@@ -4259,7 +4259,7 @@ int dt_exif_xmp_write(const int imgid, const char *filename)
   char imgfname[PATH_MAX] = { 0 };
   gboolean from_cache = TRUE;
 
-  dt_image_full_path(imgid, imgfname, sizeof(imgfname), &from_cache);
+  dt_image_full_path(imgid,  imgfname,  sizeof(imgfname),  &from_cache, __FUNCTION__);
   if(!g_file_test(imgfname, G_FILE_TEST_IS_REGULAR)) return 1;
 
   try

--- a/src/common/exif.cc
+++ b/src/common/exif.cc
@@ -2739,7 +2739,6 @@ static void add_mask_entry_to_db(int imgid, mask_entry_t *entry)
   // add the mask entry only once
   if(entry->already_added)
     return;
-  entry->already_added = TRUE;
 
   const int mask_num = 0;
 
@@ -2767,8 +2766,14 @@ static void add_mask_entry_to_db(int imgid, mask_entry_t *entry)
   {
     DT_DEBUG_SQLITE3_BIND_INT(stmt, 9, entry->mask_num);
   }
-  sqlite3_step(stmt);
+  int prepare_result = sqlite3_step(stmt);
   sqlite3_finalize(stmt);
+
+  // Mark entry to true only after confirmation the sql insert was successful
+  if(prepare_result == SQLITE_OK)
+  {
+    entry->already_added = TRUE;
+  }
 }
 
 static void add_non_clone_mask_entries_to_db(gpointer key, gpointer value, gpointer user_data)

--- a/src/common/image.c
+++ b/src/common/image.c
@@ -2505,7 +2505,7 @@ int dt_image_write_sidecar_file(const int32_t imgid)
 
     // FIRST: check if the original file is present
     gboolean from_cache = FALSE;
-    dt_image_full_path(imgid, filename, sizeof(filename), &from_cache);
+    dt_image_full_path(imgid, filename, sizeof(filename), &from_cache, __FUNCTION__);
     if(!from_cache) return 1;
 
     dt_image_path_append_version(imgid, filename, sizeof(filename));

--- a/src/common/image.c
+++ b/src/common/image.c
@@ -2493,16 +2493,7 @@ int dt_image_write_sidecar_file(const int32_t imgid)
     // FIRST: check if the original file is present
     gboolean from_cache = FALSE;
     dt_image_full_path(imgid, filename, sizeof(filename), &from_cache);
-
-    if(!g_file_test(filename, G_FILE_TEST_EXISTS))
-    {
-      // OTHERWISE: check if the local copy exists
-      from_cache = TRUE;
-      dt_image_full_path(imgid, filename, sizeof(filename), &from_cache);
-
-      //  nothing to do, the original is not accessible and there is no local copy
-      if(!from_cache) return 1;
-    }
+    if(!from_cache) return 1;
 
     dt_image_path_append_version(imgid, filename, sizeof(filename));
     g_strlcat(filename, ".xmp", sizeof(filename));

--- a/src/common/image.h
+++ b/src/common/image.h
@@ -295,7 +295,7 @@ int dt_image_monochrome_flags(const dt_image_t *img);
 gboolean dt_image_use_monochrome_workflow(const dt_image_t *img);
 /** returns the full path name where the image was imported from. from_cache=TRUE check and return local
  * cached filename if any. */
-void dt_image_full_path(const int32_t imgid, char *pathname, size_t pathname_len, gboolean *from_cache);
+void dt_image_full_path(const int32_t imgid, char *pathname, size_t pathname_len, gboolean *from_cache, const char *calling_func);
 /** returns the full directory of the associated film roll. */
 void dt_image_film_roll_directory(const dt_image_t *img, char *pathname, size_t pathname_len);
 /** returns the portion of the path used for the film roll name. */

--- a/src/common/imageio.c
+++ b/src/common/imageio.c
@@ -1088,7 +1088,7 @@ int dt_imageio_export_with_flags(const int32_t imgid, const char *filename,
                                   // happens when we write the image
     char pathname[PATH_MAX] = { 0 };
     gboolean from_cache = TRUE;
-    dt_image_full_path(imgid, pathname, sizeof(pathname), &from_cache);
+    dt_image_full_path(imgid,  pathname,  sizeof(pathname),  &from_cache, __FUNCTION__);
     // last param is dng mode, it's false here
     length = dt_exif_read_blob(&exif_profile, pathname, imgid, sRGB, processed_width, processed_height, 0);
 

--- a/src/common/mipmap_cache.c
+++ b/src/common/mipmap_cache.c
@@ -770,7 +770,7 @@ void dt_mipmap_cache_get_with_caller(
 
         char filename[PATH_MAX] = { 0 };
         gboolean from_cache = TRUE;
-        dt_image_full_path(buffered_image.id, filename, sizeof(filename), &from_cache);
+        dt_image_full_path(buffered_image.id,  filename,  sizeof(filename),  &from_cache, __FUNCTION__);
 
         buf->imgid = imgid;
         buf->size = mip;
@@ -1037,7 +1037,7 @@ static void _init_f(dt_mipmap_buffer_t *mipmap_buf, float *out, uint32_t *width,
   /* do not even try to process file if it isn't available */
   char filename[PATH_MAX] = { 0 };
   gboolean from_cache = TRUE;
-  dt_image_full_path(imgid, filename, sizeof(filename), &from_cache);
+  dt_image_full_path(imgid,  filename,  sizeof(filename),  &from_cache, __FUNCTION__);
   if(!*filename || !g_file_test(filename, G_FILE_TEST_EXISTS))
   {
     *width = *height = 0;
@@ -1162,7 +1162,7 @@ static void _init_8(uint8_t *buf, uint32_t *width, uint32_t *height, float *isca
   gboolean from_cache = TRUE;
 
   /* do not even try to process file if it isn't available */
-  dt_image_full_path(imgid, filename, sizeof(filename), &from_cache);
+  dt_image_full_path(imgid,  filename,  sizeof(filename),  &from_cache, __FUNCTION__);
   if(!*filename || !g_file_test(filename, G_FILE_TEST_EXISTS))
   {
     *width = *height = 0;
@@ -1191,7 +1191,7 @@ static void _init_8(uint8_t *buf, uint32_t *width, uint32_t *height, float *isca
     // try to load the embedded thumbnail in raw
     from_cache = TRUE;
     memset(filename, 0, sizeof(filename));
-    dt_image_full_path(imgid, filename, sizeof(filename), &from_cache);
+    dt_image_full_path(imgid,  filename,  sizeof(filename),  &from_cache, __FUNCTION__);
 
     const char *c = filename + strlen(filename);
     while(*c != '.' && c > filename) c--;

--- a/src/control/jobs/control_jobs.c
+++ b/src/control/jobs/control_jobs.c
@@ -250,7 +250,7 @@ static int32_t dt_control_write_sidecar_files_job_run(dt_job_t *job)
     const int imgid = GPOINTER_TO_INT(t->data);
     const dt_image_t *img = dt_image_cache_get(darktable.image_cache, (int32_t)imgid, 'r');
     char dtfilename[PATH_MAX] = { 0 };
-    dt_image_full_path(img->id, dtfilename, sizeof(dtfilename), &from_cache);
+    dt_image_full_path(img->id,  dtfilename,  sizeof(dtfilename),  &from_cache, __FUNCTION__);
     dt_image_path_append_version(img->id, dtfilename, sizeof(dtfilename));
     g_strlcat(dtfilename, ".xmp", sizeof(dtfilename));
     if(!dt_exif_xmp_write(imgid, dtfilename))
@@ -527,7 +527,7 @@ static int32_t dt_control_merge_hdr_job_run(dt_job_t *job)
   uint8_t *exif = NULL;
   char pathname[PATH_MAX] = { 0 };
   gboolean from_cache = TRUE;
-  dt_image_full_path(d.first_imgid, pathname, sizeof(pathname), &from_cache);
+  dt_image_full_path(d.first_imgid,  pathname,  sizeof(pathname),  &from_cache, __FUNCTION__);
 
   // last param is dng mode
   const int exif_len = dt_exif_read_blob(&exif, pathname, d.first_imgid, 0, d.wd, d.ht, 1);
@@ -1033,7 +1033,7 @@ static int32_t dt_control_delete_images_job_run(dt_job_t *job)
     const int imgid = GPOINTER_TO_INT(t->data);
     char filename[PATH_MAX] = { 0 };
     gboolean from_cache = FALSE;
-    dt_image_full_path(imgid, filename, sizeof(filename), &from_cache);
+    dt_image_full_path(imgid,  filename,  sizeof(filename),  &from_cache, __FUNCTION__);
 
 #ifdef _WIN32
     char *dirname = g_path_get_dirname(filename);
@@ -1282,7 +1282,7 @@ static int32_t dt_control_refresh_exif_run(dt_job_t *job)
     {
       gboolean from_cache = TRUE;
       char sourcefile[PATH_MAX];
-      dt_image_full_path(imgid, sourcefile, sizeof(sourcefile), &from_cache);
+      dt_image_full_path(imgid,  sourcefile,  sizeof(sourcefile),  &from_cache, __FUNCTION__);
 
       dt_image_t *img = dt_image_cache_get(darktable.image_cache, imgid, 'w');
       if(img)
@@ -1412,7 +1412,7 @@ static int32_t dt_control_export_job_run(dt_job_t *job)
     {
       char imgfilename[PATH_MAX] = { 0 };
       gboolean from_cache = TRUE;
-      dt_image_full_path(image->id, imgfilename, sizeof(imgfilename), &from_cache);
+      dt_image_full_path(image->id,  imgfilename,  sizeof(imgfilename),  &from_cache, __FUNCTION__);
       if(!g_file_test(imgfilename, G_FILE_TEST_IS_REGULAR))
       {
         dt_control_log(_("image `%s' is currently unavailable"), image->filename);

--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -1131,12 +1131,38 @@ static void _cleanup_history(const int imgid)
   sqlite3_finalize(stmt);
 }
 
+static void _warn_about_history_overuse(dt_develop_t *dev)
+{
+  /* History stores one entry per module, everytime a parameter is changed.
+  *  For modules using masks, we also store a full snapshot of masks states.
+  *  All that is saved into database and XMP. When history entries × number of mask > 250, 
+  *  we get a really bad performance penalty.
+  */
+  gint states = 0;
+
+  GList *history = dev->history;
+  for(int i = 0; history; i++)
+  {
+    dt_dev_history_item_t *hist_item = (dt_dev_history_item_t *)(history->data);
+    states += g_list_length(hist_item->forms);
+    history = g_list_next(history);
+  }
+
+  if(states > 250)
+  {
+    dt_toast_log(_("Your history is storing %d mask states. To ensure smooth operation, consider compressing "
+                   "history and removing unused masks."),
+                 states);
+  }
+}
+
 void dt_dev_write_history_ext(dt_develop_t *dev, const int imgid)
 {
   sqlite3_stmt *stmt;
   dt_lock_image(imgid);
 
   _cleanup_history(imgid);
+  _warn_about_history_overuse(dev);
 
   // write history entries
 
@@ -1568,6 +1594,8 @@ static void _dev_merge_history(dt_develop_t *dev, const int imgid)
 void _dev_write_history(dt_develop_t *dev, const int imgid)
 {
   _cleanup_history(imgid);
+  _warn_about_history_overuse(dev);
+
   // write history entries
   GList *history = dev->history;
   for(int i = 0; history; i++)

--- a/src/develop/lightroom.c
+++ b/src/develop/lightroom.c
@@ -245,7 +245,7 @@ char *dt_get_lightroom_xmp(int imgid)
   gboolean from_cache = TRUE;
 
   // Get full pathname
-  dt_image_full_path(imgid, pathname, DT_MAX_FILENAME_LEN, &from_cache);
+  dt_image_full_path(imgid,  pathname,  DT_MAX_FILENAME_LEN,  &from_cache, __FUNCTION__);
 
   // Look for extension
   char *pos = strrchr(pathname, '.');

--- a/src/dtgtk/thumbnail.c
+++ b/src/dtgtk/thumbnail.c
@@ -619,7 +619,7 @@ static gboolean _event_image_draw(GtkWidget *widget, cairo_t *cr, gpointer user_
       dt_colorspaces_color_profile_type_t color_space;
       char path[PATH_MAX] = { 0 };
       gboolean from_cache = TRUE;
-      dt_image_full_path(thumb->imgid, path, sizeof(path), &from_cache);
+      dt_image_full_path(thumb->imgid,  path,  sizeof(path),  &from_cache, __FUNCTION__);
       if(!dt_imageio_large_thumbnail(path, &full_res_thumb, &full_res_thumb_wd, &full_res_thumb_ht, &color_space))
       {
         // we look for focus areas

--- a/src/dtgtk/thumbtable.c
+++ b/src/dtgtk/thumbtable.c
@@ -1316,7 +1316,7 @@ static void _event_dnd_get(GtkWidget *widget, GdkDragContext *context, GtkSelect
         gchar pathname[PATH_MAX] = { 0 };
         gboolean from_cache = TRUE;
         const int id = GPOINTER_TO_INT(l->data);
-        dt_image_full_path(id, pathname, sizeof(pathname), &from_cache);
+        dt_image_full_path(id,  pathname,  sizeof(pathname),  &from_cache, __FUNCTION__);
         gchar *uri = g_strdup_printf("file://%s", pathname); // TODO: should we add the host?
         gtk_selection_data_set(selection_data, gtk_selection_data_get_target(selection_data),
                                _BYTE, (guchar *)uri, strlen(uri));
@@ -1330,7 +1330,7 @@ static void _event_dnd_get(GtkWidget *widget, GdkDragContext *context, GtkSelect
           const int id = GPOINTER_TO_INT(l->data);
           gchar pathname[PATH_MAX] = { 0 };
           gboolean from_cache = TRUE;
-          dt_image_full_path(id, pathname, sizeof(pathname), &from_cache);
+          dt_image_full_path(id,  pathname,  sizeof(pathname),  &from_cache, __FUNCTION__);
           gchar *uri = g_strdup_printf("file://%s", pathname); // TODO: should we add the host?
           images = g_list_prepend(images, uri);
         }

--- a/src/imageio/format/copy.c
+++ b/src/imageio/format/copy.c
@@ -41,7 +41,7 @@ int write_image(dt_imageio_module_data_t *data, const char *filename, const void
   char *targetfile = NULL;
   char *xmpfile = NULL;
 
-  dt_image_full_path(imgid, sourcefile, sizeof(sourcefile), &from_cache);
+  dt_image_full_path(imgid,  sourcefile,  sizeof(sourcefile),  &from_cache, __FUNCTION__);
 
   char *extension = g_strrstr(sourcefile, ".");
   if(extension == NULL) goto END;

--- a/src/imageio/storage/disk.c
+++ b/src/imageio/storage/disk.c
@@ -228,7 +228,7 @@ int store(dt_imageio_module_storage_t *self, dt_imageio_module_data_t *sdata, co
   char pattern[DT_MAX_PATH_FOR_PARAMS];
   g_strlcpy(pattern, d->filename, sizeof(pattern));
   gboolean from_cache = FALSE;
-  dt_image_full_path(imgid, input_dir, sizeof(input_dir), &from_cache);
+  dt_image_full_path(imgid,  input_dir,  sizeof(input_dir),  &from_cache, __FUNCTION__);
   // set variable values to expand them afterwards in darktable variables
   dt_variables_set_max_width_height(d->vp, fdata->max_width, fdata->max_height);
   dt_variables_set_upscale(d->vp, upscale);

--- a/src/imageio/storage/example.c
+++ b/src/imageio/storage/example.c
@@ -113,7 +113,7 @@ int store(dt_imageio_module_storage_t *self, dt_imageio_module_data_t *sdata, co
 
   char dirname[PATH_MAX] = { 0 };
   gboolean from_cache = FALSE;
-  dt_image_full_path(imgid, dirname, sizeof(dirname), &from_cache);
+  dt_image_full_path(imgid,  dirname,  sizeof(dirname),  &from_cache, __FUNCTION__);
   gchar *filename = g_path_get_basename(dirname);
 
   g_strlcpy(dirname, filename, sizeof(dirname));

--- a/src/imageio/storage/gallery.c
+++ b/src/imageio/storage/gallery.c
@@ -218,7 +218,7 @@ int store(dt_imageio_module_storage_t *self, dt_imageio_module_data_t *sdata, co
   char filename[PATH_MAX] = { 0 };
   char dirname[PATH_MAX] = { 0 };
   gboolean from_cache = FALSE;
-  dt_image_full_path(imgid, dirname, sizeof(dirname), &from_cache);
+  dt_image_full_path(imgid,  dirname,  sizeof(dirname),  &from_cache, __FUNCTION__);
 
   char tmp_dir[PATH_MAX] = { 0 };
 

--- a/src/iop/colorin.c
+++ b/src/iop/colorin.c
@@ -1811,7 +1811,7 @@ void reload_defaults(dt_iop_module_t *module)
     // the image has not a profile inited
     char filename[PATH_MAX] = { 0 };
     gboolean from_cache = TRUE;
-    dt_image_full_path(img->id, filename, sizeof(filename), &from_cache);
+    dt_image_full_path(img->id,  filename,  sizeof(filename),  &from_cache, __FUNCTION__);
     const gchar *cc = filename + strlen(filename);
     for(; *cc != '.' && cc > filename; cc--)
       ;

--- a/src/iop/watermark.c
+++ b/src/iop/watermark.c
@@ -430,7 +430,7 @@ static gchar *_watermark_get_svgdoc(dt_iop_module_t *self, dt_iop_watermark_data
     dt_variables_params_init(&params);
     gboolean from_cache = FALSE;
     char image_path[PATH_MAX] = { 0 };
-    dt_image_full_path(image->id, image_path, sizeof(image_path), &from_cache);
+    dt_image_full_path(image->id,  image_path,  sizeof(image_path),  &from_cache, __FUNCTION__);
     params->filename = image_path;
     params->jobcode = "infos";
     params->sequence = 0;

--- a/src/libs/metadata_view.c
+++ b/src/libs/metadata_view.c
@@ -670,7 +670,7 @@ static void _metadata_view_update_values(dt_lib_module_t *self)
       case md_internal_fullpath:
       {
         gboolean from_cache = FALSE;
-        dt_image_full_path(img->id, text, sizeof(text), &from_cache);
+        dt_image_full_path(img->id,  text,  sizeof(text),  &from_cache, __FUNCTION__);
         _metadata_update_value(md_internal_fullpath, text, self);
       }
       break;

--- a/src/libs/tools/image_infos.c
+++ b/src/libs/tools/image_infos.c
@@ -91,7 +91,7 @@ void _lib_imageinfo_update_message(gpointer instance, dt_lib_module_t *self)
   // we compute the info line (we reuse the function used in export to disk)
   char input_dir[512] = { 0 };
   gboolean from_cache = TRUE;
-  dt_image_full_path(imgid, input_dir, sizeof(input_dir), &from_cache);
+  dt_image_full_path(imgid,  input_dir,  sizeof(input_dir),  &from_cache, __FUNCTION__);
 
   dt_variables_params_t *vp;
   dt_variables_params_init(&vp);

--- a/src/lua/image.c
+++ b/src/lua/image.c
@@ -160,7 +160,7 @@ static int sidecar_member(lua_State *L)
   const dt_image_t *my_image = checkreadimage(L, 1);
   gboolean from_cache = TRUE;
   char filename[PATH_MAX] = { 0 };
-  dt_image_full_path(my_image->id, filename, sizeof(filename), &from_cache);
+  dt_image_full_path(my_image->id,  filename,  sizeof(filename),  &from_cache, __FUNCTION__);
   dt_image_path_append_version(my_image->id, filename, sizeof(filename));
   g_strlcat(filename, ".xmp", sizeof(filename));
   lua_pushstring(L, filename);
@@ -406,7 +406,7 @@ static int image_tostring(lua_State *L)
   const dt_image_t *my_image = checkreadimage(L, -1);
   char image_name[PATH_MAX] = { 0 };
   gboolean from_cache = FALSE;
-  dt_image_full_path(my_image->id, image_name, sizeof(image_name), &from_cache);
+  dt_image_full_path(my_image->id,  image_name,  sizeof(image_name),  &from_cache, __FUNCTION__);
   dt_image_path_append_version(my_image->id, image_name, sizeof(image_name));
   lua_pushstring(L, image_name);
   releasereadimage(L, my_image);

--- a/src/lua/luastorage.c
+++ b/src/lua/luastorage.c
@@ -88,7 +88,7 @@ static int store_wrapper(struct dt_imageio_module_storage_t *self, struct dt_ima
   dt_loc_get_tmp_dir(tmpdir, sizeof(tmpdir));
 
   char dirname[PATH_MAX] = { 0 };
-  dt_image_full_path(imgid, dirname, sizeof(dirname), &from_cache);
+  dt_image_full_path(imgid,  dirname,  sizeof(dirname),  &from_cache, __FUNCTION__);
   dt_image_path_append_version(imgid, dirname, sizeof(dirname));
   gchar *filename = g_path_get_basename(dirname);
   gchar *end = g_strrstr(filename, ".") + 1;

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -697,7 +697,7 @@ int try_enter(dt_view_t *self)
 
   char imgfilename[PATH_MAX] = { 0 };
   gboolean from_cache = TRUE;
-  dt_image_full_path(img->id, imgfilename, sizeof(imgfilename), &from_cache);
+  dt_image_full_path(img->id,  imgfilename,  sizeof(imgfilename),  &from_cache, __FUNCTION__);
   if(!g_file_test(imgfilename, G_FILE_TEST_IS_REGULAR))
   {
     dt_control_log(_("image `%s' is currently unavailable"), img->filename);

--- a/src/views/map.c
+++ b/src/views/map.c
@@ -2713,7 +2713,7 @@ static void _view_map_dnd_get_callback(GtkWidget *widget, GdkDragContext *contex
         const int imgid = GPOINTER_TO_INT(lib->selected_images->data);
         gchar pathname[PATH_MAX] = { 0 };
         gboolean from_cache = TRUE;
-        dt_image_full_path(imgid, pathname, sizeof(pathname), &from_cache);
+        dt_image_full_path(imgid,  pathname,  sizeof(pathname),  &from_cache, __FUNCTION__);
         gchar *uri = g_strdup_printf("file://%s", pathname); // TODO: should we add the host?
         gtk_selection_data_set(selection_data, gtk_selection_data_get_target(selection_data), _BYTE,
                                (guchar *)uri, strlen(uri));

--- a/src/views/print.c
+++ b/src/views/print.c
@@ -331,7 +331,7 @@ int try_enter(dt_view_t *self)
 
   char imgfilename[PATH_MAX] = { 0 };
   gboolean from_cache = TRUE;
-  dt_image_full_path(img->id, imgfilename, sizeof(imgfilename), &from_cache);
+  dt_image_full_path(img->id,  imgfilename,  sizeof(imgfilename),  &from_cache, __FUNCTION__);
   if(!g_file_test(imgfilename, G_FILE_TEST_IS_REGULAR))
   {
     dt_control_log(_("image `%s' is currently unavailable"), img->filename);


### PR DESCRIPTION
The state of all masks used by a module is saved for each history entry for modules using masking. After 100 history steps using 20 masks, that's 2000 copies of mask nodes to read/write from/to database and XMP, resulting in slow-downs of ~30 s each time a module parameter is changed.

The real solution would be to maintain a separate history for masks, instead of having a full snapshot of them in the module history. But properly linking mask history to module history will be some work. In any case, the current design is terrible.

For now, we only count the number of masks × history steps, and display a warning when it's > 250 (the value is completely arbitrary).