### PR TITLE
Fix make install following 38c9b5108273aeda6fd7f5427504ec5a0ed77f72

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -1,7 +1,7 @@
 #
 # Install Doc files
 #
-set(DOC_FILES README.md ../AUTHORS TRANSLATORS.md ../LICENSE)
+set(DOC_FILES ../AUTHORS ../LICENSE)
 install(FILES ${DOC_FILES} DESTINATION ${CMAKE_INSTALL_DOCDIR} COMPONENT DTDocuments)
 
 # Build manual page


### PR DESCRIPTION
The ansel-git archlinux package doesn't build anymore. It fails at make install.

It seems it's following the removal of README.md and TRANSLATORS.md from 38c9b5108273aeda6fd7f5427504ec5a0ed77f72

This PR should fix this