### PR TITLE
Remove hiddent shortcut to lighttable by double click

### DIFF
--- a/src/control/control.c
+++ b/src/control/control.c
@@ -434,8 +434,7 @@ void dt_control_button_pressed(double x, double y, double pressure, int which, i
     }
   dt_pthread_mutex_unlock(&darktable.control->toast_mutex);
 
-  if(!dt_view_manager_button_pressed(darktable.view_manager, x, y, pressure, which, type, state))
-    if(type == GDK_2BUTTON_PRESS && which == 1) dt_ctl_switch_mode();
+  dt_view_manager_button_pressed(darktable.view_manager, x, y, pressure, which, type, state);
 }
 
 static gboolean _redraw_center(gpointer user_data)


### PR DESCRIPTION
When (accidentally) double-clicking in certain areas of the darkroom (mainly on the border of the central image),
the view would switch to the Lighttable. This behavior is no longer expected or necessary,
as there is now a home button, a menu entry to open the Lighttable, and a keyboard shortcut for it.

And it gets me on my nerves 😒 
