### PR TITLE
harden crash paths

### DIFF
--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -1974,10 +1974,32 @@ void dt_iop_commit_params(dt_iop_module_t *module, dt_iop_params_t *params,
   if(module->flags() & IOP_FLAGS_ALLOW_TILING)
     piece->process_tiling_ready = 1;
 
-  if(darktable.unmuted & DT_DEBUG_PARAMS && module->so->get_introspection())
+  if(darktable.unmuted & DT_DEBUG_PARAMS && !IS_NULL_PTR(module->so)
+     && !IS_NULL_PTR(module->so->get_introspection) && module->so->get_introspection())
     _iop_validate_params(module->so->get_introspection()->field, params, TRUE);
 
-  module->commit_params(module, params, pipe, piece);
+  void (*commit_params)(struct dt_iop_module_t *self, dt_iop_params_t *params,
+                        dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece) = module->commit_params;
+
+  if(IS_NULL_PTR(commit_params) || (gsize)commit_params <= 0x1000)
+  {
+    if(!IS_NULL_PTR(module->so) && !IS_NULL_PTR(module->so->commit_params) && (gsize)module->so->commit_params > 0x1000)
+    {
+      dt_print(DT_DEBUG_ALWAYS,
+               "[dt_iop_commit_params] invalid module commit callback for `%s`, using shared-object fallback\n",
+               module->op);
+      commit_params = module->so->commit_params;
+    }
+    else
+    {
+      dt_print(DT_DEBUG_ALWAYS,
+               "[dt_iop_commit_params] invalid commit callback for `%s`, skipping params commit\n",
+               module->op);
+      return;
+    }
+  }
+
+  commit_params(module, params, pipe, piece);
 
   gchar *string = g_strdup_printf("/plugins/%s/opencl", module->op);
 

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -556,7 +556,30 @@ int dt_iop_load_module_by_so(dt_iop_module_t *module, dt_iop_module_so_t *so, dt
 void dt_iop_init_pipe(struct dt_iop_module_t *module, struct dt_dev_pixelpipe_t *pipe,
                       struct dt_dev_pixelpipe_iop_t *piece)
 {
-  module->init_pipe(module, pipe, piece);
+  if(IS_NULL_PTR(module) || IS_NULL_PTR(pipe) || IS_NULL_PTR(piece)) return;
+
+  void (*init_pipe)(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_t *pipe,
+                    struct dt_dev_pixelpipe_iop_t *piece) = module->init_pipe;
+
+  if(IS_NULL_PTR(init_pipe) || (gsize)init_pipe <= 0x1000)
+  {
+    if(!IS_NULL_PTR(module->so) && !IS_NULL_PTR(module->so->init_pipe) && (gsize)module->so->init_pipe > 0x1000)
+    {
+      dt_print(DT_DEBUG_ALWAYS,
+               "[dt_iop_init_pipe] invalid module init callback for `%s`, using shared-object fallback\n",
+               module->op);
+      init_pipe = module->so->init_pipe;
+    }
+    else
+    {
+      dt_print(DT_DEBUG_ALWAYS,
+               "[dt_iop_init_pipe] invalid init callback for `%s`, skipping module pipe init\n",
+               module->op);
+      return;
+    }
+  }
+
+  init_pipe(module, pipe, piece);
   piece->blendop_data = dt_calloc_align(sizeof(dt_develop_blend_params_t));
 }
 

--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -2205,6 +2205,7 @@ static gboolean _scroll_wrap_resize(GtkWidget *w, void *cr, const char *config_s
 {
   GtkWidget *sw = gtk_widget_get_parent(w);
   if(GTK_IS_VIEWPORT(sw)) sw = gtk_widget_get_parent(sw);
+  if(!GTK_IS_SCROLLED_WINDOW(sw)) return FALSE;
 
   const gint increment = _get_container_row_heigth(w);
 

--- a/src/libs/metadata.c
+++ b/src/libs/metadata.c
@@ -448,7 +448,8 @@ static void _update_layout(dt_lib_module_t *self)
     GtkWidget *label = gtk_grid_get_child_at(GTK_GRID(self->widget), 0, i);
     gtk_widget_set_visible(label, !hidden);
     GtkWidget *current = GTK_WIDGET(d->textview[i]);
-    gtk_widget_set_visible(gtk_widget_get_parent(current), !hidden);
+    GtkWidget *current_parent = gtk_widget_get_parent(current);
+    if(!IS_NULL_PTR(current_parent)) gtk_widget_set_visible(current_parent, !hidden);
 
     if(!hidden)
     {


### PR DESCRIPTION
- **gtk: guard _scroll_wrap_resize against unparented widget**
- **metadata: guard parent of textview before setting visibility**
- **imageop: guard invalid init_pipe callback during pipe build**
- **imageop: guard module->so deref and commit_params callback**
