### PR TITLE
fix: harden dt_iop_gui_init against gui->reset drift (NULL slider crash)

### DIFF
--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -1228,7 +1228,27 @@ void dt_iop_gui_set_enable_button(dt_iop_module_t *module)
 
 void dt_iop_gui_init(dt_iop_module_t *module)
 {
-  ++darktable.gui->reset;
+  // Suppress widget value-changed callbacks while we build the module GUI.
+  //
+  // A bare ++reset is not robust: darktable.gui->reset is a global suppression
+  // depth bumped with raw ++/-- in ~250 places, and an unbalanced bracket
+  // elsewhere (e.g. an early return, or a guard whose condition changed between
+  // the ++ and the --) can leave it *negative*. If it is -1 on entry, ++ yields
+  // 0 here and callbacks are NOT suppressed: a slider set in gui_init (e.g. a
+  // soft-range change) emits "value-changed", which re-enters the module's
+  // gui_changed handler before the rest of its widgets exist, and
+  // dt_bauhaus_slider_set(NULL) segfaults (Sentry #129494618, #129578628).
+  //
+  // Force a guaranteed-positive depth for the duration regardless of any prior
+  // imbalance, and on exit restore the previous value floored at 0 -- so a
+  // negative drift is healed here instead of silently persisting. A negative
+  // count is always a bug, so surface it in debug builds to help locate the leak.
+  const int reset_backup = darktable.gui->reset;
+  if(reset_backup < 0)
+    fprintf(stderr, "[dt_iop_gui_init] darktable.gui->reset drifted to %d before '%s' "
+                    "(unbalanced reset bracket somewhere); healing to 0.\n",
+            reset_backup, module->op);
+  darktable.gui->reset = MAX(reset_backup, 0) + 1;
 
   // Add the accelerators
   if(!dt_iop_is_hidden(module) && !(module->flags() & IOP_FLAGS_DEPRECATED))
@@ -1262,7 +1282,8 @@ void dt_iop_gui_init(dt_iop_module_t *module)
                                     G_CALLBACK(_iop_color_picker_data_ready_callback), module);
   }
 
-  --darktable.gui->reset;
+  // restore the previous depth, floored at 0 so a pre-existing negative drift is healed here
+  darktable.gui->reset = MAX(reset_backup, 0);
 }
 
 void dt_iop_reload_defaults(dt_iop_module_t *module)


### PR DESCRIPTION
## Problem

[Sentry #129494618](https://aurelienpierreeng.sentry.io/issues/129494618/) — `SIGSEGV` in `dt_bauhaus_slider_set` during a module's `gui_init`. All three events share one shape:

```
dt_bauhaus_slider_set            <- NULL widget deref
gui_changed                      (denoiseprofile / filmicrgb)
dt_bauhaus_value_changed_default_callback
dt_bauhaus_slider_set_normalized
dt_bauhaus_slider_set_soft_range
gui_init                         (module)
dt_iop_gui_init
enter (darkroom) ...
```

Setting a slider's soft range in `gui_init` emits `value-changed`, which re-enters the module's `gui_changed` **before its sibling widgets are created** (e.g. filmicrgb's `gui_changed` touches `g->white_point_source`/`g->black_point_source`, created a few lines later), so `dt_bauhaus_slider_set(NULL)` segfaults.

## Why it fired

`gui_changed` should never run during `gui_init`: `dt_iop_gui_init` brackets it with `++darktable.gui->reset`, and every value-changed callback early-returns while `reset` is nonzero. The crash means `reset` was **0** at that point — it had drifted **negative** before `dt_iop_gui_init`, so the bare `++` yielded `0` instead of a suppressing `>= 1`.

`darktable.gui->reset` is a global suppression depth bumped with raw `++`/`--` in ~250 places. A single unbalanced bracket (early return, or a guard whose condition changed between the `++` and the `--`) leaves it negative for the rest of the session (this one ran 5933s with 28 darkroom entries).

## Relationship to 86342c55e5

`86342c55e5` (already on master) stopped soft-bound setters from emitting `value-changed`, which breaks *this specific* chain — it explicitly names this issue. This PR fixes the **deeper cause** so the whole class is impossible regardless of the raise path (sliders *and* comboboxes), not just soft-bound sliders.

## Fix

In `dt_iop_gui_init`, force a guaranteed-positive suppression depth around `module->gui_init()` and restore the previous value **floored at 0**:

- callbacks are reliably suppressed during `gui_init` even if `reset` was negative on entry;
- a pre-existing negative drift is **healed** at each module init instead of persisting;
- a negative count is always a bug, so it's logged to help locate the offending unbalanced bracket.

Normal (balanced) and nested cases are unchanged: the guards only test truthiness, and nested brackets still apply relative `++`/`--`.

## Testing

- `src/develop/imageop.c` compiles warning-free; full project builds and links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)