### PR TITLE
Remove application of a missing css patch in a build script for MacOS X

### DIFF
--- a/packaging/macosx/3_make_hb_ansel_package.sh
+++ b/packaging/macosx/3_make_hb_ansel_package.sh
@@ -327,9 +327,6 @@ cp -L "$homebrewHome"/share/themes/Mac/gtk-3.0/gtk-keys.css "$dtResourcesDir"/sh
 # Add fonts
 cp fonts/*  "$dtResourcesDir"/fonts/
 
-# Patch ansel.css - Solving font issue with Roboto condensed
-patch "$dtResourcesDir"/share/ansel/themes/ansel.css ansel.css.patch
-
 # Create Icon file
 if [ -d "$buildDir"/Icons.iconset ]; then
     rm -R "$buildDir/Icons.iconset"


### PR DESCRIPTION
Remove the application of the `ansel.css.patch` patch in the `packaging/macosx/3_make_hb_ansel_package.sh` script as this patch doesn't exist anymore. So, the script won't fail when building Ansel on MacOS X.