### PR TITLE
LUT gamut mapping

### DIFF
--- a/src/common/colorspaces.c
+++ b/src/common/colorspaces.c
@@ -329,6 +329,69 @@ int dt_colorspaces_get_matrix_from_output_profile(cmsHPROFILE prof, dt_colormatr
   return dt_colorspaces_get_matrix_from_profile(prof, matrix, lutr, lutg, lutb, lutsize, 0);
 }
 
+int dt_colorspaces_get_approximate_matrix_from_profile(cmsHPROFILE prof, dt_colormatrix_t matrix_in,
+                                                        dt_colormatrix_t matrix_out)
+{
+  if(IS_NULL_PTR(prof)) return 1;
+
+  cmsHPROFILE xyz_profile = cmsCreateXYZProfile();
+  if(IS_NULL_PTR(xyz_profile)) return 1;
+
+  // relative colorimetric: we only care about the primaries' direction, not about
+  // any deliberate whitepoint rescaling an absolute intent would add.
+  cmsHTRANSFORM transform = cmsCreateTransform(prof, TYPE_RGB_DBL, xyz_profile, TYPE_XYZ_DBL,
+                                               INTENT_RELATIVE_COLORIMETRIC,
+                                               cmsFLAGS_NOCACHE | cmsFLAGS_NOOPTIMIZE);
+  cmsCloseProfile(xyz_profile);
+  if(IS_NULL_PTR(transform)) return 1;
+
+  // evaluate the profile's actual (possibly non-linear, LUT-based) transform at the pure
+  // primaries, and treat the resulting XYZ as if they were colorant tags of an equivalent
+  // matrix-shaper profile. This ignores the profile's real per-channel/cross-channel
+  // response, so it is only a gamut-shape approximation, never an accurate conversion.
+  const double rgb_primaries[3][3] = { { 1.0, 0.0, 0.0 }, { 0.0, 1.0, 0.0 }, { 0.0, 0.0, 1.0 } };
+  double xyz[3][3];
+  cmsDoTransform(transform, rgb_primaries, xyz, 3);
+  cmsDeleteTransform(transform);
+
+  dt_colormatrix_t matrix_tmp = { { xyz[0][0], xyz[1][0], xyz[2][0] },
+                                  { xyz[0][1], xyz[1][1], xyz[2][1] },
+                                  { xyz[0][2], xyz[1][2], xyz[2][2] } };
+
+  // some pathological profiles evaluate to all-zero primaries
+  float sum = 0.0f;
+  for(int k1 = 0; k1 < 3; k1++)
+    for(int k2 = 0; k2 < 3; k2++)
+      sum += matrix_tmp[k1][k2];
+  if(sum == 0.0f) return 1;
+
+  // The primaries as actually rendered by the profile do not, in general, sum to its white
+  // point the way true additive RGB primaries would: mixing full R+G+B ink on paper is nowhere
+  // near paper white, since ink is a subtractive, non-additive process. Every consumer of
+  // matrix_in/matrix_out relies on the additive invariant RGB(1,1,1) <-> XYZ(white) (it is what
+  // "target_white"/normalized chroma mean downstream); left unscaled, matrix_tmp violates it and
+  // silently sends legitimate colors far outside [0, 1], collapsing gamut-mapping consumers to a
+  // flat, clipped color. Rescale each primary column so R+G+B lands exactly on the profile's PCS
+  // white point instead - the same chromaticities+white-point construction real matrix-shaper
+  // profiles use (see _compute_prequantized_primaries() above).
+  dt_colormatrix_t matrix_tmp_inv;
+  if(mat3SSEinv(matrix_tmp_inv, matrix_tmp)) return 1;
+
+  const cmsCIEXYZ *const white_pt = cmsD50_XYZ();
+  const dt_aligned_pixel_t white_xyz = { (float)white_pt->X, (float)white_pt->Y, (float)white_pt->Z, 0.f };
+  dt_aligned_pixel_t scale;
+  dot_product(white_xyz, matrix_tmp_inv, scale);
+
+  for(int row = 0; row < 3; row++)
+    for(int col = 0; col < 3; col++)
+      matrix_tmp[row][col] *= scale[col];
+
+  memcpy(matrix_in, matrix_tmp, sizeof(dt_colormatrix_t));
+  if(mat3SSEinv(matrix_out, matrix_tmp)) return 1;
+
+  return 0;
+}
+
 static cmsHPROFILE dt_colorspaces_create_lab_profile()
 {
   return cmsCreateLab4Profile(cmsD50_xyY());

--- a/src/common/colorspaces.h
+++ b/src/common/colorspaces.h
@@ -271,6 +271,15 @@ int dt_colorspaces_get_matrix_from_input_profile(cmsHPROFILE prof, dt_colormatri
 int dt_colorspaces_get_matrix_from_output_profile(cmsHPROFILE prof, dt_colormatrix_t matrix, float *lutr, float *lutg,
                                                   float *lutb, const int lutsize);
 
+/** approximate a profile-to-XYZ (and its inverse) matrix by evaluating pure primaries and white
+ * through the profile's actual transform. Unlike dt_colorspaces_get_matrix_from_*_profile(), this
+ * works on any RGB profile, including LUT-only ones (cmsIsMatrixShaper() == FALSE) such as printer
+ * profiles, at the cost of ignoring the profile's real (nonlinear, cross-channel) behavior. Only
+ * fit for heuristics that need a gamut *shape* (e.g. filmic's soft-proof gamut mapping), never for
+ * an actual color conversion. Returns 0 on success. */
+int dt_colorspaces_get_approximate_matrix_from_profile(cmsHPROFILE prof, dt_colormatrix_t matrix_in,
+                                                        dt_colormatrix_t matrix_out);
+
 /** wrapper to get the name from a color profile. this tries to handle character encodings. */
 void dt_colorspaces_get_profile_name(cmsHPROFILE p, const char *language, const char *country, char *name,
                                      size_t len);

--- a/src/common/iop_profile.c
+++ b/src/common/iop_profile.c
@@ -61,6 +61,8 @@ static inline __attribute__((always_inline)) void _mark_as_nonmatrix_profile(dt_
   profile_info->matrix_in_transposed[0][0] = NAN;
   profile_info->matrix_out[0][0] = NAN;
   profile_info->matrix_out_transposed[0][0] = NAN;
+  profile_info->matrix_in_approx[0][0] = NAN;
+  profile_info->matrix_out_approx[0][0] = NAN;
 }
 
 __DT_CLONE_TARGETS__
@@ -674,6 +676,16 @@ static int dt_ioppr_generate_profile_info(dt_iop_order_iccprofile_info_t *profil
     {
       transpose_3xSSE(profile_info->matrix_in, profile_info->matrix_in_transposed);
       transpose_3xSSE(profile_info->matrix_out, profile_info->matrix_out_transposed);
+    }
+
+    if(isnan(profile_info->matrix_in[0][0]))
+    {
+      // exact matrix-shaper extraction failed (typically a LUT-only profile, e.g. a printer
+      // profile) - approximate a gamut shape for heuristics that don't need an accurate
+      // conversion (filmic's soft-proof gamut mapping). matrix_in/matrix_out themselves stay
+      // NAN, so every other consumer keeps taking the accurate lcms2 path.
+      dt_colorspaces_get_approximate_matrix_from_profile(rgb_profile, profile_info->matrix_in_approx,
+                                                          profile_info->matrix_out_approx);
     }
   }
 

--- a/src/common/iop_profile.h
+++ b/src/common/iop_profile.h
@@ -55,6 +55,11 @@ typedef struct dt_iop_order_iccprofile_info_t
   dt_iop_color_intent_t intent;
   dt_colormatrix_t matrix_in; // don't align on more than 16 bits or OpenCL will fail
   dt_colormatrix_t matrix_out;
+  // gamut-shape approximation of matrix_in/matrix_out (see dt_colorspaces_get_approximate_matrix_from_profile()),
+  // populated only when the profile has no exact matrix (matrix_in/matrix_out are NAN), e.g. LUT-only ICC
+  // profiles such as printer profiles. NAN when unavailable. Never use for an actual color conversion.
+  dt_colormatrix_t matrix_in_approx;
+  dt_colormatrix_t matrix_out_approx;
   int lutsize;
   float *lut_in[3];
   float *lut_out[3];

--- a/src/iop/filmicrgb.c
+++ b/src/iop/filmicrgb.c
@@ -2017,16 +2017,24 @@ static inline __attribute__((always_inline)) int filmic_v4_prepare_matrices(dt_c
   dt_colormatrix_mul(temp_matrix, XYZ_D65_to_D50_CAT16, LMS_2006_D65_to_XYZ_D65);
   dt_colormatrix_mul(output_matrix, work_profile->matrix_out, temp_matrix);
 
-  // If the pipeline output profile is supported (matrix profile), we gamut map against it
-  const int use_output_profile = (!IS_NULL_PTR(export_profile));
+  // If the pipeline output profile is supported (matrix profile, exact or approximated), we
+  // gamut map against it. LUT-only profiles (typically printer profiles) have no exact matrix;
+  // fall back to the gamut-shape approximation computed in dt_ioppr_generate_profile_info().
+  const int has_exact_matrix = !IS_NULL_PTR(export_profile) && !isnan(export_profile->matrix_in[0][0]);
+  const int has_approx_matrix = !IS_NULL_PTR(export_profile) && !isnan(export_profile->matrix_in_approx[0][0]);
+  const int use_output_profile = has_exact_matrix || has_approx_matrix;
+
   if(use_output_profile)
   {
+    const float (*const matrix_out_src)[4] = has_exact_matrix ? export_profile->matrix_out : export_profile->matrix_out_approx;
+    const float (*const matrix_in_src)[4] = has_exact_matrix ? export_profile->matrix_in : export_profile->matrix_in_approx;
+
     // Prepare the LMS 2006 -> XYZ D65 -> XYZ D50 -> output RGB (D50) matrix
     dt_colormatrix_mul(temp_matrix, XYZ_D65_to_D50_CAT16, LMS_2006_D65_to_XYZ_D65);
-    dt_colormatrix_mul(export_output_matrix, export_profile->matrix_out, temp_matrix);
+    dt_colormatrix_mul(export_output_matrix, matrix_out_src, temp_matrix);
 
     // Prepare the output RGB (D50) -> XYZ D50 -> XYZ D65 -> LMS 2006 matrix
-    dt_colormatrix_mul(temp_matrix, XYZ_D50_to_D65_CAT16, export_profile->matrix_in);
+    dt_colormatrix_mul(temp_matrix, XYZ_D50_to_D65_CAT16, matrix_in_src);
     dt_colormatrix_mul(export_input_matrix, XYZ_D65_to_LMS_2006_D65, temp_matrix);
   }
 
@@ -2616,11 +2624,14 @@ static const dt_iop_order_iccprofile_info_t *_filmic_get_output_profile(const dt
         darktable.color_profiles->softproof_intent);
     // LUT-only (non matrix-shaper) profiles - typical of printer/inkjet ICC profiles - are
     // flagged by NAN matrices. The gamut-mapping code below only knows how to use 3x3
-    // matrices, so using a NAN one silently poisons the whole image with NaN pixels. Fall
-    // back to the pipe output profile in that case; the actual soft-proof color conversion
-    // still happens correctly downstream, in colorout, which supports full lcms2 transforms.
-    if(!IS_NULL_PTR(softproof_profile) && !isnan(softproof_profile->matrix_in[0][0])
-       && !isnan(softproof_profile->matrix_out[0][0]))
+    // matrices, so using a NAN one would silently poison the whole image with NaN pixels.
+    // filmic_v4_prepare_matrices() falls back to matrix_in_approx/matrix_out_approx (a gamut
+    // shape approximation, see dt_colorspaces_get_approximate_matrix_from_profile()) when the
+    // exact matrix is unavailable, and disables output-profile gamut mapping entirely only if
+    // that approximation itself failed. The actual soft-proof color conversion always happens
+    // correctly downstream, in colorout, which supports full lcms2 transforms either way.
+    if(!IS_NULL_PTR(softproof_profile)
+       && (!isnan(softproof_profile->matrix_in[0][0]) || !isnan(softproof_profile->matrix_in_approx[0][0])))
       return softproof_profile;
   }
   return dt_ioppr_get_pipe_output_profile_info(pipe);


### PR DESCRIPTION

## filmicrgb: soft-proof gamut mapping against LUT-only (printer) profiles

Filmic's internal gamut mapping (`gamut_mapping_simd`/`clip_chroma` in `iop/filmicrgb.c`) needs a
3x3 matrix to convert between its internal Ych space and the soft-proof target profile's RGB, so
it can desaturate highlights that would otherwise clip in that profile's gamut. Matrix-shaper
profiles (sRGB, AdobeRGB) provide this directly via `matrix_in`/`matrix_out`
(`dt_iop_order_iccprofile_info_t`). LUT-only profiles — virtually all real printer/inkjet ICC
profiles — have none (`dt_ioppr_generate_profile_info()` in `common/iop_profile.c` leaves
`matrix_in[0][0]` as `NAN` for them); `colorout` handles those fine via a full lcms2 transform, but
filmic's fast SIMD gamut-mapping path has no equivalent.

`dt_colorspaces_get_approximate_matrix_from_profile()` (`common/colorspaces.c`) fills this gap by
evaluating the profile's actual transform at the pure primaries and treating the resulting XYZ as
colorant tags, same idea as `dt_colorspaces_get_matrix_from_profile()` but working from the real
(rendering-intent) transform instead of colorant tags that don't exist on a LUT profile. The result
is stored in `dt_iop_order_iccprofile_info_t.matrix_in_approx`/`matrix_out_approx`, populated only
when `matrix_in`/`matrix_out` are `NAN`, leaving those two untouched — every other consumer in the
codebase keeps taking the accurate lcms2 path via the existing `isnan()` checks; only
`filmic_v4_prepare_matrices()` falls back to the `_approx` pair when the exact one is unavailable.

**The white-point invariant is mandatory, not optional.** A first version used the primaries' raw
XYZ directly. It compiled, inverted cleanly (determinant far from singular), and still made the
entire image collapse to a flat, saturated color the moment a real printer profile was used as
soft-proof target — sRGB/AdobeRGB (matrix-shaper) targets were unaffected. Root cause: real ink
primaries don't sum to the profile's white point the way display RGB primaries do (mixing full
R+G+B ink is nowhere near paper white — ink is subtractive, not additive), so the unscaled matrix
violates the invariant every consumer of `matrix_in`/`matrix_out` assumes: RGB `(1,1,1)` maps to
XYZ *white*. `clip_chroma()`'s `target_white` parameter is calibrated against exactly that
assumption; breaking it sends legitimate mid-tones far outside `[0, target_white]`, and the final
hard `CLAMP` in `gamut_check_RGB_simd()` collapses them to a shared boundary value. The fix rescales
each primary column so R+G+B lands exactly on the profile's PCS white point (`cmsD50_XYZ()`) before
inverting — the same chromaticities+white-point construction real matrix-shaper profiles use
(mirrors `_compute_prequantized_primaries()` in the same file). This is not a numerical-precision
issue (float32 handles the ~0.01 determinant involved without trouble) — an arbitrarily precise
matrix built from unnormalized primaries is still structurally wrong for this use.