### PR TITLE
Windows: keep stdout in console when debugging

### DIFF
--- a/src/common/darktable.c
+++ b/src/common/darktable.c
@@ -578,6 +578,10 @@ int dt_init(int argc, char *argv[], const gboolean init_gui, const gboolean load
         argv[k-1] = NULL;
         argv[k] = NULL;
       }
+      else if(!strcmp(argv[k], "--debug"))
+      {
+        argv[k] = NULL;
+      }
       else if(!strcmp(argv[k], "--moduledir") && argc > k + 1)
       {
         moduledir_from_command = argv[++k];

--- a/src/main.c
+++ b/src/main.c
@@ -48,7 +48,8 @@ int main(int argc, char *argv[])
   for(int k = 1; k < argc; k++)
   {
     // For simple arguments do not redirect stdout
-    if(!strcmp(argv[k], "--help") || !strcmp(argv[k], "-h") || !strcmp(argv[k], "/?") || !strcmp(argv[k], "--version"))
+    if(!strcmp(argv[k], "--help") || !strcmp(argv[k], "-h") || !strcmp(argv[k], "/?") || !strcmp(argv[k], "--version")
+    || !strcmp(argv[k], "-d") || !strcmp(argv[k], "--debug"))
     {
       redirect_output = FALSE;
       break;


### PR DESCRIPTION
This doesn't redirect stdout and stderr stream in a file when `-d` or `--debug` are used so we keep the console open.