### PR TITLE
Lighttable: show the correct folder / collection on the first image imported

### DIFF
--- a/src/common/import.c
+++ b/src/common/import.c
@@ -220,7 +220,7 @@ static void _recurse_selection(GSList *selection, dt_import_t *const import)
   // GtkFileChooser gives us a GSList for selection, so we can't directly recurse from here
   // since the import job expects a GList.
 
-  if((import->shutdown)) return;
+  if((import->shutdown) || selection == NULL) return;
 
   GVfs *vfs = g_vfs_get_default();
   for(GSList *uri = selection; uri; uri = g_slist_next(uri))
@@ -229,6 +229,19 @@ static void _recurse_selection(GSList *selection, dt_import_t *const import)
     _filter_document(vfs, file, import);
     g_object_unref(file);
   }
+
+  // get the unsorted filtered path of the first selected element in file explorer.
+  GFile *filepath = g_vfs_get_file_for_uri(vfs, (const char *)selection->data);
+  const char *first_element = (const char*) g_file_get_path(filepath);
+  g_object_unref(filepath);
+  
+  if(first_element)
+  {
+    fprintf(stdout,"IMPORT: first element: %s\n", first_element);
+    dt_conf_set_string("ui_last/import_first_selected_str", first_element);
+  }
+  // get the number of selected elements
+  dt_conf_set_int("ui_last/import_selection_nb", g_slist_length(selection));
 
   import->files = g_list_sort(import->files, (GCompareFunc) g_strcmp0);
 }


### PR DESCRIPTION
This is something I wanted to do since I worked on import.

This code cleverly selects the directory to display, ensuring that the lighttable view moves to the appropriate directory when the first image is imported.
It is configured to also display the contents of all subdirectories within the selected directory.

The scheme is the following:

- If user imports images in place and Collection View mode is on "Tree":
  - if the user selected 1 folder in Import's file explorer:
    - the lighttable displays the contents of that folder.
  - else, the lighttable displays the contents of the folder showing in the file explorer in Import.
 
- In all other cases (other Collection View mode, images are imported as copies ...), the lighttable displays the first imported image's folder.

All this is done only if the user is currently in Lighttable, so it fixes #387.

The possibility of disabling it through a preference option is still under consideration and deserve to collect some users opinion.
