### PR TITLE
IOP order: add raster mask module user/source rules

### DIFF
--- a/src/common/iop_order.c
+++ b/src/common/iop_order.c
@@ -1471,6 +1471,9 @@ gboolean dt_ioppr_check_can_move_before_iop(GList *iop_list, dt_iop_module_t *mo
     return FALSE;
   }
 
+  if(module->raster_mask.sink.source == module_next)
+    return FALSE;
+
   gboolean can_move = FALSE;
 
   // module is before on the pipe
@@ -1503,6 +1506,9 @@ gboolean dt_ioppr_check_can_move_before_iop(GList *iop_list, dt_iop_module_t *mo
           mod2 = mod;
           break;
         }
+
+        if(mod->raster_mask.sink.source == module)
+          break;
 
         // check if module can be moved around this one
         if(mod->flags() & IOP_FLAGS_FENCE)
@@ -1580,6 +1586,9 @@ gboolean dt_ioppr_check_can_move_before_iop(GList *iop_list, dt_iop_module_t *mo
           break;
         }
 
+        if(module->raster_mask.sink.source == mod)
+          break;
+
         // check for rules
         // check if module can be moved around this one
         if(mod->flags() & IOP_FLAGS_FENCE)
@@ -1641,6 +1650,9 @@ gboolean dt_ioppr_check_can_move_before_iop(GList *iop_list, dt_iop_module_t *mo
 // this assumes that the order is always positive
 gboolean dt_ioppr_check_can_move_after_iop(GList *iop_list, dt_iop_module_t *module, dt_iop_module_t *module_prev)
 {
+  if(module_prev->raster_mask.sink.source == module)
+    return FALSE;
+  
   gboolean can_move = FALSE;
 
   // moving after module_prev is the same as moving before the very next one after module_prev

--- a/src/common/iop_order.c
+++ b/src/common/iop_order.c
@@ -1471,7 +1471,8 @@ gboolean dt_ioppr_check_can_move_before_iop(GList *iop_list, dt_iop_module_t *mo
     return FALSE;
   }
 
-  if(module->raster_mask.sink.source == module_next)
+  // we should't be here if the next module is using a raster mask and and our module is that raster mask source
+  if(module_next->raster_mask.sink.source == module)
     return FALSE;
 
   gboolean can_move = FALSE;
@@ -1507,6 +1508,7 @@ gboolean dt_ioppr_check_can_move_before_iop(GList *iop_list, dt_iop_module_t *mo
           break;
         }
 
+        // moving a module that is the source for a raster mask ABOVE the module using it is forbidden
         if(mod->raster_mask.sink.source == module)
           break;
 
@@ -1586,6 +1588,7 @@ gboolean dt_ioppr_check_can_move_before_iop(GList *iop_list, dt_iop_module_t *mo
           break;
         }
 
+        // moving a module using a raster mask BELOW its raster source module is forbidden
         if(module->raster_mask.sink.source == mod)
           break;
 
@@ -1650,7 +1653,8 @@ gboolean dt_ioppr_check_can_move_before_iop(GList *iop_list, dt_iop_module_t *mo
 // this assumes that the order is always positive
 gboolean dt_ioppr_check_can_move_after_iop(GList *iop_list, dt_iop_module_t *module, dt_iop_module_t *module_prev)
 {
-  if(module_prev->raster_mask.sink.source == module)
+  // we shouldn't be here if the previous module is the a raster mask's source and our module is using it
+  if(module->raster_mask.sink.source == module_prev)
     return FALSE;
   
   gboolean can_move = FALSE;

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -2112,7 +2112,7 @@ static gboolean _mask_indicator_tooltip(GtkWidget *treeview, gint x, gint y, gbo
       type=_("raster mask");
     else
       fprintf(stderr, "unknown mask mode '%d' in module '%s'\n", mm, module->op);
-    gchar *part1 = g_strdup_printf(_("this module has a `%s'"), type);
+    gchar *part1 = g_strdup_printf(_("this module has a '%s'"), type);
     gchar *part2 = NULL;
     if(raster && module->raster_mask.sink.source)
     {


### PR DESCRIPTION
This doesn't allow the user:
- to move a module being the source of a raster mask ABOVE a module using it,
- to move a module using a raster mask BELOW its module source.

It would be nice if there was something to alert the user on what's happening, like turning the mask button color red in module header of those concerned by the rastermask ...