### PR TITLE
Manually build and bundle newer libheif in AppImage CI

### DIFF
--- a/.github/workflows/lin-nightly.yml
+++ b/.github/workflows/lin-nightly.yml
@@ -67,6 +67,7 @@ jobs:
             libcurl4-gnutls-dev \
             libde265-dev \
             libimage-exiftool-perl \
+            libinih-dev \
             libgdk-pixbuf2.0-dev \
             libglib2.0-dev \
             libgraphicsmagick1-dev \
@@ -122,7 +123,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: 'Exiv2/exiv2'
-          ref: '0.27-maintenance'
+          ref: 'v0.28.1'
           path: 'exiv2-src'
           fetch-depth: 1
       # Install manually compiled dependencies into system, so ansel will link
@@ -146,8 +147,8 @@ jobs:
       # aom is not on GitHub so cannot use the action.
       - name: Manually build and install OAM AVI codec for libavif and libheif
         run: |
-          git clone --depth 1 https://aomedia.googlesource.com/aom
-          cd aom
+          git clone --branch v3.7.1 --depth 1 https://aomedia.googlesource.com/aom aom-src
+          cd aom-src
           cmake -B build -G Ninja \
             -DCMAKE_INSTALL_PREFIX=/usr \
             -DCMAKE_BUILD_TYPE=Release \


### PR DESCRIPTION
Also use new version of checkout hooks.

Update Exiv2 to 0.28.1, it is OK on Linux.

Use stable version of aom instead of master.