### PR TITLE
Fix error 'Exit: command not found' during building on Mac (just one line)

### DIFF
--- a/packaging/macosx/2_build_hb_ansel_custom.sh
+++ b/packaging/macosx/2_build_hb_ansel_custom.sh
@@ -22,7 +22,7 @@
 # Script to build and install ansel with custom configuration
 #
 #   
- Exit in case of error
+# Exit in case of error
 set -e -o pipefail
 trap 'echo "${BASH_SOURCE[0]}{${FUNCNAME[0]}}:${LINENO}: Error: command \`${BASH_COMMAND}\` failed with exit code $?"' ERR
 


### PR DESCRIPTION
Comment mark was missing - that's it.