### PR TITLE
Fix OpenCL crash: NULL event handle in events_flush (#129541305)

### DIFF
--- a/src/common/opencl.c
+++ b/src/common/opencl.c
@@ -2953,14 +2953,34 @@ void dt_opencl_events_wait_for(const int devid)
 
   assert(*numevents > *eventsconsolidated);
 
-  // now wait for all remaining events to terminate
-  // Risk: might never return in case of OpenCL blocks or endless loops
-  // TODO: run clWaitForEvents in separate thread and implement watchdog timer
-  cl_int err = (cl->dlocl->symbols->dt_clWaitForEvents)(*numevents - *eventsconsolidated,
-                                           (*eventlist) + *eventsconsolidated);
-  if((err != CL_SUCCESS) && (err != CL_INVALID_VALUE))
-    dt_vprint(DT_DEBUG_OPENCL, "[dt_opencl_events_wait_for] reported %i for device %i\n",
-       err, devid);
+  // Gather only the non-NULL handles before waiting. A reserved slot can hold a
+  // NULL handle when its enqueue failed (the event is not created, but get_slot
+  // had already counted the slot). Passing NULL to clWaitForEvents crashes some
+  // drivers, and on those that merely return an error it would abort the whole
+  // wait and leave the valid events that follow un-waited-for.
+  const int pending = *numevents - *eventsconsolidated;
+  cl_event *valid = malloc(sizeof(cl_event) * pending);
+  if(IS_NULL_PTR(valid)) return;
+
+  int nvalid = 0;
+  for(int k = *eventsconsolidated; k < *numevents; k++)
+  {
+    if(memcmp((*eventlist) + k, zeroevent, sizeof(cl_event)))
+      valid[nvalid++] = (*eventlist)[k];
+  }
+
+  if(nvalid > 0)
+  {
+    // now wait for all remaining events to terminate
+    // Risk: might never return in case of OpenCL blocks or endless loops
+    // TODO: run clWaitForEvents in separate thread and implement watchdog timer
+    cl_int err = (cl->dlocl->symbols->dt_clWaitForEvents)(nvalid, valid);
+    if((err != CL_SUCCESS) && (err != CL_INVALID_VALUE))
+      dt_vprint(DT_DEBUG_OPENCL, "[dt_opencl_events_wait_for] reported %i for device %i\n",
+         err, devid);
+  }
+
+  free(valid);
 }
 
 

--- a/src/common/opencl.c
+++ b/src/common/opencl.c
@@ -2953,34 +2953,27 @@ void dt_opencl_events_wait_for(const int devid)
 
   assert(*numevents > *eventsconsolidated);
 
-  // Gather only the non-NULL handles before waiting. A reserved slot can hold a
-  // NULL handle when its enqueue failed (the event is not created, but get_slot
-  // had already counted the slot). Passing NULL to clWaitForEvents crashes some
-  // drivers, and on those that merely return an error it would abort the whole
-  // wait and leave the valid events that follow un-waited-for.
-  const int pending = *numevents - *eventsconsolidated;
-  cl_event *valid = malloc(sizeof(cl_event) * pending);
-  if(IS_NULL_PTR(valid)) return;
-
-  int nvalid = 0;
+  // Wait for all remaining events to terminate, skipping NULL handles. A reserved
+  // slot can hold a NULL handle when its enqueue failed (the event is never
+  // created, but get_slot had already counted the slot). Passing NULL to
+  // clWaitForEvents crashes some drivers and, on those that merely return an
+  // error, would abort a batched wait and leave the valid events that follow
+  // un-waited-for before flush checks/releases them. We wait on each handle
+  // individually rather than gathering them into a temporary array: a heap
+  // allocation could fail under the very memory pressure that creates these NULL
+  // slots, and returning early on that failure would skip the wait entirely.
+  // Risk: might never return in case of OpenCL blocks or endless loops
+  // TODO: run clWaitForEvents in separate thread and implement watchdog timer
   for(int k = *eventsconsolidated; k < *numevents; k++)
   {
-    if(memcmp((*eventlist) + k, zeroevent, sizeof(cl_event)))
-      valid[nvalid++] = (*eventlist)[k];
-  }
+    if(!memcmp((*eventlist) + k, zeroevent, sizeof(cl_event)))
+      continue; // NULL handle from a failed enqueue
 
-  if(nvalid > 0)
-  {
-    // now wait for all remaining events to terminate
-    // Risk: might never return in case of OpenCL blocks or endless loops
-    // TODO: run clWaitForEvents in separate thread and implement watchdog timer
-    cl_int err = (cl->dlocl->symbols->dt_clWaitForEvents)(nvalid, valid);
+    cl_int err = (cl->dlocl->symbols->dt_clWaitForEvents)(1, &((*eventlist)[k]));
     if((err != CL_SUCCESS) && (err != CL_INVALID_VALUE))
       dt_vprint(DT_DEBUG_OPENCL, "[dt_opencl_events_wait_for] reported %i for device %i\n",
          err, devid);
   }
-
-  free(valid);
 }
 
 

--- a/src/common/opencl.c
+++ b/src/common/opencl.c
@@ -2904,10 +2904,15 @@ void dt_opencl_events_reset(const int devid)
 
   if(IS_NULL_PTR(*eventlist) || *numevents == 0) return; // nothing to do
 
-  // release all remaining events in eventlist, not to waste resources
+  static const cl_event zeroevent[1]; // implicitly initialized to zero
+
+  // release all remaining events in eventlist, not to waste resources.
+  // Skip NULL handles left behind by failed enqueues: releasing them is
+  // pointless and crashes some drivers.
   for(int k = *eventsconsolidated; k < *numevents; k++)
   {
-    (cl->dlocl->symbols->dt_clReleaseEvent)((*eventlist)[k]);
+    if(memcmp((*eventlist) + k, zeroevent, sizeof(cl_event)))
+      (cl->dlocl->symbols->dt_clReleaseEvent)((*eventlist)[k]);
   }
 
   memset(*eventtags, 0, sizeof(dt_opencl_eventtag_t) * *maxevents);
@@ -2980,6 +2985,8 @@ cl_int dt_opencl_events_flush(const int devid, const int reset)
 
   cl_int *summary = &(cl->dev[devid].summary);
 
+  static const cl_event zeroevent[1]; // implicitly initialized to zero
+
   if(IS_NULL_PTR(*eventlist) || *numevents == 0) return CL_COMPLETE; // nothing to do, no news is good news
 
   // Wait for command queue to terminate (side effect: might adjust *numevents)
@@ -2988,6 +2995,18 @@ cl_int dt_opencl_events_flush(const int devid, const int reset)
   // now check return status and profiling data of all newly terminated events
   for(int k = *eventsconsolidated; k < *numevents; k++)
   {
+    // A reserved slot can still hold a NULL handle when the matching enqueue
+    // failed: OpenCL does not create the event in that case, but get_slot had
+    // already counted the slot. Passing such a NULL handle to the driver
+    // crashes some implementations (e.g. NVIDIA on Windows), so treat it as a
+    // lost event and skip it.
+    if(!memcmp((*eventlist) + k, zeroevent, sizeof(cl_event)))
+    {
+      (*lostevents)++;
+      (*eventsconsolidated)++;
+      continue;
+    }
+
     cl_int err;
     char *tag = (*eventtags)[k].tag;
     cl_int *retval = &((*eventtags)[k].retval);


### PR DESCRIPTION
## Context

Fixes the crash reported by Sentry issue [#129541305](https://aurelienpierreeng.sentry.io/issues/129541305/) — an `EXCEPTION_ACCESS_VIOLATION` (`AccessViolation`, unhandled `SIGSEGV`) on a Windows / NVIDIA RTX 3060 nightly build (`0.0.0+3856~g612eede039`), during a `darkroom-preview` pixelpipe run after ~197 images processed.

### Crash signature

```
dt_opencl_events_flush      (opencl.c:2996)
dt_opencl_finish            (opencl.c:1356)
pixelpipe_process_on_GPU    (pixelpipe_gpu.c:609)
dt_dev_pixelpipe_process_rec ...
```

The faulting frames above `dt_opencl_events_flush` are inside the NVIDIA driver: line 2996 calls `clGetEventInfo((*eventlist)[k], …)` on an **invalid (NULL) `cl_event` handle**.

### Root cause

Every OpenCL enqueue wrapper reserves an event slot before enqueuing:

```c
cl_event *eventp = dt_opencl_events_get_slot(dev, buf); // numevents++, slot zeroed
cl_int err = dt_clEnqueueNDRangeKernel(..., eventp);     // writes *eventp ONLY on success
if(err != CL_SUCCESS) /* just logs */;
```

When the enqueue **fails** — plausible under GPU memory pressure after many images (`CL_OUT_OF_RESOURCES` / allocation failure) — OpenCL does not create the event, so the reserved slot keeps its **NULL** handle while `numevents` was already incremented. `dt_opencl_events_wait_for()` only compensates for a *single trailing* NULL slot, so a NULL handle reached by the `events_flush()` loop is passed straight to `clGetEventInfo()`, which dereferences it and crashes (NVIDIA on Windows).

### Fix

- In the `dt_opencl_events_flush()` loop, skip any slot holding a NULL handle, counting it as a lost event (`lostevents++` / `eventsconsolidated++`) — consistent with the existing trailing-zero "lost event" accounting.
- Harden `dt_opencl_events_reset()` the same way so `clReleaseEvent()` is never called on a NULL handle.

The driver is therefore never handed a NULL `cl_event`. Behavior is unchanged on the normal path where all reserved slots hold valid events.

🤖 Generated with [Claude Code](https://claude.com/claude-code)