### PR TITLE
Lighttable: show the correct folder / collection on the first image imported

### DIFF
--- a/data/anselconfig.xml.in
+++ b/data/anselconfig.xml.in
@@ -726,10 +726,17 @@
     <longdescription>Duplicate the original files on the filesystem, using naming patterns. Useful when the original files are on a temporary storage, like a flash drive or a memory card.</longdescription>
   </dtconfig>
   <dtconfig>
-    <name>ui_last/import_last_image</name>
+    <name>ui_last/imported_last_image</name>
     <type>int</type>
     <default>-1</default>
     <shortdescription>Image ID of the last imported image</shortdescription>
+    <longdescription />
+  </dtconfig>
+  <dtconfig>
+    <name>ui_last/import_selection_nb</name>
+    <type>int</type>
+    <default>0</default>
+    <shortdescription>Number of elements selected in the import popup</shortdescription>
     <longdescription />
   </dtconfig>
   <dtconfig>
@@ -737,6 +744,13 @@
     <type>int</type>
     <default>0</default>
     <shortdescription>Number of images imported in the last fileroll</shortdescription>
+    <longdescription />
+  </dtconfig>
+  <dtconfig>
+    <name>ui_last/import_first_selected_str</name>
+    <type>string</type>
+    <default/>
+    <shortdescription>First selected item in import popup</shortdescription>
     <longdescription />
   </dtconfig>
   <dtconfig ui="yes">

--- a/src/common/collection.c
+++ b/src/common/collection.c
@@ -2128,9 +2128,10 @@ static void _dt_collection_filmroll_imported_callback(gpointer instance, const i
     }
   }
 
-  dt_conf_set_string("plugins/lighttable/collect/string0", g_strdup_printf("%s*", dir));
+  const char *opt = (dt_conf_get_int("plugins/lighttable/collect/item0") == 1) ? "*" : "" ;
+  dt_conf_set_string("plugins/lighttable/collect/string0", g_strdup_printf("%s%s", dir, opt));
+  
   dt_conf_set_int("plugins/lighttable/collect/num_rules", 1);
-  dt_conf_set_int("plugins/lighttable/collect/item0", 1);
 
   dt_collection_t *collection = (dt_collection_t *)user_data;
   const int old_count = collection->count;

--- a/src/common/import.c
+++ b/src/common/import.c
@@ -222,15 +222,30 @@ static void _recurse_selection(GSList *selection, dt_import_t *const import)
 
   if((import->shutdown)) return;
 
-  GVfs *vfs = g_vfs_get_default();
-  for(GSList *uri = selection; uri; uri = g_slist_next(uri))
+  if(selection != NULL)
   {
-    GFile *file = g_vfs_get_file_for_uri(vfs, (const char *)uri->data);
-    _filter_document(vfs, file, import);
-    g_object_unref(file);
+    GVfs *vfs = g_vfs_get_default();
+    for(GSList *uri = selection; uri; uri = g_slist_next(uri))
+    {
+      GFile *file = g_vfs_get_file_for_uri(vfs, (const char *)uri->data);
+      _filter_document(vfs, file, import);
+      g_object_unref(file);
+    }
+
+    GFile *filepath = g_vfs_get_file_for_uri(vfs, (const char *)selection->data);
+    const char *first_element = (const char*) g_file_get_path(filepath);
+    g_object_unref(filepath);
+    
+    if(first_element)
+    {
+      fprintf(stdout,"IMPORT: first element: %s\n", first_element);
+      dt_conf_set_string("ui_last/import_first_selected_str", first_element);
+    }
+    
+    dt_conf_set_int("ui_last/import_selection_nb", g_slist_length(selection));
+    import->files = g_list_sort(import->files, (GCompareFunc) g_strcmp0);
   }
 
-  import->files = g_list_sort(import->files, (GCompareFunc) g_strcmp0);
 }
 
 static gboolean _delayed_file_count(gpointer data)

--- a/src/control/jobs/control_jobs.c
+++ b/src/control/jobs/control_jobs.c
@@ -2354,7 +2354,6 @@ gboolean _import_image(const GList *img, dt_control_import_t *data, const int in
     {
       _write_xmp_id(filename, imgid);
       fprintf(stdout, "imgid: %i\n", imgid);
-
       dt_conf_set_int("ui_last/imported_last_image", imgid);
     }
   }

--- a/src/control/jobs/control_jobs.c
+++ b/src/control/jobs/control_jobs.c
@@ -2394,6 +2394,7 @@ static int32_t _control_import_job_run(dt_job_t *job)
     {
       data->total_imported_elements += 1;
       fprintf(stdout, "N: %i\n", data->total_imported_elements);
+      DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_IMAGE_IMPORT);
     }
     index++;
     if(index == 1)

--- a/src/control/jobs/control_jobs.c
+++ b/src/control/jobs/control_jobs.c
@@ -2174,7 +2174,7 @@ const int32_t _import_job(dt_control_import_t *data, gchar *img_path_to_db)
 {
   fprintf(stdout, "::IMPORT FILE::\n%s to DB\n", img_path_to_db);
 
-  dt_conf_set_int("ui_last/import_last_image", -1);
+  dt_conf_set_int("ui_last/imported_last_image", -1);
   gchar *dirname = g_strdup(dt_util_path_get_dirname(img_path_to_db));
 
   dt_film_t film;
@@ -2354,7 +2354,8 @@ gboolean _import_image(const GList *img, dt_control_import_t *data, const int in
     {
       _write_xmp_id(filename, imgid);
       fprintf(stdout, "imgid: %i\n", imgid);
-      dt_conf_set_int("ui_last/import_last_image", imgid);
+
+      dt_conf_set_int("ui_last/imported_last_image", imgid);
     }
   }
 
@@ -2395,6 +2396,8 @@ static int32_t _control_import_job_run(dt_job_t *job)
       fprintf(stdout, "N: %i\n", data->total_imported_elements);
     }
     index++;
+    if(index == 1)
+      DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_FIRST_IMAGE_IMPORTED);
 
     fprintf(stdout, "BOTTOM LOOP.\n\n");
   }

--- a/src/control/signal.c
+++ b/src/control/signal.c
@@ -166,6 +166,8 @@ static dt_signal_description _signal_description[DT_SIGNAL_COUNT] = {
     FALSE }, // DT_SIGNAL_CONTROL_PROFILE_USER_CHANGED
   { "dt-image-import", NULL, NULL, G_TYPE_NONE, g_cclosure_marshal_VOID__INT, 1, int_arg, NULL,
     FALSE }, // DT_SIGNAL_IMAGE_IMPORT
+  { "dt-first-image-imported", NULL, NULL, G_TYPE_NONE, g_cclosure_marshal_VOID__UINT, 1, uint_arg, NULL,
+    FALSE }, // DT_SIGNAL_FIRST-IMAGE_IMPORTED
   { "dt-image-export-tmpfile", NULL, NULL, G_TYPE_NONE, g_cclosure_marshal_generic, 6, image_export_arg, NULL,
     TRUE }, // DT_SIGNAL_IMAGE_EXPORT_TMPFILE
   { "dt-imageio-storage-change", NULL, NULL, G_TYPE_NONE, g_cclosure_marshal_VOID__VOID, 0, NULL, NULL,

--- a/src/control/signal.h
+++ b/src/control/signal.h
@@ -194,6 +194,12 @@ typedef enum dt_signal_t
     */
   DT_SIGNAL_IMAGE_IMPORT,
 
+  /** \brief This signal is raised when the first image of a list just been imported (not cloned).
+  1 uint32_t :  the new image id.
+  no return.
+  */
+  DT_SIGNAL_FIRST_IMAGE_IMPORTED,
+
   /** \brief This signal is raised after an image has been exported
     to a file, but before it is sent to facebook/picasa etc...
     export won't happen until this function returns

--- a/src/control/signal.h
+++ b/src/control/signal.h
@@ -195,7 +195,6 @@ typedef enum dt_signal_t
   DT_SIGNAL_IMAGE_IMPORT,
 
   /** \brief This signal is raised when the first image of a list just been imported (not cloned).
-  1 uint32_t :  the new image id.
   no return.
   */
   DT_SIGNAL_FIRST_IMAGE_IMPORTED,

--- a/src/libs/tools/filter.c
+++ b/src/libs/tools/filter.c
@@ -713,6 +713,9 @@ void gui_init(dt_lib_module_t *self)
   DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals, DT_SIGNAL_IMAGES_ORDER_CHANGE,
                             G_CALLBACK(_lib_filter_images_order_change), self);
 
+  DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals, DT_SIGNAL_IMAGE_IMPORT,
+                              G_CALLBACK(_refresh_collection_callback), NULL);
+
   // context menu
   d->menu = gtk_menu_new();
 


### PR DESCRIPTION
This is something I wanted to do since I worked on import.

This code intelligently selects the directory to display, ensuring that the lighttable view moves to the appropriate directory when the first image is imported.
It is configured to also display the contents of all subdirectories within the selected directory.

The scheme is the following:
- If files are imported with COPY mode ON
  - the lighttable displays the contents of the first image’s folder.
- If files are imported with COPY mode OFF:
  - If a single folder is imported, that folder is opened in the lighttable.
  - Otherwise, the lighttable navigates to the same directory shown in the import popup, as the previous behavior.
  
The possibility of disabling it through a preference option is still under consideration and deserve to collect some users opinion.