### PR TITLE
Export: Set default color profile to sRGB perceptual

### DIFF
--- a/data/anselconfig.xml.in
+++ b/data/anselconfig.xml.in
@@ -2193,7 +2193,7 @@
   <dtconfig>
     <name>plugins/lighttable/export/icctype</name>
     <type>int</type>
-    <default>-1</default>
+    <default>1</default>
     <shortdescription>ICC profile type to use for export</shortdescription>
     <longdescription>this overrides the per-image settings, if not set to -1.</longdescription>
   </dtconfig>
@@ -2207,7 +2207,7 @@
   <dtconfig>
     <name>plugins/lighttable/export/iccintent</name>
     <type>int</type>
-    <default>-1</default>
+    <default>1</default>
     <shortdescription>ICC rendering intent</shortdescription>
     <longdescription>if non-negative, this overrides the per-image output color profile rendering intent on export.</longdescription>
   </dtconfig>

--- a/src/libs/export.c
+++ b/src/libs/export.c
@@ -1229,7 +1229,7 @@ void gui_init(dt_lib_module_t *self)
       dt_bauhaus_combobox_add(d->profile, prof->name);
   }
 
-  dt_bauhaus_combobox_set(d->profile, 0);
+  dt_bauhaus_combobox_set(d->profile, 1);
 
   char *system_profile_dir = g_build_filename(datadir, "color", "out", NULL);
   char *user_profile_dir = g_build_filename(confdir, "color", "out", NULL);


### PR DESCRIPTION
Because "Same as original" is set as default and is not good.