### PR TITLE
build.sh: check if file exist before creating .desktop simlink

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -484,13 +484,15 @@ if [ $DO_INSTALL ] ; then
 		$SUDO rm /usr/local/bin/ansel
 	fi
 
-	$SUDO ln -s $INSTALL_PREFIX/bin/ansel /usr/local/bin/ansel
+	$SUDO ln -s "$INSTALL_PREFIX"/bin/ansel /usr/local/bin/ansel
 
-	if [ -f "/usr/share/applications/ansel.desktop" ]; then
-		$SUDO rm /usr/share/applications/ansel.desktop
+	if [ -f "$INSTALL_PREFIX/share/applications/photos.ansel.app.desktop" ]; then
+		if [ -f "/usr/share/applications/ansel.desktop" ]; then
+			$SUDO rm /usr/share/applications/ansel.desktop
+		fi
+
+		$SUDO ln -s "$INSTALL_PREFIX"/share/applications/photos.ansel.app.desktop /usr/share/applications/ansel.desktop
 	fi
-
-	$SUDO ln -s $INSTALL_PREFIX/share/applications/photos.ansel.app.desktop /usr/share/applications/ansel.desktop
 fi
 
 # update Lensfun


### PR DESCRIPTION
### WHAT DOES THIS DO?

When building on Windows, the Ansel's .desktop file is not generated and the script get stuck when trying to create a simlink to it.
I added a check on the file existence before the script creates the simlink.