### PR TITLE
Export: Big refactor

### DIFF
--- a/src/control/jobs/control_jobs.c
+++ b/src/control/jobs/control_jobs.c
@@ -1362,7 +1362,7 @@ gboolean _init_module_storage(GList **param_index, dt_control_export_t *data)
   
   if(module_storage->initialize_store)
   {
-    if(module_storage->initialize_store(module_storage, module_data, &module_format, &fdata, param_index, data->high_quality, data->upscale))
+    if(module_storage->initialize_store(module_storage, module_data, &module_format, &fdata, param_index, data->high_quality))
     {
       // bail out, something went wrong
       return 0;
@@ -1396,7 +1396,6 @@ static int32_t _control_export_job_run(dt_job_t *job)
                   "format_index: %i\n"
                   "storage_index: %i\n"
                   "high_quality: %i\n"
-                  "upscale: %i\n"
                   "export_masks: %i\n"
                   "style: %s\n"
                   "style_append: %i\n"

--- a/src/control/jobs/control_jobs.h
+++ b/src/control/jobs/control_jobs.h
@@ -54,6 +54,8 @@ typedef struct dt_control_export_t
   int max_height;
   int format_index;
   int storage_index;
+  int total;
+
   gboolean high_quality;
   gboolean export_masks;
   gchar *style;
@@ -63,6 +65,9 @@ typedef struct dt_control_export_t
   dt_iop_color_intent_t icc_intent;
 
   gchar *metadata_export;
+
+  dt_imageio_module_format_t *module_format;
+  dt_imageio_module_storage_t *module_storage;
 
   /** 
   * Needed since the gui thread resets things like overwrite once the export

--- a/src/control/jobs/control_jobs.h
+++ b/src/control/jobs/control_jobs.h
@@ -47,6 +47,31 @@ typedef struct dt_control_import_t
 } dt_control_import_t;
 
 
+typedef struct dt_control_export_t
+{
+  GList *imgid_list;
+  int max_width;
+  int max_height;
+  int format_index;
+  int storage_index;
+  gboolean high_quality;
+  gboolean export_masks;
+  gchar *style;
+  gboolean style_append;
+  dt_colorspaces_color_profile_type_t icc_type;
+  gchar *icc_filename;
+  dt_iop_color_intent_t icc_intent;
+
+  gchar *metadata_export;
+
+  /** 
+  * Needed since the gui thread resets things like overwrite once the export
+  * is dispatched, but we have to keep that information.
+  */
+  dt_imageio_module_data_t *module_data;
+
+} dt_control_export_t;
+
 void dt_control_gpx_apply(const gchar *filename, int32_t filmid, const gchar *tz, GList *imgs);
 
 void dt_control_datetime(const GTimeSpan offset, const char *datetime, GList *imgs);
@@ -62,11 +87,7 @@ void dt_control_move_images();
 void dt_control_copy_images();
 void dt_control_set_local_copy_images();
 void dt_control_reset_local_copy_images();
-void dt_control_export(GList *imgid_list, int max_width, int max_height, int format_index, int storage_index,
-                       gboolean high_quality, gboolean export_masks,
-                       char *style, gboolean style_append,
-                       dt_colorspaces_color_profile_type_t icc_type, const gchar *icc_filename,
-                       dt_iop_color_intent_t icc_intent, const gchar *metadata_export);
+void dt_control_export(dt_control_export_t data);
 void dt_control_merge_hdr();
 
 /**

--- a/src/libs/export.c
+++ b/src/libs/export.c
@@ -262,18 +262,69 @@ static void _scale_optim()
   free(scale_str);
 }
 
+/**
+ * @brief get style from config
+ * 
+ * @return gchar* 
+ */
+gchar *_conf_get_style()
+{
+  gchar *style = NULL;
+  const gchar *tmp_style = dt_conf_get_string_const(CONFIG_PREFIX "style");
+  if(tmp_style)
+  {
+    style = g_strdup(tmp_style);
+  }
+
+  return style;
+}
+
+
+gint _export_confirm_message()
+{
+  gint res = -1;
+  char *confirm_message = NULL;
+  dt_imageio_module_storage_t *mstorage = dt_imageio_get_storage();
+  if(mstorage->ask_user_confirmation)
+    confirm_message = mstorage->ask_user_confirmation(mstorage);
+
+  if(confirm_message)
+  {
+    const GtkWidget *win = dt_ui_main_window(darktable.gui->ui);
+    GtkWidget *dialog = gtk_message_dialog_new(
+        GTK_WINDOW(win), GTK_DIALOG_DESTROY_WITH_PARENT, GTK_MESSAGE_QUESTION, GTK_BUTTONS_YES_NO,
+        "%s", confirm_message);
+
+#ifdef GDK_WINDOWING_QUARTZ
+    dt_osx_disallow_fullscreen(dialog);
+#endif
+
+    gtk_window_set_title(GTK_WINDOW(dialog), _("export to disk"));
+    res = gtk_dialog_run(GTK_DIALOG(dialog));
+    gtk_widget_destroy(dialog);
+    g_free(confirm_message);
+    confirm_message = NULL;
+  }
+
+  return res;
+}
+
 static void _export_button_clicked(GtkWidget *widget, dt_lib_export_t *d)
 {
-  /* write current history changes so nothing gets lost,
-     do that only in the darkroom as there is nothing to be saved
-     when in the lighttable (and it would write over current history stack) */
+  if(_export_confirm_message() == GTK_RESPONSE_NO)
+    return;
+
+  /**
+  * do that only in the darkroom as there is nothing to be saved
+  * when in the lighttable (and it would write over current history stack) 
+  */
   const dt_view_t *cv = dt_view_manager_get_current_view(darktable.view_manager);
   if(cv->view(cv) == DT_VIEW_DARKROOM) dt_dev_write_history(darktable.develop);
 
-  char style[128] = { 0 };
-
-  // get the format_name and storage_name settings which are plug-ins name and not necessary what is displayed on the combobox.
-  // note that we cannot take directly the combobox entry index as depending on the storage some format are not listed.
+  /**
+  * the format_name and storage_name settings which are plug-ins name and not necessary what is displayed on the combobox.
+  * note that we cannot take directly the combobox entry index as depending on the storage some format are not listed.
+  */
   const char *format_name = dt_conf_get_string_const(CONFIG_PREFIX "format_name");
   const char *storage_name = dt_conf_get_string_const(CONFIG_PREFIX "storage_name");
   const int format_index = dt_imageio_get_index_of_format(dt_imageio_get_format_by_name(format_name));
@@ -290,53 +341,39 @@ static void _export_button_clicked(GtkWidget *widget, dt_lib_export_t *d)
     return;
   }
 
-  char *confirm_message = NULL;
-  dt_imageio_module_storage_t *mstorage = dt_imageio_get_storage();
-  if(mstorage->ask_user_confirmation)
-    confirm_message = mstorage->ask_user_confirmation(mstorage);
-  if(confirm_message)
-  {
-    const GtkWidget *win = dt_ui_main_window(darktable.gui->ui);
-    GtkWidget *dialog = gtk_message_dialog_new(
-        GTK_WINDOW(win), GTK_DIALOG_DESTROY_WITH_PARENT, GTK_MESSAGE_QUESTION, GTK_BUTTONS_YES_NO,
-        "%s", confirm_message);
-#ifdef GDK_WINDOWING_QUARTZ
-    dt_osx_disallow_fullscreen(dialog);
-#endif
-
-    gtk_window_set_title(GTK_WINDOW(dialog), _("export to disk"));
-    const gint res = gtk_dialog_run(GTK_DIALOG(dialog));
-    gtk_widget_destroy(dialog);
-    g_free(confirm_message);
-    confirm_message = NULL;
-
-    if(res != GTK_RESPONSE_YES)
-    {
-      return;
-    }
-  }
-
-  // Let's get the max dimension restriction if any...
-  uint32_t max_width = dt_conf_get_int(CONFIG_PREFIX "width");
-  uint32_t max_height = dt_conf_get_int(CONFIG_PREFIX "height");
-
-  const gboolean export_masks = dt_conf_get_bool(CONFIG_PREFIX "export_masks");
-  const gboolean style_append = dt_conf_get_bool(CONFIG_PREFIX "style_append");
-  const char *tmp = dt_conf_get_string_const(CONFIG_PREFIX "style");
-  if(tmp)
-  {
-    g_strlcpy(style, tmp, sizeof(style));
-  }
-
-  const dt_colorspaces_color_profile_type_t icc_type = sanitize_colorspaces(dt_conf_get_int(CONFIG_PREFIX "icctype"));
-  gchar *icc_filename = dt_conf_get_string(CONFIG_PREFIX "iccprofile");
-  const dt_iop_color_intent_t icc_intent = dt_conf_get_int(CONFIG_PREFIX "iccintent");
-
   GList *list = dt_act_on_get_images(TRUE, TRUE, TRUE);
-  dt_control_export(list, max_width, max_height, format_index, storage_index, TRUE, export_masks,
-                    style, style_append, icc_type, icc_filename, icc_intent, d->metadata_export);
 
-  g_free(icc_filename);
+  dt_imageio_module_storage_t *module_storage = dt_imageio_get_storage_by_index(storage_index);
+  g_assert(module_storage);
+  // get shared storage param struct (global sequence counter, one picasa connection etc)
+  dt_imageio_module_data_t *sdata = module_storage->get_params(module_storage);
+  if(sdata == NULL)
+  {
+    dt_control_log(_("failed to get parameters from storage module `%s', aborting export.."),
+                   module_storage->name(module_storage));
+    return;
+  }
+
+  dt_control_export_t data = { .imgid_list = dt_act_on_get_images(TRUE, TRUE, TRUE),
+                               .max_width = dt_conf_get_int(CONFIG_PREFIX "width"),
+                               .max_height = dt_conf_get_int(CONFIG_PREFIX "height"),
+                               .format_index = format_index,
+                               .storage_index = storage_index,
+                               .high_quality = TRUE,
+                               .export_masks = dt_conf_get_bool(CONFIG_PREFIX "export_masks"),
+                               .style = _conf_get_style(),
+                               .style_append = dt_conf_get_bool(CONFIG_PREFIX "style_append"),
+                               .icc_type = sanitize_colorspaces(dt_conf_get_int(CONFIG_PREFIX "icctype")),
+                               .icc_filename = dt_conf_get_string(CONFIG_PREFIX "iccprofile"),
+                               .icc_intent = dt_conf_get_int(CONFIG_PREFIX "iccintent"),
+                               .metadata_export = d->metadata_export,
+                               .module_data = sdata                               
+                             };
+  
+  dt_control_export(data);
+
+  // tell the storage that we got its params for an export so it can reset itself to a safe state
+  module_storage->export_dispatched(module_storage);
 
   _scale_optim();
   gtk_entry_set_text(GTK_ENTRY(d->scale), dt_conf_get_string_const(CONFIG_PREFIX "resizing_factor"));


### PR DESCRIPTION
**This is a draft project.**

As we have done for import, let's do some cleaning in export.

- Put duplicated code between import and export in functions to be shared.
- Put export datas shared through function in one struct.
- Make the export path works the same way as import path.