### PR TITLE
opencl: add exclusion tags in programs.conf; disable crystgrain for Intel

### DIFF
--- a/data/kernels/programs.conf
+++ b/data/kernels/programs.conf
@@ -30,4 +30,4 @@ channelmixer.cl         32
 diffuse.cl              33
 blurs.cl                34
 bspline.cl              35
-crystgrain.cl           36
+crystgrain.cl           36  !INTEL

--- a/src/common/opencl.c
+++ b/src/common/opencl.c
@@ -749,6 +749,16 @@ static int dt_opencl_device_init(dt_opencl_t *cl, const int dev, cl_device_id *d
         }
       if(confentry[0] == '\0') continue;
 
+      // Vendor-exclusion tags: append !AMD, !NVIDIA, or !INTEL after the
+      // program number to skip that program for that vendor's OpenCL runtime.
+      if((vendor_id == DT_OPENCL_VENDOR_INTEL   && strstr(confentry, "!INTEL"))  ||
+         (vendor_id == DT_OPENCL_VENDOR_AMD     && strstr(confentry, "!AMD"))    ||
+         (vendor_id == DT_OPENCL_VENDOR_NVIDIA  && strstr(confentry, "!NVIDIA")))
+      {
+        dt_print(DT_DEBUG_OPENCL, "[dt_opencl_device_init] skipping program `%s' (vendor exclusion)\n", confentry);
+        continue;
+      }
+
       const char *programname = NULL, *programnumber = NULL;
       gchar **tokens = g_strsplit_set(confentry, " \t", 2);
       if(tokens)


### PR DESCRIPTION
## The bug

Intel IGC 2.34.4 / intel-opencl 26.18.38308.1 (Fedora 44, installed 2026-05-25) crashes with SIGSEGV inside the JIT compiler when compiling crystgrain.cl. The crash happens at startup during clBuildProgram(), before any image is processed, so Ansel cannot catch it and simply dies.

## Root cause

The crash is triggered by OpenCL atomic built-ins (atomic_add, atomic_cmpxchg) used inside nested for-loops whose bounds are not compile-time constants:

  for(int dy = -radius; dy <= radius; dy++)   // radius is a runtime value
    for(int dx = -radius; dx <= radius; dx++)
      atomic_add_f(result + dst, deposited);  // calls atomic_add / atomic_cmpxchg

The two kernels affected are crystgrain_simulate_layer and crystgrain_simulate_layer_color, which implement a stochastic scatter pass: each pixel that is drawn as a grain seed atomically deposits energy into its neighbourhood. The scatter pattern requires atomics because multiple concurrent work-items write to overlapping output pixels.

Bisection confirmed the trigger is specifically the combination of:
  - variable-bound outer loops (bounds come from a runtime kernel-bank entry)
  - any atomic built-in inside the innermost loop body

The following were ruled out as root causes through successive isolation:
  - do-while vs. for-loop in the CAS retry helper
  - union-based vs. as_uint()/as_float() type punning for float atomics
  - global volatile vs. plain global pointer casts
  - static vs. non-static device function linkage
  - unbounded while-loop in reflect_index() (replaced with pure arithmetic)
  - crystgrain_kernel_coverage() calling complex trig (asin, cos, atan2)
  - calling any user-defined device function from the loop body

Replacing the variable-bound loops with fixed compile-time-bound loops would work around the IGC crash but makes the kernel iterate over a worst-case (radius ≈ 48 pixel) neighbourhood regardless of the actual grain size, which is unacceptably slow. The correct fix is for Intel to fix the IGC JIT.

## Workaround

Two changes:

1. programs.conf: support vendor-exclusion tags of the form !AMD, !NVIDIA, !INTEL appended after the program number on any line.  The opencl loader skips that program entirely for the matching vendor.  strtol() already stops at non-digit characters so the tag does not affect program-number parsing; it is invisible to all other vendors.

2. crystgrain.cl is tagged !INTEL.  When the program is absent, all kernel handles are -1; the first dt_opencl_enqueue_kernel_2d() call returns an error; process_cl() returns FALSE; the pipeline falls back to the CPU implementation transparently.  All other OpenCL kernels (AMD, NVIDIA) are unaffected.