### PR TITLE
rawspeed sraw: prevent C++ exceptions escaping OpenMP regions (terminate→abort)

### DIFF
--- a/src/common/imageio_rawspeed.cc
+++ b/src/common/imageio_rawspeed.cc
@@ -593,10 +593,12 @@ dt_imageio_retval_t dt_imageio_open_rawspeed_sraw(dt_image_t *img,
 
     if(r->getDataType() == TYPE_USHORT16)
     {
-      __OMP_PARALLEL_FOR_CPP__(shared(r) firstprivate(height, width, buf, cpp))
+      // Fetch the rawspeed view in the serial region: it may throw, and an
+      // exception escaping an OpenMP parallel block calls std::terminate.
+      const Array2DRef<uint16_t> in = r->getU16DataAsUncroppedArray2DRef();
+      __OMP_PARALLEL_FOR_CPP__(shared(in) firstprivate(height, width, buf, cpp))
       for(int j = 0; j < height; j++)
       {
-        const Array2DRef<uint16_t> in = r->getU16DataAsUncroppedArray2DRef();
         float *out = ((float *)buf) + (size_t)4 * j * width;
 
         for(int i = 0; i < width; i++, out += 4)
@@ -609,10 +611,12 @@ dt_imageio_retval_t dt_imageio_open_rawspeed_sraw(dt_image_t *img,
     }
     else // r->getDataType() == TYPE_FLOAT32
     {
-      __OMP_PARALLEL_FOR_CPP__(shared(r) firstprivate(height, width, buf, cpp))
+      // Fetch the rawspeed view in the serial region: it may throw, and an
+      // exception escaping an OpenMP parallel block calls std::terminate.
+      const Array2DRef<float> in = r->getF32DataAsUncroppedArray2DRef();
+      __OMP_PARALLEL_FOR_CPP__(shared(in) firstprivate(height, width, buf, cpp))
       for(int j = 0; j < height; j++)
       {
-        const Array2DRef<float> in = r->getF32DataAsUncroppedArray2DRef();
         float *out = ((float *)buf) + (size_t)4 * j * width;
 
         for(int i = 0; i < width; i++, out += 4)
@@ -633,10 +637,12 @@ dt_imageio_retval_t dt_imageio_open_rawspeed_sraw(dt_image_t *img,
 
     if(r->getDataType() == TYPE_USHORT16)
     {
-      __OMP_PARALLEL_FOR_CPP__(shared(r) firstprivate(height, width, buf, cpp))
+      // Fetch the rawspeed view in the serial region: it may throw, and an
+      // exception escaping an OpenMP parallel block calls std::terminate.
+      const Array2DRef<uint16_t> in = r->getU16DataAsUncroppedArray2DRef();
+      __OMP_PARALLEL_FOR_CPP__(shared(in) firstprivate(height, width, buf, cpp))
       for(int j = 0; j < height; j++)
       {
-        const Array2DRef<uint16_t> in = r->getU16DataAsUncroppedArray2DRef();
         float *out = ((float *)buf) + (size_t)4 * j * width;
 
         for(int i = 0; i < width; i++, out += 4)
@@ -650,10 +656,12 @@ dt_imageio_retval_t dt_imageio_open_rawspeed_sraw(dt_image_t *img,
     }
     else // r->getDataType() == TYPE_FLOAT32
     {
-      __OMP_PARALLEL_FOR_CPP__(shared(r) firstprivate(height, width, buf, cpp))
+      // Fetch the rawspeed view in the serial region: it may throw, and an
+      // exception escaping an OpenMP parallel block calls std::terminate.
+      const Array2DRef<float> in = r->getF32DataAsUncroppedArray2DRef();
+      __OMP_PARALLEL_FOR_CPP__(shared(in) firstprivate(height, width, buf, cpp))
       for(int j = 0; j < height; j++)
       {
-        const Array2DRef<float> in = r->getF32DataAsUncroppedArray2DRef();
         float *out = ((float *)buf) + (size_t)4 * j * width;
 
         for(int i = 0; i < width; i++, out += 4)


### PR DESCRIPTION
## Context

Defensive hardening prompted by Sentry issue [#129664611](https://aurelienpierreeng.sentry.io/issues/129664611/) — an `abort()` (`STATUS_FATAL_APP_EXIT`) on a worker thread during heavy thumbnail generation.

**Important caveat:** this is *not* a confirmed fix for that exact crash. The report is from a **self-build whose commit (`d6af87a`) is not in this repository**, the event has **no debug symbols / debug images**, and the crashed image took the regular (non-sraw) NEF path. What the report *does* show clearly is the signature **libansel → C++ runtime → `abort`**, i.e. `std::terminate` from an uncaught C++ exception during multithreaded raw work. This PR fixes a genuine latent instance of that class found while auditing.

## Bug

In `dt_imageio_open_rawspeed_sraw()`, the pixel-copy loops fetched the rawspeed image view from **inside** the OpenMP parallel region (and once per row):

```c
__OMP_PARALLEL_FOR_CPP__(shared(r) firstprivate(...))
for(int j = 0; j < height; j++)
{
  const Array2DRef<uint16_t> in = r->getU16DataAsUncroppedArray2DRef();  // can throw, inside OMP
  ...
}
```

Those rawspeed accessors can throw. An exception that escapes an OpenMP structured block is undefined behaviour — it does **not** unwind to the function's outer `try/catch`; it calls `std::terminate` → `abort`. (It's also wasteful to re-fetch the same view every row.)

## Fix

Hoist the accessor call into the surrounding serial region (which *is* covered by the `try/catch` in the caller) and share the resulting read-only `Array2DRef` view across threads. Applied to all four copy loops (uint16/float × mono/3-channel). Also removes the per-row redundant call.

## Sweep of other C++/OpenMP sites

Checked every non-rawspeed C++ file with OpenMP regions for throw-capable calls inside the parallel block:

- `iop/lens.cc` — calls lensfun `ApplyColorModification` / `ApplySubpixelGeometryDistortion` (non-throwing C-style API)
- `iop/tonemap.cc`, `iop/bilateral.cc`, `demosaic/amaze.cc` — use `dt_*` / `calloc` allocators that return `NULL` (don't throw)
- `imageio/format/exr.cc` — SIMD copy on the export path, no throwing calls

No changes needed there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)