### PR TITLE
Harmonise OpenCL invokations in the guided filter and the haze removal module

### DIFF
--- a/src/common/guided_filter.c
+++ b/src/common/guided_filter.c
@@ -371,14 +371,14 @@ static int cl_split_rgb(const int devid, const int width, const int height, cl_m
                         cl_mem imgg_g, cl_mem imgg_b, const float guide_weight)
 {
   const int kernel = darktable.opencl->guided_filter->kernel_guided_filter_split_rgb;
-  dt_opencl_set_kernel_arg(devid, kernel, 0, sizeof(width), &width);
-  dt_opencl_set_kernel_arg(devid, kernel, 1, sizeof(height), &height);
-  dt_opencl_set_kernel_arg(devid, kernel, 2, sizeof(guide), &guide);
-  dt_opencl_set_kernel_arg(devid, kernel, 3, sizeof(imgg_r), &imgg_r);
-  dt_opencl_set_kernel_arg(devid, kernel, 4, sizeof(imgg_g), &imgg_g);
-  dt_opencl_set_kernel_arg(devid, kernel, 5, sizeof(imgg_b), &imgg_b);
-  dt_opencl_set_kernel_arg(devid, kernel, 6, sizeof(guide_weight), &guide_weight);
-  const size_t sizes[] = { ROUNDUPDWD(width, devid), ROUNDUPDHT(height, devid) };
+  dt_opencl_set_kernel_arg(devid, kernel, 0, sizeof(int), &width);
+  dt_opencl_set_kernel_arg(devid, kernel, 1, sizeof(int), &height);
+  dt_opencl_set_kernel_arg(devid, kernel, 2, sizeof(int), &guide);
+  dt_opencl_set_kernel_arg(devid, kernel, 3, sizeof(cl_mem), &imgg_r);
+  dt_opencl_set_kernel_arg(devid, kernel, 4, sizeof(cl_mem), &imgg_g);
+  dt_opencl_set_kernel_arg(devid, kernel, 5, sizeof(cl_mem), &imgg_b);
+  dt_opencl_set_kernel_arg(devid, kernel, 6, sizeof(float), &guide_weight);
+  const size_t sizes[] = { ROUNDUPDWD(width, devid), ROUNDUPDHT(height, devid), 1 };
   return dt_opencl_enqueue_kernel_2d(devid, kernel, sizes);
 }
 
@@ -387,22 +387,22 @@ static int cl_box_mean(const int devid, const int width, const int height, const
                        cl_mem temp)
 {
   const int kernel_x = darktable.opencl->guided_filter->kernel_guided_filter_box_mean_x;
-  dt_opencl_set_kernel_arg(devid, kernel_x, 0, sizeof(width), &width);
-  dt_opencl_set_kernel_arg(devid, kernel_x, 1, sizeof(height), &height);
-  dt_opencl_set_kernel_arg(devid, kernel_x, 2, sizeof(in), &in);
-  dt_opencl_set_kernel_arg(devid, kernel_x, 3, sizeof(temp), &temp);
-  dt_opencl_set_kernel_arg(devid, kernel_x, 4, sizeof(w), &w);
-  const size_t sizes_x[] = { 1, ROUNDUPDHT(height, devid) };
+  dt_opencl_set_kernel_arg(devid, kernel_x, 0, sizeof(int), &width);
+  dt_opencl_set_kernel_arg(devid, kernel_x, 1, sizeof(int), &height);
+  dt_opencl_set_kernel_arg(devid, kernel_x, 2, sizeof(cl_mem), &in);
+  dt_opencl_set_kernel_arg(devid, kernel_x, 3, sizeof(cl_mem), &temp);
+  dt_opencl_set_kernel_arg(devid, kernel_x, 4, sizeof(int), &w);
+  const size_t sizes_x[] = { 1, ROUNDUPDHT(height, devid), 1 };
   const int err = dt_opencl_enqueue_kernel_2d(devid, kernel_x, sizes_x);
   if(err != CL_SUCCESS) return err;
 
   const int kernel_y = darktable.opencl->guided_filter->kernel_guided_filter_box_mean_y;
-  dt_opencl_set_kernel_arg(devid, kernel_y, 0, sizeof(width), &width);
-  dt_opencl_set_kernel_arg(devid, kernel_y, 1, sizeof(height), &height);
-  dt_opencl_set_kernel_arg(devid, kernel_y, 2, sizeof(temp), &temp);
-  dt_opencl_set_kernel_arg(devid, kernel_y, 3, sizeof(out), &out);
-  dt_opencl_set_kernel_arg(devid, kernel_y, 4, sizeof(w), &w);
-  const size_t sizes_y[] = { ROUNDUPDWD(width, devid), 1 };
+  dt_opencl_set_kernel_arg(devid, kernel_y, 0, sizeof(int), &width);
+  dt_opencl_set_kernel_arg(devid, kernel_y, 1, sizeof(int), &height);
+  dt_opencl_set_kernel_arg(devid, kernel_y, 2, sizeof(cl_mem), &temp);
+  dt_opencl_set_kernel_arg(devid, kernel_y, 3, sizeof(cl_mem), &out);
+  dt_opencl_set_kernel_arg(devid, kernel_y, 4, sizeof(int), &w);
+  const size_t sizes_y[] = { ROUNDUPDWD(width, devid), 1, 1 };
   return dt_opencl_enqueue_kernel_2d(devid, kernel_y, sizes_y);
 }
 
@@ -412,15 +412,15 @@ static int cl_covariances(const int devid, const int width, const int height, cl
                           const float guide_weight)
 {
   const int kernel = darktable.opencl->guided_filter->kernel_guided_filter_guided_filter_covariances;
-  dt_opencl_set_kernel_arg(devid, kernel, 0, sizeof(width), &width);
-  dt_opencl_set_kernel_arg(devid, kernel, 1, sizeof(height), &height);
-  dt_opencl_set_kernel_arg(devid, kernel, 2, sizeof(guide), &guide);
-  dt_opencl_set_kernel_arg(devid, kernel, 3, sizeof(in), &in);
-  dt_opencl_set_kernel_arg(devid, kernel, 4, sizeof(cov_imgg_img_r), &cov_imgg_img_r);
-  dt_opencl_set_kernel_arg(devid, kernel, 5, sizeof(cov_imgg_img_g), &cov_imgg_img_g);
-  dt_opencl_set_kernel_arg(devid, kernel, 6, sizeof(cov_imgg_img_b), &cov_imgg_img_b);
-  dt_opencl_set_kernel_arg(devid, kernel, 7, sizeof(guide_weight), &guide_weight);
-  const size_t sizes[] = { ROUNDUPDWD(width, devid), ROUNDUPDHT(height, devid) };
+  dt_opencl_set_kernel_arg(devid, kernel, 0, sizeof(int), &width);
+  dt_opencl_set_kernel_arg(devid, kernel, 1, sizeof(int), &height);
+  dt_opencl_set_kernel_arg(devid, kernel, 2, sizeof(cl_mem), &guide);
+  dt_opencl_set_kernel_arg(devid, kernel, 3, sizeof(cl_mem), &in);
+  dt_opencl_set_kernel_arg(devid, kernel, 4, sizeof(cl_mem), &cov_imgg_img_r);
+  dt_opencl_set_kernel_arg(devid, kernel, 5, sizeof(cl_mem), &cov_imgg_img_g);
+  dt_opencl_set_kernel_arg(devid, kernel, 6, sizeof(cl_mem), &cov_imgg_img_b);
+  dt_opencl_set_kernel_arg(devid, kernel, 7, sizeof(float), &guide_weight);
+  const size_t sizes[] = { ROUNDUPDWD(width, devid), ROUNDUPDHT(height, devid), 1 };
   return dt_opencl_enqueue_kernel_2d(devid, kernel, sizes);
 }
 
@@ -430,17 +430,17 @@ static int cl_variances(const int devid, const int width, const int height, cl_m
                         cl_mem var_imgg_bb, const float guide_weight)
 {
   const int kernel = darktable.opencl->guided_filter->kernel_guided_filter_guided_filter_variances;
-  dt_opencl_set_kernel_arg(devid, kernel, 0, sizeof(width), &width);
-  dt_opencl_set_kernel_arg(devid, kernel, 1, sizeof(height), &height);
-  dt_opencl_set_kernel_arg(devid, kernel, 2, sizeof(guide), &guide);
-  dt_opencl_set_kernel_arg(devid, kernel, 3, sizeof(var_imgg_rr), &var_imgg_rr);
-  dt_opencl_set_kernel_arg(devid, kernel, 4, sizeof(var_imgg_rg), &var_imgg_rg);
-  dt_opencl_set_kernel_arg(devid, kernel, 5, sizeof(var_imgg_rb), &var_imgg_rb);
-  dt_opencl_set_kernel_arg(devid, kernel, 6, sizeof(var_imgg_gg), &var_imgg_gg);
-  dt_opencl_set_kernel_arg(devid, kernel, 7, sizeof(var_imgg_gb), &var_imgg_gb);
-  dt_opencl_set_kernel_arg(devid, kernel, 8, sizeof(var_imgg_bb), &var_imgg_bb);
-  dt_opencl_set_kernel_arg(devid, kernel, 9, sizeof(guide_weight), &guide_weight);
-  size_t sizes[] = { ROUNDUPDWD(width, devid), ROUNDUPDHT(height, devid) };
+  dt_opencl_set_kernel_arg(devid, kernel, 0, sizeof(int), &width);
+  dt_opencl_set_kernel_arg(devid, kernel, 1, sizeof(int), &height);
+  dt_opencl_set_kernel_arg(devid, kernel, 2, sizeof(cl_mem), &guide);
+  dt_opencl_set_kernel_arg(devid, kernel, 3, sizeof(cl_mem), &var_imgg_rr);
+  dt_opencl_set_kernel_arg(devid, kernel, 4, sizeof(cl_mem), &var_imgg_rg);
+  dt_opencl_set_kernel_arg(devid, kernel, 5, sizeof(cl_mem), &var_imgg_rb);
+  dt_opencl_set_kernel_arg(devid, kernel, 6, sizeof(cl_mem), &var_imgg_gg);
+  dt_opencl_set_kernel_arg(devid, kernel, 7, sizeof(cl_mem), &var_imgg_gb);
+  dt_opencl_set_kernel_arg(devid, kernel, 8, sizeof(cl_mem), &var_imgg_bb);
+  dt_opencl_set_kernel_arg(devid, kernel, 9, sizeof(float), &guide_weight);
+  size_t sizes[] = { ROUNDUPDWD(width, devid), ROUNDUPDHT(height, devid), 1 };
   return dt_opencl_enqueue_kernel_2d(devid, kernel, sizes);
 }
 
@@ -449,14 +449,14 @@ static int cl_update_covariance(const int devid, const int width, const int heig
                                 cl_mem a, cl_mem b, float eps)
 {
   const int kernel = darktable.opencl->guided_filter->kernel_guided_filter_update_covariance;
-  dt_opencl_set_kernel_arg(devid, kernel, 0, sizeof(width), &width);
-  dt_opencl_set_kernel_arg(devid, kernel, 1, sizeof(height), &height);
-  dt_opencl_set_kernel_arg(devid, kernel, 2, sizeof(in), &in);
-  dt_opencl_set_kernel_arg(devid, kernel, 3, sizeof(out), &out);
-  dt_opencl_set_kernel_arg(devid, kernel, 4, sizeof(a), &a);
-  dt_opencl_set_kernel_arg(devid, kernel, 5, sizeof(b), &b);
-  dt_opencl_set_kernel_arg(devid, kernel, 6, sizeof(eps), &eps);
-  const size_t sizes[] = { ROUNDUPDWD(width, devid), ROUNDUPDHT(height, devid) };
+  dt_opencl_set_kernel_arg(devid, kernel, 0, sizeof(int), &width);
+  dt_opencl_set_kernel_arg(devid, kernel, 1, sizeof(int), &height);
+  dt_opencl_set_kernel_arg(devid, kernel, 2, sizeof(cl_mem), &in);
+  dt_opencl_set_kernel_arg(devid, kernel, 3, sizeof(cl_mem), &out);
+  dt_opencl_set_kernel_arg(devid, kernel, 4, sizeof(cl_mem), &a);
+  dt_opencl_set_kernel_arg(devid, kernel, 5, sizeof(cl_mem), &b);
+  dt_opencl_set_kernel_arg(devid, kernel, 6, sizeof(float), &eps);
+  const size_t sizes[] = { ROUNDUPDWD(width, devid), ROUNDUPDHT(height, devid), 1 };
   return dt_opencl_enqueue_kernel_2d(devid, kernel, sizes);
 }
 
@@ -468,26 +468,26 @@ static int cl_solve(const int devid, const int width, const int height, cl_mem i
                     cl_mem b)
 {
   const int kernel = darktable.opencl->guided_filter->kernel_guided_filter_solve;
-  dt_opencl_set_kernel_arg(devid, kernel, 0, sizeof(width), &width);
-  dt_opencl_set_kernel_arg(devid, kernel, 1, sizeof(height), &height);
-  dt_opencl_set_kernel_arg(devid, kernel, 2, sizeof(img_mean), &img_mean);
-  dt_opencl_set_kernel_arg(devid, kernel, 3, sizeof(imgg_mean_r), &imgg_mean_r);
-  dt_opencl_set_kernel_arg(devid, kernel, 4, sizeof(imgg_mean_g), &imgg_mean_g);
-  dt_opencl_set_kernel_arg(devid, kernel, 5, sizeof(imgg_mean_b), &imgg_mean_b);
-  dt_opencl_set_kernel_arg(devid, kernel, 6, sizeof(cov_imgg_img_r), &cov_imgg_img_r);
-  dt_opencl_set_kernel_arg(devid, kernel, 7, sizeof(cov_imgg_img_g), &cov_imgg_img_g);
-  dt_opencl_set_kernel_arg(devid, kernel, 8, sizeof(cov_imgg_img_b), &cov_imgg_img_b);
-  dt_opencl_set_kernel_arg(devid, kernel, 9, sizeof(var_imgg_rr), &var_imgg_rr);
-  dt_opencl_set_kernel_arg(devid, kernel, 10, sizeof(var_imgg_rg), &var_imgg_rg);
-  dt_opencl_set_kernel_arg(devid, kernel, 11, sizeof(var_imgg_rb), &var_imgg_rb);
-  dt_opencl_set_kernel_arg(devid, kernel, 12, sizeof(var_imgg_gg), &var_imgg_gg);
-  dt_opencl_set_kernel_arg(devid, kernel, 13, sizeof(var_imgg_gb), &var_imgg_gb);
-  dt_opencl_set_kernel_arg(devid, kernel, 14, sizeof(var_imgg_bb), &var_imgg_bb);
-  dt_opencl_set_kernel_arg(devid, kernel, 15, sizeof(a_r), &a_r);
-  dt_opencl_set_kernel_arg(devid, kernel, 16, sizeof(a_g), &a_g);
-  dt_opencl_set_kernel_arg(devid, kernel, 17, sizeof(a_b), &a_b);
-  dt_opencl_set_kernel_arg(devid, kernel, 18, sizeof(b), &b);
-  const size_t sizes[] = { ROUNDUPDWD(width, devid), ROUNDUPDHT(height, devid) };
+  dt_opencl_set_kernel_arg(devid, kernel, 0, sizeof(int), &width);
+  dt_opencl_set_kernel_arg(devid, kernel, 1, sizeof(int), &height);
+  dt_opencl_set_kernel_arg(devid, kernel, 2, sizeof(cl_mem), &img_mean);
+  dt_opencl_set_kernel_arg(devid, kernel, 3, sizeof(cl_mem), &imgg_mean_r);
+  dt_opencl_set_kernel_arg(devid, kernel, 4, sizeof(cl_mem), &imgg_mean_g);
+  dt_opencl_set_kernel_arg(devid, kernel, 5, sizeof(cl_mem), &imgg_mean_b);
+  dt_opencl_set_kernel_arg(devid, kernel, 6, sizeof(cl_mem), &cov_imgg_img_r);
+  dt_opencl_set_kernel_arg(devid, kernel, 7, sizeof(cl_mem), &cov_imgg_img_g);
+  dt_opencl_set_kernel_arg(devid, kernel, 8, sizeof(cl_mem), &cov_imgg_img_b);
+  dt_opencl_set_kernel_arg(devid, kernel, 9, sizeof(cl_mem), &var_imgg_rr);
+  dt_opencl_set_kernel_arg(devid, kernel, 10, sizeof(cl_mem), &var_imgg_rg);
+  dt_opencl_set_kernel_arg(devid, kernel, 11, sizeof(cl_mem), &var_imgg_rb);
+  dt_opencl_set_kernel_arg(devid, kernel, 12, sizeof(cl_mem), &var_imgg_gg);
+  dt_opencl_set_kernel_arg(devid, kernel, 13, sizeof(cl_mem), &var_imgg_gb);
+  dt_opencl_set_kernel_arg(devid, kernel, 14, sizeof(cl_mem), &var_imgg_bb);
+  dt_opencl_set_kernel_arg(devid, kernel, 15, sizeof(cl_mem), &a_r);
+  dt_opencl_set_kernel_arg(devid, kernel, 16, sizeof(cl_mem), &a_g);
+  dt_opencl_set_kernel_arg(devid, kernel, 17, sizeof(cl_mem), &a_b);
+  dt_opencl_set_kernel_arg(devid, kernel, 18, sizeof(cl_mem), &b);
+  const size_t sizes[] = { ROUNDUPDWD(width, devid), ROUNDUPDHT(height, devid), 1 };
   return dt_opencl_enqueue_kernel_2d(devid, kernel, sizes);
 }
 
@@ -497,18 +497,18 @@ static int cl_generate_result(const int devid, const int width, const int height
                               const float min, const float max)
 {
   const int kernel = darktable.opencl->guided_filter->kernel_guided_filter_generate_result;
-  dt_opencl_set_kernel_arg(devid, kernel, 0, sizeof(width), &width);
-  dt_opencl_set_kernel_arg(devid, kernel, 1, sizeof(height), &height);
-  dt_opencl_set_kernel_arg(devid, kernel, 2, sizeof(guide), &guide);
-  dt_opencl_set_kernel_arg(devid, kernel, 3, sizeof(a_r), &a_r);
-  dt_opencl_set_kernel_arg(devid, kernel, 4, sizeof(a_g), &a_g);
-  dt_opencl_set_kernel_arg(devid, kernel, 5, sizeof(a_b), &a_b);
-  dt_opencl_set_kernel_arg(devid, kernel, 6, sizeof(b), &b);
-  dt_opencl_set_kernel_arg(devid, kernel, 7, sizeof(out), &out);
-  dt_opencl_set_kernel_arg(devid, kernel, 8, sizeof(guide_weight), &guide_weight);
-  dt_opencl_set_kernel_arg(devid, kernel, 9, sizeof(min), &min);
-  dt_opencl_set_kernel_arg(devid, kernel, 10, sizeof(max), &max);
-  const size_t sizes[] = { ROUNDUPDWD(width, devid), ROUNDUPDHT(height, devid) };
+  dt_opencl_set_kernel_arg(devid, kernel, 0, sizeof(int), &width);
+  dt_opencl_set_kernel_arg(devid, kernel, 1, sizeof(int), &height);
+  dt_opencl_set_kernel_arg(devid, kernel, 2, sizeof(cl_mem), &guide);
+  dt_opencl_set_kernel_arg(devid, kernel, 3, sizeof(cl_mem), &a_r);
+  dt_opencl_set_kernel_arg(devid, kernel, 4, sizeof(cl_mem), &a_g);
+  dt_opencl_set_kernel_arg(devid, kernel, 5, sizeof(cl_mem), &a_b);
+  dt_opencl_set_kernel_arg(devid, kernel, 6, sizeof(cl_mem), &b);
+  dt_opencl_set_kernel_arg(devid, kernel, 7, sizeof(cl_mem), &out);
+  dt_opencl_set_kernel_arg(devid, kernel, 8, sizeof(float), &guide_weight);
+  dt_opencl_set_kernel_arg(devid, kernel, 9, sizeof(float), &min);
+  dt_opencl_set_kernel_arg(devid, kernel, 10, sizeof(float), &max);
+  const size_t sizes[] = { ROUNDUPDWD(width, devid), ROUNDUPDHT(height, devid), 1 };
   return dt_opencl_enqueue_kernel_2d(devid, kernel, sizes);
 }
 

--- a/src/iop/hazeremoval.c
+++ b/src/iop/hazeremoval.c
@@ -564,22 +564,22 @@ static int box_min_cl(struct dt_iop_module_t *self, int devid, cl_mem in, cl_mem
   void *temp = dt_opencl_alloc_device(devid, width, height, (int)sizeof(float));
 
   const int kernel_x = gd->kernel_hazeremoval_box_min_x;
-  dt_opencl_set_kernel_arg(devid, kernel_x, 0, sizeof(width), &width);
-  dt_opencl_set_kernel_arg(devid, kernel_x, 1, sizeof(height), &height);
-  dt_opencl_set_kernel_arg(devid, kernel_x, 2, sizeof(in), &in);
-  dt_opencl_set_kernel_arg(devid, kernel_x, 3, sizeof(temp), &temp);
-  dt_opencl_set_kernel_arg(devid, kernel_x, 4, sizeof(w), &w);
-  const size_t sizes_x[] = { 1, ROUNDUPDHT(height, devid) };
+  dt_opencl_set_kernel_arg(devid, kernel_x, 0, sizeof(int), &width);
+  dt_opencl_set_kernel_arg(devid, kernel_x, 1, sizeof(int), &height);
+  dt_opencl_set_kernel_arg(devid, kernel_x, 2, sizeof(cl_mem), &in);
+  dt_opencl_set_kernel_arg(devid, kernel_x, 3, sizeof(cl_mem), &temp);
+  dt_opencl_set_kernel_arg(devid, kernel_x, 4, sizeof(int), &w);
+  const size_t sizes_x[] = { 1, ROUNDUPDHT(height, devid), 1 };
   int err = dt_opencl_enqueue_kernel_2d(devid, kernel_x, sizes_x);
   if(err != CL_SUCCESS) goto error;
 
   const int kernel_y = gd->kernel_hazeremoval_box_min_y;
-  dt_opencl_set_kernel_arg(devid, kernel_y, 0, sizeof(width), &width);
-  dt_opencl_set_kernel_arg(devid, kernel_y, 1, sizeof(height), &height);
-  dt_opencl_set_kernel_arg(devid, kernel_y, 2, sizeof(temp), &temp);
-  dt_opencl_set_kernel_arg(devid, kernel_y, 3, sizeof(out), &out);
-  dt_opencl_set_kernel_arg(devid, kernel_y, 4, sizeof(w), &w);
-  const size_t sizes_y[] = { ROUNDUPDWD(width, devid), 1 };
+  dt_opencl_set_kernel_arg(devid, kernel_y, 0, sizeof(int), &width);
+  dt_opencl_set_kernel_arg(devid, kernel_y, 1, sizeof(int), &height);
+  dt_opencl_set_kernel_arg(devid, kernel_y, 2, sizeof(cl_mem), &temp);
+  dt_opencl_set_kernel_arg(devid, kernel_y, 3, sizeof(cl_mem), &out);
+  dt_opencl_set_kernel_arg(devid, kernel_y, 4, sizeof(int), &w);
+  const size_t sizes_y[] = { ROUNDUPDWD(width, devid), 1, 1 };
   err = dt_opencl_enqueue_kernel_2d(devid, kernel_y, sizes_y);
 
 error:
@@ -597,22 +597,22 @@ static int box_max_cl(struct dt_iop_module_t *self, int devid, cl_mem in, cl_mem
   void *temp = dt_opencl_alloc_device(devid, width, height, (int)sizeof(float));
 
   const int kernel_x = gd->kernel_hazeremoval_box_max_x;
-  dt_opencl_set_kernel_arg(devid, kernel_x, 0, sizeof(width), &width);
-  dt_opencl_set_kernel_arg(devid, kernel_x, 1, sizeof(height), &height);
-  dt_opencl_set_kernel_arg(devid, kernel_x, 2, sizeof(in), &in);
-  dt_opencl_set_kernel_arg(devid, kernel_x, 3, sizeof(temp), &temp);
-  dt_opencl_set_kernel_arg(devid, kernel_x, 4, sizeof(w), &w);
-  const size_t sizes_x[] = { 1, ROUNDUPDHT(height, devid) };
+  dt_opencl_set_kernel_arg(devid, kernel_x, 0, sizeof(int), &width);
+  dt_opencl_set_kernel_arg(devid, kernel_x, 1, sizeof(int), &height);
+  dt_opencl_set_kernel_arg(devid, kernel_x, 2, sizeof(cl_mem), &in);
+  dt_opencl_set_kernel_arg(devid, kernel_x, 3, sizeof(cl_mem), &temp);
+  dt_opencl_set_kernel_arg(devid, kernel_x, 4, sizeof(int), &w);
+  const size_t sizes_x[] = { 1, ROUNDUPDHT(height, devid), 1 };
   int err = dt_opencl_enqueue_kernel_2d(devid, kernel_x, sizes_x);
   if(err != CL_SUCCESS) goto error;
 
   const int kernel_y = gd->kernel_hazeremoval_box_max_y;
-  dt_opencl_set_kernel_arg(devid, kernel_y, 0, sizeof(width), &width);
-  dt_opencl_set_kernel_arg(devid, kernel_y, 1, sizeof(height), &height);
-  dt_opencl_set_kernel_arg(devid, kernel_y, 2, sizeof(temp), &temp);
-  dt_opencl_set_kernel_arg(devid, kernel_y, 3, sizeof(out), &out);
-  dt_opencl_set_kernel_arg(devid, kernel_y, 4, sizeof(w), &w);
-  const size_t sizes_y[] = { ROUNDUPDWD(width, devid), 1 };
+  dt_opencl_set_kernel_arg(devid, kernel_y, 0, sizeof(int), &width);
+  dt_opencl_set_kernel_arg(devid, kernel_y, 1, sizeof(int), &height);
+  dt_opencl_set_kernel_arg(devid, kernel_y, 2, sizeof(cl_mem), &temp);
+  dt_opencl_set_kernel_arg(devid, kernel_y, 3, sizeof(cl_mem), &out);
+  dt_opencl_set_kernel_arg(devid, kernel_y, 4, sizeof(int), &w);
+  const size_t sizes_y[] = { ROUNDUPDWD(width, devid), 1, 1 };
   err = dt_opencl_enqueue_kernel_2d(devid, kernel_y, sizes_y);
 
 error:
@@ -630,15 +630,15 @@ static int transition_map_cl(struct dt_iop_module_t *self, int devid, cl_mem img
   const int height = dt_opencl_get_image_height(img1);
 
   const int kernel = gd->kernel_hazeremoval_transision_map;
-  dt_opencl_set_kernel_arg(devid, kernel, 0, sizeof(width), &width);
-  dt_opencl_set_kernel_arg(devid, kernel, 1, sizeof(height), &height);
-  dt_opencl_set_kernel_arg(devid, kernel, 2, sizeof(img1), &img1);
-  dt_opencl_set_kernel_arg(devid, kernel, 3, sizeof(img2), &img2);
-  dt_opencl_set_kernel_arg(devid, kernel, 4, sizeof(strength), &strength);
-  dt_opencl_set_kernel_arg(devid, kernel, 5, sizeof(A0[0]), &A0[0]);
-  dt_opencl_set_kernel_arg(devid, kernel, 6, sizeof(A0[1]), &A0[1]);
-  dt_opencl_set_kernel_arg(devid, kernel, 7, sizeof(A0[2]), &A0[2]);
-  size_t sizes[2] = { ROUNDUPDWD(width, devid), ROUNDUPDHT(height, devid) };
+  dt_opencl_set_kernel_arg(devid, kernel, 0, sizeof(int), &width);
+  dt_opencl_set_kernel_arg(devid, kernel, 1, sizeof(int), &height);
+  dt_opencl_set_kernel_arg(devid, kernel, 2, sizeof(cl_mem), &img1);
+  dt_opencl_set_kernel_arg(devid, kernel, 3, sizeof(cl_mem), &img2);
+  dt_opencl_set_kernel_arg(devid, kernel, 4, sizeof(float), &strength);
+  dt_opencl_set_kernel_arg(devid, kernel, 5, sizeof(float), &A0[0]);
+  dt_opencl_set_kernel_arg(devid, kernel, 6, sizeof(float), &A0[1]);
+  dt_opencl_set_kernel_arg(devid, kernel, 7, sizeof(float), &A0[2]);
+  size_t sizes[] = { ROUNDUPDWD(width, devid), ROUNDUPDHT(height, devid), 1 };
   int err = dt_opencl_enqueue_kernel_2d(devid, kernel, sizes);
   if(err != CL_SUCCESS)
   {
@@ -659,16 +659,16 @@ static int dehaze_cl(struct dt_iop_module_t *self, int devid, cl_mem img_in, cl_
   const int height = dt_opencl_get_image_height(img_in);
 
   const int kernel = gd->kernel_hazeremoval_dehaze;
-  dt_opencl_set_kernel_arg(devid, kernel, 0, sizeof(width), &width);
-  dt_opencl_set_kernel_arg(devid, kernel, 1, sizeof(height), &height);
-  dt_opencl_set_kernel_arg(devid, kernel, 2, sizeof(img_in), &img_in);
-  dt_opencl_set_kernel_arg(devid, kernel, 3, sizeof(trans_map), &trans_map);
-  dt_opencl_set_kernel_arg(devid, kernel, 4, sizeof(img_out), &img_out);
-  dt_opencl_set_kernel_arg(devid, kernel, 5, sizeof(t_min), &t_min);
-  dt_opencl_set_kernel_arg(devid, kernel, 6, sizeof(A0[0]), &A0[0]);
-  dt_opencl_set_kernel_arg(devid, kernel, 7, sizeof(A0[1]), &A0[1]);
-  dt_opencl_set_kernel_arg(devid, kernel, 8, sizeof(A0[2]), &A0[2]);
-  size_t sizes[2] = { ROUNDUPDWD(width, devid), ROUNDUPDHT(height, devid) };
+  dt_opencl_set_kernel_arg(devid, kernel, 0, sizeof(int), &width);
+  dt_opencl_set_kernel_arg(devid, kernel, 1, sizeof(int), &height);
+  dt_opencl_set_kernel_arg(devid, kernel, 2, sizeof(cl_mem), &img_in);
+  dt_opencl_set_kernel_arg(devid, kernel, 3, sizeof(cl_mem), &trans_map);
+  dt_opencl_set_kernel_arg(devid, kernel, 4, sizeof(cl_mem), &img_out);
+  dt_opencl_set_kernel_arg(devid, kernel, 5, sizeof(float), &t_min);
+  dt_opencl_set_kernel_arg(devid, kernel, 6, sizeof(float), &A0[0]);
+  dt_opencl_set_kernel_arg(devid, kernel, 7, sizeof(float), &A0[1]);
+  dt_opencl_set_kernel_arg(devid, kernel, 8, sizeof(float), &A0[2]);
+  size_t sizes[] = { ROUNDUPDWD(width, devid), ROUNDUPDHT(height, devid), 1 };
   int err = dt_opencl_enqueue_kernel_2d(devid, kernel, sizes);
   if(err != CL_SUCCESS) dt_print(DT_DEBUG_OPENCL, "[hazeremoval, dehaze_cl] unknown error: %d\n", err);
   return err;


### PR DESCRIPTION
Hi,

I want to preface this by saying that I am not very familiar with DT/Ansel's codebase, nor OpenCL.

With that out of the way, the first commit seems to fix issue #369, by replacing all `sizeof(variable)` by `sizeof(type)`, and by adding a third dimension to the kernel sizes, like almost all other OpenCL pathes in the codebase.  I don't know what the exact mechanisms behind this issue are, but I no longer have artifacts as described in #369 with this patch.

The second commit is a preemptive attempt to prevent the same kind of issue in the haze removal module.

Best regards.

