### PR TITLE
Attach a locally-symbolicated backtrace to Sentry on Windows crashes

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -625,6 +625,7 @@ if(WIN32)
   target_link_libraries(ansel_deps INTERFACE
     psapi      # GetProcessMemoryInfo()
     exchndl    # exception handling / backtrace
+    dbghelp    # Sym*: locally symbolicated crash backtrace for Sentry
   )
 endif()
 

--- a/src/common/sentry.c
+++ b/src/common/sentry.c
@@ -43,6 +43,14 @@
 #include <unistd.h>     // for fork, getpid
 #endif
 
+#if defined(_WIN32)
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN // limit windows.h macro pollution next to GLib/GTK
+#endif
+#include <windows.h>
+#include <dbghelp.h>    // for Sym*, locally symbolicated backtrace
+#endif
+
 #ifndef SENTRY_DSN
 #define SENTRY_DSN ""
 #endif
@@ -181,6 +189,91 @@ static char *_sentry_capture_gdb_backtrace(gsize *len)
 }
 #endif // __linux__
 
+#if defined(_WIN32)
+// Resolve the short module name owning a given address (e.g. "libansel.dll").
+static void _sentry_module_name(DWORD64 addr, char *out, size_t out_len)
+{
+  g_strlcpy(out, "?", out_len);
+  HMODULE mod = NULL;
+  if(GetModuleHandleExA(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS
+                            | GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
+                        (LPCSTR)(uintptr_t)addr, &mod)
+     && mod)
+  {
+    char path[MAX_PATH];
+    if(GetModuleFileNameA(mod, path, sizeof(path)))
+    {
+      const char *base = strrchr(path, '\\');
+      g_strlcpy(out, base ? base + 1 : path, out_len);
+    }
+  }
+}
+
+// Capture the crashing thread's backtrace and symbolicate it locally with
+// DbgHelp. Mirrors the Linux gdb capture: returns a NUL-terminated buffer
+// (*len excludes the terminator) to attach to the crash report, or NULL on
+// failure. Local symbolication is the whole point on Windows: self-builds carry
+// matching .pdb files on the user's disk but never upload them to Sentry, so
+// without this their crashes arrive as bare addresses (see #129664611).
+static char *_sentry_capture_windows_backtrace(const sentry_ucontext_t *uctx, gsize *len)
+{
+  if(IS_NULL_PTR(uctx)) return NULL;
+
+  void *frames[128];
+  const size_t n = sentry_unwind_stack_from_ucontext(uctx, frames, 128);
+  if(n == 0) return NULL;
+
+  const HANDLE proc = GetCurrentProcess();
+  SymSetOptions(SYMOPT_DEFERRED_LOADS | SYMOPT_LOAD_LINES | SYMOPT_UNDNAME);
+  // May fail with ERROR_INVALID_PARAMETER if sentry already initialized the
+  // symbol handler for this process; symbols stay usable either way.
+  SymInitialize(proc, NULL, TRUE);
+
+  GString *out = g_string_new(NULL);
+  g_string_append_printf(out, "this is %s reporting a crash (local DbgHelp backtrace, crashing thread):\n\n",
+                         darktable_package_string);
+
+  // SYMBOL_INFO with room for the (undecorated) symbol name right after it.
+  char symbuf[sizeof(SYMBOL_INFO) + 512];
+  SYMBOL_INFO *sym = (SYMBOL_INFO *)symbuf;
+  memset(symbuf, 0, sizeof(symbuf));
+  sym->SizeOfStruct = sizeof(SYMBOL_INFO);
+  sym->MaxNameLen = 512;
+
+  for(size_t i = 0; i < n; i++)
+  {
+    const DWORD64 addr = (DWORD64)(uintptr_t)frames[i];
+
+    char modname[MAX_PATH];
+    _sentry_module_name(addr, modname, sizeof(modname));
+
+    const unsigned long long fno = (unsigned long long)i;
+    DWORD64 disp = 0;
+    if(SymFromAddr(proc, addr, &disp, sym))
+    {
+      DWORD line_disp = 0;
+      IMAGEHLP_LINE64 line;
+      memset(&line, 0, sizeof(line));
+      line.SizeOfStruct = sizeof(IMAGEHLP_LINE64);
+      if(SymGetLineFromAddr64(proc, addr, &line_disp, &line))
+        g_string_append_printf(out, "#%-2llu 0x%016llx  %s+0x%llx  (%s:%lu)  [%s]\n", fno,
+                               (unsigned long long)addr, sym->Name, (unsigned long long)disp,
+                               line.FileName, (unsigned long)line.LineNumber, modname);
+      else
+        g_string_append_printf(out, "#%-2llu 0x%016llx  %s+0x%llx  [%s]\n", fno, (unsigned long long)addr,
+                               sym->Name, (unsigned long long)disp, modname);
+    }
+    else
+    {
+      g_string_append_printf(out, "#%-2llu 0x%016llx  ?  [%s]\n", fno, (unsigned long long)addr, modname);
+    }
+  }
+
+  if(len) *len = out->len;
+  return g_string_free(out, FALSE);
+}
+#endif // _WIN32
+
 // on_crash replaces before_send for crash events (inproc). It runs before the
 // crash event/attachments are serialized, so this is where we both stamp the
 // session length and attach a full gdb backtrace to the report.
@@ -199,6 +292,17 @@ static sentry_value_t _sentry_on_crash(const sentry_ucontext_t *uctx, sentry_val
 
     // Tell the local signal handler (which runs next in the chain) not to run
     // gdb again for this same crash.
+    _sentry_backtrace_captured = 1;
+  }
+  g_free(bt);
+#elif defined(_WIN32)
+  gsize bt_len = 0;
+  char *bt = _sentry_capture_windows_backtrace(uctx, &bt_len);
+  if(bt && bt_len > 0)
+  {
+    sentry_attach_bytes(bt, bt_len, "windows-backtrace.txt");
+    // Tell the local exception filter (which runs next in the chain) not to
+    // pop its own backtrace dialog for this same crash.
     _sentry_backtrace_captured = 1;
   }
   g_free(bt);

--- a/src/common/system_signal_handling.c
+++ b/src/common/system_signal_handling.c
@@ -200,6 +200,12 @@ static int _times_handlers_were_set = 0;
 
 static LONG WINAPI dt_toplevel_exception_handler(PEXCEPTION_POINTERS pExceptionInfo)
 {
+  // Sentry's crash handler runs first and chains here. If it already captured a
+  // (locally symbolicated) backtrace attached to the crash report, don't write
+  // a second one nor pop the dialog; just pass the exception on.
+  if(dt_sentry_backtrace_captured())
+    return _dt_exceptionfilter_old_handler(pExceptionInfo);
+
   gchar *name_used;
   int fout;
   BOOL ok;


### PR DESCRIPTION
## Motivation

Follow-up to the missing-symbols problem behind [#129664611](https://aurelienpierreeng.sentry.io/issues/129664611/): a Windows **self-build** crash that arrived as bare addresses, with no way to root-cause it.

On **Linux**, the Sentry inproc `on_crash` hook already runs gdb and attaches a full backtrace (`gdb-backtrace.txt`), so crashes stay readable even when server-side symbols are missing. **Windows** had no equivalent — drmingw only wrote a local file + popped a dialog, and nothing was attached to the Sentry report. Self-builds keep their `.pdb` files locally but never upload them to Sentry, so their crashes are unsymbolicated and unactionable.

Note: official nightly builds already upload symbols (see `tools/sentry-upload-symbols.sh` wired into the nightly workflows), so they symbolicate server-side. This change specifically closes the **self-build** gap, where server-side symbols can never match.

## What this does

Adds a Windows branch to `_sentry_on_crash` that:

1. Unwinds the crashing thread with `sentry_unwind_stack_from_ucontext()` (sentry handles the `EXCEPTION_POINTERS` for us).
2. Symbolicates each frame **locally** with DbgHelp (`SymFromAddr` + `SymGetLineFromAddr64`), resolving `function+offset (file:line) [module.dll]`.
3. Attaches the text as `windows-backtrace.txt`, mirroring the Linux `gdb-backtrace.txt` flow.

Because symbolication is local, it uses the `.pdb` on the user's machine — so **self-builds become debuggable with zero symbol upload**.

It also sets the existing `_sentry_backtrace_captured` flag so the top-level drmingw exception filter skips its duplicate file/dialog (same pattern the Linux signal handler already uses).

## Changes

- `src/common/sentry.c` — `_sentry_capture_windows_backtrace()` + `_sentry_module_name()` helper; wired into `on_crash` under `#elif defined(_WIN32)`.
- `src/common/system_signal_handling.c` — `dt_toplevel_exception_handler` early-returns to the previous filter when `dt_sentry_backtrace_captured()`.
- `src/CMakeLists.txt` — link `dbghelp` on Windows.

## Caveats / testing

- All new code is guarded by `_WIN32`; the **Linux build is unchanged and compiles** (verified locally).
- I have **no Windows cross-compiler here**, so the Windows path is unbuilt locally — it needs the **win-nightly CI** (or a local Windows build) to confirm it compiles and produces a sensible attachment. Worth an explicit check that `windows.h`/`dbghelp.h` coexist with the GLib/GTK includes in this TU (guarded `WIN32_LEAN_AND_MEAN` added to reduce macro pollution).
- **Crashing thread only** for now (the Linux side does `thread apply all bt full`). All-threads walking on Windows needs thread enumeration + suspend/`StackWalk64`, which is riskier in a crash handler — left as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)