### PR TITLE
Move extern "C" to each C headers

### DIFF
--- a/src/bauhaus/bauhaus.h
+++ b/src/bauhaus/bauhaus.h
@@ -30,6 +30,10 @@
 #include <stdlib.h>
 #include <string.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define DT_BAUHAUS_WIDGET_TYPE dt_bh_get_type()
 #define DT_BAUHAUS_WIDGET(obj) G_TYPE_CHECK_INSTANCE_CAST((obj), DT_BAUHAUS_WIDGET_TYPE, DtBauhausWidget)
 #define DT_BAUHAUS_WIDGET_CLASS(obj) G_TYPE_CHECK_CLASS_CAST((obj), DT_BAUHAUS_WIDGET, DtBauhausWidgetClass)
@@ -396,6 +400,10 @@ void dt_bauhaus_set_use_default_callback(GtkWidget *widget);
 void dt_bauhaus_set_expand(GtkWidget *widget, gboolean expand);
 
 void dt_bauhaus_set_show_label(GtkWidget *widget, gboolean show);
+
+#ifdef __cplusplus
+}
+#endif
 
 // clang-format off
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py

--- a/src/common/atomic.h
+++ b/src/common/atomic.h
@@ -26,10 +26,6 @@
 //   4. otherwise: fall back to using Posix mutex to serialize access
 
 #if defined(__cplusplus) && __cplusplus > 201100
-// G++ throws an error on trying to use C++ atomics with C linkage
-// all of the C++ files which (indirectly) include this header do so inside an extern "C" {}, so we need to
-//   exit out of the extern statement, make our definitions, and then restart another extern block.
-} // end of extern "C" block
 #include <atomic>
 
 typedef std::atomic<int> dt_atomic_int;
@@ -40,8 +36,6 @@ inline int dt_atomic_sub_int(dt_atomic_int *var, int decr) { return std::atomic_
 inline int dt_atomic_exch_int(dt_atomic_int *var, int value) { return std::atomic_exchange(var,value); }
 inline int dt_atomic_CAS_int(dt_atomic_int *var, int *expected, int value)
 { return std::atomic_compare_exchange_strong(var,expected,value); }
-
-extern "C" { // restart C linkage block
 
 #elif !defined(__STDC_NO_ATOMICS__)
 

--- a/src/common/colorlabels.h
+++ b/src/common/colorlabels.h
@@ -1,6 +1,11 @@
 #pragma once
 
 #include <gtk/gtk.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /** array of names and constant to ease label manipulation */
 typedef enum dt_colorlables_enum
 {
@@ -31,6 +36,10 @@ void dt_colorlabels_remove_label(const int32_t imgid, const int color);
 const char *dt_colorlabels_to_string(int label);
 /** check if an image has a color label */
 int dt_colorlabels_check_label(const int32_t imgid, const int color);
+
+#ifdef __cplusplus
+}
+#endif
 
 // clang-format off
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py

--- a/src/common/colorspaces.h
+++ b/src/common/colorspaces.h
@@ -24,6 +24,10 @@
 
 #include <lcms2.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 // this was removed from lcms2 in 2.4
 #ifndef TYPE_XYZA_FLT
   #define TYPE_XYZA_FLT (FLOAT_SH(1)|COLORSPACE_SH(PT_XYZ)|EXTRA_SH(1)|CHANNELS_SH(3)|BYTES_SH(4))
@@ -311,6 +315,10 @@ static inline dt_colorspaces_color_profile_type_t sanitize_colorspaces(dt_colors
  * @return dt_colorspaces_color_profile_type_t type of profile detected. This type is tested internally and guaranteed to work.
  */
 dt_colorspaces_color_profile_type_t dt_image_find_best_color_profile(int32_t imgid, cmsHPROFILE *output, gboolean *new_profile);
+
+#ifdef __cplusplus
+}
+#endif
 
 // clang-format off
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py

--- a/src/common/darktable.h
+++ b/src/common/darktable.h
@@ -47,6 +47,7 @@
 #else
 #include <sys/resource.h>
 #endif
+#include <stdint.h>
 #include <glib.h>
 #include <glib/gstdio.h>
 #include <glib/gi18n.h>
@@ -68,6 +69,10 @@
 
 // for signal debugging symbols
 #include "control/signal.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 #define DT_MODULE_VERSION 23 // version of dt's module interface
 
@@ -135,6 +140,9 @@ char *dt_version_major_minor();
 // Default code for imgid meaning the picture is unknown or invalid
 #define UNKNOWN_IMAGE -1
 
+#ifdef __cplusplus
+}
+#endif
 
 /********************************* */
 
@@ -170,9 +178,6 @@ typedef unsigned int u_int;
 #if defined(__SSE__)
 #include <xmmintrin.h> // needed for _mm_stream_ps
 #endif
-
-#include <glib.h>
-#include <stdint.h>
 
 #ifdef _OPENMP
 # include <omp.h>
@@ -216,6 +221,10 @@ typedef unsigned int u_int;
 # define omp_get_thread_num() 0
 
 #endif /* _OPENMP */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 static inline int dt_get_thread_num()
 {
@@ -784,6 +793,9 @@ static inline gchar *delete_underscore(const char *s)
   return text;
 }
 
+#ifdef __cplusplus
+}
+#endif
 
 // clang-format off
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py

--- a/src/common/database.c
+++ b/src/common/database.c
@@ -39,7 +39,6 @@
 #include <gio/gio.h>
 #include <glib.h>
 #include <glib/gstdio.h>
-#include <sqlite3.h>
 
 #include <errno.h>
 #include <fcntl.h>

--- a/src/common/database.h
+++ b/src/common/database.h
@@ -19,6 +19,11 @@
 #pragma once
 
 #include <glib.h>
+#include <sqlite3.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 struct dt_database_t;
 
@@ -27,7 +32,7 @@ struct dt_database_t *dt_database_init(const char *alternative, const gboolean l
 /** closes down database and frees memory */
 void dt_database_destroy(const struct dt_database_t *);
 /** get handle */
-struct sqlite3 *dt_database_get(const struct dt_database_t *);
+sqlite3 *dt_database_get(const struct dt_database_t *);
 /** Returns database path */
 const gchar *dt_database_get_path(const struct dt_database_t *db);
 /** test if database was already locked by another instance */
@@ -59,6 +64,9 @@ void dt_database_rollback_transaction(const struct dt_database_t *db);
 #define dt_database_start_transaction(db) DT_DEBUG_TRACE_WRAPPER(DT_DEBUG_SQL, dt_database_start_transaction_debug, (db))
 #define dt_database_release_transaction(db) DT_DEBUG_TRACE_WRAPPER(DT_DEBUG_SQL, dt_database_release_transaction_debug, (db))
 
+#ifdef __cplusplus
+}
+#endif
 
 // clang-format off
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py

--- a/src/common/datetime.h
+++ b/src/common/datetime.h
@@ -20,6 +20,10 @@
 #include <glib.h>
 #include "common/image.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define DT_DATETIME_LENGTH 24       // includes msec
 #define DT_DATETIME_EXIF_LENGTH 20  // exif format string length
 
@@ -116,6 +120,10 @@ GTimeSpan dt_datetime_gtimespan_add_numbers(const GTimeSpan dt, const dt_datetim
 // add values (represented by dt_datetime_t) to exif datetime
 gboolean dt_datetime_exif_add_numbers(const gchar *exif, const dt_datetime_t numbers, const gboolean add,
                                       gchar **result);
+
+#ifdef __cplusplus
+}
+#endif
 
 // clang-format off
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py

--- a/src/common/debug.h
+++ b/src/common/debug.h
@@ -20,6 +20,10 @@
 
 #include <sqlite3.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 // define this to see all sql queries passed to prepare and exec at compile time, or a variable name
 // warning:
 // there are some direct calls to sqlite3_exec and sqlite3_prepare_v2 which are missing here. grep manually.
@@ -118,6 +122,10 @@
               #function, __FUNCTION__, __FILE__, __LINE__);              \
     function(__VA_ARGS__);                                               \
   } while (0)
+
+#ifdef __cplusplus
+}
+#endif
 
 // clang-format off
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py

--- a/src/common/dng_opcode.h
+++ b/src/common/dng_opcode.h
@@ -21,6 +21,10 @@
 #include <stdint.h>
 #include "image.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 typedef struct dt_dng_gain_map_t
 {
   uint32_t top;
@@ -42,3 +46,7 @@ typedef struct dt_dng_gain_map_t
 } dt_dng_gain_map_t;
 
 void dt_dng_opcode_process_opcode_list_2(uint8_t *buf, uint32_t size, dt_image_t *img);
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/common/exif.cc
+++ b/src/common/exif.cc
@@ -52,7 +52,6 @@
 
 #include "glib.h"
 
-extern "C" {
 #include "common/colorlabels.h"
 #include "common/darktable.h"
 #include "common/debug.h"
@@ -74,7 +73,6 @@ extern "C" {
 #include "develop/imageop.h"
 #include "develop/blend.h"
 #include "develop/masks.h"
-}
 
 using namespace std;
 

--- a/src/common/file_location.h
+++ b/src/common/file_location.h
@@ -21,6 +21,10 @@
 #include <gtk/gtk.h>
 #include <string.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /** returns the users home directory */
 gchar *dt_loc_get_home_dir(const gchar *user);
 
@@ -58,6 +62,10 @@ void dt_loc_get_localedir(char *localedir, size_t bufsize);
 void dt_loc_get_tmp_dir(char *tmpdir, size_t bufsize);
 void dt_loc_get_user_config_dir(char *configdir, size_t bufsize);
 void dt_loc_get_user_cache_dir(char *cachedir, size_t bufsize);
+
+#ifdef __cplusplus
+}
+#endif
 
 // clang-format off
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py

--- a/src/common/history.h
+++ b/src/common/history.h
@@ -22,6 +22,10 @@
 #include <inttypes.h>
 #include <sqlite3.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 // history hash is designed to detect any change made on the image
 // if current = basic the image has only the mandatory modules with their original settings
 // if current = auto the image has the mandatory and auto applied modules with their original settings
@@ -130,6 +134,10 @@ void dt_history_hash_write(const int32_t imgid, dt_history_hash_values_t *hash);
 
 /** read hash values from db */
 void dt_history_hash_read(const int32_t imgid, dt_history_hash_values_t *hash);
+
+#ifdef __cplusplus
+}
+#endif
 
 // clang-format off
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py

--- a/src/common/image.h
+++ b/src/common/image.h
@@ -28,6 +28,10 @@
 #include <glib.h>
 #include <inttypes.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /** return value of image io functions. */
 typedef enum dt_imageio_retval_t
 {
@@ -434,6 +438,11 @@ char *dt_image_camera_missing_sample_message(const struct dt_image_t *img, gbool
 void dt_image_check_camera_missing_sample(const struct dt_image_t *img);
 /** get dirname from imgid */
 void dt_get_dirname_from_imgid(gchar *dir, const int32_t imgid);
+
+#ifdef __cplusplus
+}
+#endif
+
 // clang-format off
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py
 // vim: shiftwidth=2 expandtab tabstop=2 cindent

--- a/src/common/image_cache.h
+++ b/src/common/image_cache.h
@@ -21,6 +21,10 @@
 #include "common/cache.h"
 #include "common/image.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 typedef struct dt_image_cache_t
 {
   dt_cache_t cache;
@@ -72,6 +76,10 @@ void dt_image_cache_set_change_timestamp_from_image(dt_image_cache_t *cache, con
 void dt_image_cache_unset_change_timestamp(dt_image_cache_t *cache, const int32_t imgid);
 void dt_image_cache_set_export_timestamp(dt_image_cache_t *cache, const int32_t imgid);
 void dt_image_cache_set_print_timestamp(dt_image_cache_t *cache, const int32_t imgid);
+
+#ifdef __cplusplus
+}
+#endif
 
 // clang-format off
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py

--- a/src/common/imagebuf.h
+++ b/src/common/imagebuf.h
@@ -23,6 +23,10 @@
 
 #include "develop/imageop.h" // for dt_iop_roi_t
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 // Allocate a 64-byte aligned buffer for an image of the given dimensions and channels.
 // The return value must be freed with dt_free_align().
 static inline float *__restrict__ dt_iop_image_alloc(const size_t width, const size_t height, const size_t ch)
@@ -136,6 +140,10 @@ void dt_iop_image_copy_benchmark();
 
 // load configurable settings from anselrc
 void dt_iop_image_copy_configure();
+
+#ifdef __cplusplus
+}
+#endif
 
 // clang-format off
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py

--- a/src/common/imageio.h
+++ b/src/common/imageio.h
@@ -24,8 +24,11 @@
 #include "common/tags.h"
 #include <glib.h>
 #include <stdio.h>
-
 #include <inttypes.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 #define FILTERS_ARE_CYGM(filters)                                                                                 \
   ((filters) == 0xb4b4b4b4 || (filters) == 0x4b4b4b4b || (filters) == 0x1e1e1e1e || (filters) == 0xe1e1e1e1)
@@ -116,6 +119,10 @@ gboolean dt_imageio_lookup_makermodel(const char *maker, const char *model,
 
 // get the type of image from its extension
 dt_image_flags_t dt_imageio_get_type_from_extension(const char *extension);
+
+#ifdef __cplusplus
+}
+#endif
 
 // clang-format off
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py

--- a/src/common/imageio_exr.cc
+++ b/src/common/imageio_exr.cc
@@ -39,7 +39,6 @@
 
 #include "glib.h"
 
-extern "C" {
 #include "common/colorspaces.h"
 #include "common/darktable.h"
 #include "common/exif.h"
@@ -47,7 +46,7 @@ extern "C" {
 #include "common/imageio_exr.h"
 #include "control/conf.h"
 #include "develop/develop.h"
-}
+
 #include "common/imageio_exr.hh"
 
 dt_imageio_retval_t dt_imageio_open_exr(dt_image_t *img, const char *filename, dt_mipmap_buffer_t *mbuf)

--- a/src/common/imageio_jpeg.h
+++ b/src/common/imageio_jpeg.h
@@ -32,6 +32,10 @@
 #include "common/image.h"
 #include "common/mipmap_cache.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 typedef struct dt_imageio_jpeg_t
 {
   int width, height;
@@ -69,6 +73,10 @@ dt_colorspaces_color_profile_type_t dt_imageio_jpeg_read_color_space(dt_imageio_
 
 /** utility function to read and open jpeg from imagio.c */
 dt_imageio_retval_t dt_imageio_open_jpeg(dt_image_t *img, const char *filename, dt_mipmap_buffer_t *buf);
+
+#ifdef __cplusplus
+}
+#endif
 
 // clang-format off
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py

--- a/src/common/imageio_module.h
+++ b/src/common/imageio_module.h
@@ -33,6 +33,9 @@
 #include "lua/types.h"
 #endif
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /** Flag for the format modules */
 typedef enum dt_imageio_format_flags_t
@@ -145,6 +148,10 @@ void dt_imageio_remove_storage(dt_imageio_module_storage_t *storage);
 // and improve the readability of the displayed string itself in the "scale" field
 // of the settings export.
 gchar *dt_imageio_resizing_factor_get_and_parsing(double *num, double *denum);
+
+#ifdef __cplusplus
+}
+#endif
 
 // clang-format off
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py

--- a/src/common/imageio_rawspeed.cc
+++ b/src/common/imageio_rawspeed.cc
@@ -35,7 +35,6 @@
 
 #include "glib.h"
 
-extern "C" {
 #include "common/colorspaces.h"
 #include "common/darktable.h"
 #include "common/exif.h"
@@ -45,7 +44,6 @@ extern "C" {
 #include "common/tags.h"
 #include "develop/imageop.h"
 #include <stdint.h>
-}
 
 // define this function, it is only declared in rawspeed:
 int rawspeed_get_number_of_processor_cores()

--- a/src/common/imageio_rawspeed.h
+++ b/src/common/imageio_rawspeed.h
@@ -18,12 +18,12 @@
 
 #pragma once
 
+#include "common/image.h"
+#include "common/mipmap_cache.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include "common/image.h"
-#include "common/mipmap_cache.h"
 
 gboolean dt_rawspeed_lookup_makermodel(const char *maker, const char *model,
                                        char *mk, int mk_len, char *md, int md_len,

--- a/src/common/iop_order.h
+++ b/src/common/iop_order.h
@@ -124,6 +124,10 @@
 #include "config.h"
 #endif
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 struct dt_iop_module_t;
 struct dt_develop_t;
 struct dt_dev_pixelpipe_t;
@@ -246,6 +250,10 @@ int dt_ioppr_check_iop_order(struct dt_develop_t *dev, const int32_t imgid, cons
 void dt_ioppr_print_module_iop_order(GList *iop_list, const char *msg);
 void dt_ioppr_print_history_iop_order(GList *history_list, const char *msg);
 void dt_ioppr_print_iop_order(GList *iop_order_list, const char *msg);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif
 // clang-format off

--- a/src/common/metadata.h
+++ b/src/common/metadata.h
@@ -21,6 +21,10 @@
 #include "common/darktable.h"
 #include "gui/gtk.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 typedef enum dt_metadata_t
 {
   // do change the order. Must match with dt_metadata_def[] in metadata.c.
@@ -126,6 +130,10 @@ void dt_metadata_clear(const GList *imgs, const gboolean undo_on); // libs/metad
 
 /** Return the first imgid of the filename-datetime "Xmp.darktable.image_id" if it already exists */
 int dt_metadata_already_imported(const char *filename, const char *datetime);
+
+#ifdef __cplusplus
+}
+#endif
 
 // clang-format off
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py

--- a/src/common/mipmap_cache.h
+++ b/src/common/mipmap_cache.h
@@ -22,6 +22,10 @@
 #include "common/colorspaces.h"
 #include "common/image.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 // sizes stored in the mipmap cache, set to fixed values in mipmap_cache.c
 typedef enum dt_mipmap_size_t {
   DT_MIPMAP_0 = 0,
@@ -163,6 +167,11 @@ void dt_mipmap_cache_copy_thumbnails(const dt_mipmap_cache_t *cache, const uint3
 
 // return the mipmap corresponding to text value saved in prefs
 dt_mipmap_size_t dt_mipmap_cache_get_min_mip_from_pref(const char *value);
+
+#ifdef __cplusplus
+}
+#endif
+
 // clang-format off
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py
 // vim: shiftwidth=2 expandtab tabstop=2 cindent

--- a/src/common/module.h
+++ b/src/common/module.h
@@ -20,10 +20,18 @@
 
 #include <glib.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 GList *dt_module_load_modules(const char *subdir, size_t module_size,
                               int (*load_module_so)(void *module, const char *libname, const char *plugin_name),
                               void (*init_module)(void *module),
                               gint (*sort_modules)(gconstpointer a, gconstpointer b));
+
+#ifdef __cplusplus
+}
+#endif
 
 // clang-format off
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py

--- a/src/common/opencl.h
+++ b/src/common/opencl.h
@@ -52,6 +52,10 @@
 #include <CL/cl.h>
 // #pragma GCC diagnostic
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define ROUNDUP(a, n) ((a) % (n) == 0 ? (a) : ((a) / (n)+1) * (n))
 
 // use per device roundups here
@@ -492,9 +496,19 @@ int dt_opencl_avoid_atomics(const int devid);
 int dt_opencl_micro_nap(const int devid);
 gboolean dt_opencl_use_pinned_memory(const int devid);
 
+#ifdef __cplusplus
+}
+#endif
+
 #else
+
 #include "control/conf.h"
 #include <stdlib.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 typedef struct dt_opencl_t
 {
   int inited;
@@ -632,6 +646,11 @@ static inline int dt_opencl_events_flush(const int devid, const int reset)
 static inline void dt_opencl_events_profiling(const int devid, const int aggregated)
 {
 }
+
+#ifdef __cplusplus
+}
+#endif
+
 #endif
 
 // clang-format off

--- a/src/common/ratings.h
+++ b/src/common/ratings.h
@@ -21,6 +21,10 @@
 #include "common/darktable.h"
 #include <gtk/gtk.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define DT_VIEW_RATINGS_MASK 0x7
 // first three bits of dt_view_image_over_t
 
@@ -34,6 +38,9 @@ void dt_ratings_apply_on_image(const int32_t imgid, const int rating, const gboo
 /** apply rating to all images in the list */
 void dt_ratings_apply_on_list(GList *list, const int rating, const gboolean undo_on);
 
+#ifdef __cplusplus
+}
+#endif
 
 // clang-format off
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py

--- a/src/common/tags.h
+++ b/src/common/tags.h
@@ -22,6 +22,10 @@
 #include <sqlite3.h>
 #include <stdint.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 typedef struct dt_tag_t
 {
   guint id;
@@ -205,6 +209,10 @@ uint32_t dt_tag_get_tag_id_by_name(const char * const name);
 
 /** init the darktable tags table */
 void dt_set_darktable_tags();
+
+#ifdef __cplusplus
+}
+#endif
 
 // clang-format off
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py

--- a/src/common/utility.h
+++ b/src/common/utility.h
@@ -22,6 +22,10 @@
 #include <string.h>
 #include <librsvg/rsvg.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /** dynamically allocate and concatenate string */
 gchar *dt_util_dstrcat(gchar *str, const gchar *format, ...) __attribute__((format(printf, 2, 3)));
 
@@ -122,6 +126,10 @@ gchar *dt_util_remove_whitespace(const gchar *path);
 
 // Get the datetime of modification for a given file, identified by its full path
 GDateTime *dt_util_get_file_datetime(const char *const path);
+
+#ifdef __cplusplus
+}
+#endif
 
 // clang-format off
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py

--- a/src/common/variables.h
+++ b/src/common/variables.h
@@ -21,6 +21,10 @@
 #include <glib.h>
 #include <stdint.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 typedef struct dt_variables_params_t
 {
   /** used for expanding variables that uses filename $(FILE_FOLDER) $(FILE_NAME) and $(FILE_EXTENSION). */
@@ -72,6 +76,10 @@ void dt_variables_reset_sequence(dt_variables_params_t *params);
  * @return `gboolean` Returns TRUE if success.
  */
 gboolean dt_get_user_pictures_dir(const gchar *homedir, gchar *picdir, size_t picdir_size);
+
+#ifdef __cplusplus
+}
+#endif
 
 // clang-format off
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py

--- a/src/control/conf.h
+++ b/src/control/conf.h
@@ -28,6 +28,10 @@
 #include <gtk/gtk.h>
 #include <inttypes.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 typedef enum dt_confgen_type_t
 {
   DT_INT,
@@ -126,6 +130,10 @@ const char *dt_confgen_get_tooltip(const char *name);
 
 gboolean dt_conf_is_default(const char *name);
 gchar* dt_conf_expand_default_dir(const char *dir);
+
+#ifdef __cplusplus
+}
+#endif
 
 // clang-format off
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py

--- a/src/control/control.h
+++ b/src/control/control.h
@@ -38,6 +38,10 @@
 #include <shobjidl.h>
 #endif
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 struct dt_lib_backgroundjob_element_t;
 
 typedef GdkCursorType dt_cursor_t;
@@ -265,6 +269,10 @@ static inline int32_t dt_ctl_get_num_procs()
 #endif
 #endif
 }
+
+#ifdef __cplusplus
+}
+#endif
 
 // clang-format off
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py

--- a/src/control/jobs/control_jobs.h
+++ b/src/control/jobs/control_jobs.h
@@ -28,6 +28,10 @@
 #include "common/cups_print.h"
 #endif
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 typedef struct dt_control_import_t
 {
   GList *imgs;
@@ -90,6 +94,10 @@ void dt_control_refresh_exif();
  * @return gchar* The full path after variables expansion
  */
 gchar *dt_build_filename_from_pattern(const char *const filename, const int index, dt_image_t *img, dt_control_import_t *data);
+
+#ifdef __cplusplus
+}
+#endif
 
 // clang-format off
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py

--- a/src/control/signal.h
+++ b/src/control/signal.h
@@ -20,6 +20,8 @@
 
 #include <glib-object.h>
 
+G_BEGIN_DECLS
+
 /** \brief enum of signals to listen for in darktable.
     \note To add a new signal, first off add a enum and
     document what it's used for, then add a matching signal string
@@ -314,6 +316,8 @@ void dt_control_signal_unblock_by_func(const struct dt_control_signal_t *ctlsig,
     }                                                                                                                            \
     dt_control_signal_disconnect(ctlsig, cb, user_data);                                                                         \
   } while (0)
+
+G_END_DECLS
 
 // clang-format off
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py

--- a/src/develop/blend.h
+++ b/src/develop/blend.h
@@ -25,6 +25,10 @@
 #include "dtgtk/gradientslider.h"
 #include "gui/color_picker_proxy.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define DEVELOP_BLEND_VERSION (11)
 
 typedef enum dt_develop_blend_colorspace_t
@@ -473,6 +477,10 @@ int dt_iop_gui_blending_mode_seq(dt_iop_gui_blend_data_t *bd, int mode);
 int dt_develop_blend_process_cl(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *piece,
                                 cl_mem dev_in, cl_mem dev_out, const struct dt_iop_roi_t *roi_in,
                                 const struct dt_iop_roi_t *roi_out);
+#endif
+
+#ifdef __cplusplus
+}
 #endif
 
 // clang-format off

--- a/src/develop/dev_history.h
+++ b/src/develop/dev_history.h
@@ -26,11 +26,6 @@ struct dt_iop_module_t;
 struct dt_develop_blend_params_t;
 struct dt_develop_t;
 
-#ifdef __cplusplus
-}
-#endif
-
-
 typedef struct dt_dev_history_item_t
 {
   struct dt_iop_module_t *module; // pointer to image operation module
@@ -114,3 +109,7 @@ int dt_history_copy_and_paste_on_image(int32_t imgid, int32_t dest_imgid, GList 
  * @param dev
  */
 void dt_dev_history_compress(struct dt_develop_t *dev);
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/develop/develop.h
+++ b/src/develop/develop.h
@@ -31,6 +31,10 @@
 #include "develop/imageop.h"
 #include "develop/dev_history.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 struct dt_iop_module_t;
 
 typedef enum dt_dev_overexposed_colorscheme_t
@@ -516,6 +520,10 @@ guint dt_dev_mask_history_overload(GList *dev_history, guint threshold);
 
 // Write the `darktable|changed` tag on the current picture upon history modification
 void dt_dev_append_changed_tag(const int32_t imgid);
+
+#ifdef __cplusplus
+}
+#endif
 
 // clang-format off
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py

--- a/src/develop/imageop.h
+++ b/src/develop/imageop.h
@@ -23,12 +23,20 @@
 #include <sched.h>
 #include <stdint.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /** region of interest */
 typedef struct dt_iop_roi_t
 {
   int x, y, width, height;
   float scale;
 } dt_iop_roi_t;
+
+#ifdef __cplusplus
+}
+#endif
 
 #include "common/darktable.h"
 #include "common/introspection.h"
@@ -39,6 +47,10 @@ typedef struct dt_iop_roi_t
 #include "develop/pixelpipe.h"
 #include "dtgtk/togglebutton.h"
 #include "gui/gtk.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 struct dt_develop_t;
 struct dt_dev_pixelpipe_t;
@@ -554,6 +566,9 @@ static inline void dt_sfence()
 #define dt_omploop_sfence() dt_sfence()
 #endif
 
+#ifdef __cplusplus
+}
+#endif
 
 // clang-format off
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py

--- a/src/develop/imageop_gui.h
+++ b/src/develop/imageop_gui.h
@@ -20,6 +20,10 @@
 
 #include "develop/imageop.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 GtkWidget *dt_bauhaus_slider_from_params(dt_iop_module_t *self, const char *param);
 
 GtkWidget *dt_bauhaus_combobox_from_params(dt_iop_module_t *self, const char *param);
@@ -36,6 +40,10 @@ GtkWidget *dt_iop_button_new(dt_iop_module_t *self, const gchar *label,
 
 /* returns up or !up depending on the masks_updown preference */
 gboolean dt_mask_scroll_increases(int up);
+
+#ifdef __cplusplus
+}
+#endif
 
 // clang-format off
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py

--- a/src/develop/imageop_math.h
+++ b/src/develop/imageop_math.h
@@ -32,6 +32,10 @@
 #include <stddef.h>          // for size_t, NULL
 #include <stdint.h>          // for uint8_t, uint16_t, uint32_t
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /** flip according to orientation bits, also zoom to given size. */
 void dt_iop_flip_and_zoom_8(const uint8_t *in, int32_t iw, int32_t ih, uint8_t *out, int32_t ow, int32_t oh,
                             const dt_image_orientation_t orientation, uint32_t *width, uint32_t *height);
@@ -222,6 +226,10 @@ static inline int fcol(const int row, const int col, const uint32_t filters, con
   else
     return FC(row, col, filters);
 }
+
+#ifdef __cplusplus
+}
+#endif
 
 // clang-format off
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py

--- a/src/develop/masks.h
+++ b/src/develop/masks.h
@@ -28,6 +28,10 @@
 
 #include <assert.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define DEVELOP_MASKS_VERSION (6)
 
 /**forms types */
@@ -676,6 +680,9 @@ int dt_masks_roundup(int num, int mult)
   return (rem == 0) ? num : num + mult - rem;
 }
 
+#ifdef __cplusplus
+}
+#endif
 
 // clang-format off
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py

--- a/src/develop/tiling.h
+++ b/src/develop/tiling.h
@@ -22,6 +22,10 @@
 #include "develop/imageop.h"
 #include "develop/pixelpipe.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 typedef struct dt_develop_tiling_t
 {
   /** memory requirement as a multiple of image buffer size (on host/CPU) */
@@ -73,6 +77,10 @@ void tiling_callback(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t
 
 int dt_tiling_piece_fits_host_memory(const size_t width, const size_t height, const unsigned bpp,
                                      const float factor, const size_t overhead);
+
+#ifdef __cplusplus
+}
+#endif
 
 // clang-format off
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py

--- a/src/dtgtk/paint.h
+++ b/src/dtgtk/paint.h
@@ -21,6 +21,10 @@
 #include <cairo.h>
 #include <gtk/gtk.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define CPF_USER_DATA 0x1000
 
 typedef enum dtgtk_cairo_paint_flags_t
@@ -335,6 +339,10 @@ void dtgtk_cairo_paint_shortcut(cairo_t *cr, gint x, gint y, gint w, gint h, gin
 
 /** Paint a pined icon for filtering */
 void dtgtk_cairo_paint_pin(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data);
+
+#ifdef __cplusplus
+}
+#endif
 
 // clang-format off
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py

--- a/src/gui/actions/display.h
+++ b/src/gui/actions/display.h
@@ -65,7 +65,7 @@ static gboolean _toggle_side_borders_accel_callback(GtkAccelGroup *accel_group, 
   return TRUE;
 }
 
-void dt_ui_toggle_panels_visibility(struct dt_ui_t *ui)
+void dt_ui_toggle_panels_visibility(dt_ui_t *ui)
 {
   gchar *key = panels_get_view_path("panel_collaps_state");
   const uint32_t state = dt_conf_get_int(key);

--- a/src/gui/draw.h
+++ b/src/gui/draw.h
@@ -36,6 +36,10 @@
 #include <stdlib.h>
 #include <gui/gtk.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #ifndef M_PI
 #define M_PI 3.141592654
 #endif
@@ -520,6 +524,10 @@ static inline GdkPixbuf *dt_draw_paint_to_pixbuf
   cairo_surface_destroy(cst);
   return pixbuf;
 }
+
+#ifdef __cplusplus
+}
+#endif
 
 // clang-format off
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py

--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -904,13 +904,13 @@ void dt_ui_container_focus_widget(dt_ui_t *ui, const dt_ui_container_t c, GtkWid
   gtk_widget_queue_draw(ui->containers[c]);
 }
 
-void dt_ui_container_foreach(struct dt_ui_t *ui, const dt_ui_container_t c, GtkCallback callback)
+void dt_ui_container_foreach(dt_ui_t *ui, const dt_ui_container_t c, GtkCallback callback)
 {
   g_return_if_fail(GTK_IS_CONTAINER(ui->containers[c]));
   gtk_container_foreach(GTK_CONTAINER(ui->containers[c]), callback, (gpointer)ui->containers[c]);
 }
 
-void dt_ui_container_destroy_children(struct dt_ui_t *ui, const dt_ui_container_t c)
+void dt_ui_container_destroy_children(dt_ui_t *ui, const dt_ui_container_t c)
 {
   dt_gui_container_destroy_children(GTK_CONTAINER(ui->containers[c]));
 }

--- a/src/gui/gtk.h
+++ b/src/gui/gtk.h
@@ -27,6 +27,10 @@
 #include <gtk/gtk.h>
 #include <stdint.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define DT_GUI_IOP_MODULE_CONTROL_SPACING 0
 
 /* helper macro that applies the DPI transformation to fixed pixel values. input should be defaulting to 96
@@ -83,7 +87,7 @@ typedef enum dt_gui_color_t
 typedef struct dt_gui_gtk_t
 {
 
-  struct dt_ui_t *ui;
+  dt_ui_t *ui;
 
   dt_gui_widgets_t widgets;
 
@@ -230,38 +234,38 @@ gboolean dt_gui_get_scroll_delta(const GdkEventScroll *event, gdouble *delta);
 gboolean dt_gui_get_scroll_unit_delta(const GdkEventScroll *event, int *delta);
 
 /** \brief gives a widget focus in the container */
-void dt_ui_container_focus_widget(struct dt_ui_t *ui, const dt_ui_container_t c, GtkWidget *w);
+void dt_ui_container_focus_widget(dt_ui_t *ui, const dt_ui_container_t c, GtkWidget *w);
 /** \brief calls a callback on all children widgets from container */
-void dt_ui_container_foreach(struct dt_ui_t *ui, const dt_ui_container_t c, GtkCallback callback);
+void dt_ui_container_foreach(dt_ui_t *ui, const dt_ui_container_t c, GtkCallback callback);
 /** \brief destroy all child widgets from container */
-void dt_ui_container_destroy_children(struct dt_ui_t *ui, const dt_ui_container_t c);
+void dt_ui_container_destroy_children(dt_ui_t *ui, const dt_ui_container_t c);
 /** \brief shows/hide a panel */
-void dt_ui_panel_show(struct dt_ui_t *ui, const dt_ui_panel_t, gboolean show, gboolean write);
+void dt_ui_panel_show(dt_ui_t *ui, const dt_ui_panel_t, gboolean show, gboolean write);
 /** \brief toggle view of panels eg. collapse/expands to previous view state */
-void dt_ui_toggle_panels_visibility(struct dt_ui_t *ui);
+void dt_ui_toggle_panels_visibility(dt_ui_t *ui);
 /** \brief draw user's attention */
 void dt_ui_notify_user();
 /** \brief get visible state of panel */
-gboolean dt_ui_panel_visible(struct dt_ui_t *ui, const dt_ui_panel_t);
+gboolean dt_ui_panel_visible(dt_ui_t *ui, const dt_ui_panel_t);
 /**  \brief get width of right, left, or bottom panel */
-int dt_ui_panel_get_size(struct dt_ui_t *ui, const dt_ui_panel_t p);
+int dt_ui_panel_get_size(dt_ui_t *ui, const dt_ui_panel_t p);
 /**  \brief set width of right, left, or bottom panel */
-void dt_ui_panel_set_size(struct dt_ui_t *ui, const dt_ui_panel_t p, int s);
+void dt_ui_panel_set_size(dt_ui_t *ui, const dt_ui_panel_t p, int s);
 /** \brief is the panel ancestor of widget */
-gboolean dt_ui_panel_ancestor(struct dt_ui_t *ui, const dt_ui_panel_t p, GtkWidget *w);
+gboolean dt_ui_panel_ancestor(dt_ui_t *ui, const dt_ui_panel_t p, GtkWidget *w);
 /** \brief get the center drawable widget */
-GtkWidget *dt_ui_center(struct dt_ui_t *ui);
-GtkWidget *dt_ui_center_base(struct dt_ui_t *ui);
+GtkWidget *dt_ui_center(dt_ui_t *ui);
+GtkWidget *dt_ui_center_base(dt_ui_t *ui);
 /** \brief get the main window widget */
-GtkWidget *dt_ui_main_window(struct dt_ui_t *ui);
+GtkWidget *dt_ui_main_window(dt_ui_t *ui);
 /** \brief get the thumb table */
-struct dt_thumbtable_t *dt_ui_thumbtable(struct dt_ui_t *ui);
+struct dt_thumbtable_t *dt_ui_thumbtable(dt_ui_t *ui);
 /** \brief get the log message widget */
-GtkWidget *dt_ui_log_msg(struct dt_ui_t *ui);
+GtkWidget *dt_ui_log_msg(dt_ui_t *ui);
 /** \brief get the toast message widget */
-GtkWidget *dt_ui_toast_msg(struct dt_ui_t *ui);
+GtkWidget *dt_ui_toast_msg(dt_ui_t *ui);
 
-GtkBox *dt_ui_get_container(struct dt_ui_t *ui, const dt_ui_container_t c);
+GtkBox *dt_ui_get_container(dt_ui_t *ui, const dt_ui_container_t c);
 
 /*  activate ellipsization of the combox entries */
 void dt_ellipsize_combo(GtkComboBox *cbox);
@@ -409,6 +413,9 @@ GtkBox *attach_help_popover(GtkWidget *widget, const char *label);
  */
 void dt_accels_disconnect_on_text_input(GtkWidget *widget);
 
+#ifdef __cplusplus
+}
+#endif
 
 // clang-format off
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py

--- a/src/gui/window_manager.c
+++ b/src/gui/window_manager.c
@@ -168,7 +168,7 @@ static void update_manager_sizes(dt_ui_t *ui)
 }
 
 
-gboolean dt_ui_panel_ancestor(struct dt_ui_t *ui, const dt_ui_panel_t p, GtkWidget *w)
+gboolean dt_ui_panel_ancestor(dt_ui_t *ui, const dt_ui_panel_t p, GtkWidget *w)
 {
   g_return_val_if_fail(GTK_IS_WIDGET(ui->panels[p]), FALSE);
   return gtk_widget_is_ancestor(w, ui->panels[p]) || gtk_widget_is_ancestor(ui->panels[p], w);
@@ -182,15 +182,15 @@ GtkWidget *dt_ui_center_base(dt_ui_t *ui)
 {
   return ui->center_base;
 }
-dt_thumbtable_t *dt_ui_thumbtable(struct dt_ui_t *ui)
+dt_thumbtable_t *dt_ui_thumbtable(dt_ui_t *ui)
 {
   return ui->thumbtable;
 }
-GtkWidget *dt_ui_log_msg(struct dt_ui_t *ui)
+GtkWidget *dt_ui_log_msg(dt_ui_t *ui)
 {
   return ui->log_msg;
 }
-GtkWidget *dt_ui_toast_msg(struct dt_ui_t *ui)
+GtkWidget *dt_ui_toast_msg(dt_ui_t *ui)
 {
   return ui->toast_msg;
 }
@@ -200,7 +200,7 @@ GtkWidget *dt_ui_main_window(dt_ui_t *ui)
   return ui->main_window;
 }
 
-GtkBox *dt_ui_get_container(struct dt_ui_t *ui, const dt_ui_container_t c)
+GtkBox *dt_ui_get_container(dt_ui_t *ui, const dt_ui_container_t c)
 {
   return GTK_BOX(ui->containers[c]);
 }

--- a/src/gui/window_manager.h
+++ b/src/gui/window_manager.h
@@ -5,6 +5,10 @@
 #include <gtk/gtk.h>
 #include <stdint.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define DT_UI_PANEL_MODULE_SPACING 0
 #define DT_UI_PANEL_SIDE_DEFAULT_SIZE 350
 #define DT_UI_PANEL_BOTTOM_DEFAULT_SIZE 120
@@ -109,18 +113,22 @@ gchar *panels_get_panel_path(dt_ui_panel_t panel, char *suffix);
 int dt_ui_panel_get_size(dt_ui_t *ui, const dt_ui_panel_t p);
 void dt_ui_panel_set_size(dt_ui_t *ui, const dt_ui_panel_t p, int s);
 
-gboolean dt_ui_panel_ancestor(struct dt_ui_t *ui, const dt_ui_panel_t p, GtkWidget *w);
+gboolean dt_ui_panel_ancestor(dt_ui_t *ui, const dt_ui_panel_t p, GtkWidget *w);
 GtkWidget *dt_ui_center(dt_ui_t *ui);
 GtkWidget *dt_ui_center_base(dt_ui_t *ui);
-dt_thumbtable_t *dt_ui_thumbtable(struct dt_ui_t *ui);
-GtkWidget *dt_ui_log_msg(struct dt_ui_t *ui);
-GtkWidget *dt_ui_toast_msg(struct dt_ui_t *ui);
+dt_thumbtable_t *dt_ui_thumbtable(dt_ui_t *ui);
+GtkWidget *dt_ui_log_msg(dt_ui_t *ui);
+GtkWidget *dt_ui_toast_msg(dt_ui_t *ui);
 GtkWidget *dt_ui_main_window(dt_ui_t *ui);
 
-void dt_ui_init_main_table(GtkWidget *container, struct dt_ui_t *ui);
+void dt_ui_init_main_table(GtkWidget *container, dt_ui_t *ui);
 void dt_ui_cleanup_main_table(dt_ui_t *ui);
 
-GtkBox *dt_ui_get_container(struct dt_ui_t *ui, const dt_ui_container_t c);
+GtkBox *dt_ui_get_container(dt_ui_t *ui, const dt_ui_container_t c);
 void dt_ui_container_add_widget(dt_ui_t *ui, const dt_ui_container_t c, GtkWidget *w);
 
 void dt_ui_restore_panels(dt_ui_t *ui);
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/imageio/format/exr.cc
+++ b/src/imageio/format/exr.cc
@@ -31,7 +31,6 @@
 
 #include "glib.h"
 
-extern "C" {
 #include "bauhaus/bauhaus.h"
 #include "common/colorspaces.h"
 #include "common/darktable.h"
@@ -42,7 +41,7 @@ extern "C" {
 #include "control/conf.h"
 #include "control/control.h"
 #include "imageio/format/imageio_format_api.h"
-}
+
 #include "common/imageio_exr.hh"
 
 #ifdef __cplusplus

--- a/src/imageio/format/imageio_format_api.h
+++ b/src/imageio/format/imageio_format_api.h
@@ -20,18 +20,18 @@
 
 #ifdef FULL_API_H
 
+#include <stddef.h>
+#include <stdint.h>
+
+#include "common/colorspaces.h" // because forward declaring enums doesn't work in C++ :(
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-#include <stddef.h>
-#include <stdint.h>
-
 struct dt_imageio_module_format_t;
 struct dt_imageio_module_data_t;
 struct dt_dev_pixelpipe_t;
-
-#include "common/colorspaces.h" // because forward declaring enums doesn't work in C++ :(
 
 /* early definition of modules to do type checking */
 

--- a/src/iop/bilateral.cc
+++ b/src/iop/bilateral.cc
@@ -20,7 +20,6 @@
 
 #include "glib.h"
 
-extern "C" {
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif
@@ -39,12 +38,13 @@ extern "C" {
 #include <math.h>
 #include <stdlib.h>
 #include <string.h>
-}
+
 #include "iop/Permutohedral.h"
-extern "C" {
+
 #include <gtk/gtk.h>
 #include <inttypes.h>
 
+extern "C" {
 /**
  * implementation of the 5d-color bilateral filter using andrew adams et al.'s
  * permutohedral lattice, which they kindly provided online as c++ code, under new bsd license.

--- a/src/iop/demosaic/amaze.cc
+++ b/src/iop/demosaic/amaze.cc
@@ -22,11 +22,11 @@
 #include <xmmintrin.h>
 #endif
 
-extern "C" {
 #include "develop/imageop.h"
 #include "develop/imageop_math.h"
 
 // otherwise the name will be mangled and the linker won't be able to see the function ...
+extern "C" {
 void amaze_demosaic_RT(
     dt_dev_pixelpipe_iop_t *piece,
     const float *const in,

--- a/src/iop/lens.cc
+++ b/src/iop/lens.cc
@@ -18,8 +18,6 @@
 
 #include "glib.h"
 
-extern "C" {
-
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif
@@ -46,7 +44,6 @@ extern "C" {
 #include <math.h>
 #include <stdlib.h>
 #include <string.h>
-}
 
 #include <lensfun.h>
 

--- a/src/iop/tonemap.cc
+++ b/src/iop/tonemap.cc
@@ -28,8 +28,6 @@
 
 #include "glib.h"
 
-extern "C" {
-
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif
@@ -48,7 +46,7 @@ extern "C" {
 #include "iop/iop_api.h"
 #include <gtk/gtk.h>
 #include <inttypes.h>
-}
+
 
 #include "iop/Permutohedral.h"
 


### PR DESCRIPTION
GLib contains both C and C++ declarations and it already uses `extern "C"` for C declarations, so we cannot simply use `extern "C"` for headers that include GLib. Instead, we use `extern "C"` inside C headers for our C declarations.

Ideally we should use `extern "C"` in all C headers for a good practice, but this commit only add it to C headers used by C++ sources.

Follow the suggestion from GLib maintainers in <https://gitlab.gnome.org/GNOME/glib/-/issues/3631>.