### PR TITLE
Fix build with Clang 21

### DIFF
--- a/data/kernels/CMakeLists.txt
+++ b/data/kernels/CMakeLists.txt
@@ -15,7 +15,7 @@ macro(testcompile_opencl_kernel IN)
 
   add_custom_command(
     OUTPUT  ${TOUCH}
-    COMMAND ${CLANG_OPENCL_COMPILER} -cc1 -cl-std=CL1.2 -isystem ${CLANG_OPENCL_INCLUDE_DIR} -finclude-default-header -I${CMAKE_CURRENT_SOURCE_DIR} ${IN}
+    COMMAND ${CLANG_OPENCL_COMPILER} -cc1 -cl-std=CL1.2 -isystem ${CLANG_OPENCL_INCLUDE_DIR} -D__IMAGE_SUPPORT__=1 -finclude-default-header -I${CMAKE_CURRENT_SOURCE_DIR} ${IN}
     COMMAND ${CMAKE_COMMAND} -E touch ${TOUCH} # will be empty!
     DEPENDS ${IN}
     COMMENT "Test-compiling OpenCL program ${KERNAME}"


### PR DESCRIPTION
llvm/llvm-project@c1aebd4 wrapped all the image function declarations in the IMAGE_SUPPORT macro, so ansel needs to define this macro in order to use these functions.