### PR TITLE
Bauhaus: Fix wrongly floored value of percentage sliders

### DIFF
--- a/src/bauhaus/bauhaus.c
+++ b/src/bauhaus/bauhaus.c
@@ -2777,7 +2777,7 @@ static void dt_bauhaus_slider_set_normalized(struct dt_bauhaus_widget_t *w, floa
   if(old_pos != new_pos || raise)
   {
     const float new_value = new_pos * (d->max - d->min) + d->min;
-    const float precision = (float)ipow(10, d->digits);
+    const float precision = (float)ipow(10, d->digits) * d->factor;
     const float rounded_value = roundf(new_value * precision) / precision;
     d->pos = (rounded_value - d->min) / (d->max - d->min);
     d->oldpos = d->pos;


### PR DESCRIPTION
When format of a slider is set to percentage, it will decrease 2 digits and set factor to 100, so when we set normalized value of the slider, we need to handle both digits and factor.

In the large refator of commit 48a86a9c0353f87444fd6956f087af933ecad599, we forget to multiply factor while setting normalized value, this makes percentage sliders always get floored to integer value and lose the float value.

This commit fixes it by multiplying factor while setting normalized value.