### PR TITLE
build.sh help : the quoted code piece was actually executed

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -181,7 +181,7 @@ Cleanup actions:
                               ignoring any errors
 
 Update actions:
-   --update                   Run `git pull` to update the source code and submodules
+   --update                   Run 'git pull' to update the source code and submodules
 	                            from the project master branch.
 	                            Git needs to be installed on the computer.
 															(default: disabled)


### PR DESCRIPTION
When executing `./build.sh -h`, it was running the quoted code 'git pull' in the --update command description, and the text was not showing.

I replaced the backticks.