### PR TITLE
gpx: fix double free

### DIFF
--- a/src/common/gpx.c
+++ b/src/common/gpx.c
@@ -382,10 +382,12 @@ void _gpx_parser_end_element(GMarkupParseContext *context, const gchar *element_
     }
     else if(strcmp(element_name, "trkpt") == 0)
     {
-      if(!gpx->invalid_track_point)
+      if(!gpx->invalid_track_point) {
         gpx->trkpts = g_list_prepend(gpx->trkpts, gpx->current_track_point);
-      else
+        gpx->current_track_point = NULL;
+      } else {
         dt_free(gpx->current_track_point);
+      }
 
     }
     else if(strcmp(element_name, "trkseg") == 0)


### PR DESCRIPTION
Ansel crashes when a GPX file is previewed or applied for geotagging.

There are a lot of log lines before the crash saying:
`broken GPX file, new trkpt element before the previous ended.`

and the backtrace is:
```
Thread 1 "ansel" received signal SIGABRT, Aborted.
__pthread_kill_implementation (no_tid=0, signo=6, threadid=140737234194688) at ./nptl/pthread_kill.c:44
44	./nptl/pthread_kill.c: No such file or directory.
(gdb) bt
#0  __pthread_kill_implementation (no_tid=0, signo=6, threadid=140737234194688) at ./nptl/pthread_kill.c:44
#1  __pthread_kill_internal (signo=6, threadid=140737234194688) at ./nptl/pthread_kill.c:78
#2  __GI___pthread_kill (threadid=140737234194688, signo=signo@entry=6) at ./nptl/pthread_kill.c:89
#3  0x00007ffff7442476 in __GI_raise (sig=sig@entry=6) at ../sysdeps/posix/raise.c:26
#4  0x00007ffff74287f3 in __GI_abort () at ./stdlib/abort.c:79
#5  0x00007ffff7489677 in __libc_message (action=action@entry=do_abort, fmt=fmt@entry=0x7ffff75dbb77 "%s\n") at ../sysdeps/posix/libc_fatal.c:156
#6  0x00007ffff74a0cfc in malloc_printerr (str=str@entry=0x7ffff75de6f0 "free(): double free detected in tcache 2") at ./malloc/malloc.c:5666
#7  0x00007ffff74a30ab in _int_free (av=0x7ffff761ac80 <main_arena>, p=0x555558135f60, have_lock=0) at ./malloc/malloc.c:4473
#8  0x00007ffff74a5453 in __GI___libc_free (mem=<optimized out>) at ./malloc/malloc.c:3391
#9  0x00007ffff53b1f80 in g_list_foreach () at /lib/x86_64-linux-gnu/libglib-2.0.so.0
#10 0x00007ffff53b246f in g_list_free_full () at /lib/x86_64-linux-gnu/libglib-2.0.so.0
#11 0x00007ffff793c9e1 in dt_gpx_destroy (gpx=<optimized out>, gpx=0x555557eab940) at /home/tbilles/sources/ansel/src/common/gpx.c:158
#12 0x00007ffd47e607a1 in _preview_gpx_file (self=0x5555574d9480, widget=0x555557eb0450) at /home/tbilles/sources/ansel/src/libs/geotagging.c:899
#13 _choose_gpx_callback (widget=<optimized out>, self=0x5555574d9480) at /home/tbilles/sources/ansel/src/libs/geotagging.c:984
#14 0x00007ffff54cf700 in g_signal_emit_valist () at /lib/x86_64-linux-gnu/libgobject-2.0.so.0
#15 0x00007ffff54cf863 in g_signal_emit () at /lib/x86_64-linux-gnu/libgobject-2.0.so.0
#16 0x00007ffff593dab0 in  () at /lib/x86_64-linux-gnu/libgtk-3.so.0
#17 0x00007ffff54cf700 in g_signal_emit_valist () at /lib/x86_64-linux-gnu/libgobject-2.0.so.0
#18 0x00007ffff54cf863 in g_signal_emit () at /lib/x86_64-linux-gnu/libgobject-2.0.so.0
#19 0x00007ffff593d884 in  () at /lib/x86_64-linux-gnu/libgtk-3.so.0
#20 0x00007ffff5bf0bf5 in  () at /lib/x86_64-linux-gnu/libgtk-3.so.0
#21 0x00007ffff54cf700 in g_signal_emit_valist () at /lib/x86_64-linux-gnu/libgobject-2.0.so.0
#22 0x00007ffff54cf863 in g_signal_emit () at /lib/x86_64-linux-gnu/libgobject-2.0.so.0
#23 0x00007ffff5a07ffc in  () at /lib/x86_64-linux-gnu/libgtk-3.so.0
#24 0x00007ffff54b6866 in g_cclosure_marshal_VOID__BOXEDv () at /lib/x86_64-linux-gnu/libgobject-2.0.so.0
#25 0x00007ffff54cf700 in g_signal_emit_valist () at /lib/x86_64-linux-gnu/libgobject-2.0.so.0
#26 0x00007ffff54cf863 in g_signal_emit () at /lib/x86_64-linux-gnu/libgobject-2.0.so.0
#27 0x00007ffff59ffacb in  () at /lib/x86_64-linux-gnu/libgtk-3.so.0
#28 0x00007ffff5a0783b in  () at /lib/x86_64-linux-gnu/libgtk-3.so.0
#29 0x00007ffff5a08443 in  () at /lib/x86_64-linux-gnu/libgtk-3.so.0
#30 0x00007ffff59cefa0 in gtk_event_controller_handle_event () at /lib/x86_64-linux-gnu/libgtk-3.so.0
#31 0x00007ffff5ba0055 in  () at /lib/x86_64-linux-gnu/libgtk-3.so.0
#32 0x00007ffff5be6ec8 in  () at /lib/x86_64-linux-gnu/libgtk-3.so.0
#33 0x00007ffff54cf700 in g_signal_emit_valist () at /lib/x86_64-linux-gnu/libgobject-2.0.so.0
#34 0x00007ffff54cf863 in g_signal_emit () at /lib/x86_64-linux-gnu/libgobject-2.0.so.0
#35 0x00007ffff5bae734 in  () at /lib/x86_64-linux-gnu/libgtk-3.so.0
#36 0x00007ffff5a516b0 in  () at /lib/x86_64-linux-gnu/libgtk-3.so.0
#37 0x00007ffff5a5255a in gtk_main_do_event () at /lib/x86_64-linux-gnu/libgtk-3.so.0
#38 0x00007ffff6132743 in  () at /lib/x86_64-linux-gnu/libgdk-3.so.0
#39 0x00007ffff6169f56 in  () at /lib/x86_64-linux-gnu/libgdk-3.so.0
#40 0x00007ffff53b7d3b in g_main_context_dispatch () at /lib/x86_64-linux-gnu/libglib-2.0.so.0
#41 0x00007ffff540d488 in  () at /lib/x86_64-linux-gnu/libglib-2.0.so.0
#42 0x00007ffff53b72b3 in g_main_loop_run () at /lib/x86_64-linux-gnu/libglib-2.0.so.0
#43 0x00007ffff5a48d2d in gtk_main () at /lib/x86_64-linux-gnu/libgtk-3.so.0
#44 0x00007ffff7b39d91 in dt_gui_gtk_run(dt_gui_gtk_t*) (gui=<optimized out>) at /home/tbilles/sources/ansel/src/gui/gtk.c:1368
#45 0x00005555555550d3 in main (argc=<optimized out>, argv=<optimized out>) at /home/tbilles/sources/ansel/src/main.c:106
```

The problem seems to be a double free. When the end tag for a trkpt is processed that trkpt data is saved to a list of trkpts, but the current_track_point pointer is not NULL-ed. So at the start of the next trkpt tag, the code assumes there was no end tag, and (probably to avoid memleaks) frees current_track_point. So now the trkpts list contains a pointer to an already freed memory, which then leads to either a use-after-free or a double free.

The fix is to properly "close" current_track_point.