### PR TITLE
D&S : Threshold percent decimal to 2

### DIFF
--- a/src/iop/diffuse.c
+++ b/src/iop/diffuse.c
@@ -1607,6 +1607,7 @@ void gui_init(struct dt_iop_module_t *self)
 
   g->threshold = dt_bauhaus_slider_from_params(self, "threshold");
   dt_bauhaus_slider_set_format(g->threshold, "%");
+  dt_bauhaus_slider_set_digits(g->threshold, 2);
   gtk_widget_set_tooltip_text(g->threshold,
                               _("luminance threshold for the mask.\n"
                                 "0. disables the luminance masking and applies the module on the whole image.\n"


### PR DESCRIPTION
This PR lets have more flexibility to the `Luminance masking threshold` setting in D&S by adding 2 decimal to the setting.

Setting at `0.0 %`:
![Capture d’écran du 2025-02-24 13-04-28](https://github.com/user-attachments/assets/905e1799-427d-4571-9b39-e4c41cb2698a)

Setting at `1.0 %`
Observe the gap at the low values in the scope.
![Capture d’écran du 2025-02-24 13-05-01](https://github.com/user-attachments/assets/026af143-a41d-4aa6-afcd-6d42778c2729)

Setting at `0.01 %` with this PR.
Not a big gap in low values.
![Capture d’écran du 2025-02-24 13-05-23](https://github.com/user-attachments/assets/29dcedfa-47d4-4272-8209-bf5ded1f3eab)

Top : `1.0 %`
Bottom : `0.01 %`
![Capture d’écran du 2025-02-24 13-06-20](https://github.com/user-attachments/assets/999d3c98-ffb1-404a-979f-0e28ee8ac65f)

Thank you.