### PR TITLE
ansel.desktop : Complete path to icon

### DIFF
--- a/data/ansel.desktop.in
+++ b/data/ansel.desktop.in
@@ -19,6 +19,6 @@ StartupNotify=true
 
 MimeType=application/x-ansel;image/x-dcraw;image/jpeg;image/jpg;image/jp2;image/png;image/tiff;image/x-portable-pixmap;image/x-portable-floatmap;image/x-exr;
 
-Icon=ansel
+Icon=${CMAKE_INSTALL_PREFIX}/share/icons/hicolor/scalable/apps/ansel.svg
 
 X-Unity-IconBackgroundColor=#252525


### PR DESCRIPTION
### WHAT'S THE PROBLEM?
The icon path in ansel.desktop doesn't point to Ansel's icon folder / file and the program doesn't show the Ansel's icon.
`Icon=ansel`

### WHAT THIS PR DOES?
It points no to ansel.svg in Ansel's program folder so the system find what icon to use.
`Icon=${CMAKE_INSTALL_PREFIX}/share/icons/hicolor/scalable/apps/ansel.svg`

