### PR TITLE
Update the default patterns in anselconfig

### DIFF
--- a/data/anselconfig.xml.in
+++ b/data/anselconfig.xml.in
@@ -545,7 +545,7 @@
   <dtconfig>
     <name>session/filename_pattern</name>
     <type>string</type>
-    <default>$(JOBCODE)-$(FILENAME)-$(SEQUENCE).$(FILE_EXTENSION)</default>
+    <default>$(JOBCODE)-$(FILE.NAME)-$(SEQUENCE).$(FILE.EXTENSION)</default>
     <shortdescription>Picture naming pattern</shortdescription>
     <longdescription>file naming pattern used for a import session</longdescription>
   </dtconfig>
@@ -1936,7 +1936,7 @@
   <dtconfig>
     <name>plugins/imageio/storage/disk/file_directory</name>
     <type>string</type>
-    <default>$(FILE_FOLDER)/ansel_exported/$(FILE_NAME)</default>
+    <default>$(FILE.FOLDER)/ansel_exported/$(FILE.NAME)</default>
     <shortdescription/>
     <longdescription/>
   </dtconfig>

--- a/src/gui/gtkentry.c
+++ b/src/gui/gtkentry.c
@@ -233,7 +233,7 @@ const dt_gtkentry_completion_spec *dt_gtkentry_get_default_path_compl_list()
           { "PUBLISHER", N_("$(PUBLISHER) - publisher from metadata") },
           { "RIGHTS", N_("$(RIGHTS) - rights from metadata") },
           { "USERNAME", N_("$(USERNAME) - login name") },
-          { "FOLDER.PICTURE", N_("$(FOLDER.PICTURES) - pictures folder") },
+          { "FOLDER.PICTURES", N_("$(FOLDER.PICTURES) - pictures folder") },
           { "FOLDER.HOME", N_("$(FOLDER.HOME) - home folder") },
           { "FOLDER.DESKTOP", N_("$(FOLDER.DESKTOP) - desktop folder") },
           { "OPENCL.ACTIVATED", N_("$(OPENCL.ACTIVATED) - whether OpenCL is activated") },


### PR DESCRIPTION
### WHAT DOES THIS DO?
This PR corrects the default file patterns:
- `$(FILEFOLDER)` was used instead of `$(FILE.FOLDER)`
- Other variables use a valid form but doesn't correspond to the auto-completion's patterns which is supposed to show good practice. (`.` is used to separate words in auto-completion, instead of a `_` in the default patterns)