### PR TITLE
CMake: Fix build check on AVIF exporter

### DIFF
--- a/src/imageio/format/CMakeLists.txt
+++ b/src/imageio/format/CMakeLists.txt
@@ -32,7 +32,7 @@ if(OpenJPEG_FOUND)
   add_library(j2k MODULE "j2k.c")
 endif(OpenJPEG_FOUND)
 
-if(avif_FOUND)
+if(libavif_FOUND)
   list(APPEND MODULES "avif_format")
   add_library(avif_format MODULE "avif.c")
   set_target_properties(avif_format PROPERTIES OUTPUT_NAME avif)


### PR DESCRIPTION
If you read too much CMake, you need to have a break, otherwise you are very likely to make mistakes. Use the correct variable to fix it.