### PR TITLE
pixelpipe: check if `piece' is null to avoid crashes

### DIFF
--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -685,7 +685,7 @@ static void pixelpipe_get_histogram_backbuf(dt_dev_pixelpipe_t *pipe, dt_develop
                                             const uint64_t hash, const size_t bpp)
 {
   // Runs only on full image but downscaled for perf, aka preview pipe
-  if(((pipe->type & DT_DEV_PIXELPIPE_PREVIEW) != DT_DEV_PIXELPIPE_PREVIEW) || !piece->enabled) return;
+  if(((pipe->type & DT_DEV_PIXELPIPE_PREVIEW) != DT_DEV_PIXELPIPE_PREVIEW) || piece == NULL || !piece->enabled) return;
 
   // Not an RGBa float buffer ?
   if(!((bpp == 4 * sizeof(float)) || (bpp == 4 * sizeof(uint8_t)))) return;


### PR DESCRIPTION
pixelpipe_get_histogram_backbuf() can be called with `piece` set to NULL, which can lead to crashes under some conditions (e.g. when the crop filter is active) as it is directly dereferenced without checking its validity.  Such a crash is mentioned in issue #357.

This PR adds a null pointer check before dereferencing `piece`, making the function return early if it is not successful.
