### PR TITLE
Enable Exiv2 0.28.x compilation. Solving issue #8

### DIFF
--- a/packaging/macosx/1_install_hb_dependencies.sh
+++ b/packaging/macosx/1_install_hb_dependencies.sh
@@ -19,13 +19,6 @@ fi
 brew update
 brew upgrade
 
-# Ensure you still have the version 0.27.6 of exiv2
-# Procedure:
-# brew remove exiv2 (if already installed)
-# brew tap homebrew/core
-# brew tap-new $USER/local-exiv2
-# brew extract --version=0.27.6 exiv2 $USER/local-exiv2
-
 # Define homebrew dependencies
 hbDependencies="adwaita-icon-theme \
     cmake \
@@ -33,7 +26,7 @@ hbDependencies="adwaita-icon-theme \
     cmocka \
     curl \
     desktop-file-utils \
-    exiv2@0.27.6 \
+    exiv2 \
     gettext \
     git \
     glib \

--- a/tools/basecurve/CMakeLists.txt
+++ b/tools/basecurve/CMakeLists.txt
@@ -5,6 +5,10 @@ find_library(M_LIBRARY m)
 find_package(Exiv2 REQUIRED)
 include_directories(${Exiv2_INCLUDE_DIR})
 
+if(CMAKE_CXX_COMPILER_ID MATCHES "Clang" AND Exiv2_VERSION VERSION_GREATER_EQUAL "0.28.0")
+    set(CMAKE_CXX_STANDARD 17)
+endif()
+
 add_executable(ansel-curve-tool ansel-curve-tool.c exif-wrapper.cpp)
 if(OPENMP_FOUND)
     set_target_properties(ansel-curve-tool PROPERTIES COMPILE_FLAGS ${OpenMP_CXX_FLAGS})


### PR DESCRIPTION
Solving the issue caused by Exiv2 version 0.28.x during compiling /tools/basecurve (do we still need that tool?) with Apple clang. Solution copied from darktable by changing c++ standard to 17.