### PR TITLE
Import: fix issues on win

### DIFF
--- a/src/common/import.c
+++ b/src/common/import.c
@@ -591,11 +591,12 @@ static void _set_test_path(dt_lib_import_t *d)
   }
   else
   {
+    gchar *basedir = dt_conf_get_string("session/base_directory_pattern");
     dt_control_import_t data = {.imgs = file,
                                 .datetime = dt_string_to_datetime(date),
                                 .copy = 1,
                                 .jobcode = dt_conf_get_string("ui_last/import_jobcode"),
-                                .target_folder = g_strrstr(dt_conf_get_string("session/base_directory_pattern"), G_DIR_SEPARATOR_S),
+                                .target_folder = basedir,
                                 .target_subfolder_pattern = dt_conf_get_string("session/sub_directory_pattern"),
                                 .target_file_pattern = dt_conf_get_string("session/filename_pattern"),
                                 .target_dir = NULL,
@@ -613,12 +614,17 @@ static void _set_test_path(dt_lib_import_t *d)
     params->imgid = -1;
     dt_variables_set_datetime(params, data.datetime);
 
-    gchar *fake_path = dt_build_filename_from_pattern(params, &data);
+    gchar *_path = dt_build_filename_from_pattern(params, &data);
+    gchar * cut = g_strdup(g_strrstr(basedir, G_DIR_SEPARATOR_S));
+    gchar *fake_path = g_strdup(g_strrstr(_path, cut));
 
     gtk_label_set_text(GTK_LABEL(d->test_path), (fake_path && fake_path != NULL)
                   ? g_strdup_printf(_("Result of the pattern : ...%s"), fake_path)
                   : g_strdup(_("Can't build a valid path.")));
-
+    
+    g_free(basedir);
+    g_free(cut);
+    g_free(_path);
     g_free(fake_path);
     dt_variables_params_destroy(params);
     g_list_free_full(file, g_free);

--- a/src/common/utility.c
+++ b/src/common/utility.c
@@ -699,23 +699,6 @@ gchar *dt_util_normalize_path(const gchar *_input)
   // this handles filenames in the formats <drive letter>:\path\to\file or \\host-name\share-name\file
   // some other formats like \Device\... are not supported
 
-  // the Windows api expects wide chars and not utf8 :(
-  wchar_t *wfilename = g_utf8_to_utf16(filename, -1, NULL, NULL, NULL);
-  g_free(filename);
-  if(!wfilename)
-    return NULL;
-
-  wchar_t LongPath[MAX_PATH] = {0};
-  const DWORD size = GetLongPathNameW(wfilename, LongPath, MAX_PATH);
-  g_free(wfilename);
-  if(size == 0 || size > MAX_PATH)
-    return NULL;
-
-  // back to utf8!
-  filename = g_utf16_to_utf8(LongPath, -1, NULL, NULL, NULL);
-  if(!filename)
-    return NULL;
-
   GFile *gfile = g_file_new_for_path(filename);
   g_free(filename);
   if(!gfile)

--- a/src/control/jobs/control_jobs.c
+++ b/src/control/jobs/control_jobs.c
@@ -2126,20 +2126,11 @@ gchar *dt_build_filename_from_pattern(dt_variables_params_t *params, dt_control_
   gchar *path = _path_cleanup(path_expand);
   g_free(file_expand);
   g_free(path_expand);
+  fprintf(stdout, "+Dir: %s\n", data->target_folder);
   fprintf(stdout, "+Path: %s\n", path);
   fprintf(stdout, "+File: %s\n", file);
 
   gchar *dir = g_build_path(G_DIR_SEPARATOR_S, data->target_folder, path, (char *) NULL);
-
-#ifdef WIN32
-  if(data->target_dir && (strlen(data->target_dir) > 1))
-  {
-    const char first = g_ascii_toupper(data->target_dir[0]);
-    if(first >= 'A' && first <= 'Z' && data->target_dir[1] == ':') // path format is <drive letter>:\path\to\file
-      data->target_dir[0] = first;                                 // drive letter in uppercase looks nicer
-  }
-#endif
-
   data->target_dir = dt_util_normalize_path(dir);
   gchar *res = g_build_path(G_DIR_SEPARATOR_S, data->target_dir, file, (char *) NULL);
 


### PR DESCRIPTION
- control_jobs.c : removed redundant path formatting code for windows.
- utility.c : removed a path validity test for windows in a function that was only normalizing.
- import.c : cut the beginning of base directory path AFTER decoding pattern to satisfy win normalization.