### PR TITLE
Add DT_DEBUG_TRACE_WRAPPER() and use it to unify trace debug helpers

### DIFF
--- a/src/common/debug.h
+++ b/src/common/debug.h
@@ -106,6 +106,19 @@
 #define DT_DEBUG_SQLITE3_CLEAR_BINDINGS(a) __DT_DEBUG_ASSERT__(sqlite3_clear_bindings(a))
 #define DT_DEBUG_SQLITE3_RESET(a) __DT_DEBUG_ASSERT__(sqlite3_reset(a))
 
+// Use this to re-define a function to trace it, so you don't need to modify all
+// callers. `thread` should be `dt_debug_thread_t`. This requires verbose mode.
+//
+// Example:
+// void dt_dev_invalidate_real(dt_develop_t *dev);
+// #define dt_dev_invalidate(dev) DT_DEBUG_TRACE_WRAPPER(DT_DEBUG_DEV, dt_dev_invalidate_real, (dev))
+#define DT_DEBUG_TRACE_WRAPPER(thread, function, ...)                    \
+  do {                                                                   \
+    dt_vprint((thread), "[debug_trace] %s is called from %s at %s:%d\n", \
+              #function, __FUNCTION__, __FILE__, __LINE__);              \
+    function(__VA_ARGS__);                                               \
+  } while (0)
+
 // clang-format off
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py
 // vim: shiftwidth=2 expandtab tabstop=2 cindent

--- a/src/develop/blend_gui.c
+++ b/src/develop/blend_gui.c
@@ -1081,7 +1081,7 @@ static void _blendop_blendif_tab_switch(GtkNotebook *notebook, GtkWidget *page, 
          || gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(data->colorpicker_set_values))))
   {
     dt_iop_color_picker_set_cst(data->module, _blendop_blendif_get_picker_colorspace(data));
-    dt_dev_invalidate_all(data->module->dev, __FUNCTION__, __FILE__, __LINE__);
+    dt_dev_invalidate_all(data->module->dev);
     dt_dev_refresh_ui_images(data->module->dev);
   }
 
@@ -1131,7 +1131,7 @@ static void _blendop_blendif_details_callback(GtkWidget *slider, dt_iop_gui_blen
 
   if((oldval == 0.0f) && (bp->details != 0.0f))
   {
-    dt_dev_invalidate_all(data->module->dev, __FUNCTION__, __FILE__, __LINE__);
+    dt_dev_invalidate_all(data->module->dev);
     dt_dev_refresh_ui_images(data->module->dev);
   }
 }
@@ -1626,7 +1626,7 @@ static gboolean _blendif_change_blend_colorspace(dt_iop_module_t *module, dt_dev
         gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(bd->colorpicker_set_values))))
     {
       dt_iop_color_picker_set_cst(bd->module, _blendop_blendif_get_picker_colorspace(bd));
-      dt_dev_invalidate_all(bd->module->dev, __FUNCTION__, __FILE__, __LINE__);
+      dt_dev_invalidate_all(bd->module->dev);
       dt_dev_refresh_ui_images(bd->module->dev);
     }
 
@@ -2045,7 +2045,7 @@ void dt_iop_gui_update_blendif(dt_iop_module_t *module)
     if(module->request_mask_display != (bd->save_for_leave & ~DT_DEV_PIXELPIPE_DISPLAY_STICKY))
     {
       module->request_mask_display = bd->save_for_leave & ~DT_DEV_PIXELPIPE_DISPLAY_STICKY;
-      dt_dev_invalidate_all(module->dev, __FUNCTION__, __FILE__, __LINE__);//DBG
+      dt_dev_invalidate_all(module->dev);//DBG
       dt_dev_refresh_ui_images(module->dev);
     }
   }
@@ -2445,7 +2445,7 @@ static void _raster_value_changed_callback(GtkWidget *widget, struct dt_iop_modu
 
   if(reprocess)
   {
-    dt_dev_invalidate_all(module->dev, __FUNCTION__, __FILE__, __LINE__);
+    dt_dev_invalidate_all(module->dev);
     dt_dev_refresh_ui_images(module->dev);
   }
 }

--- a/src/develop/develop.h
+++ b/src/develop/develop.h
@@ -23,6 +23,7 @@
 #include <inttypes.h>
 #include <stdint.h>
 
+#include "common/debug.h"
 #include "common/darktable.h"
 #include "common/dtpthread.h"
 #include "common/image.h"
@@ -332,9 +333,8 @@ void dt_dev_process_preview(dt_develop_t *dev);
 
 // Lazy helpers that will update GUI pipelines (main image and small preview)
 // only when needed, and only the one(s) needed.
-void dt_dev_refresh_ui_images_real(dt_develop_t *dev, const char *file, const int line);
-
-#define dt_dev_refresh_ui_images(dev) dt_dev_refresh_ui_images_real(dev, __FILE__, __LINE__);
+void dt_dev_refresh_ui_images_real(dt_develop_t *dev);
+#define dt_dev_refresh_ui_images(dev) DT_DEBUG_TRACE_WRAPPER(DT_DEBUG_DEV, dt_dev_refresh_ui_images_real, (dev))
 
 int dt_dev_load_image(dt_develop_t *dev, const uint32_t imgid);
 void dt_dev_reload_image(dt_develop_t *dev, const uint32_t imgid);
@@ -344,9 +344,8 @@ int dt_dev_is_current_image(dt_develop_t *dev, uint32_t imgid);
 
 const dt_dev_history_item_t *dt_dev_get_history_item(dt_develop_t *dev, const char *op);
 void dt_dev_add_history_item_ext(dt_develop_t *dev, struct dt_iop_module_t *module, gboolean enable, gboolean no_image);
-void dt_dev_add_history_item_real(dt_develop_t *dev, struct dt_iop_module_t *module, gboolean enable, const char *file, const int line);
-
-#define dt_dev_add_history_item(dev, module, enable) dt_dev_add_history_item_real(dev, module, enable, __FILE__, __LINE__)
+void dt_dev_add_history_item_real(dt_develop_t *dev, struct dt_iop_module_t *module, gboolean enable);
+#define dt_dev_add_history_item(dev, module, enable) DT_DEBUG_TRACE_WRAPPER(DT_DEBUG_DEV, dt_dev_add_history_item_real, (dev), (module), (enable))
 
 void dt_dev_add_masks_history_item_ext(dt_develop_t *dev, struct dt_iop_module_t *_module, gboolean _enable, gboolean no_image);
 void dt_dev_add_masks_history_item(dt_develop_t *dev, struct dt_iop_module_t *_module, gboolean enable);
@@ -363,10 +362,14 @@ void dt_dev_invalidate_history_module(GList *list, struct dt_iop_module_t *modul
 // force a rebuild of the pipe, needed when a module order is changed for example
 void dt_dev_pixelpipe_rebuild(struct dt_develop_t *dev);
 
-void dt_dev_invalidate(dt_develop_t *dev, const char *caller, const char *file, const long line);
-void dt_dev_invalidate_preview(dt_develop_t *dev, const char *caller, const char *file, const long line);
-void dt_dev_invalidate_all(dt_develop_t *dev, const char *caller, const char *file, const long line);
-void dt_dev_invalidate_zoom(dt_develop_t *dev, const char *caller, const char *file, const long line);
+void dt_dev_invalidate_real(dt_develop_t *dev);
+#define dt_dev_invalidate(dev) DT_DEBUG_TRACE_WRAPPER(DT_DEBUG_DEV, dt_dev_invalidate_real, (dev))
+void dt_dev_invalidate_preview_real(dt_develop_t *dev);
+#define dt_dev_invalidate_preview(dev) DT_DEBUG_TRACE_WRAPPER(DT_DEBUG_DEV, dt_dev_invalidate_preview_real, (dev))
+void dt_dev_invalidate_all_real(dt_develop_t *dev);
+#define dt_dev_invalidate_all(dev) DT_DEBUG_TRACE_WRAPPER(DT_DEBUG_DEV, dt_dev_invalidate_all_real, (dev))
+void dt_dev_invalidate_zoom_real(dt_develop_t *dev);
+#define dt_dev_invalidate_zoom(dev) DT_DEBUG_TRACE_WRAPPER(DT_DEBUG_DEV, dt_dev_invalidate_zoom_real, (dev))
 void dt_dev_set_histogram(dt_develop_t *dev);
 void dt_dev_set_histogram_pre(dt_develop_t *dev);
 void dt_dev_get_history_item_label(dt_dev_history_item_t *hist, char *label, const int cnt);

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -2875,7 +2875,7 @@ void dt_iop_refresh_center(dt_iop_module_t *module)
   dt_develop_t *dev = module->dev;
   if (dev && dev->gui_attached)
   {
-    dt_dev_invalidate(dev, __FUNCTION__, __FILE__, __LINE__);
+    dt_dev_invalidate(dev);
     dt_dev_refresh_ui_images(dev);
   }
 }
@@ -2886,7 +2886,7 @@ void dt_iop_refresh_preview(dt_iop_module_t *module)
   dt_develop_t *dev = module->dev;
   if (dev && dev->gui_attached)
   {
-    dt_dev_invalidate_preview(dev, __FUNCTION__, __FILE__, __LINE__);
+    dt_dev_invalidate_preview(dev);
     dt_dev_refresh_ui_images(dev);
   }
 }

--- a/src/develop/masks/masks.c
+++ b/src/develop/masks/masks.c
@@ -1976,7 +1976,7 @@ void dt_masks_update_image(dt_develop_t *dev)
   // dt_similarity_image_dirty(dev->image_storage.id);
 
   // invalidate buffers and force redraw of darkroom
-  dt_dev_invalidate_all(dev, __FUNCTION__, __FILE__, __LINE__);
+  dt_dev_invalidate_all(dev);
   dt_dev_refresh_ui_images(dev);
 }
 

--- a/src/gui/actions/display.h
+++ b/src/gui/actions/display.h
@@ -24,7 +24,7 @@ static void full_screen_callback()
   else
     gtk_window_fullscreen(GTK_WINDOW(widget));
 
-  dt_dev_invalidate(darktable.develop, __FUNCTION__, __FILE__, __LINE__);
+  dt_dev_invalidate(darktable.develop);
   dt_dev_refresh_ui_images(darktable.develop);
 
   /* redraw center view */
@@ -57,7 +57,7 @@ static void _toggle_side_borders_accel_callback(dt_action_t *action)
   dt_ui_toggle_panels_visibility(darktable.gui->ui);
 
   /* trigger invalidation of centerview to reprocess pipe */
-  dt_dev_invalidate(darktable.develop, __FUNCTION__, __FILE__, __LINE__);
+  dt_dev_invalidate(darktable.develop);
   dt_dev_refresh_ui_images(darktable.develop);
   gtk_widget_queue_draw(dt_ui_center(darktable.gui->ui));
 }
@@ -251,7 +251,7 @@ static void profile_callback(GtkWidget *widget)
     dt_colorspaces_update_display_transforms();
     pthread_rwlock_unlock(&darktable.color_profiles->xprofile_lock);
     DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_CONTROL_PROFILE_USER_CHANGED, DT_COLORSPACES_PROFILE_TYPE_DISPLAY);
-    dt_dev_invalidate_all(darktable.develop, __FUNCTION__, __FILE__, __LINE__);
+    dt_dev_invalidate_all(darktable.develop);
     dt_dev_refresh_ui_images(darktable.develop);
   }
 }
@@ -287,7 +287,7 @@ static void intent_callback(GtkWidget *widget)
     pthread_rwlock_rdlock(&darktable.color_profiles->xprofile_lock);
     dt_colorspaces_update_display_transforms();
     pthread_rwlock_unlock(&darktable.color_profiles->xprofile_lock);
-    dt_dev_invalidate_all(darktable.develop, __FUNCTION__, __FILE__, __LINE__);
+    dt_dev_invalidate_all(darktable.develop);
     dt_dev_refresh_ui_images(darktable.develop);
   }
 }

--- a/src/gui/color_picker_proxy.c
+++ b/src/gui/color_picker_proxy.c
@@ -214,7 +214,7 @@ static gboolean _color_picker_callback_button_press(GtkWidget *button, GdkEventB
     }
     // force applying the next incoming sample
     self->changed = TRUE;
-    dt_dev_invalidate_all(darktable.develop, __FUNCTION__, __FILE__, __LINE__);
+    dt_dev_invalidate_all(darktable.develop);
   }
   else
   {

--- a/src/iop/ashift.c
+++ b/src/iop/ashift.c
@@ -3035,7 +3035,7 @@ static int _do_get_structure_auto(dt_iop_module_t *module, dt_iop_ashift_params_
     dt_control_log(_("data pending - please repeat"));
     // force to reprocess the preview, otherwise the buffer is ko
     dt_dev_pixelpipe_flush_caches(module->dev->preview_pipe);
-    dt_dev_invalidate_preview(module->dev, __FUNCTION__, __FILE__, __LINE__);
+    dt_dev_invalidate_preview(module->dev);
     dt_dev_refresh_ui_images(module->dev);
     goto error;
   }
@@ -3086,7 +3086,7 @@ static void _do_get_structure_lines(dt_iop_module_t *self)
     dt_control_log(_("data pending - please repeat"));
     // force to reprocess the preview, otherwise the buffer is ko
     dt_dev_pixelpipe_flush_caches(self->dev->preview_pipe);
-    dt_dev_invalidate_preview(self->dev, __FUNCTION__, __FILE__, __LINE__);
+    dt_dev_invalidate_preview(self->dev);
     dt_dev_refresh_ui_images(self->dev);
     return;
   }
@@ -3133,7 +3133,7 @@ static void _do_get_structure_quad(dt_iop_module_t *self)
     dt_control_log(_("data pending - please repeat"));
     // force to reprocess the preview, otherwise the buffer is ko
     dt_dev_pixelpipe_flush_caches(self->dev->preview_pipe);
-    dt_dev_invalidate_preview(self->dev, __FUNCTION__, __FILE__, __LINE__);
+    dt_dev_invalidate_preview(self->dev);
     dt_dev_refresh_ui_images(self->dev);
     return;
   }

--- a/src/iop/basicadj.c
+++ b/src/iop/basicadj.c
@@ -214,7 +214,7 @@ static void _auto_levels_callback(GtkButton *button, dt_iop_module_t *self)
   }
   dt_iop_gui_leave_critical_section(self);
 
-  dt_dev_invalidate_all(self->dev, __FUNCTION__, __FILE__, __LINE__);
+  dt_dev_invalidate_all(self->dev);
   dt_dev_refresh_ui_images(self->dev);
 }
 
@@ -355,7 +355,7 @@ int button_released(struct dt_iop_module_t *self, double x, double y, int which,
       g->button_down = 0;
       g->call_auto_exposure = 1;
 
-      dt_dev_invalidate_all(self->dev, __FUNCTION__, __FILE__, __LINE__);
+      dt_dev_invalidate_all(self->dev);
       dt_dev_refresh_ui_images(self->dev);
     }
     else

--- a/src/iop/channelmixerrgb.c
+++ b/src/iop/channelmixerrgb.c
@@ -2576,7 +2576,7 @@ static void run_profile_callback(GtkWidget *widget, GdkEventButton *event, gpoin
   g->run_profile = TRUE;
   dt_iop_gui_leave_critical_section(self);
 
-  dt_dev_invalidate_preview(self->dev, __FUNCTION__, __FILE__, __LINE__);
+  dt_dev_invalidate_preview(self->dev);
   dt_dev_refresh_ui_images(self->dev);
 }
 
@@ -2590,7 +2590,7 @@ static void run_validation_callback(GtkWidget *widget, GdkEventButton *event, gp
   g->run_validation = TRUE;
   dt_iop_gui_leave_critical_section(self);
 
-  dt_dev_invalidate_preview(self->dev, __FUNCTION__, __FILE__, __LINE__);
+  dt_dev_invalidate_preview(self->dev);
   dt_dev_refresh_ui_images(self->dev);
 }
 

--- a/src/iop/crop.c
+++ b/src/iop/crop.c
@@ -972,7 +972,7 @@ static void _enter_edit_mode(GtkToggleButton* button, struct dt_iop_module_t *se
   }
 
   // It sucks that we need to invalidate the preview too but we need its final dimension.
-  dt_dev_invalidate_all(self->dev, __FUNCTION__, __FILE__, __LINE__);
+  dt_dev_invalidate_all(self->dev);
   dt_control_queue_redraw_center();
   dt_control_navigation_redraw();
   dt_dev_refresh_ui_images(self->dev);

--- a/src/iop/demosaic.c
+++ b/src/iop/demosaic.c
@@ -1543,7 +1543,7 @@ static void _visualize_callback(GtkWidget *quad, gpointer user_data)
   dt_iop_demosaic_gui_data_t *g = (dt_iop_demosaic_gui_data_t *)self->gui_data;
 
   g->visual_mask = dt_bauhaus_widget_get_quad_active(quad);
-  dt_dev_invalidate(self->dev, __FUNCTION__, __FILE__, __LINE__);
+  dt_dev_invalidate(self->dev);
   dt_dev_refresh_ui_images(self->dev);
 }
 
@@ -1555,7 +1555,7 @@ void gui_focus(struct dt_iop_module_t *self, gboolean in)
     const gboolean was_dualmask = g->visual_mask;
     dt_bauhaus_widget_set_quad_active(g->dual_thrs, FALSE);
     g->visual_mask = FALSE;
-    if(was_dualmask) dt_dev_invalidate(self->dev, __FUNCTION__, __FILE__, __LINE__);
+    if(was_dualmask) dt_dev_invalidate(self->dev);
     dt_dev_refresh_ui_images(self->dev);
   }
 }

--- a/src/iop/filmicrgb.c
+++ b/src/iop/filmicrgb.c
@@ -2801,7 +2801,7 @@ static void show_mask_callback(GtkToggleButton *button, GdkEventButton *event, g
   dt_iop_filmicrgb_gui_data_t *g = (dt_iop_filmicrgb_gui_data_t *)self->gui_data;
   g->show_mask = !(g->show_mask);
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->show_highlight_mask), !g->show_mask);
-  dt_dev_invalidate(self->dev, __FUNCTION__, __FILE__, __LINE__);
+  dt_dev_invalidate(self->dev);
   dt_dev_refresh_ui_images(self->dev);
 }
 
@@ -3191,7 +3191,7 @@ void gui_focus(struct dt_iop_module_t *self, gboolean in)
     gint mask_was_shown = g->show_mask;
     g->show_mask = FALSE;
     gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->show_highlight_mask), FALSE);
-    if(mask_was_shown) dt_dev_invalidate(self->dev, __FUNCTION__, __FILE__, __LINE__);
+    if(mask_was_shown) dt_dev_invalidate(self->dev);
     dt_dev_refresh_ui_images(self->dev);
   }
 }

--- a/src/iop/highlights.c
+++ b/src/iop/highlights.c
@@ -2233,7 +2233,7 @@ static void _visualize_callback(GtkWidget *quad, gpointer user_data)
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
   dt_iop_highlights_gui_data_t *g = (dt_iop_highlights_gui_data_t *)self->gui_data;
   g->show_visualize = dt_bauhaus_widget_get_quad_active(quad);
-  dt_dev_invalidate(self->dev, __FUNCTION__, __FILE__, __LINE__);
+  dt_dev_invalidate(self->dev);
   dt_dev_refresh_ui_images(self->dev);
 }
 
@@ -2245,7 +2245,7 @@ void gui_focus(struct dt_iop_module_t *self, gboolean in)
     const gboolean was_visualize = g->show_visualize;
     dt_bauhaus_widget_set_quad_active(g->clip, FALSE);
     g->show_visualize = FALSE;
-    if(was_visualize) dt_dev_invalidate(self->dev, __FUNCTION__, __FILE__, __LINE__);
+    if(was_visualize) dt_dev_invalidate(self->dev);
     dt_dev_refresh_ui_images(self->dev);
   }
 }

--- a/src/iop/retouch.c
+++ b/src/iop/retouch.c
@@ -1538,7 +1538,7 @@ static gboolean rt_display_wavelet_scale_callback(GtkToggleButton *togglebutton,
   }
   dt_iop_gui_leave_critical_section(self);
 
-  dt_dev_invalidate(self->dev, __FUNCTION__, __FILE__, __LINE__);
+  dt_dev_invalidate(self->dev);
   dt_dev_refresh_ui_images(self->dev);
 
   gtk_toggle_button_set_active(togglebutton, g->display_wavelet_scale);

--- a/src/iop/rgblevels.c
+++ b/src/iop/rgblevels.c
@@ -275,7 +275,7 @@ int button_released(struct dt_iop_module_t *self, double x, double y, int which,
       g->button_down = 0;
       g->call_auto_levels = 1;
 
-      dt_dev_invalidate_all(self->dev, __FUNCTION__, __FILE__, __LINE__);
+      dt_dev_invalidate_all(self->dev);
       dt_dev_refresh_ui_images(self->dev);
     }
     else
@@ -702,7 +702,7 @@ static void _auto_levels_callback(GtkButton *button, dt_iop_module_t *self)
   }
   dt_iop_gui_leave_critical_section(self);
 
-  dt_dev_invalidate_all(self->dev, __FUNCTION__, __FILE__, __LINE__);
+  dt_dev_invalidate_all(self->dev);
   dt_dev_refresh_ui_images(self->dev);
 }
 

--- a/src/iop/toneequal.c
+++ b/src/iop/toneequal.c
@@ -2415,7 +2415,7 @@ void gui_focus(struct dt_iop_module_t *self, gboolean in)
     const gboolean was_mask = g->mask_display;
     g->mask_display = FALSE;
     gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->show_luminance_mask), FALSE);
-    if(was_mask) dt_dev_invalidate(self->dev, __FUNCTION__, __FILE__, __LINE__);
+    if(was_mask) dt_dev_invalidate(self->dev);
     dt_dev_refresh_ui_images(self->dev);
     dt_collection_hint_message(darktable.collection);
   }

--- a/src/libs/duplicate.c
+++ b/src/libs/duplicate.c
@@ -133,7 +133,7 @@ static void _lib_duplicate_thumb_press_callback(GtkWidget *widget, GdkEventButto
       dt_develop_t *dev = darktable.develop;
       if(!dev) return;
 
-      dt_dev_invalidate(dev, __FUNCTION__, __FILE__, __LINE__);
+      dt_dev_invalidate(dev);
       dt_control_queue_redraw_center();
       dt_dev_refresh_ui_images(darktable.develop);
 

--- a/src/libs/history.c
+++ b/src/libs/history.c
@@ -1186,7 +1186,7 @@ static gboolean _lib_history_button_clicked_callback(GtkWidget *widget, GdkEvent
   dt_iop_connect_accels_all();
   dt_dev_modulegroups_set(darktable.develop, dt_dev_modulegroups_get(darktable.develop));
 
-  dt_dev_invalidate_all(darktable.develop, __FUNCTION__, __FILE__, __LINE__);
+  dt_dev_invalidate_all(darktable.develop);
   dt_dev_refresh_ui_images(darktable.develop);
   return FALSE;
 }

--- a/src/libs/navigation.c
+++ b/src/libs/navigation.c
@@ -378,7 +378,7 @@ void _lib_navigation_set_position(dt_lib_module_t *self, double x, double y, int
     gtk_widget_queue_draw(self->widget);
 
     /* redraw pipe */
-    dt_dev_invalidate_zoom(darktable.develop, __FUNCTION__, __FILE__, __LINE__);
+    dt_dev_invalidate_zoom(darktable.develop);
     dt_control_queue_redraw_center();
   }
 }
@@ -480,7 +480,7 @@ static void _zoom_preset_change(uint64_t val)
   dt_control_set_dev_closeup(closeup);
   dt_control_set_dev_zoom_x(zoom_x);
   dt_control_set_dev_zoom_y(zoom_y);
-  dt_dev_invalidate_zoom(dev, __FUNCTION__, __FILE__, __LINE__);
+  dt_dev_invalidate_zoom(dev);
   dt_control_queue_redraw();
   dt_dev_refresh_ui_images(dev);
 }

--- a/src/libs/snapshots.c
+++ b/src/libs/snapshots.c
@@ -505,7 +505,7 @@ static void _lib_snapshots_toggled_callback(GtkToggleButton *widget, gpointer us
     dt_control_set_dev_closeup(s->closeup);
     dt_control_set_dev_zoom_scale(s->zoom_scale);
 
-    dt_dev_invalidate(darktable.develop, __FUNCTION__, __FILE__, __LINE__);
+    dt_dev_invalidate(darktable.develop);
     dt_dev_refresh_ui_images(darktable.develop);
 
     d->snapshot_image = dt_cairo_image_surface_create_from_png(s->filename);

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -798,7 +798,7 @@ static void zoom_key_accel(dt_action_t *action)
   dt_control_queue_redraw_center();
   dt_control_navigation_redraw();
 
-  dt_dev_invalidate(dev, __FUNCTION__, __FILE__, __LINE__);
+  dt_dev_invalidate(dev);
   dt_dev_refresh_ui_images(dev);
 }
 
@@ -1037,7 +1037,7 @@ static void _overexposed_quickbutton_clicked(GtkWidget *w, gpointer user_data)
 {
   dt_develop_t *d = (dt_develop_t *)user_data;
   d->overexposed.enabled = !d->overexposed.enabled;
-  dt_dev_invalidate(d, __FUNCTION__, __FILE__, __LINE__);
+  dt_dev_invalidate(d);
   dt_dev_refresh_ui_images(d);
 }
 
@@ -1048,7 +1048,7 @@ static void colorscheme_callback(GtkWidget *combo, gpointer user_data)
   if(d->overexposed.enabled == FALSE)
     gtk_button_clicked(GTK_BUTTON(d->overexposed.button));
   else
-    dt_dev_invalidate(d, __FUNCTION__, __FILE__, __LINE__);
+    dt_dev_invalidate(d);
 
   dt_dev_refresh_ui_images(d);
 }
@@ -1060,7 +1060,7 @@ static void lower_callback(GtkWidget *slider, gpointer user_data)
   if(d->overexposed.enabled == FALSE)
     gtk_button_clicked(GTK_BUTTON(d->overexposed.button));
   else
-    dt_dev_invalidate(d, __FUNCTION__, __FILE__, __LINE__);
+    dt_dev_invalidate(d);
 
   dt_dev_refresh_ui_images(d);
 }
@@ -1072,7 +1072,7 @@ static void upper_callback(GtkWidget *slider, gpointer user_data)
   if(d->overexposed.enabled == FALSE)
     gtk_button_clicked(GTK_BUTTON(d->overexposed.button));
   else
-    dt_dev_invalidate(d, __FUNCTION__, __FILE__, __LINE__);
+    dt_dev_invalidate(d);
 
   dt_dev_refresh_ui_images(d);
 }
@@ -1084,7 +1084,7 @@ static void mode_callback(GtkWidget *slider, gpointer user_data)
   if(d->overexposed.enabled == FALSE)
     gtk_button_clicked(GTK_BUTTON(d->overexposed.button));
   else
-    dt_dev_invalidate(d, __FUNCTION__, __FILE__, __LINE__);
+    dt_dev_invalidate(d);
 
   dt_dev_refresh_ui_images(d);
 }
@@ -1094,7 +1094,7 @@ static void _rawoverexposed_quickbutton_clicked(GtkWidget *w, gpointer user_data
 {
   dt_develop_t *d = (dt_develop_t *)user_data;
   d->rawoverexposed.enabled = !d->rawoverexposed.enabled;
-  dt_dev_invalidate(d, __FUNCTION__, __FILE__, __LINE__);
+  dt_dev_invalidate(d);
   dt_dev_refresh_ui_images(d);
 }
 
@@ -1105,7 +1105,7 @@ static void rawoverexposed_mode_callback(GtkWidget *combo, gpointer user_data)
   if(d->rawoverexposed.enabled == FALSE)
     gtk_button_clicked(GTK_BUTTON(d->rawoverexposed.button));
   else
-    dt_dev_invalidate(d, __FUNCTION__, __FILE__, __LINE__);
+    dt_dev_invalidate(d);
 
   dt_dev_refresh_ui_images(d);
 }
@@ -1117,7 +1117,7 @@ static void rawoverexposed_colorscheme_callback(GtkWidget *combo, gpointer user_
   if(d->rawoverexposed.enabled == FALSE)
     gtk_button_clicked(GTK_BUTTON(d->rawoverexposed.button));
   else
-    dt_dev_invalidate(d, __FUNCTION__, __FILE__, __LINE__);
+    dt_dev_invalidate(d);
 
   dt_dev_refresh_ui_images(d);
 }
@@ -1129,7 +1129,7 @@ static void rawoverexposed_threshold_callback(GtkWidget *slider, gpointer user_d
   if(d->rawoverexposed.enabled == FALSE)
     gtk_button_clicked(GTK_BUTTON(d->rawoverexposed.button));
   else
-    dt_dev_invalidate(d, __FUNCTION__, __FILE__, __LINE__);
+    dt_dev_invalidate(d);
 
   dt_dev_refresh_ui_images(d);
 }
@@ -1145,7 +1145,7 @@ static void _softproof_quickbutton_clicked(GtkWidget *w, gpointer user_data)
 
   _update_softproof_gamut_checking(d);
 
-  dt_dev_invalidate(d, __FUNCTION__, __FILE__, __LINE__);
+  dt_dev_invalidate(d);
   dt_dev_refresh_ui_images(d);
 }
 
@@ -1160,7 +1160,7 @@ static void _gamut_quickbutton_clicked(GtkWidget *w, gpointer user_data)
 
   _update_softproof_gamut_checking(d);
 
-  dt_dev_invalidate(d, __FUNCTION__, __FILE__, __LINE__);
+  dt_dev_invalidate(d);
   dt_dev_refresh_ui_images(d);
 }
 
@@ -1212,7 +1212,7 @@ end:
   if(profile_changed)
   {
     DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_CONTROL_PROFILE_USER_CHANGED, DT_COLORSPACES_PROFILE_TYPE_SOFTPROOF);
-    dt_dev_invalidate_all(d, __FUNCTION__, __FILE__, __LINE__);
+    dt_dev_invalidate_all(d);
     dt_dev_refresh_ui_images(d);
   }
 }
@@ -1376,7 +1376,7 @@ static float _action_process_preview(gpointer target, dt_action_element_t elemen
         lib->full_preview = FALSE;
         dt_iop_request_focus(lib->full_preview_last_module);
         dt_masks_set_edit_mode(darktable.develop->gui_module, lib->full_preview_masks_state);
-        dt_dev_invalidate(darktable.develop, __FUNCTION__, __FILE__, __LINE__);
+        dt_dev_invalidate(darktable.develop);
         dt_control_queue_redraw_center();
         dt_control_navigation_redraw();
         dt_dev_refresh_ui_images(darktable.develop);
@@ -1411,7 +1411,7 @@ static float _action_process_preview(gpointer target, dt_action_element_t elemen
         lib->full_preview_last_module = darktable.develop->gui_module;
         dt_iop_request_focus(NULL);
         gtk_widget_grab_focus(dt_ui_center(darktable.gui->ui));
-        dt_dev_invalidate(darktable.develop, __FUNCTION__, __FILE__, __LINE__);
+        dt_dev_invalidate(darktable.develop);
         dt_control_queue_redraw_center();
         dt_dev_refresh_ui_images(darktable.develop);
       }
@@ -1459,7 +1459,7 @@ static float _action_process_move(gpointer target, dt_action_element_t element, 
     dt_control_queue_redraw_center();
     dt_control_navigation_redraw();
 
-    dt_dev_invalidate(dev, __FUNCTION__, __FILE__, __LINE__);
+    dt_dev_invalidate(dev);
     dt_dev_refresh_ui_images(dev);
   }
 
@@ -2715,7 +2715,7 @@ void mouse_moved(dt_view_t *self, double x, double y, double pressure, int which
     dt_control_queue_redraw_center();
     dt_control_navigation_redraw();
 
-    dt_dev_invalidate(dev, __FUNCTION__, __FILE__, __LINE__);
+    dt_dev_invalidate(dev);
     dt_dev_refresh_ui_images(dev);
   }
 }
@@ -2744,7 +2744,7 @@ int button_released(dt_view_t *self, double x, double y, int which, uint32_t sta
     dt_control_queue_redraw_center();
 
     // FIXME: use invalidate_top in the future
-    dt_dev_invalidate_preview(dev, __FUNCTION__, __FILE__, __LINE__);
+    dt_dev_invalidate_preview(dev);
     dt_dev_refresh_ui_images(dev);
     return 1;
   }
@@ -2753,7 +2753,7 @@ int button_released(dt_view_t *self, double x, double y, int which, uint32_t sta
   {
     // Change on mask parameters and image output.
     // FIXME: use invalidate_top in the future
-    dt_dev_invalidate_all(dev, __FUNCTION__, __FILE__, __LINE__);
+    dt_dev_invalidate_all(dev);
     dt_control_queue_redraw_center();
     dt_dev_refresh_ui_images(dev);
     return 1;
@@ -2764,7 +2764,7 @@ int button_released(dt_view_t *self, double x, double y, int which, uint32_t sta
      && dev->gui_module->button_released(dev->gui_module, x, y, which, state))
   {
     // Click in modules should handle history changes internally. Only update zoom here.
-    dt_dev_invalidate_zoom(dev, __FUNCTION__, __FILE__, __LINE__);
+    dt_dev_invalidate_zoom(dev);
     dt_control_queue_redraw_center();
     dt_dev_refresh_ui_images(dev);
     return 1;
@@ -2826,7 +2826,7 @@ int button_released(dt_view_t *self, double x, double y, int which, uint32_t sta
 
     dt_control_queue_redraw_center();
     dt_control_navigation_redraw();
-    dt_dev_invalidate_zoom(dev, __FUNCTION__, __FILE__, __LINE__);
+    dt_dev_invalidate_zoom(dev);
     dt_dev_refresh_ui_images(dev);
     return 1;
   }
@@ -2997,7 +2997,7 @@ void scrolled(dt_view_t *self, double x, double y, int up, int state)
   {
     // Scroll on masks changes their size, therefore mask parameters and image output.
     // FIXME: use invalidate_top in the future
-    dt_dev_invalidate_all(dev, __FUNCTION__, __FILE__, __LINE__);
+    dt_dev_invalidate_all(dev);
     dt_control_queue_redraw_center();
     dt_dev_refresh_ui_images(dev);
     return;
@@ -3007,7 +3007,7 @@ void scrolled(dt_view_t *self, double x, double y, int up, int state)
   if(dev->gui_module && dev->gui_module->scrolled && dev->gui_module->scrolled(dev->gui_module, x, y, up, state))
   {
     // Scroll in modules should handle history changes internally. Only update zoom here.
-    dt_dev_invalidate_zoom(dev, __FUNCTION__, __FILE__, __LINE__);
+    dt_dev_invalidate_zoom(dev);
     dt_control_queue_redraw_center();
     dt_dev_refresh_ui_images(dev);
     return;
@@ -3134,7 +3134,7 @@ void scrolled(dt_view_t *self, double x, double y, int up, int state)
   dt_control_queue_redraw_center();
   dt_control_navigation_redraw();
 
-  dt_dev_invalidate_zoom(dev, __FUNCTION__, __FILE__, __LINE__);
+  dt_dev_invalidate_zoom(dev);
   dt_dev_refresh_ui_images(dev);
 }
 


### PR DESCRIPTION
Provide a single way to trace a function without modify all callers.