### PR TITLE
Fix image rejection not reflected in thumbnail UI

### DIFF
--- a/src/common/image_cache.c
+++ b/src/common/image_cache.c
@@ -611,6 +611,15 @@ void dt_image_cache_write_release(dt_image_cache_t *cache, dt_image_t *img, dt_i
   dt_colorlabels_set_labels(img->id, img->color_labels);
   _image_cache_write_history_hash(img);
 
+  // Sync derived fields from flags before releasing the write lock,
+  // so any reader that immediately testget()s the cache sees consistent data.
+  img->rating = dt_image_get_xmp_rating_from_flags(img->flags);
+  img->has_localcopy = (img->flags & DT_IMAGE_LOCAL_COPY) != 0;
+  img->has_audio = (img->flags & DT_IMAGE_HAS_WAV) != 0;
+  img->is_bw = dt_image_monochrome_flags(img);
+  img->is_bw_flow = dt_image_use_monochrome_workflow(img);
+  img->is_hdr = dt_image_is_hdr(img);
+
   const int32_t imgid = img->id;
   dt_cache_release(&cache->cache, img->cache_entry);
 

--- a/src/dtgtk/thumbnail.c
+++ b/src/dtgtk/thumbnail.c
@@ -151,10 +151,12 @@ static void _image_update_group_tooltip(dt_thumbnail_t *thumb)
 static void _thumb_update_rating_class(dt_thumbnail_t *thumb)
 {
   thumb_return_if_fails(thumb);
+  const int rating = (thumb->info.flags & DT_IMAGE_REJECTED) ? DT_VIEW_REJECT
+                                                              : (thumb->info.flags & DT_VIEW_RATINGS_MASK);
   for(int i = DT_VIEW_DESERT; i <= DT_VIEW_REJECT; i++)
   {
     gchar *cn = g_strdup_printf("dt_thumbnail_rating_%d", i);
-    if(thumb->info.rating == i)
+    if(rating == i)
       dt_gui_add_class(thumb->w_main, cn);
     else
       dt_gui_remove_class(thumb->w_main, cn);
@@ -717,12 +719,14 @@ static void _thumb_update_icons(dt_thumbnail_t *thumb)
   _set_flag(thumb->w_main, GTK_STATE_FLAG_PRELIGHT, thumb->mouse_over);
   _set_flag(thumb->widget, GTK_STATE_FLAG_PRELIGHT, thumb->mouse_over);
 
-  _set_flag(thumb->w_reject, GTK_STATE_FLAG_ACTIVE, (thumb->info.rating == DT_VIEW_REJECT));
+  const int rating = (thumb->info.flags & DT_IMAGE_REJECTED) ? DT_VIEW_REJECT
+                                                              : (thumb->info.flags & DT_VIEW_RATINGS_MASK);
+  _set_flag(thumb->w_reject, GTK_STATE_FLAG_ACTIVE, (rating == DT_VIEW_REJECT));
 
   for(int i = 0; i < MAX_STARS; i++)
   {
     gtk_widget_set_visible(thumb->w_stars[i], show || DEBUG);
-    _set_flag(thumb->w_stars[i], GTK_STATE_FLAG_ACTIVE, (thumb->info.rating > i && thumb->info.rating < DT_VIEW_REJECT));
+    _set_flag(thumb->w_stars[i], GTK_STATE_FLAG_ACTIVE, (rating > i && rating < DT_VIEW_REJECT));
   }
 
   _set_flag(thumb->w_group, GTK_STATE_FLAG_ACTIVE, (thumb->info.id == thumb->info.group_id));
@@ -937,7 +941,9 @@ static gboolean _event_star_leave(GtkWidget *widget, GdkEventCrossing *event, gp
     _set_flag(thumb->w_stars[i], GTK_STATE_FLAG_PRELIGHT, FALSE);
 
     // restore active state
-    _set_flag(thumb->w_stars[i], GTK_STATE_FLAG_ACTIVE, i < thumb->info.rating && thumb->info.rating < DT_VIEW_REJECT);
+    const int rating = (thumb->info.flags & DT_IMAGE_REJECTED) ? DT_VIEW_REJECT
+                                                                : (thumb->info.flags & DT_VIEW_RATINGS_MASK);
+    _set_flag(thumb->w_stars[i], GTK_STATE_FLAG_ACTIVE, i < rating && rating < DT_VIEW_REJECT);
   }
   return TRUE;
 }


### PR DESCRIPTION
Two bugs introduced by ee86a6073 ("Merge dt_thumbnail_info_t with dt_image_t"):

1. dt_image_cache_write_release() flushed updated flags to the database
   but never resynced the derived fields (rating, has_audio, is_bw, etc.)
   that are computed from flags. Any reader that obtained the cache entry
   immediately after a write (e.g. via testget() in the IMAGE_INFO_CHANGED
   signal handler) would see a stale rating and other stale booleans.
   Fixed by recomputing all flag-derived fields before releasing the write
   lock, matching what _image_cache_reload_from_db() already does on load.

2. The old dt_thumbnail_image_info_t stored rating in *view scale*:
       rating = (flags & DT_IMAGE_REJECTED) ? DT_VIEW_REJECT : (flags & DT_VIEW_RATINGS_MASK)
   i.e. rejected = 6 (DT_VIEW_REJECT). The commit replaced that struct with
   a plain memcpy of dt_image_t, whose rating field is set by
   dt_image_get_xmp_rating_from_flags() which returns -1 for rejected
   images (XMP standard). The thumbnail display code compares against
   DT_VIEW_REJECT (6), so the check was always false and the reject icon
   never lit up.
   Fixed by computing view-scale rating directly from thumb->info.flags
   at the three display sites in thumbnail.c, eliminating the dependency
   on the cached rating field entirely.

Fixes #637

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
