### PR TITLE
fix: serialize all exiv2/XMP toolkit access to stop concurrent-import crash

### DIFF
--- a/src/common/darktable.c
+++ b/src/common/darktable.c
@@ -521,7 +521,11 @@ int dt_init(int argc, char *argv[], const gboolean init_gui, const gboolean load
   pthread_mutexattr_settype(&recursive_locking, PTHREAD_MUTEX_RECURSIVE);
   dt_pthread_mutex_init(&(darktable.plugin_threadsafe), NULL);
   dt_pthread_mutex_init(&(darktable.capabilities_threadsafe), NULL);
-  dt_pthread_mutex_init(&(darktable.exiv2_threadsafe), NULL);
+  // exiv2 and the Adobe XMP toolkit keep process-global state and are not thread-safe; this mutex
+  // serializes all exiv2 access (src/common/exif.cc). Make it recursive so a public exif function can
+  // hold it across its whole critical section while inner helpers (read_metadata_threadsafe) or
+  // re-entrant calls (e.g. variable expansion that reads metadata) re-lock it without deadlocking.
+  dt_pthread_mutex_init(&(darktable.exiv2_threadsafe), &recursive_locking);
   dt_pthread_mutex_init(&(darktable.readFile_mutex), NULL);
   dt_pthread_mutex_init(&(darktable.pipeline_threadsafe), NULL);
   dt_pthread_rwlock_init(&(darktable.database_threadsafe), NULL);

--- a/src/common/exif.cc
+++ b/src/common/exif.cc
@@ -388,7 +388,7 @@ public:
 
 #define read_metadata_threadsafe(image)                       \
 {                                                             \
-  Lock lock;                                                  \
+  Lock exiv2_lock;                                            \
   image->readMetadata();                                      \
 }
 
@@ -1817,6 +1817,11 @@ int dt_exif_write_blob(uint8_t *blob, uint32_t size, const char *path, const int
 {
   try
   {
+    // Serialize the whole exiv2 region (read + write): writeMetadata() below re-enters the
+    // non-thread-safe exiv2/XMP toolkit, so it must not run concurrently with other exiv2 work.
+    // The mutex is recursive, so the nested read_metadata_threadsafe() re-locks harmlessly.
+    Lock lock;
+
     std::unique_ptr<Exiv2::Image> image(Exiv2::ImageFactory::open(WIDEN(path)));
     assert(image.get() != 0);
     read_metadata_threadsafe(image);
@@ -4117,6 +4122,10 @@ char *dt_exif_xmp_read_string(const int32_t imgid)
 {
   try
   {
+    // Serialize the non-thread-safe exiv2/XMP toolkit (XmpParser::decode()/encode() below) against
+    // all other exiv2 work. Recursive mutex, so nested helpers re-lock harmlessly.
+    Lock lock;
+
     char input_filename[PATH_MAX] = { 0 };
     gboolean from_cache = FALSE;
     dt_image_full_path(imgid,  input_filename,  sizeof(input_filename),  &from_cache, __FUNCTION__);
@@ -4243,6 +4252,13 @@ int dt_exif_xmp_attach_export(const int32_t imgid, const char *filename, void *m
   dt_export_metadata_t *m = (dt_export_metadata_t *)metadata;
   try
   {
+    // Serialize the whole exiv2 region: this function mixes readMetadata(), XmpParser::decode() and
+    // writeMetadata(), all of which touch the non-thread-safe exiv2/XMP toolkit and must not run
+    // concurrently with other exiv2 work. The mutex is recursive, so the nested
+    // read_metadata_threadsafe() calls (and any metadata read during variable expansion) re-lock
+    // harmlessly.
+    Lock lock;
+
     char input_filename[PATH_MAX] = { 0 };
     gboolean from_cache = TRUE;
     dt_image_full_path(imgid,  input_filename,  sizeof(input_filename),  &from_cache, __FUNCTION__);
@@ -4494,6 +4510,13 @@ int dt_exif_xmp_write_with_imgpath(const dt_image_t *image, const char *filename
 
   try
   {
+    // The Adobe XMP toolkit behind Exiv2::XmpParser::decode()/encode() keeps process-global
+    // state and is NOT thread-safe. Sidecar writes run on the worker thread pool, so several
+    // imports/writes can hit dt_exif_xmp_write_with_imgpath() at once (and race the locked
+    // readMetadata() in dt_exif_read()), corrupting the heap -> SIGABRT in free(). Serialize the
+    // whole exiv2 region on the same (recursive) mutex read_metadata_threadsafe() uses.
+    Lock lock;
+
     Exiv2::XmpData xmpData;
     std::string xmpPacket;
     char *checksum_old = NULL;


### PR DESCRIPTION
## Problem

[Sentry #129978857](https://aurelienpierreeng.sentry.io/issues/129978857/) — `SIGABRT` (heap corruption surfacing in `free()`) during import. Across all 3 events the gdb backtraces show **multiple worker threads inside the exiv2/XMP code at once** — in the linked event, four workers in `dt_exif_xmp_write_with_imgpath()` simultaneously, racing the locked `readMetadata()` in `dt_exif_read()`.

## Root cause

exiv2 and the Adobe XMP toolkit keep **process-global state and are not thread-safe**. Only `readMetadata()` was serialized (via the `read_metadata_threadsafe()` helper on `darktable.exiv2_threadsafe`). The other toolkit entry points — `XmpParser::decode()`/`encode()` and `writeMetadata()` — ran **unlocked**, so concurrent sidecar writes / exports (all run on the worker thread pool) corrupted the shared global state → abort.

## Fix

- Make `darktable.exiv2_threadsafe` **recursive**, so a public exif function can hold the lock across its whole critical section while inner helpers (`read_metadata_threadsafe`) or re-entrant calls (variable expansion that reads metadata) re-lock without deadlocking.
- Take the lock for the **full exiv2 region** in every function that mutates toolkit state:
  - `dt_exif_xmp_write_with_imgpath` — the crash site
  - `dt_exif_write_blob` — unlocked `writeMetadata()`
  - `dt_exif_xmp_read_string` — unlocked `XmpParser::decode/encode`
  - `dt_exif_xmp_attach_export` — unlocked `decode` + two `writeMetadata()` (export path)
- Rename the `read_metadata_threadsafe` macro's internal `Lock` variable to `exiv2_lock` to avoid `-Wshadow` now that callers hold an outer `Lock`.

Functions that only do `readMetadata()` followed by read-only `findKey` lookups (`dt_exif_read`, `dt_exif_get_thumbnail`, …) were already correctly serialized and are unchanged — read-only registry lookups are not the hazard.

## Testing

- `src/common/exif.cc` and `src/common/darktable.c` compile warning-free.
- Full project builds and links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)