### PR TITLE
Import and remove from database fixes

### DIFF
--- a/src/common/image.c
+++ b/src/common/image.c
@@ -1269,6 +1269,10 @@ void dt_image_remove(const int32_t imgid)
                               NULL);
   DT_DEBUG_SQLITE3_BIND_INT(stmt, 1, imgid);
   sqlite3_step(stmt);
+  DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db), "DELETE FROM main.meta_data WHERE id = ?1", -1, &stmt,
+                              NULL);
+  DT_DEBUG_SQLITE3_BIND_INT(stmt, 1, imgid);
+  sqlite3_step(stmt);
   sqlite3_finalize(stmt);
 
   // also clear all thumbnails in mipmap_cache.

--- a/src/common/import.c
+++ b/src/common/import.c
@@ -549,9 +549,9 @@ static void update_preview_cb(GtkFileChooser *file_chooser, gpointer userdata)
   /* Do we already have this picture in library ? */
   gchar *folder = dt_util_path_get_dirname(filename);
   gchar *basename = g_file_get_basename(in);
-  g_object_unref(in);
   const int is_path_in_lib = _is_in_library_by_path(folder, basename);
-  const int is_metadata_in_lib = _is_in_library_by_metadata(gtk_file_chooser_get_file(file_chooser));
+  const int is_metadata_in_lib = _is_in_library_by_metadata(in);
+  g_object_unref(in);
   const gboolean is_in_lib = (is_path_in_lib > -1) || (is_metadata_in_lib > -1);
   g_free(folder);
   g_free(basename);


### PR DESCRIPTION
**Database:**
in the Import file chooser, there can be a crash when selecting a file which have been copied earlier and the copy have then been removed from database.
The entry in the `meta_data` table was still existing and was used to recover an `imgid` and tried to find a path even if the file was deleted.
To fix this, when removing an image, now it deletes the image's entry in `meta_data` table too.

**Import preview:**
The function to refresh preview now uses the list of selected file instead of the selected file from file chooser, to find if a file is in the library by metadata.
