### PR TITLE
Always use cacheline size as alignment for dt_alloc_align

### DIFF
--- a/src/common/cache.c
+++ b/src/common/cache.c
@@ -230,7 +230,7 @@ restart:
   if(cache->allocate)
     cache->allocate(cache->allocate_data, entry);
   else
-    entry->data = dt_alloc_align(64, entry->data_size);
+    entry->data = dt_alloc_align(entry->data_size);
 
   assert(entry->data_size);
   ASAN_POISON_MEMORY_REGION(entry->data, entry->data_size);

--- a/src/common/darktable.c
+++ b/src/common/darktable.c
@@ -1524,8 +1524,9 @@ void dt_vprint(dt_debug_thread_t thread, const char *msg, ...)
   }
 }
 
-void *dt_alloc_align(size_t alignment, size_t size)
+void *dt_alloc_align(size_t size)
 {
+  const size_t alignment = DT_CACHELINE_BYTES;
   const size_t aligned_size = dt_round_size(size, alignment);
 #if defined(__FreeBSD_version) && __FreeBSD_version < 700013
   return malloc(aligned_size);

--- a/src/common/distance_transform.h
+++ b/src/common/distance_transform.h
@@ -125,7 +125,7 @@ float dt_image_distance_transform(float *const restrict src, float *const restri
     float *f = dt_alloc_align_float(maxdim);
     float *z = dt_alloc_align_float(maxdim + 1);
     float *d = dt_alloc_align_float(maxdim);
-    int *v = dt_alloc_align(64, maxdim * sizeof (int));
+    int *v = dt_alloc_align(maxdim * sizeof(int));
 
     // transform along columns
 #ifdef _OPENMP

--- a/src/common/dttypes.h
+++ b/src/common/dttypes.h
@@ -40,7 +40,7 @@
 // Helper to force heap vectors to be aligned on 64 byte blocks to enable AVX2
 // If this is applied to a struct member and the struct is allocated on the heap, then it must be allocated
 // on a 64 byte boundary to avoid crashes or undefined behavior because of unaligned memory access.
-#define DT_ALIGNED_ARRAY __attribute__((aligned(64)))
+#define DT_ALIGNED_ARRAY __attribute__((aligned(DT_CACHELINE_BYTES)))
 #define DT_ALIGNED_PIXEL __attribute__((aligned(16)))
 
 // utility type to ease declaration of aligned small arrays to hold a pixel (and document their purpose)

--- a/src/common/focus_peaking.h
+++ b/src/common/focus_peaking.h
@@ -47,7 +47,7 @@ static inline void dt_focuspeaking(cairo_t *cr, int width, int height,
                                    const int buf_width, const int buf_height)
 {
   float *const restrict luma = dt_alloc_align_float((size_t)buf_width * buf_height);
-  uint8_t *const restrict focus_peaking = dt_alloc_align(64, sizeof(uint8_t) * buf_width * buf_height * 4);
+  uint8_t *const restrict focus_peaking = dt_alloc_align(sizeof(uint8_t) * buf_width * buf_height * 4);
 
   const size_t npixels = (size_t)buf_height * buf_width;
   // Create a luma buffer as the euclidian norm of RGB channels

--- a/src/common/guided_filter.c
+++ b/src/common/guided_filter.c
@@ -664,9 +664,9 @@ static void guided_filter_cl_fallback(int devid, cl_mem guide, cl_mem in, cl_mem
 {
   // fall-back implementation: copy data from device memory to host memory and perform filter
   // by CPU until there is a proper OpenCL implementation
-  float *guide_host = dt_alloc_align(64, sizeof(*guide_host) * width * height * ch);
-  float *in_host = dt_alloc_align(64, sizeof(*in_host) * width * height);
-  float *out_host = dt_alloc_align(64, sizeof(*out_host) * width * height);
+  float *guide_host = dt_alloc_align(sizeof(*guide_host) * width * height * ch);
+  float *in_host = dt_alloc_align(sizeof(*in_host) * width * height);
+  float *out_host = dt_alloc_align(sizeof(*out_host) * width * height);
   int err;
   err = dt_opencl_read_host_from_device(devid, guide_host, guide, width, height, ch * sizeof(float));
   if(err != CL_SUCCESS) goto error;

--- a/src/common/guided_filter.h
+++ b/src/common/guided_filter.h
@@ -48,7 +48,7 @@ typedef struct gray_image
 // allocate space for 1-component image of size width x height
 static inline gray_image new_gray_image(int width, int height)
 {
-  return (gray_image){ dt_alloc_align(64, sizeof(float) * width * height), width, height };
+  return (gray_image){ dt_alloc_align(sizeof(float) * width * height), width, height };
 }
 
 

--- a/src/common/heal.c
+++ b/src/common/heal.c
@@ -327,8 +327,8 @@ static void _heal_laplace_loop(float *const restrict red_pixels, float *const re
   // a handful of runs in each row of pixels.
   // Note that using `unsigned` instead of size_t, the stamp is limited to ~8 gigapixels (the main image can be larger)
   const size_t subwidth = (width+1)/2;  // round up to be able to handle odd widths
-  unsigned *const restrict red_runs = dt_alloc_align(64, sizeof(unsigned) * subwidth * (height + 2));
-  unsigned *const restrict black_runs = dt_alloc_align(64, sizeof(unsigned) * subwidth * (height + 2));
+  unsigned *const restrict red_runs = dt_alloc_align(sizeof(unsigned) * subwidth * (height + 2));
+  unsigned *const restrict black_runs = dt_alloc_align(sizeof(unsigned) * subwidth * (height + 2));
   if(!red_runs || !black_runs)
   {
     fprintf(stderr, "_heal_laplace_loop: error allocating memory for healing\n");

--- a/src/common/imageio.c
+++ b/src/common/imageio.c
@@ -141,7 +141,7 @@ int dt_imageio_large_thumbnail(const char *filename, uint8_t **buffer, int32_t *
     // Decompress the JPG into our own memory format
     dt_imageio_jpeg_t jpg;
     if(dt_imageio_jpeg_decompress_header(buf, bufsize, &jpg)) goto error;
-    *buffer = (uint8_t *)dt_alloc_align(64, sizeof(uint8_t) * 4 * jpg.width * jpg.height);
+    *buffer = (uint8_t *)dt_alloc_align(sizeof(uint8_t) * 4 * jpg.width * jpg.height);
     if(!*buffer) goto error;
 
     *width = jpg.width;
@@ -181,7 +181,7 @@ int dt_imageio_large_thumbnail(const char *filename, uint8_t **buffer, int32_t *
     *height = image->rows;
     *color_space = DT_COLORSPACE_SRGB; // FIXME: this assumes that embedded thumbnails are always srgb
 
-    *buffer = (uint8_t *)dt_alloc_align(64, sizeof(uint8_t) * 4 * image->columns * image->rows);
+    *buffer = (uint8_t *)dt_alloc_align(sizeof(uint8_t) * 4 * image->columns * image->rows);
     if(!*buffer) goto error_gm;
 
     for(uint32_t row = 0; row < image->rows; row++)

--- a/src/common/imageio_jpeg.c
+++ b/src/common/imageio_jpeg.c
@@ -175,7 +175,7 @@ static int decompress_jsc(dt_imageio_jpeg_t *jpg, uint8_t *out)
 static int decompress_plain(dt_imageio_jpeg_t *jpg, uint8_t *out)
 {
   JSAMPROW row_pointer[1];
-  row_pointer[0] = (uint8_t *)dt_alloc_align(64, (size_t)jpg->dinfo.output_width * jpg->dinfo.num_components);
+  row_pointer[0] = (uint8_t *)dt_alloc_align((size_t)jpg->dinfo.output_width * jpg->dinfo.num_components);
   uint8_t *tmp = out;
   while(jpg->dinfo.output_scanline < jpg->dinfo.image_height)
   {
@@ -291,7 +291,7 @@ int dt_imageio_jpeg_compress(const uint8_t *in, uint8_t *out, const int width, c
   if(quality > 90) jpg.cinfo.comp_info[0].v_samp_factor = 1;
   if(quality > 92) jpg.cinfo.comp_info[0].h_samp_factor = 1;
   jpeg_start_compress(&(jpg.cinfo), TRUE);
-  uint8_t *row = dt_alloc_align(64, sizeof(uint8_t) * 3 * width);
+  uint8_t *row = dt_alloc_align(sizeof(uint8_t) * 3 * width);
   const uint8_t *buf;
   while(jpg.cinfo.next_scanline < jpg.cinfo.image_height)
   {
@@ -531,7 +531,7 @@ int dt_imageio_jpeg_write_with_icc_profile(const char *filename, const uint8_t *
     cmsSaveProfileToMem(out_profile, 0, &len);
     if(len > 0)
     {
-      unsigned char *buf = dt_alloc_align(64, sizeof(unsigned char) * len);
+      unsigned char *buf = dt_alloc_align(sizeof(unsigned char) * len);
       cmsSaveProfileToMem(out_profile, buf, &len);
       write_icc_profile(&(jpg.cinfo), buf, len);
       dt_free_align(buf);
@@ -540,7 +540,7 @@ int dt_imageio_jpeg_write_with_icc_profile(const char *filename, const uint8_t *
 
   if(exif && exif_len > 0 && exif_len < 65534) jpeg_write_marker(&(jpg.cinfo), JPEG_APP0 + 1, exif, exif_len);
 
-  uint8_t *row = dt_alloc_align(64, sizeof(uint8_t) * 3 * width);
+  uint8_t *row = dt_alloc_align(sizeof(uint8_t) * 3 * width);
   const uint8_t *buf;
   while(jpg.cinfo.next_scanline < jpg.cinfo.image_height)
   {
@@ -615,7 +615,7 @@ static int read_jsc(dt_imageio_jpeg_t *jpg, uint8_t *out)
 static int read_plain(dt_imageio_jpeg_t *jpg, uint8_t *out)
 {
   JSAMPROW row_pointer[1];
-  row_pointer[0] = (uint8_t *)dt_alloc_align(64, (size_t)jpg->dinfo.output_width * jpg->dinfo.num_components);
+  row_pointer[0] = (uint8_t *)dt_alloc_align((size_t)jpg->dinfo.output_width * jpg->dinfo.num_components);
   uint8_t *tmp = out;
   while(jpg->dinfo.output_scanline < jpg->dinfo.image_height)
   {
@@ -739,7 +739,7 @@ dt_imageio_retval_t dt_imageio_open_jpeg(dt_image_t *img, const char *filename, 
   img->width = jpg.width;
   img->height = jpg.height;
 
-  uint8_t *tmp = (uint8_t *)dt_alloc_align(64, sizeof(uint8_t) * 4 * jpg.width * jpg.height);
+  uint8_t *tmp = (uint8_t *)dt_alloc_align(sizeof(uint8_t) * 4 * jpg.width * jpg.height);
   if(dt_imageio_jpeg_read(&jpg, tmp))
   {
     dt_free_align(tmp);

--- a/src/common/imageio_png.c
+++ b/src/common/imageio_png.c
@@ -178,7 +178,7 @@ dt_imageio_retval_t dt_imageio_open_png(dt_image_t *img, const char *filename, d
     return DT_IMAGEIO_CACHE_FULL;
   }
 
-  buf = dt_alloc_align(64, (size_t)image.height * png_get_rowbytes(image.png_ptr, image.info_ptr));
+  buf = dt_alloc_align((size_t)image.height * png_get_rowbytes(image.png_ptr, image.info_ptr));
 
   if(!buf)
   {

--- a/src/common/interpolation.c
+++ b/src/common/interpolation.c
@@ -859,7 +859,7 @@ static gboolean _prepare_resampling_plan(const struct dt_interpolation *itor,
   const size_t metareq = dt_round_size(pmeta ? 4 * sizeof(int) * out : 0, DT_CACHELINE_BYTES);
 
   const size_t totalreq = kernelreq + lengthreq + indexreq + scratchreq + metareq;
-  void *blob = dt_alloc_align(DT_CACHELINE_BYTES, totalreq);
+  void *blob = dt_alloc_align(totalreq);
   if(!blob) return TRUE;
 
   int *lengths = (int *)blob;

--- a/src/common/iop_profile.c
+++ b/src/common/iop_profile.c
@@ -746,7 +746,7 @@ dt_ioppr_add_profile_info_to_list(struct dt_develop_t *dev,
   dt_iop_order_iccprofile_info_t *profile_info = dt_ioppr_get_profile_info_from_list(dev, profile_type, profile_filename);
   if(profile_info == NULL)
   {
-    profile_info = dt_alloc_align(64, sizeof(dt_iop_order_iccprofile_info_t));
+    profile_info = dt_alloc_align(sizeof(dt_iop_order_iccprofile_info_t));
     dt_ioppr_init_profile_info(profile_info, 0);
     const int err = dt_ioppr_generate_profile_info(profile_info, profile_type, profile_filename, intent);
     if(err == 0)

--- a/src/common/nlmeans_core.c
+++ b/src/common/nlmeans_core.c
@@ -112,7 +112,7 @@ define_patches(const dt_nlmeans_param_t *const params, const int stride, int *nu
     n_patches = (n_patches + 1) / 2;
   *num_patches = n_patches ;
   // allocate a cacheline-aligned buffer
-  struct patch_t* patches = dt_alloc_align(64, sizeof(struct patch_t) * n_patches);
+  struct patch_t* patches = dt_alloc_align(sizeof(struct patch_t) * n_patches);
   // set up the patch offsets
   int patch_num = 0;
   int shift = 0;

--- a/src/common/opencl.c
+++ b/src/common/opencl.c
@@ -1286,7 +1286,7 @@ static float dt_opencl_benchmark_gpu(const int devid, const size_t width, const 
 
   unsigned int *const tea_states = alloc_tea_states(dt_get_num_threads());
 
-  buf = dt_alloc_align(64, width * height * bpp);
+  buf = dt_alloc_align(width * height * bpp);
   if(buf == NULL) goto error;
 
 #ifdef _OPENMP
@@ -1361,7 +1361,7 @@ static float dt_opencl_benchmark_cpu(const size_t width, const size_t height, co
 
   unsigned int *const tea_states = alloc_tea_states(dt_get_num_threads());
 
-  buf = dt_alloc_align(64, width * height * bpp);
+  buf = dt_alloc_align(width * height * bpp);
   if(buf == NULL) goto error;
 
 #ifdef _OPENMP

--- a/src/common/points.h
+++ b/src/common/points.h
@@ -1127,7 +1127,7 @@ void init_by_array(sfmt_state_t *s, uint32_t *init_key, int key_length)
 
 static inline void dt_points_init(dt_points_t *p, const unsigned int num_threads)
 {
-  sfmt_state_t *states = (sfmt_state_t *)dt_alloc_align(64, sizeof(sfmt_state_t) * num_threads);
+  sfmt_state_t *states = (sfmt_state_t *)dt_alloc_align(sizeof(sfmt_state_t) * num_threads);
   p->s = (sfmt_state_t **)calloc(num_threads, sizeof(sfmt_state_t *));
   p->num = num_threads;
 

--- a/src/common/tea.h
+++ b/src/common/tea.h
@@ -23,10 +23,10 @@
 // cache line will be running in lock-step as the cache line bounces back and forth between them, effectively
 // cutting throughput by a factor equal to the number of threads sharing a cache line (8 with a 64-byte cache
 // line and 32-bit ints)
-#define TEA_STATE_SIZE (MAX(64, 2*sizeof(unsigned int)))
+#define TEA_STATE_SIZE (MAX(DT_CACHELINE_BYTES, 2*sizeof(unsigned int)))
 static inline unsigned int* alloc_tea_states(size_t numthreads)
 {
-  unsigned int* states = dt_alloc_align(64, numthreads * TEA_STATE_SIZE);
+  unsigned int* states = dt_alloc_align(numthreads * TEA_STATE_SIZE);
   if (states) memset(states, 0, numthreads * TEA_STATE_SIZE);
   return states;
 }

--- a/src/develop/imageop.h
+++ b/src/develop/imageop.h
@@ -459,7 +459,7 @@ const char **dt_iop_set_description(dt_iop_module_t *module, const char *main_te
 static inline dt_iop_gui_data_t *_iop_gui_alloc(dt_iop_module_t *module, size_t size)
 {
   // Align so that DT_ALIGNED_ARRAY may be used within gui_data struct
-  module->gui_data = (dt_iop_gui_data_t*)dt_calloc_align(64, size);
+  module->gui_data = (dt_iop_gui_data_t*)dt_calloc_align(size);
   dt_pthread_mutex_init(&module->gui_lock,NULL);
   return module->gui_data;
 }

--- a/src/develop/masks/path.c
+++ b/src/develop/masks/path.c
@@ -405,7 +405,7 @@ static int _path_find_self_intersection(dt_masks_dynbuf_t *inter, int nb_corners
   const size_t ss = (size_t)hb * wb;
   if(ss < 10 || hb < 0 || wb < 0) return 0;
 
-  int *binter = dt_alloc_align(64, sizeof(int) * ss);
+  int *binter = dt_alloc_align(sizeof(int) * ss);
   if(binter == NULL) return 0;
   memset(binter, 0, sizeof(int) * ss);
 
@@ -3038,7 +3038,7 @@ static int _path_get_mask_roi(const dt_iop_module_t *const module, const dt_dev_
   // deal with feather if it does not lie outside of roi
   if(!path_encircles_roi)
   {
-    int *dpoints = dt_alloc_align(64, sizeof(int) * 4 * border_count);
+    int *dpoints = dt_alloc_align(sizeof(int) * 4 * border_count);
     if(dpoints == NULL)
     {
       dt_free_align(points);

--- a/src/develop/pixelpipe_cache.c
+++ b/src/develop/pixelpipe_cache.c
@@ -49,7 +49,7 @@ int dt_dev_pixelpipe_cache_init(dt_dev_pixelpipe_cache_t *cache, int entries, si
     cache->size[k] = size;
     if(size)
     { // allow 0 initial buffer size (yet unknown dimensions)
-      cache->data[k] = (void *)dt_alloc_align(64, size);
+      cache->data[k] = (void *)dt_alloc_align(size);
       if(!cache->data[k]) goto alloc_memory_fail;
 #ifdef _DEBUG
       memset(cache->data[k], 0x5d, size);
@@ -141,7 +141,7 @@ int dt_dev_pixelpipe_cache_get_weighted(dt_dev_pixelpipe_cache_t *cache, const u
     if(cache->size[index_max] < size)
     {
       dt_free_align(cache->data[index_max]);
-      cache->data[index_max] = (void *)dt_alloc_align(64, size);
+      cache->data[index_max] = (void *)dt_alloc_align(size);
       cache->size[index_max] = size;
     }
     *data = cache->data[index_max];

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -698,7 +698,7 @@ static void pixelpipe_get_histogram_backbuf(dt_dev_pixelpipe_t *pipe, dt_develop
   if(backbuf->buffer == NULL)
   {
     // Buffer uninited
-    backbuf->buffer = dt_alloc_align(64, roi->width * roi->height * bpp);
+    backbuf->buffer = dt_alloc_align(roi->width * roi->height * bpp);
     backbuf->height = roi->height;
     backbuf->width = roi->width;
     backbuf->bpp = bpp;
@@ -709,7 +709,7 @@ static void pixelpipe_get_histogram_backbuf(dt_dev_pixelpipe_t *pipe, dt_develop
     // There is no reason yet why this should happen because the preview pipe doesn't change size during its lifetime.
     // But let's future-proof it in case someone gets creative.
     dt_free_align(backbuf->buffer); // maybe write a dt_realloc_align routine ?
-    backbuf->buffer = dt_alloc_align(64, roi->width * roi->height * bpp);
+    backbuf->buffer = dt_alloc_align(roi->width * roi->height * bpp);
     backbuf->height = roi->height;
     backbuf->width = roi->width;
     backbuf->bpp = bpp;
@@ -750,7 +750,7 @@ static void pixelpipe_get_histogram_backbuf(dt_dev_pixelpipe_t *pipe, dt_develop
   if(!strcmp(module->op, "gamma") || bpp == 4 * sizeof(uint8_t))
   {
     // We got 8 bits data, we need to convert it back to float32 for uniform handling
-    float *new_buffer = dt_alloc_align(64, roi->width * roi->height * 4 * sizeof(float));
+    float *new_buffer = dt_alloc_align(roi->width * roi->height * 4 * sizeof(float));
     if(new_buffer == NULL) return;
 
     uint8_t *old_buffer = (uint8_t *)backbuf->buffer;
@@ -910,7 +910,7 @@ static void pixelpipe_picker_cl(int devid, dt_iop_module_t *module, dt_dev_pixel
   if(buffer && bufsize >= size * bpp)
     pixel = buffer;
   else
-    pixel = tmpbuf = dt_alloc_align(64, size * bpp);
+    pixel = tmpbuf = dt_alloc_align(size * bpp);
 
   if(pixel == NULL) return;
 

--- a/src/develop/tiling.c
+++ b/src/develop/tiling.c
@@ -708,14 +708,14 @@ static void _default_process_tiling_ptp(struct dt_iop_module_t *self, struct dt_
            tiles_x, tiles_y, width, height, overlap);
 
   /* reserve input and output buffers for tiles */
-  input = dt_alloc_align(64, (size_t)width * height * in_bpp);
+  input = dt_alloc_align((size_t)width * height * in_bpp);
   if(input == NULL)
   {
     dt_print(DT_DEBUG_TILING, "[default_process_tiling_ptp] could not alloc input buffer for module '%s'\n",
              self->op);
     goto error;
   }
-  output = dt_alloc_align(64, (size_t)width * height * out_bpp);
+  output = dt_alloc_align((size_t)width * height * out_bpp);
   if(output == NULL)
   {
     dt_print(DT_DEBUG_TILING, "[default_process_tiling_ptp] could not alloc output buffer for module '%s'\n",
@@ -1085,14 +1085,14 @@ static void _default_process_tiling_roi(struct dt_iop_module_t *self, struct dt_
                tx, ty, iroi_full.width, iroi_full.height, iroi_full.x, iroi_full.y);
 
       /* prepare input tile buffer */
-      input = dt_alloc_align(64, (size_t)iroi_full.width * iroi_full.height * in_bpp);
+      input = dt_alloc_align((size_t)iroi_full.width * iroi_full.height * in_bpp);
       if(input == NULL)
       {
         dt_print(DT_DEBUG_TILING, "[default_process_tiling_roi] could not alloc input buffer for module '%s'\n",
                  self->op);
         goto error;
       }
-      output = dt_alloc_align(64, (size_t)oroi_full.width * oroi_full.height * out_bpp);
+      output = dt_alloc_align((size_t)oroi_full.width * oroi_full.height * out_bpp);
       if(output == NULL)
       {
         dt_print(DT_DEBUG_TILING, "[default_process_tiling_roi] could not alloc output buffer for module '%s'\n",

--- a/src/imageio/format/jpeg.c
+++ b/src/imageio/format/jpeg.c
@@ -358,7 +358,7 @@ int write_image(dt_imageio_module_data_t *jpg_tmp, const char *filename, const v
     }
   }
 
-  uint8_t *row = dt_alloc_align(64, sizeof(uint8_t) * 3 * jpg->global.width);
+  uint8_t *row = dt_alloc_align(sizeof(uint8_t) * 3 * jpg->global.width);
   const uint8_t *buf;
   while(jpg->cinfo.next_scanline < jpg->cinfo.image_height)
   {
@@ -416,7 +416,7 @@ int read_image(dt_imageio_module_data_t *jpg_tmp, uint8_t *out)
   }
   (void)jpeg_start_decompress(&(jpg->dinfo));
   JSAMPROW row_pointer[1];
-  row_pointer[0] = (uint8_t *)dt_alloc_align(64, (size_t)jpg->dinfo.output_width * jpg->dinfo.num_components);
+  row_pointer[0] = (uint8_t *)dt_alloc_align((size_t)jpg->dinfo.output_width * jpg->dinfo.num_components);
   uint8_t *tmp = out;
   while(jpg->dinfo.output_scanline < jpg->dinfo.image_height)
   {

--- a/src/imageio/format/pdf.c
+++ b/src/imageio/format/pdf.c
@@ -309,7 +309,7 @@ int write_image(dt_imageio_module_data_t *data, const char *filename, const void
   {
     if(d->params.bpp == 8)
     {
-      image_data = dt_alloc_align(64, (size_t)3 * data->width * data->height);
+      image_data = dt_alloc_align((size_t)3 * data->width * data->height);
       const uint8_t *in_ptr = (const uint8_t *)in;
       uint8_t *out_ptr = (uint8_t *)image_data;
       for(int y = 0; y < data->height; y++)
@@ -320,7 +320,7 @@ int write_image(dt_imageio_module_data_t *data, const char *filename, const void
     }
     else
     {
-      image_data = dt_alloc_align(64, sizeof(uint16_t) * 3 * data->width * data->height);
+      image_data = dt_alloc_align(sizeof(uint16_t) * 3 * data->width * data->height);
       const uint16_t *in_ptr = (const uint16_t *)in;
       uint16_t *out_ptr = (uint16_t *)image_data;
       for(int y = 0; y < data->height; y++)

--- a/src/imageio/format/png.c
+++ b/src/imageio/format/png.c
@@ -212,7 +212,7 @@ int write_image(dt_imageio_module_data_t *p_tmp, const char *filename, const voi
    */
   png_set_filler(png_ptr, 0, PNG_FILLER_AFTER);
 
-  png_bytep *row_pointers = dt_alloc_align(64, sizeof(png_bytep) * height);
+  png_bytep *row_pointers = dt_alloc_align(sizeof(png_bytep) * height);
 
   if(p->bpp > 8)
   {

--- a/src/iop/basicadj.c
+++ b/src/iop/basicadj.c
@@ -757,7 +757,7 @@ static void _get_auto_exp_histogram(const float *const img, const int width, con
   uint32_t *histogram = NULL;
   const float mul = hist_size;
 
-  histogram = dt_alloc_align(64, sizeof(uint32_t) * hist_size);
+  histogram = dt_alloc_align(sizeof(uint32_t) * hist_size);
   if(histogram == NULL) goto cleanup;
 
   memset(histogram, 0, sizeof(uint32_t) * hist_size);

--- a/src/iop/blurs.c
+++ b/src/iop/blurs.c
@@ -761,7 +761,7 @@ static gboolean dt_iop_tonecurve_draw(GtkWidget *widget, cairo_t *crf, gpointer 
 
   if(!g->img_cached)
   {
-    g->img = dt_alloc_align(64, sizeof(unsigned char) * 4 * allocation.width * allocation.width);
+    g->img = dt_alloc_align(sizeof(unsigned char) * 4 * allocation.width * allocation.width);
     g->img_width = allocation.width;
     g->img_cached = TRUE;
     build_gui_kernel(g->img, g->img_width, g->img_width, p);

--- a/src/iop/channelmixerrgb.c
+++ b/src/iop/channelmixerrgb.c
@@ -1620,8 +1620,8 @@ void extract_color_checker(const float *const restrict in, float *const restrict
   compute_patches_delta_E(patches, g->checker, g->delta_E_in, &post_wb_delta_E, &post_wb_max_delta_E);
 
   /* Compute the matrix of mix */
-  double *const restrict Y = dt_alloc_align(64, g->checker->patches * 3 * sizeof(double));
-  double *const restrict A = dt_alloc_align(64, g->checker->patches * 3 * 9 * sizeof(double));
+  double *const restrict Y = dt_alloc_align(g->checker->patches * 3 * sizeof(double));
+  double *const restrict A = dt_alloc_align(g->checker->patches * 3 * 9 * sizeof(double));
 
   for(size_t k = 0; k < g->checker->patches; k++)
   {
@@ -3335,7 +3335,7 @@ static void illum_xy_callback(GtkWidget *slider, gpointer user_data)
 
 void init_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
 {
-  piece->data = dt_calloc_align(64, sizeof(dt_iop_channelmixer_rbg_data_t));
+  piece->data = dt_calloc_align(sizeof(dt_iop_channelmixer_rbg_data_t));
   piece->data_size = sizeof(dt_iop_channelmixer_rbg_data_t);
 }
 

--- a/src/iop/colorreconstruction.c
+++ b/src/iop/colorreconstruction.c
@@ -267,7 +267,7 @@ static dt_iop_colorreconstruct_bilateral_t *dt_iop_colorreconstruct_bilateral_in
   b->scale = iscale / roi->scale;
   b->sigma_s = MAX(roi->height / (b->size_y - 1.0f), roi->width / (b->size_x - 1.0f));
   b->sigma_r = 100.0f / (b->size_z - 1.0f);
-  b->buf = dt_alloc_align(64, sizeof(dt_iop_colorreconstruct_Lab_t) * b->size_x * b->size_y * b->size_z);
+  b->buf = dt_alloc_align(sizeof(dt_iop_colorreconstruct_Lab_t) * b->size_x * b->size_y * b->size_z);
   if(!b->buf)
   {
     fprintf(stderr, "[color reconstruction] not able to allocate buffer (b)\n");
@@ -305,7 +305,7 @@ static dt_iop_colorreconstruct_bilateral_frozen_t *dt_iop_colorreconstruct_bilat
   bf->scale = b->scale;
   bf->sigma_s = b->sigma_s;
   bf->sigma_r = b->sigma_r;
-  bf->buf = dt_alloc_align(64, sizeof(dt_iop_colorreconstruct_Lab_t) * b->size_x * b->size_y * b->size_z);
+  bf->buf = dt_alloc_align(sizeof(dt_iop_colorreconstruct_Lab_t) * b->size_x * b->size_y * b->size_z);
   if(bf->buf && b->buf)
   {
     memcpy(bf->buf, b->buf, sizeof(dt_iop_colorreconstruct_Lab_t) * b->size_x * b->size_y * b->size_z);
@@ -341,7 +341,7 @@ static dt_iop_colorreconstruct_bilateral_t *dt_iop_colorreconstruct_bilateral_th
   b->scale = bf->scale;
   b->sigma_s = bf->sigma_s;
   b->sigma_r = bf->sigma_r;
-  b->buf = dt_alloc_align(64, sizeof(dt_iop_colorreconstruct_Lab_t) * b->size_x * b->size_y * b->size_z);
+  b->buf = dt_alloc_align(sizeof(dt_iop_colorreconstruct_Lab_t) * b->size_x * b->size_y * b->size_z);
   if(b->buf && bf->buf)
   {
     memcpy(b->buf, bf->buf, sizeof(dt_iop_colorreconstruct_Lab_t) * b->size_x * b->size_y * b->size_z);
@@ -819,7 +819,7 @@ static dt_iop_colorreconstruct_bilateral_frozen_t *dt_iop_colorreconstruct_bilat
   bf->scale = b->scale;
   bf->sigma_s = b->sigma_s;
   bf->sigma_r = b->sigma_r;
-  bf->buf = dt_alloc_align(64, sizeof(dt_iop_colorreconstruct_Lab_t) * b->size_x * b->size_y * b->size_z);
+  bf->buf = dt_alloc_align(sizeof(dt_iop_colorreconstruct_Lab_t) * b->size_x * b->size_y * b->size_z);
   if(bf->buf && b->dev_grid)
   {
     // read bilateral grid from device memory to host buffer (blocking)

--- a/src/iop/demosaic/vng.c
+++ b/src/iop/demosaic/vng.c
@@ -59,7 +59,7 @@ static void vng_interpolate(float *out, const float *const in,
   if(only_vng_linear) return;
 
   char *buffer
-      = (char *)dt_alloc_align(64, sizeof(**brow) * width * 3 + sizeof(*ip) * prow * pcol * 320);
+      = (char *)dt_alloc_align(sizeof(**brow) * width * 3 + sizeof(*ip) * prow * pcol * 320);
   if(!buffer)
   {
     fprintf(stderr, "[demosaic] not able to allocate VNG buffer\n");

--- a/src/iop/diffuse.c
+++ b/src/iop/diffuse.c
@@ -1073,7 +1073,7 @@ void process(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *c
   float *restrict temp_in = NULL;
   float *restrict temp_out = NULL;
 
-  uint8_t *const restrict mask = dt_alloc_align(64, sizeof(uint8_t) * roi_out->width * roi_out->height);
+  uint8_t *const restrict mask = dt_alloc_align(sizeof(uint8_t) * roi_out->width * roi_out->height);
 
   const float scale = fmaxf(piece->iscale / roi_in->scale, 1.f);
   const float final_radius = (data->radius + data->radius_center) * 2.f / scale;

--- a/src/iop/filmicrgb.c
+++ b/src/iop/filmicrgb.c
@@ -3209,7 +3209,7 @@ void gui_focus(struct dt_iop_module_t *self, gboolean in)
 
 void init_pipe(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
 {
-  piece->data = dt_calloc_align(64, sizeof(dt_iop_filmicrgb_data_t));
+  piece->data = dt_calloc_align(sizeof(dt_iop_filmicrgb_data_t));
   piece->data_size = sizeof(dt_iop_filmicrgb_data_t);
 }
 

--- a/src/iop/gaussian_elimination.h
+++ b/src/iop/gaussian_elimination.h
@@ -159,8 +159,8 @@ static inline int pseudo_solve_gaussian(double *const restrict A,
     return 0;
   }
 
-  double *const restrict A_square = dt_alloc_align(64, n * n * sizeof(double));
-  double *const restrict y_square = dt_alloc_align(64, n * sizeof(double));
+  double *const restrict A_square = dt_alloc_align(n * n * sizeof(double));
+  double *const restrict y_square = dt_alloc_align(n * sizeof(double));
 
   #ifdef _OPENMP
   #pragma omp parallel sections

--- a/src/iop/hazeremoval.c
+++ b/src/iop/hazeremoval.c
@@ -542,7 +542,7 @@ static float ambient_light_cl(struct dt_iop_module_t *self, int devid, cl_mem im
   const int width = dt_opencl_get_image_width(img);
   const int height = dt_opencl_get_image_height(img);
   const int element_size = dt_opencl_get_image_element_size(img);
-  float *in = dt_alloc_align(64, (size_t)width * height * element_size);
+  float *in = dt_alloc_align((size_t)width * height * element_size);
   int err = dt_opencl_read_host_from_device(devid, in, img, width, height, element_size);
   if(err != CL_SUCCESS) goto error;
   const const_rgb_image img_in = (const_rgb_image){ in, width, height, element_size / sizeof(float) };

--- a/src/iop/lens.cc
+++ b/src/iop/lens.cc
@@ -500,7 +500,7 @@ void process(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *c
   {
     // acquire temp memory for image buffer
     const size_t bufsize = (size_t)roi_in->width * roi_in->height * ch * sizeof(float);
-    void *buf = dt_alloc_align(64, bufsize);
+    void *buf = dt_alloc_align(bufsize);
     memcpy(buf, ivoid, bufsize);
 
     if(modflags & LF_MODIFY_VIGNETTING)
@@ -665,7 +665,7 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
       return FALSE;
   }
 
-  tmpbuf = (float *)dt_alloc_align(64, tmpbuflen);
+  tmpbuf = (float *)dt_alloc_align(tmpbuflen);
   if(tmpbuf == NULL) goto error;
 
   dev_tmp = (cl_mem)dt_opencl_alloc_device(devid, width, height, sizeof(float) * 4);
@@ -1042,7 +1042,7 @@ void modify_roi_in(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *
     float xm = FLT_MAX, xM = -FLT_MAX, ym = FLT_MAX, yM = -FLT_MAX;
     const size_t nbpoints = 2 * awidth + 2 * aheight;
 
-    float *const buf = (float *)dt_alloc_align(64, sizeof(float) * nbpoints * 2 * 3);
+    float *const buf = (float *)dt_alloc_align(sizeof(float) * nbpoints * 2 * 3);
 
 #ifdef _OPENMP
 #pragma omp parallel default(none) \

--- a/src/iop/liquify.c
+++ b/src/iop/liquify.c
@@ -833,7 +833,7 @@ static float complex point_at_arc_length(const float complex points[], const int
 
 static float *build_lookup_table(const int distance, const float control1, const float control2)
 {
-  float complex *clookup = dt_alloc_align(64, sizeof(float complex) * (distance + 2));
+  float complex *clookup = dt_alloc_align(sizeof(float complex) * (distance + 2));
 
   interpolate_cubic_bezier(I, control1 + I, control2, 1.0, clookup, distance + 2);
 
@@ -1133,7 +1133,7 @@ static float complex *create_global_distortion_map(const cairo_rectangle_int_t *
   }
 
   // allocate distortion map big enough to contain all paths
-  float complex *map = dt_alloc_align(64, sizeof(float complex) * mapsize);
+  float complex *map = dt_alloc_align(sizeof(float complex) * mapsize);
   memset(map, 0, sizeof(float complex) * mapsize);
 
   // build map
@@ -1149,7 +1149,7 @@ static float complex *create_global_distortion_map(const cairo_rectangle_int_t *
 
   if(inverted)
   {
-    float complex * const imap = dt_alloc_align(64, sizeof(float complex) * mapsize);
+    float complex * const imap = dt_alloc_align(sizeof(float complex) * mapsize);
     memset(imap, 0, sizeof(float complex) * mapsize);
 
     // copy map into imap(inverted map).

--- a/src/iop/lut3d.c
+++ b/src/iop/lut3d.c
@@ -460,7 +460,7 @@ uint8_t calculate_clut_compressed(dt_iop_lut3d_params_t *const p, const char *co
 
   get_cache_filename(p->lutname, cache_filename);
   buf_size_lut = (size_t)(level * level * level * 3);
-  lclut = dt_alloc_align(16, sizeof(float) * buf_size_lut);
+  lclut = dt_alloc_align(sizeof(float) * buf_size_lut);
   if(!lclut)
   {
     fprintf(stderr, "[lut3d] error allocating buffer for gmz lut\n");
@@ -542,7 +542,7 @@ uint16_t calculate_clut_haldclut(dt_iop_lut3d_params_t *const p, const char *con
   const size_t buf_size = (size_t)png.height * png_get_rowbytes(png.png_ptr, png.info_ptr);
   dt_print(DT_DEBUG_DEV, "[lut3d] allocating %zu bytes for png file\n", buf_size);
   uint8_t *buf = NULL;
-  buf = dt_alloc_align(16, buf_size);
+  buf = dt_alloc_align(buf_size);
   if(!buf)
   {
     fprintf(stderr, "[lut3d] error allocating buffer for png lut\n");
@@ -560,7 +560,7 @@ uint16_t calculate_clut_haldclut(dt_iop_lut3d_params_t *const p, const char *con
   }
   const size_t buf_size_lut = (size_t)png.height * png.height * 3;
   dt_print(DT_DEBUG_DEV, "[lut3d] allocating %zu floats for png lut - level %d\n", buf_size_lut, level);
-  float *lclut = dt_alloc_align(16, sizeof(float) * buf_size_lut);
+  float *lclut = dt_alloc_align(sizeof(float) * buf_size_lut);
   if(!lclut)
   {
     fprintf(stderr, "[lut3d] error - allocating buffer for png lut\n");
@@ -790,7 +790,7 @@ uint16_t calculate_clut_cube(const char *const filepath, float **clut)
         }
         buf_size = level * level * level * 3;
         dt_print(DT_DEBUG_DEV, "[lut3d] allocating %zu bytes for cube lut - level %d\n", buf_size, level);
-        lclut = dt_alloc_align(16, sizeof(float) * buf_size);
+        lclut = dt_alloc_align(sizeof(float) * buf_size);
         if(!lclut)
         {
           fprintf(stderr, "[lut3d] error - allocating buffer for cube lut\n");
@@ -894,7 +894,7 @@ uint16_t calculate_clut_3dl(const char *const filepath, float **clut)
             }
             buf_size = level * level * level * 3;
             dt_print(DT_DEBUG_DEV, "[lut3d] allocating %zu bytes for cube lut - level %d\n", buf_size, level);
-            lclut = dt_alloc_align(16, sizeof(float) * buf_size);
+            lclut = dt_alloc_align(sizeof(float) * buf_size);
             if(!lclut)
             {
               fprintf(stderr, "[lut3d] error - allocating buffer for cube lut\n");

--- a/src/iop/rawoverexposed.c
+++ b/src/iop/rawoverexposed.c
@@ -283,7 +283,7 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
 
   const size_t coordbufsize = (size_t)height * width * 2 * sizeof(float);
 
-  coordbuf = dt_alloc_align(64, coordbufsize);
+  coordbuf = dt_alloc_align(coordbufsize);
   if(coordbuf == NULL) goto error;
 
 #ifdef _OPENMP

--- a/src/iop/restorescans.c
+++ b/src/iop/restorescans.c
@@ -113,7 +113,7 @@ void commit_params(dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pixelpipe_
 
 void init_pipe(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
 {
-  piece->data = dt_calloc_align(64, sizeof(dt_iop_restorescans_data_t));
+  piece->data = dt_calloc_align(sizeof(dt_iop_restorescans_data_t));
   piece->data_size = sizeof(dt_iop_restorescans_data_t);
 }
 

--- a/src/iop/toneequal.c
+++ b/src/iop/toneequal.c
@@ -1584,7 +1584,7 @@ void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pix
 
 void init_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
 {
-  piece->data = dt_calloc_align(64, sizeof(dt_iop_toneequalizer_data_t));
+  piece->data = dt_calloc_align(sizeof(dt_iop_toneequalizer_data_t));
   piece->data_size = sizeof(dt_iop_toneequalizer_data_t);
 }
 

--- a/src/libs/histogram.c
+++ b/src/libs/histogram.c
@@ -368,7 +368,7 @@ static void _paint_parade(cairo_t *cr, uint8_t *const restrict image, const int 
   // We need to isolate each channel, then paint it at a third of the nominal image width/height.
   for(int c = 0; c < 3; c++)
   {
-    uint8_t *const restrict channel = dt_alloc_align(64, img_width * img_height * 4 * sizeof(uint8_t));
+    uint8_t *const restrict channel = dt_alloc_align(img_width * img_height * 4 * sizeof(uint8_t));
     _mask_waveform(image, channel, img_width, img_height, c);
     cairo_surface_t *background = cairo_image_surface_create_for_data(channel, CAIRO_FORMAT_ARGB32, img_width, img_height, stride);
     const double x = (vertical) ? 0. : (double)c * img_width;
@@ -386,14 +386,14 @@ static void _process_waveform(dt_backbuf_t *backbuf, cairo_t *cr, const int widt
   const size_t binning_size = (vertical) ? 4 * TONES * backbuf->height : 4 * TONES * backbuf->width;
 
   // 1. Pixel binning along columns/rows, aka compute a column/row-wise histogram
-  uint32_t *const restrict bins = dt_alloc_align(64, binning_size * sizeof(uint32_t));
+  uint32_t *const restrict bins = dt_alloc_align(binning_size * sizeof(uint32_t));
   _bin_pixels_waveform(backbuf->buffer, bins, backbuf->width, backbuf->height, binning_size, vertical);
 
   // 2. Paint image.
   // In a 1D histogram, pixel frequencies are shown as height (y axis) for each RGB quantum (x axis).
   // Here, we do a sort of 2D histogram : pixel frequencies are shown as opacity ("z" axis),
   // for each image column (x axis), for each RGB quantum (y axis)
-  uint8_t *const restrict image = dt_alloc_align(64, binning_size * sizeof(uint8_t));
+  uint8_t *const restrict image = dt_alloc_align(binning_size * sizeof(uint8_t));
   const size_t img_width = (vertical) ? TONES : backbuf->width;
   const size_t img_height = (vertical) ? backbuf->height : TONES;
   const uint32_t overall_max_hist = _find_max_histogram(bins, binning_size);
@@ -527,11 +527,11 @@ static void _process_vectorscope(dt_backbuf_t *backbuf, cairo_t *cr, const int w
   if(profile == NULL) return;
 
   // 1. Process data
-  uint32_t *const restrict vectorscope = dt_alloc_align(64, HISTOGRAM_BINS * HISTOGRAM_BINS * sizeof(uint32_t));
+  uint32_t *const restrict vectorscope = dt_alloc_align(HISTOGRAM_BINS * HISTOGRAM_BINS * sizeof(uint32_t));
   _bin_pixels_vectorscope(backbuf->buffer, vectorscope, profile, backbuf->width * backbuf->height, zoom);
 
   const uint32_t max_hist = _find_max_histogram(vectorscope, HISTOGRAM_BINS * HISTOGRAM_BINS);
-  uint8_t *const restrict image = dt_alloc_align(64, 4 * HISTOGRAM_BINS * HISTOGRAM_BINS * sizeof(uint8_t));
+  uint8_t *const restrict image = dt_alloc_align(4 * HISTOGRAM_BINS * HISTOGRAM_BINS * sizeof(uint8_t));
   _create_vectorscope_image(vectorscope, image, profile, max_hist, zoom);
 
   // 2. Draw
@@ -903,7 +903,7 @@ void gui_reset(dt_lib_module_t *self)
 void gui_init(dt_lib_module_t *self)
 {
   /* initialize ui widgets */
-  dt_lib_histogram_t *d = (dt_lib_histogram_t *)dt_calloc_align(64, sizeof(dt_lib_histogram_t));
+  dt_lib_histogram_t *d = (dt_lib_histogram_t *)dt_calloc_align(sizeof(dt_lib_histogram_t));
   self->data = (void *)d;
   d->cst = NULL;
 

--- a/src/tests/cache.c
+++ b/src/tests/cache.c
@@ -19,7 +19,7 @@
 
 #define DT_UNIT_TEST
 // define dt alloc, so we don't need to include the rest of dt:
-#define dt_alloc_align(A, B) malloc(B)
+#define dt_alloc_align(B) malloc(B)
 #define MAX(a, b) ((a) > (b) ? (a) : (b))
 
 // unit test for the concurrent hopscotch hashmap and the LRU cache built on top of it.

--- a/src/views/slideshow.c
+++ b/src/views/slideshow.c
@@ -180,7 +180,7 @@ static int process_image(dt_slideshow_t *d, dt_slideshow_slot_t slot)
   dat.head.height = dat.head.max_height = d->height;
   dat.head.style[0] = '\0';
   dat.rank = d->buf[slot].rank;
-  dat.buf.buf = dt_alloc_align(64, sizeof(uint32_t) * d->width * d->height);
+  dat.buf.buf = dt_alloc_align(sizeof(uint32_t) * d->width * d->height);
 
   d->exporting++;
 
@@ -408,7 +408,7 @@ void enter(dt_view_t *self)
 
   for(int k=S_LEFT; k<S_SLOT_LAST; k++)
   {
-    d->buf[k].buf = dt_alloc_align(64, sizeof(uint32_t) * d->width * d->height);
+    d->buf[k].buf = dt_alloc_align(sizeof(uint32_t) * d->width * d->height);
     d->buf[k].width =  d->width;
     d->buf[k].height = d->height;
     d->buf[k].invalidated = TRUE;


### PR DESCRIPTION
Apple Silicon has a larger cache line, with this we can use different size for different platforms.

Based on following darktable commits:

- <https://github.com/darktable-org/darktable/commit/3b851641fcdf7ea54231f87f5f0ed72a6e238bce>
- <https://github.com/darktable-org/darktable/commit/0e5587112cbc2feb7dff52df1469bb82df772bdf>
- <https://github.com/darktable-org/darktable/commit/5a16b1ee05d1ea427bc7b38d0a30dedb67d9a52f>