### PR TITLE
"Import end" behavior from darkroom.

### DIFF
--- a/src/common/collection.c
+++ b/src/common/collection.c
@@ -2601,6 +2601,20 @@ static void _dt_collection_recount_callback_2(gpointer instance, const int32_t i
   _dt_collection_recount_callback_1(instance, user_data);
 }
 
+static inline void _dt_collection_change_view_after_import(const dt_view_t *current_view)
+{
+  const int nb = dt_conf_get_int("ui_last/nb_imported"); 
+  if(nb == 1)
+  {
+    if(!g_strcmp0(current_view->module_name, "darkroom")) // if current view IS "darkroom".
+      dt_ctl_reload_view("darkroom");
+    else
+      dt_ctl_switch_mode_to("darkroom");
+  }
+  else if(nb > 1 && g_strcmp0(current_view->module_name, "lighttable")) // if current view IS NOT "lighttable".
+    dt_ctl_switch_mode_to("lighttable");
+}
+
 static void _dt_collection_filmroll_imported_callback(gpointer instance, const int32_t id, gpointer user_data)
 {
   dt_collection_t *collection = (dt_collection_t *)user_data;
@@ -2635,8 +2649,8 @@ static void _dt_collection_filmroll_imported_callback(gpointer instance, const i
 
     DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_TAG_CHANGED);
 
-    if(dt_conf_get_int("ui_last/nb_imported") == 1)
-      dt_ctl_switch_mode_to("darkroom");
+    const dt_view_t *current_view = dt_view_manager_get_current_view(darktable.view_manager);
+    if(current_view) _dt_collection_change_view_after_import(current_view);
   }
 }
 

--- a/src/control/control.c
+++ b/src/control/control.c
@@ -378,13 +378,16 @@ static gboolean _dt_ctl_switch_mode_to_by_view(gpointer user_data)
 void dt_ctl_switch_mode_to(const char *mode)
 {
   const dt_view_t *current_view = dt_view_manager_get_current_view(darktable.view_manager);
-  if(current_view && !strcmp(mode, current_view->module_name))
+  // if we are not in lighttable and we want to switch to the same view as current view,
+  // we switch back to lighttable (kind of reloading)
+  if(current_view && !strcmp(mode, current_view->module_name) && strcmp(current_view->module_name, "lighttable"))
   {
-    // if we are not in lighttable, we switch back to that view
-    if(strcmp(current_view->module_name, "lighttable")) dt_ctl_switch_mode_to("lighttable");
-    return;
+    dt_ctl_switch_mode_to("lighttable");
+    // no need to reswitch to lighttable again
+    if(!strcmp(mode, "lighttable"))
+      return;
   }
-
+  
   g_main_context_invoke(NULL, _dt_ctl_switch_mode_to, (gpointer)mode);
 }
 

--- a/src/control/control.c
+++ b/src/control/control.c
@@ -378,14 +378,11 @@ static gboolean _dt_ctl_switch_mode_to_by_view(gpointer user_data)
 void dt_ctl_switch_mode_to(const char *mode)
 {
   const dt_view_t *current_view = dt_view_manager_get_current_view(darktable.view_manager);
-  // if we are not in lighttable and we want to switch to the same view as current view,
-  // we switch back to lighttable (kind of reloading)
-  if(current_view && !strcmp(mode, current_view->module_name) && strcmp(current_view->module_name, "lighttable"))
+  if(current_view && !strcmp(mode, current_view->module_name))
   {
-    dt_ctl_switch_mode_to("lighttable");
-    // no need to reswitch to lighttable again
-    if(!strcmp(mode, "lighttable"))
-      return;
+    // if we are not in lighttable, we switch back to that view
+    if(strcmp(current_view->module_name, "lighttable")) dt_ctl_switch_mode_to("lighttable");
+    return;
   }
   
   g_main_context_invoke(NULL, _dt_ctl_switch_mode_to, (gpointer)mode);
@@ -402,6 +399,14 @@ void dt_ctl_switch_mode()
   const dt_view_t *view = dt_view_manager_get_current_view(darktable.view_manager);
   const char *mode = (view && !strcmp(view->module_name, "lighttable")) ? "darkroom" : "lighttable";
   dt_ctl_switch_mode_to(mode);
+}
+
+void dt_ctl_reload_view(const char *mode)
+{
+  const dt_view_t *current_view = dt_view_manager_get_current_view(darktable.view_manager);
+  if(current_view && g_strcmp0(current_view->module_name, "lighttable"))
+    dt_ctl_switch_mode_to("lighttable");
+  g_main_context_invoke(NULL, _dt_ctl_switch_mode_to, (gpointer)mode);
 }
 
 static gboolean _dt_ctl_log_message_timeout_callback(gpointer data)

--- a/src/control/control.h
+++ b/src/control/control.h
@@ -104,6 +104,7 @@ void dt_control_toast_redraw();
 void dt_ctl_switch_mode();
 void dt_ctl_switch_mode_to(const char *mode);
 void dt_ctl_switch_mode_to_by_view(const dt_view_t *view);
+void dt_ctl_reload_view(const char *mode);
 
 struct dt_control_t;
 

--- a/src/gui/actions/file.h
+++ b/src/gui/actions/file.h
@@ -118,11 +118,7 @@ gboolean _is_lighttable()
 
 void import_files_callback()
 {
-  // Workaround : Darkroom is not wired properly to manage importing. Disable import outsile of lighttable.
-  if(_is_lighttable())
     dt_images_import();
-  else
-    dt_control_log(_("Import is not allowed yet outside of lighttable."));
 }
 
 void _close_export_popup(GtkWidget *dialog, gint response_id, gpointer data)
@@ -195,7 +191,7 @@ void append_file(GtkWidget **menus, GList **lists, const dt_menus_t index)
   dt_action_t *ac;
 
   add_sub_menu_entry(menus, lists, _("Import..."), index, NULL, import_files_callback, NULL, NULL,
-                     _is_lighttable);
+                     NULL);
   ac = dt_action_define(pnl, NULL, N_("Import images"), get_last_widget(lists), NULL);
   dt_action_register(ac, NULL, import_files_callback, GDK_KEY_i, GDK_CONTROL_MASK | GDK_SHIFT_MASK);
 


### PR DESCRIPTION
Activated import in global menu from darkroom.

**changed the switching process after import :**
- Added a function to "reload" a view. This just switch
     view to `lighttable` then to the desired view.
     
After import process:
- `darkroom` is loaded if 1 image has been imported.
If the current view is `darkroom`, it reloads the view using the new reload function. Because the collection and image's focus changed onto a different image, the `darkroom` reloads with a different image;
- `lighttable` is loaded if more images have been imported, excepted if the current view is `lighttable`;
