### PR TITLE
fix: local_laplacian crash on allocation failure (goto over initializer)

### DIFF
--- a/src/common/locallaplacian.c
+++ b/src/common/locallaplacian.c
@@ -370,7 +370,14 @@ int local_laplacian_internal(
   const int max_supp = 1<<last_level;
   int w, h;
   int err = 0;
+  // All pyramid buffer arrays must be declared and zero-initialized up here, before any
+  // `goto error`. The error path frees padded[]/output[]/buf[][]; if output/buf were declared
+  // further down (past an early `goto error` from a failed padded[] allocation), the goto would
+  // skip their `= {0}` initializers, leaving indeterminate pointers that the cleanup then frees
+  // -> SIGSEGV under memory pressure when an allocation fails (Sentry #129715026).
   float *padded[max_levels] = {0};
+  float *output[max_levels] = {0};
+  float *buf[num_gamma][max_levels] = {{0}};
   if(b && b->mode == 2)
     padded[0] = ll_pad_input(input, wd, ht, max_supp, &w, &h, b);
   else
@@ -392,8 +399,7 @@ int local_laplacian_internal(
     }
   }
 
-  // allocate pyramid pointers for output
-  float *output[max_levels] = {0};
+  // allocate pyramid pointers for output (declared at the top of the function)
   for(int l=0;l<=last_level;l++)
   {
     output[l] = dt_pixelpipe_cache_alloc_align_float_cache((size_t)dl(w,l) * dl(h,l), 0);
@@ -414,8 +420,7 @@ int local_laplacian_internal(
   for(int k=0;k<num_gamma;k++) gamma[k] = (k+.5f)/(float)num_gamma;
   // for(int k=0;k<num_gamma;k++) gamma[k] = k/(num_gamma-1.0f);
 
-  // allocate memory for intermediate laplacian pyramids
-  float *buf[num_gamma][max_levels] = {{0}};
+  // allocate memory for intermediate laplacian pyramids (declared at the top of the function)
   for(int k=0;k<num_gamma;k++) for(int l=0;l<=last_level;l++)
   {
     buf[k][l] = dt_pixelpipe_cache_alloc_align_float_cache((size_t)dl(w,l)*dl(h,l), 0);


### PR DESCRIPTION
## Problem

[Sentry #129715026](https://aurelienpierreeng.sentry.io/issues/129715026/) — `SIGSEGV` inside `local_laplacian_internal`, reached from bilat's `process` (CPU path, `opencl=no`) on a long session (~98 min) under memory pressure (~15 GB RAM). The symbolicated frames point at the inlined `local_laplacian` wrapper ([locallaplacian.h:80](src/common/locallaplacian.h#L80)) → `process` ([bilat.c:351](src/iop/bilat.c#L351)), with the actual fault in libansel below it.

## Root cause — `goto` over a variable initializer

`local_laplacian_internal` declares its pyramid buffer arrays at different points in the function:

- `padded[]` at the top;
- `output[]` ~20 lines down (after the `padded[0]`/`padded[l]` allocation checks);
- `buf[][]` further down still.

There are several `goto error` sites that fire *before* `output[]`/`buf[][]` are declared — when `ll_pad_input()` returns NULL, or a `padded[l]` cache allocation fails. Because these are fixed-size arrays (`max_levels`/`num_gamma` are macros), jumping over their `= {0}` declarations **compiles**, but the initializer never runs, so `output[]` and `buf[][]` hold **indeterminate values**.

The `error:` cleanup then frees them:

```c
dt_pixelpipe_cache_free_align(output[l]);
... dt_pixelpipe_cache_free_align(buf[k][l]);
```

→ freeing garbage pointers → segfault. This triggers precisely when an allocation **fails** (low memory / cache budget exhausted), which is consistent with the long-running, no-OpenCL, memory-pressured session in the report.

## Fix

Declare and zero-initialize `padded[]`, `output[]` and `buf[][]` together at the top of the function, before any `goto error`. The cleanup then always frees valid pointers (NULL for untouched levels, live buffers otherwise). The normal (no-failure) path is unchanged.

The OpenCL variant (`locallaplaciancl.c`) keeps its buffers in a heap-allocated struct, not jumped-over stack locals, so it is not affected.

## Testing

- `src/common/locallaplacian.c` compiles warning-free; full project builds and links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)