### PR TITLE
build: scope static CMake flag probes

### DIFF
--- a/cmake/march-mtune.cmake
+++ b/cmake/march-mtune.cmake
@@ -1,5 +1,10 @@
-# Make Windows behave like Mac and Linux regarding flag support detection
-set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)
+# Make Windows behave like Mac and Linux regarding flag support detection.
+# Avoid linking while checking compiler flags, but keep this setting local to
+# each probe so it does not affect unrelated CMake checks.
+function(_check_c_compiler_flag flag result)
+  set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)
+  CHECK_C_COMPILER_FLAG("${flag}" "${result}")
+endfunction()
 
 # -----------------------------------------------------------------------------
 # Detect Apple universal builds (multiple archs)
@@ -34,7 +39,7 @@ if(NOT BINARY_PACKAGE_BUILD AND NOT DT_APPLE_UNIVERSAL_BUILD)
   # ---------------------------------------------------------------------------
   if(APPLE AND CMAKE_C_COMPILER_ID STREQUAL "AppleClang")
 
-    CHECK_C_COMPILER_FLAG("-mcpu=native" HAS_MCPU_NATIVE)
+    _check_c_compiler_flag("-mcpu=native" HAS_MCPU_NATIVE)
     if(HAS_MCPU_NATIVE)
       set(MARCH "-mcpu=native")
       add_definitions("-DNATIVE_ARCH")
@@ -59,7 +64,7 @@ else()
 
   if(DT_IS_X86)
     # Our baseline is Intel Sandy Bridge / AMD Bulldozer arch (~2011)
-    CHECK_C_COMPILER_FLAG("-march=x86-64-v2" HAS_X86_V2)
+    _check_c_compiler_flag("-march=x86-64-v2" HAS_X86_V2)
     if(HAS_X86_V2)
       set(MARCH "-march=x86-64-v2 -mtune=core-avx2")
     else()

--- a/src/external/CMakeLists.txt
+++ b/src/external/CMakeLists.txt
@@ -132,15 +132,6 @@ if(USE_SENTRY)
   set(SENTRY_BUILD_EXAMPLES OFF CACHE BOOL "" FORCE)
   set(BUILD_SHARED_LIBS OFF)
 
-  # sentry derives SIZEOF_LONG via check_type_size("long"); on the Windows
-  # clang/UCRT64 toolchain that check can come back empty, which expands to
-  # "SIZEOF_LONG=" and breaks "#if SIZEOF_LONG == 8" in sentry_sync.h. On every
-  # Windows ABI (LLP64) long is 4 bytes, so pre-seed the cache to skip the check.
-  if(WIN32)
-    set(HAVE_CMAKE_SIZEOF_LONG TRUE CACHE INTERNAL "" FORCE)
-    set(CMAKE_SIZEOF_LONG 4 CACHE INTERNAL "" FORCE)
-  endif()
-
   add_subdirectory(sentry-native)
 
   set(BUILD_SHARED_LIBS "${_SENTRY_SHARED_SAVE}")


### PR DESCRIPTION
Keep `CMAKE_TRY_COMPILE_TARGET_TYPE=STATIC_LIBRARY` limited to the CPU compiler flag checks in `march-mtune.cmake` so it does not affect [type-size detection](https://cmake.org/cmake/help/latest/module/CheckTypeSize.html) elsewhere in the project tree.

Solves: getsentry/sentry-native#1810