### PR TITLE
fix: rawprepare use-after-free on DNG GainMaps (own a pipe-local copy)

### DIFF
--- a/src/iop/rawprepare.c
+++ b/src/iop/rawprepare.c
@@ -788,6 +788,16 @@ gboolean check_gain_maps(dt_iop_module_t *self, dt_dng_gain_map_t **gainmaps_out
   return TRUE;
 }
 
+// Free the pipe-owned deep copies of the GainMaps held in piece->data (see commit_params).
+static void _free_owned_gainmaps(dt_iop_rawprepare_data_t *d)
+{
+  for(int i = 0; i < 4; i++)
+  {
+    g_free(d->gainmaps[i]);
+    d->gainmaps[i] = NULL;
+  }
+}
+
 void commit_params(dt_iop_module_t *self, dt_iop_params_t *params, dt_dev_pixelpipe_t *pipe,
                    dt_dev_pixelpipe_iop_t *piece)
 {
@@ -840,10 +850,37 @@ void commit_params(dt_iop_module_t *self, dt_iop_params_t *params, dt_dev_pixelp
   piece->dsc_out.rawprepare.raw_white_point = d->rawprepare.raw_white_point;
   for(int k = 0; k < 4; k++) piece->dsc_out.processed_maximum[k] = 1.0f;
 
+  // check_gain_maps() returns pointers into image_storage.dng_gain_maps, which is a shallow copy
+  // borrowed from the image cache (see _dt_dev_refresh_image_storage): the cache lock is dropped
+  // immediately, so that list can be freed/rebuilt (e.g. eviction under thumbnail-generation
+  // pressure) before process() dereferences it -> use-after-free crash (Sentry #129880848).
+  // Keep a private, pipe-owned deep copy that lives for the lifetime of the pixelpipe piece.
+  _free_owned_gainmaps(d);
+  d->apply_gainmaps = FALSE;
   if(p->flat_field == FLAT_FIELD_EMBEDDED)
-    d->apply_gainmaps = check_gain_maps(self, d->gainmaps);
-  else
-    d->apply_gainmaps = FALSE;
+  {
+    dt_dng_gain_map_t *src[4] = { 0 };
+    if(check_gain_maps(self, src))
+    {
+      gboolean copied = TRUE;
+      for(int i = 0; i < 4; i++)
+      {
+        // map_planes == 1 is enforced by check_gain_maps(), so the gain payload is
+        // map_points_h * map_points_v floats -- exactly what process() indexes.
+        const size_t sz = sizeof(dt_dng_gain_map_t)
+                          + (size_t)src[i]->map_points_h * src[i]->map_points_v * sizeof(float);
+        d->gainmaps[i] = g_malloc(sz);
+        if(d->gainmaps[i])
+          memcpy(d->gainmaps[i], src[i], sz);
+        else
+          copied = FALSE;
+      }
+      if(copied)
+        d->apply_gainmaps = TRUE;
+      else
+        _free_owned_gainmaps(d); // partial copy (OOM): drop everything, don't apply
+    }
+  }
 
   if(image_set_rawcrops(pipe->dev->image_storage.id, d->x + d->width, d->y + d->height))
     DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_METADATA_UPDATE);
@@ -868,6 +905,8 @@ void init_pipe(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe
 
 void cleanup_pipe(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
 {
+  dt_iop_rawprepare_data_t *d = (dt_iop_rawprepare_data_t *)piece->data;
+  if(d) _free_owned_gainmaps(d);
   dt_free_align(piece->data);
   piece->data = NULL;
 }

--- a/src/iop/rawprepare.c
+++ b/src/iop/rawprepare.c
@@ -798,6 +798,35 @@ static void _free_owned_gainmaps(dt_iop_rawprepare_data_t *d)
   }
 }
 
+// Build pipe-owned deep copies of the image's GainMaps into d->gainmaps[]. The pointers from
+// check_gain_maps() borrow image_storage.dng_gain_maps, which is a shallow copy of cache-owned
+// memory with the cache lock already dropped (see _dt_dev_refresh_image_storage): it can be
+// freed/rebuilt (e.g. eviction under thumbnail-generation pressure) before process() reads it
+// -> use-after-free (Sentry #129880848). Owning a private copy decouples us from the cache.
+// Caller must have freed/NULLed d->gainmaps[] first. Returns TRUE only if all four were copied.
+static gboolean _own_gainmaps(dt_iop_module_t *self, dt_iop_rawprepare_data_t *d)
+{
+  dt_dng_gain_map_t *src[4] = { 0 };
+  if(!check_gain_maps(self, src))
+    return FALSE;
+
+  for(int i = 0; i < 4; i++)
+  {
+    // map_planes == 1 is enforced by check_gain_maps(), so the gain payload is
+    // map_points_h * map_points_v floats -- exactly what process() indexes.
+    const size_t sz = sizeof(dt_dng_gain_map_t)
+                      + (size_t)src[i]->map_points_h * src[i]->map_points_v * sizeof(float);
+    d->gainmaps[i] = g_malloc(sz);
+    if(IS_NULL_PTR(d->gainmaps[i]))
+    {
+      _free_owned_gainmaps(d); // partial copy (OOM): drop everything, don't apply
+      return FALSE;
+    }
+    memcpy(d->gainmaps[i], src[i], sz);
+  }
+  return TRUE;
+}
+
 void commit_params(dt_iop_module_t *self, dt_iop_params_t *params, dt_dev_pixelpipe_t *pipe,
                    dt_dev_pixelpipe_iop_t *piece)
 {
@@ -850,37 +879,10 @@ void commit_params(dt_iop_module_t *self, dt_iop_params_t *params, dt_dev_pixelp
   piece->dsc_out.rawprepare.raw_white_point = d->rawprepare.raw_white_point;
   for(int k = 0; k < 4; k++) piece->dsc_out.processed_maximum[k] = 1.0f;
 
-  // check_gain_maps() returns pointers into image_storage.dng_gain_maps, which is a shallow copy
-  // borrowed from the image cache (see _dt_dev_refresh_image_storage): the cache lock is dropped
-  // immediately, so that list can be freed/rebuilt (e.g. eviction under thumbnail-generation
-  // pressure) before process() dereferences it -> use-after-free crash (Sentry #129880848).
-  // Keep a private, pipe-owned deep copy that lives for the lifetime of the pixelpipe piece.
+  // Refresh our private, pipe-owned copy of the GainMaps (see _own_gainmaps() for why we must own
+  // them rather than borrow image_storage.dng_gain_maps). Free the previous copy in all cases.
   _free_owned_gainmaps(d);
-  d->apply_gainmaps = FALSE;
-  if(p->flat_field == FLAT_FIELD_EMBEDDED)
-  {
-    dt_dng_gain_map_t *src[4] = { 0 };
-    if(check_gain_maps(self, src))
-    {
-      gboolean copied = TRUE;
-      for(int i = 0; i < 4; i++)
-      {
-        // map_planes == 1 is enforced by check_gain_maps(), so the gain payload is
-        // map_points_h * map_points_v floats -- exactly what process() indexes.
-        const size_t sz = sizeof(dt_dng_gain_map_t)
-                          + (size_t)src[i]->map_points_h * src[i]->map_points_v * sizeof(float);
-        d->gainmaps[i] = g_malloc(sz);
-        if(d->gainmaps[i])
-          memcpy(d->gainmaps[i], src[i], sz);
-        else
-          copied = FALSE;
-      }
-      if(copied)
-        d->apply_gainmaps = TRUE;
-      else
-        _free_owned_gainmaps(d); // partial copy (OOM): drop everything, don't apply
-    }
-  }
+  d->apply_gainmaps = (p->flat_field == FLAT_FIELD_EMBEDDED) && _own_gainmaps(self, d);
 
   if(image_set_rawcrops(pipe->dev->image_storage.id, d->x + d->width, d->y + d->height))
     DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_METADATA_UPDATE);


### PR DESCRIPTION
## Problem

[Sentry #129880848](https://aurelienpierreeng.sentry.io/issues/129880848/) — `SIGSEGV` in `rawprepare`'s `process` (`process.omp_outlined.15`, dispatched by libomp) while generating a **thumbnail** for a **DNG that carries GainMaps** (`opencl=no`, CPU path; folder browse, `images_processed=6`).

Of the four OpenMP regions in `process`, only the GainMap one (the `d->apply_gainmaps` block) dereferences pointer chains (`d->gainmaps[f]->map_gain[...]`); the other three only touch plain arrays in `d`. `BL()` masks its result to `[0,3]`, so the `map_row0[id]` index is safe — the fault is a bad `d->gainmaps[f]` pointer.

## Root cause — borrowed pointer into cache-owned memory, lock dropped

- `commit_params()` stores into `piece->data` the pointers returned by `check_gain_maps()`, which point into `dev->image_storage.dng_gain_maps`.
- `dev->image_storage` is a **shallow** copy: [`_dt_dev_refresh_image_storage()`](src/develop/develop.c#L837) does `dev->image_storage = *image` and then **immediately releases the cache read lock**. The `dng_gain_maps` list and its `dt_dng_gain_map_t` payloads remain **owned by the image cache**, with no lock held for the pipe's lifetime.
- Under thumbnail-generation pressure the cache can evict/rebuild that image (`dt_image_cache_deallocate` → `g_list_free_full(img->dng_gain_maps, …)`), leaving `d->gainmaps[]` **dangling**. `process()`/`process_cl()` then dereference freed memory → crash.

## Fix

Give the pixelpipe piece its **own deep copy** of the four GainMaps:

- `commit_params()` frees any previous copy, then `g_malloc`s and `memcpy`s each validated map (size `sizeof(dt_dng_gain_map_t) + map_points_h*map_points_v*float`, exact because `check_gain_maps()` enforces `map_planes == 1`) into `d->gainmaps[]`. Only sets `apply_gainmaps = TRUE` if all four copies succeed.
- `cleanup_pipe()` frees the owned copies.

Processing now never depends on cache-owned memory. `rawprepare` is the only consumer of `dng_gain_maps`, so this fully closes the dangling-pointer window for both the CPU and OpenCL paths.

## Testing

- `rawprepare.c` compiles warning-free; full project builds and links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)