### PR TITLE
Fix denoiseprofile crash: NULL slider deref during gui_init (#129494618)

### DIFF
--- a/src/iop/denoiseprofile.c
+++ b/src/iop/denoiseprofile.c
@@ -3658,13 +3658,19 @@ void gui_init(dt_iop_module_t *self)
   gtk_box_pack_start(GTK_BOX(self->widget), g->box_wavelets, TRUE, TRUE, 0);
 
   g->overshooting = dt_bauhaus_slider_from_params(self, "overshooting");
-  dt_bauhaus_slider_set_soft_max(g->overshooting, 4.0f);
   g->strength = dt_bauhaus_slider_from_params(self, N_("strength"));
   dt_bauhaus_slider_set_soft_max(g->strength, 4.0f);
   dt_bauhaus_slider_set_digits(g->strength, 3);
   g->shadows = dt_bauhaus_slider_from_params(self, "shadows");
   g->bias = dt_bauhaus_slider_from_params(self, "bias");
   dt_bauhaus_slider_set_soft_range(g->bias, -10.0f, 10.0f);
+
+  // Set the overshooting soft range only once the sliders that its
+  // value-changed handler (gui_changed) touches exist: changing a slider's
+  // soft bound re-applies the value and emits "value-changed", which calls
+  // gui_changed(overshooting) -> dt_bauhaus_slider_set(g->shadows / g->bias).
+  // Those are created just above, so doing this earlier dereferenced NULL.
+  dt_bauhaus_slider_set_soft_max(g->overshooting, 4.0f);
 
   gtk_box_pack_start(GTK_BOX(self->widget), g->box_variance, TRUE, TRUE, 0);
 


### PR DESCRIPTION
## Context

Fixes the crash reported by Sentry issue [#129494618](https://aurelienpierreeng.sentry.io/issues/129494618/) — an unhandled `SIGSEGV` in `dt_bauhaus_slider_set` on macOS (Apple M4 Pro), `RelWithDebInfo` build `0.0.0+3843~gfe8df22039`, while entering the darkroom.

### Crash signature

```
dt_bauhaus_slider_set                          (bauhaus.c)        <- crash, NULL widget
gui_changed                                    (libdenoiseprofile.so)
dt_bauhaus_value_changed_default_callback      (libansel.dylib)
dt_bauhaus_slider_set_normalized               (bauhaus.c)
gui_init                                        (libdenoiseprofile.so)
dt_iop_gui_init
enter                                           (libdarkroom.so)
dt_view_manager_switch_by_view
```

### Root cause

In `denoiseprofile`'s `gui_init()`:

```c
g->overshooting = dt_bauhaus_slider_from_params(self, "overshooting");
dt_bauhaus_slider_set_soft_max(g->overshooting, 4.0f);   // <-- here
...
g->shadows = dt_bauhaus_slider_from_params(self, "shadows");  // created later
g->bias    = dt_bauhaus_slider_from_params(self, "bias");     // created later
```

`dt_bauhaus_slider_set_soft_max()` re-applies the slider's value through `dt_bauhaus_slider_set()`, which emits `"value-changed"` and runs `gui_changed(self, g->overshooting, …)`. That handler unconditionally calls:

```c
dt_bauhaus_slider_set(g->shadows, infer_shadows_from_profile(a * gain));
dt_bauhaus_slider_set(g->bias,    infer_bias_from_profile(a * gain));
```

But `g->shadows` and `g->bias` are created a few lines *after* the `set_soft_max` call, so they were still `NULL`. `dt_bauhaus_slider_set(NULL)` → `DT_BAUHAUS_WIDGET(NULL)` dereferences a NULL pointer → segfault.

`gui_changed(overshooting)` also touches `g->radius`/`g->scattering`, but those are created earlier, so only `shadows`/`bias` were the dangling references.

### Fix

Move the `overshooting` soft-max setup to *after* `g->shadows` and `g->bias` are created, so every widget the `overshooting` `gui_changed` branch touches already exists when the bound change emits `value-changed`. Minimal, localized to `gui_init`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)