### PR TITLE
Vectorscope: fix infinite scroll due to mishandled event

### DIFF
--- a/src/libs/histogram.c
+++ b/src/libs/histogram.c
@@ -858,8 +858,9 @@ static gboolean _area_scrolled_callback(GtkWidget *widget, GdkEventScroll *event
 {
   if(dt_bauhaus_combobox_get(d->display) != DT_LIB_HISTOGRAM_SCOPE_VECTORSCOPE) return FALSE;
 
-  int delta_y;
-  dt_gui_get_scroll_unit_deltas(event, NULL, &delta_y);
+  int delta_y = 0;
+  if (!dt_gui_get_scroll_unit_deltas(event, NULL, &delta_y)) return TRUE;
+
   const float new_value = 4.f * delta_y + d->zoom;
 
   if(new_value < 512.f && new_value > 32.f)


### PR DESCRIPTION
Vector scope is always zooming out due to the fact `delta_y` is not initialized (or initialized with garbage) and the return of `dt_gui_get_scroll_unit_deltas()` is not handled properly causing `new_value` to always increase.
