### PR TITLE
Preferences : New "timeout" setting

### DIFF
--- a/data/anselconfig.xml.in
+++ b/data/anselconfig.xml.in
@@ -231,6 +231,13 @@
     <shortdescription>Number of image processing states to cache</shortdescription>
     <longdescription>Module outputs are cached for improved performance, until the cache is full. For modules which parameters did not change between two pipeline recomputations, we can then fetch the cached output instead of recomputing it.\nThe actual size of each cache entry depends on what module is cached (some use the full-resolution image, some only the part that is visible on screen).\n Increase with care and monitor your RAM use.</longdescription>
   </dtconfig>
+    <dtconfig prefs="processing" section="cpugpu" restart="true">
+    <name>timeout</name>
+    <type min="0">int</type>
+    <default>100</default>
+    <shortdescription>Pipe recompute timeout (milliseconds)</shortdescription>
+    <longdescription>Timeout preventing intermediate setting steps (e.g. while scrolling) to recompute the pipeline too often. Set to 0 to recompute immediately on module change.</longdescription>
+  </dtconfig>
   <dtconfig prefs="processing" section="cpugpu">
     <name>cache_disk_backend</name>
     <type>bool</type>

--- a/src/bauhaus/bauhaus.c
+++ b/src/bauhaus/bauhaus.c
@@ -994,6 +994,7 @@ static void _bauhaus_widget_init(struct dt_bauhaus_widget_t *w, dt_iop_module_t 
   w->quad_toggle = 0;
   w->show_quad = TRUE;
   w->show_label = TRUE;
+  w->timeout = dt_conf_get_int("processing/timeout");
 
   gtk_widget_add_events(GTK_WIDGET(w), GDK_POINTER_MOTION_MASK
                                        | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK
@@ -2887,8 +2888,11 @@ static void dt_bauhaus_slider_set_normalized(struct dt_bauhaus_widget_t *w, floa
         g_source_remove(d->timeout_handle);
         d->timeout_handle = 0;
       }
-      // TODO: map the timeout to an user config ? Arguably, that value will be higher for senior citizen
-      d->timeout_handle = g_timeout_add(350, _delayed_slider_commit, w);
+
+      if (w->timeout > 0)
+        d->timeout_handle = g_timeout_add(w->timeout, _delayed_slider_commit, w);
+      else
+        _delayed_slider_commit(w);
     }
   }
 }

--- a/src/bauhaus/bauhaus.h
+++ b/src/bauhaus/bauhaus.h
@@ -169,6 +169,8 @@ typedef struct dt_bauhaus_widget_t
   // margin and padding structure, defined in css, retrieve on each draw
   GtkBorder *margin, *padding;
 
+  int timeout;
+
   // goes last, might extend past the end:
   dt_bauhaus_data_t data;
 } dt_bauhaus_widget_t;


### PR DESCRIPTION
This lets the user set the timeout value, to prevent the pipeline to recompute while scrolling.

Under Preference > Processing > CPU GPU