### PR TITLE
masks: add a Progression falloff exponent to all 5 drawn-mask shapes

### DIFF
--- a/src/develop/masks.h
+++ b/src/develop/masks.h
@@ -123,7 +123,7 @@ GList darktable.develop->forms
 extern "C" {
 #endif
 
-#define DEVELOP_MASKS_VERSION (6)
+#define DEVELOP_MASKS_VERSION (7)
 
 /**forms types */
 typedef enum dt_masks_type_t
@@ -233,6 +233,7 @@ typedef struct dt_masks_node_circle_t
   float center[2]; // point in normalized input space
   float radius;
   float border;
+  float gamma; // falloff shaping exponent between the shape and the outer border edge; 1.0 = unchanged
 } dt_masks_node_circle_t;
 
 /** structure used to store 1 node for an ellipse */
@@ -243,6 +244,7 @@ typedef struct dt_masks_node_ellipse_t
   float rotation;
   float border;
   dt_masks_ellipse_flags_t flags;
+  float gamma; // falloff shaping exponent between the shape and the outer border edge; 1.0 = unchanged
 } dt_masks_node_ellipse_t;
 
 /** structure used to store 1 node for a path form */
@@ -253,6 +255,7 @@ typedef struct dt_masks_node_polygon_t
   float ctrl2[2];
   float border[2];
   dt_masks_points_states_t state;
+  float gamma; // falloff shaping exponent between the shape and the outer border edge; 1.0 = unchanged
 } dt_masks_node_polygon_t;
 
 /** structure used to store 1 node for a brush form */
@@ -265,6 +268,7 @@ typedef struct dt_masks_node_brush_t
   float density;
   float hardness;
   dt_masks_points_states_t state;
+  float gamma; // falloff shaping exponent between the shape and the outer border edge; 1.0 = unchanged
 } dt_masks_node_brush_t;
 
 /** structure used to store anchor for a gradient */
@@ -273,7 +277,8 @@ typedef struct dt_masks_anchor_gradient_t
   float center[2];
   float rotation;
   float extent;
-  float steepness;
+  float gamma; // falloff shaping exponent between the shape and the outer border edge; 1.0 = unchanged
+                // (formerly the unused "steepness" field; same offset, repurposed)
   float curvature;
   dt_masks_gradient_states_t state;
 } dt_masks_anchor_gradient_t;
@@ -305,6 +310,7 @@ typedef enum dt_masks_interaction_t
   DT_MASKS_INTERACTION_SIZE = 1,     // property of the form (shape), explicit
   DT_MASKS_INTERACTION_HARDNESS = 2, // property of the form (shape), explicit
   DT_MASKS_INTERACTION_OPACITY = 3,  // property of the group in which the form is included, explicit
+  DT_MASKS_INTERACTION_GAMMA = 4,    // property of the form (shape), explicit
   DT_MASKS_INTERACTION_LAST
 } dt_masks_interaction_t;
 
@@ -490,9 +496,10 @@ typedef struct dt_masks_form_gui_t
   gboolean border_selected;
   gboolean source_selected;
   gboolean pivot_selected;
+  gboolean gamma_handle_hovered; // cursor is near the on-canvas gamma falloff handle (circle/ellipse/gradient)
 
   int group_selected;
-  
+
   int source_pos_type;
 
   gboolean form_dragging;
@@ -500,6 +507,7 @@ typedef struct dt_masks_form_gui_t
   gboolean form_rotating;
   gboolean border_toggling;
   gboolean gradient_toggling;
+  gboolean gamma_dragging; // dragging the on-canvas gamma falloff handle
   int node_dragging;
   int handle_dragging;
   int seg_dragging;
@@ -643,6 +651,29 @@ static inline void dt_masks_gui_delta_from_raw_anchor(dt_develop_t *dev, const d
   dt_masks_gui_delta_to_raw_norm(dev, gui, point);
   *delta_x = point[0] - anchor[0];
   *delta_y = point[1] - anchor[1];
+}
+
+// Circle/ellipse falloff formula: mask = f^(2*gamma), f = clip((total_r^2-l^2)/(total_r^2-inner_r^2)),
+// l = radial distance from center. Returns the normalized linear position t in [0,1] between
+// inner_r (t=0, shape edge) and total_r (t=1, outer border edge) where the falloff crosses 50%
+// opacity, for the on-canvas gamma handle to sit at.
+static inline float dt_masks_gamma_to_t_quadratic(const float gamma, const float inner_r, const float total_r)
+{
+  if(total_r <= inner_r) return 0.0f;
+  const float f = powf(0.5f, 1.0f / (2.0f * gamma));
+  const float l2 = sqf(total_r) - f * (sqf(total_r) - sqf(inner_r));
+  const float l = sqrtf(fmaxf(l2, 0.0f));
+  return CLAMPF((l - inner_r) / (total_r - inner_r), 0.0f, 1.0f);
+}
+
+// Inverse of dt_masks_gamma_to_t_quadratic: given the handle's linear position t in [0,1], returns gamma.
+static inline float dt_masks_t_to_gamma_quadratic(const float t, const float inner_r, const float total_r)
+{
+  const float l = inner_r + CLAMPF(t, 0.0f, 1.0f) * (total_r - inner_r);
+  const float denom = sqf(total_r) - sqf(inner_r);
+  if(denom <= 0.0f) return 1.0f;
+  const float f = CLAMPF((sqf(total_r) - sqf(l)) / denom, 1e-4f, 1.0f - 1e-4f);
+  return logf(0.5f) / (2.0f * logf(f));
 }
 
 // Clone and spot forms share the same default presets, while regular drawn masks use their own.
@@ -918,6 +949,24 @@ int dt_masks_copy_used_forms_for_module(dt_develop_t *dev_dest, dt_develop_t *de
                                         const struct dt_iop_module_t *mod_src);
 /** return the mask manager module instance if present */
 struct dt_iop_module_t *dt_masks_get_mask_manager(struct dt_develop_t *dev);
+
+// post_expose() callbacks only receive `gui`/`index`, not the concrete shape form being drawn.
+// dt_masks_get_visible_form() may return a wrapping DT_MASKS_GROUP instead of the shape itself
+// (groups store a GList of dt_masks_form_group_t {formid,...} entries, not raw shape points), so
+// resolve through the same by-formid lookup dt_group_events_post_expose() uses internally.
+static inline dt_masks_form_t *dt_masks_get_drawn_form(int index)
+{
+  dt_masks_form_t *visible_form = dt_masks_get_visible_form(darktable.develop);
+  if(IS_NULL_PTR(visible_form)) return NULL;
+  if(visible_form->type & DT_MASKS_GROUP)
+  {
+    const dt_masks_form_group_t *entry
+        = (const dt_masks_form_group_t *)g_list_nth_data(visible_form->points, index);
+    if(IS_NULL_PTR(entry)) return NULL;
+    return dt_masks_get_from_id(darktable.develop, entry->formid);
+  }
+  return visible_form;
+}
 
 /** read the forms from the db */
 void dt_masks_read_masks_history(dt_develop_t *dev, const int32_t imgid);

--- a/src/develop/masks/brush.c
+++ b/src/develop/masks/brush.c
@@ -49,6 +49,9 @@
 #define HARDNESS_MIN 0.00001f
 #define HARDNESS_MAX 1.0f
 
+#define GAMMA_MIN 0.1f
+#define GAMMA_MAX 10.0f
+
 #define BORDER_MIN 0.00005f
 #define BORDER_MAX 0.5f
 
@@ -175,6 +178,7 @@ static GList *_brush_ramer_douglas_peucker(const float *point_buffer, int point_
     first_node->hardness = payload_buffer[1];
     first_node->density = payload_buffer[2];
     first_node->state = DT_MASKS_POINT_STATE_NORMAL;
+    first_node->gamma = 1.0f;
     result_list = g_list_append(result_list, (gpointer)first_node);
 
     dt_masks_node_brush_t *last_node = malloc(sizeof(dt_masks_node_brush_t));
@@ -185,6 +189,7 @@ static GList *_brush_ramer_douglas_peucker(const float *point_buffer, int point_
     last_node->hardness = payload_buffer[(point_count - 1) * 4 + 1];
     last_node->density = payload_buffer[(point_count - 1) * 4 + 2];
     last_node->state = DT_MASKS_POINT_STATE_NORMAL;
+    last_node->gamma = 1.0f;
     result_list = g_list_append(result_list, (gpointer)last_node);
   }
 
@@ -1381,6 +1386,21 @@ static float _brush_get_interaction_value(const dt_masks_form_t *mask_form, dt_m
 
       return hardness_count > 0 ? hardness_sum / (float)hardness_count : NAN;
     }
+    case DT_MASKS_INTERACTION_GAMMA:
+    {
+      float gamma_sum = 0.0f;
+      int gamma_count = 0;
+
+      for(const GList *point_node = mask_form->points; point_node; point_node = g_list_next(point_node))
+      {
+        const dt_masks_node_brush_t *node = (const dt_masks_node_brush_t *)point_node->data;
+        if(IS_NULL_PTR(node)) continue;
+        gamma_sum += node->gamma;
+        gamma_count++;
+      }
+
+      return gamma_count > 0 ? gamma_sum / (float)gamma_count : NAN;
+    }
     default:
       return NAN;
   }
@@ -1417,6 +1437,9 @@ static int _change_hardness(dt_masks_form_t *mask_form, int parentid, dt_masks_f
 static int _change_size(dt_masks_form_t *mask_form, int parentid, dt_masks_form_gui_t *mask_gui,
                         struct dt_iop_module_t *module, int index, const float amount,
                         const dt_masks_increment_t increment, const int flow);
+static int _change_gamma(dt_masks_form_t *mask_form, int parentid, dt_masks_form_gui_t *mask_gui,
+                         struct dt_iop_module_t *module, int index, const float amount,
+                         const dt_masks_increment_t increment, const int flow);
 
 static float _brush_set_interaction_value(dt_masks_form_t *mask_form, dt_masks_interaction_t interaction, float value,
                                           dt_masks_increment_t increment, int flow,
@@ -1432,6 +1455,9 @@ static float _brush_set_interaction_value(dt_masks_form_t *mask_form, dt_masks_i
       return _brush_get_interaction_value(mask_form, interaction);
     case DT_MASKS_INTERACTION_HARDNESS:
       if(!_change_hardness(mask_form, 0, mask_gui, module, index, value, increment, flow)) return NAN;
+      return _brush_get_interaction_value(mask_form, interaction);
+    case DT_MASKS_INTERACTION_GAMMA:
+      if(!_change_gamma(mask_form, 0, mask_gui, module, index, value, increment, flow)) return NAN;
       return _brush_get_interaction_value(mask_form, interaction);
     default:
       return NAN;
@@ -1460,6 +1486,29 @@ static int _change_hardness(dt_masks_form_t *mask_form, int parentid, dt_masks_f
   }
 
   dt_masks_get_set_conf_value(mask_form, "hardness", result_amount, HARDNESS_MIN, HARDNESS_MAX, increment, flow);
+
+  // we recreate the form points
+  dt_masks_gui_form_create(mask_form, mask_gui, index, module);
+
+  return 1;
+}
+
+static int _change_gamma(dt_masks_form_t *mask_form, int parentid, dt_masks_form_gui_t *mask_gui,
+                         struct dt_iop_module_t *module, int index, const float amount,
+                         const dt_masks_increment_t increment, const int flow)
+{
+  if(IS_NULL_PTR(mask_form) || IS_NULL_PTR(mask_form->points)) return 0;
+  int node_index = 0;
+  for(GList *node_entry = mask_form->points; node_entry; node_entry = g_list_next(node_entry), node_index++)
+  {
+    if(dt_masks_gui_change_affects_selected_node_or_all(mask_gui, node_index))
+    {
+      dt_masks_node_brush_t *node = (dt_masks_node_brush_t *)node_entry->data;
+      if(!node) continue;
+      node->gamma = CLAMPF(dt_masks_apply_increment(node->gamma, amount, increment, flow),
+                           GAMMA_MIN, GAMMA_MAX);
+    }
+  }
 
   // we recreate the form points
   dt_masks_gui_form_create(mask_form, mask_gui, index, module);
@@ -1613,6 +1662,7 @@ static void _add_node_to_segment(struct dt_iop_module_t *module, dt_masks_form_t
   new_node->border[1] = point0->border[1] * (1.0f - t) + point1->border[1] * t;
   new_node->hardness = point0->hardness * (1.0f - t) + point1->hardness * t;
   new_node->density = point0->density * (1.0f - t) + point1->density * t;
+  new_node->gamma = point0->gamma * (1.0f - t) + point1->gamma * t;
 
   mask_form->points = g_list_insert(mask_form->points, new_node, selected_segment + 1);
   _brush_init_ctrl_points(mask_form);
@@ -2686,7 +2736,8 @@ static int _brush_get_area(const dt_iop_module_t *const module, dt_dev_pixelpipe
 
 /** we write a falloff segment */
 static void _brush_falloff(float *const restrict buffer, int segment_start[2], int segment_end[2],
-                           int offset_x, int offset_y, int buffer_width, float hardness, float density)
+                           int offset_x, int offset_y, int buffer_width, float hardness, float density,
+                           const float gamma)
 {
   // segment length
   const int segment_length = sqrt((segment_end[0] - segment_start[0]) * (segment_end[0] - segment_start[0])
@@ -2705,7 +2756,7 @@ static void _brush_falloff(float *const restrict buffer, int segment_start[2], i
     // position
     const int x = (int)((float)step * segment_dx * inv_length) + segment_start[0] - offset_x;
     const int y = (int)((float)step * segment_dy * inv_length) + segment_start[1] - offset_y;
-    const float opacity = density * ((step <= solid_length) ? 1.0f : 1.0f - (float)(step - solid_length) * inv_soft);
+    const float opacity = density * ((step <= solid_length) ? 1.0f : powf(1.0f - (float)(step - solid_length) * inv_soft, gamma));
     const int buffer_index = y * buffer_width + x;
     buffer[buffer_index] = MAX(buffer[buffer_index], opacity);
     if(x > 0)
@@ -2784,6 +2835,7 @@ static int _brush_get_mask(const dt_iop_module_t *const module, dt_dev_pixelpipe
   memset(*buffer, 0, sizeof(float) * buffer_size);
 
   // now we fill the falloff
+  const float gamma = ((dt_masks_node_brush_t *)mask_form->points->data)->gamma;
   int segment_start[2], segment_end[2];
   int prev_start[2] = { 0, 0 };
   int prev_end[2] = { 0, 0 };
@@ -2812,12 +2864,12 @@ static int _brush_get_mask(const dt_iop_module_t *const module, dt_dev_pixelpipe
                               (int)floorf(prev_end[1] + t * (segment_end[1] - prev_end[1]) + 0.5f) };
         const float hard = prev_payload[0] + t * (payload[border_index * 2] - prev_payload[0]);
         const float dens = prev_payload[1] + t * (payload[border_index * 2 + 1] - prev_payload[1]);
-        _brush_falloff(*buffer, interp_start, interp_end, *offset_x, *offset_y, *width, hard, dens);
+        _brush_falloff(*buffer, interp_start, interp_end, *offset_x, *offset_y, *width, hard, dens, gamma);
       }
     }
 
     _brush_falloff(*buffer, segment_start, segment_end, *offset_x, *offset_y, *width,
-                   payload[border_index * 2], payload[border_index * 2 + 1]);
+                   payload[border_index * 2], payload[border_index * 2 + 1], gamma);
 
     prev_start[0] = segment_start[0];
     prev_start[1] = segment_start[1];
@@ -2841,13 +2893,16 @@ static int _brush_get_mask(const dt_iop_module_t *const module, dt_dev_pixelpipe
 
 /** we write a falloff segment respecting limits of buffer */
 static inline void _brush_falloff_roi(float *buffer, const int *segment_start, const int *segment_end,
-                                      int buffer_width, int buffer_height, float hardness, float density)
+                                      int buffer_width, int buffer_height, float hardness, float density,
+                                      const float gamma)
 {
   // segment length (increase by 1 to avoid division-by-zero special case handling)
   const int segment_length = sqrt((segment_end[0] - segment_start[0]) * (segment_end[0] - segment_start[0])
                                   + (segment_end[1] - segment_start[1]) * (segment_end[1] - segment_start[1]))
                              + 1;
   const int solid_length = hardness * segment_length;
+  const int soft_length = segment_length - solid_length;
+  const float inv_soft = (soft_length > 0) ? 1.0f / (float)soft_length : 0.0f;
 
   const float step_x = (float)(segment_end[0] - segment_start[0]) / (float)segment_length;
   const float step_y = (float)(segment_end[1] - segment_start[1]) / (float)segment_length;
@@ -2859,9 +2914,6 @@ static inline void _brush_falloff_roi(float *buffer, const int *segment_start, c
 
   float cursor_x = segment_start[0];
   float cursor_y = segment_start[1];
-
-  float opacity = density;
-  const float opacity_step = density / (float)(segment_length - solid_length);
 
   const int start_x = segment_start[0], start_y = segment_start[1];
   const int end_x = segment_end[0], end_y = segment_end[1];
@@ -2879,7 +2931,8 @@ static inline void _brush_falloff_roi(float *buffer, const int *segment_start, c
 
     cursor_x += step_x;
     cursor_y += step_y;
-    if(step > solid_length) opacity -= opacity_step;
+    const float opacity = density * ((step <= solid_length) ? 1.0f
+                                     : powf(1.0f - (float)(step - solid_length) * inv_soft, gamma));
 
     if(!fully_inside && (x < 0 || x >= buffer_width || y < 0 || y >= buffer_height)) continue;
 
@@ -2989,6 +3042,7 @@ static int _brush_get_mask_roi(const dt_iop_module_t *const module, dt_dev_pixel
   }
 
   // now we fill the falloff
+  const float gamma = ((dt_masks_node_brush_t *)mask_form->points->data)->gamma;
   if(!use_sparse)
   {
     __OMP_PARALLEL_FOR__(if(border_count - node_count * 3 > 1000))
@@ -3004,7 +3058,7 @@ static int _brush_get_mask_roi(const dt_iop_module_t *const module, dt_dev_pixel
         continue;
 
       _brush_falloff_roi(buffer, segment_start, segment_end, roi_width, roi_height, payload[border_index * 2],
-                         payload[border_index * 2 + 1]);
+                         payload[border_index * 2 + 1], gamma);
     }
   }
   else
@@ -3036,7 +3090,7 @@ static int _brush_get_mask_roi(const dt_iop_module_t *const module, dt_dev_pixel
           {
             const float hard = prev_payload[0] + t * (payload[border_index * 2] - prev_payload[0]);
             const float dens = prev_payload[1] + t * (payload[border_index * 2 + 1] - prev_payload[1]);
-            _brush_falloff_roi(buffer, interp_start, interp_end, roi_width, roi_height, hard, dens);
+            _brush_falloff_roi(buffer, interp_start, interp_end, roi_width, roi_height, hard, dens, gamma);
           }
         }
       }
@@ -3045,7 +3099,7 @@ static int _brush_get_mask_roi(const dt_iop_module_t *const module, dt_dev_pixel
            || MAX(segment_start[1], segment_end[1]) < 0
            || MIN(segment_start[1], segment_end[1]) >= roi_height))
         _brush_falloff_roi(buffer, segment_start, segment_end, roi_width, roi_height,
-                           payload[border_index * 2], payload[border_index * 2 + 1]);
+                           payload[border_index * 2], payload[border_index * 2 + 1], gamma);
 
       prev_start[0] = segment_start[0];
       prev_start[1] = segment_start[1];

--- a/src/develop/masks/circle.c
+++ b/src/develop/masks/circle.c
@@ -45,6 +45,9 @@
 #define HARDNESS_MIN 0.0005f
 #define HARDNESS_MAX 1.0f
 
+#define GAMMA_MIN 0.1f
+#define GAMMA_MAX 10.0f
+
 #define BORDER_MIN 0.00005f
 #define BORDER_MAX 0.5f
 
@@ -106,10 +109,56 @@ static void _circle_distance_cb(float pointer_x, float pointer_y, float cursor_r
                        inside_border, near, inside_source, dist);
 }
 
+/**
+ * @brief Locate the shape-edge point, border-edge point and gamma handle point along the
+ * "north" radial line (straight up from center), in the same absolute screen space as
+ * gpt->points/gpt->border.
+ */
+static gboolean _circle_gamma_handle_points(const dt_masks_form_gui_points_t *gpt,
+                                            const dt_masks_node_circle_t *circle,
+                                            float edge[2], float border_pt[2], float handle[2])
+{
+  const int l_shape = gpt->points_count - 1;
+  const int l_border = gpt->border_count - 1;
+  if(l_shape <= 0 || l_border <= 0) return FALSE;
+
+  // sample index for angle = 3*pi/2 ("north", since alpha = (i-1)*2*pi/l)
+  const int idx_shape = CLAMP((int)roundf(3.0f * l_shape / 4.0f) + 1, 1, l_shape);
+  const int idx_border = CLAMP((int)roundf(3.0f * l_border / 4.0f) + 1, 1, l_border);
+
+  edge[0] = gpt->points[idx_shape * 2];
+  edge[1] = gpt->points[idx_shape * 2 + 1];
+  border_pt[0] = gpt->border[idx_border * 2];
+  border_pt[1] = gpt->border[idx_border * 2 + 1];
+
+  const float t = dt_masks_gamma_to_t_quadratic(circle->gamma, circle->radius, circle->radius + circle->border);
+  handle[0] = edge[0] + t * (border_pt[0] - edge[0]);
+  handle[1] = edge[1] + t * (border_pt[1] - edge[1]);
+  return TRUE;
+}
+
 static int _find_closest_handle(dt_masks_form_t *mask_form, dt_masks_form_gui_t *mask_gui, int form_index)
 {
-  return dt_masks_find_closest_handle_common(mask_form, mask_gui, form_index, 0,
-                                             NULL, NULL, NULL, _circle_distance_cb, NULL, NULL);
+  const int result = dt_masks_find_closest_handle_common(mask_form, mask_gui, form_index, 0,
+                                                          NULL, NULL, NULL, _circle_distance_cb, NULL, NULL);
+
+  mask_gui->gamma_handle_hovered = FALSE;
+  if(!mask_gui->creation && mask_gui->group_selected == form_index && mask_gui->node_dragging < 0
+     && !mask_gui->form_dragging && !mask_gui->source_dragging && !mask_gui->gamma_dragging)
+  {
+    const dt_masks_node_circle_t *circle = (const dt_masks_node_circle_t *)mask_form->points->data;
+    const dt_masks_form_gui_points_t *gpt
+        = (const dt_masks_form_gui_points_t *)g_list_nth_data(mask_gui->points, form_index);
+    float edge[2], border_pt[2], handle[2];
+    if(circle && gpt && _circle_gamma_handle_points(gpt, circle, edge, border_pt, handle)
+       && dt_masks_point_is_within_radius(mask_gui->pos[0], mask_gui->pos[1], handle[0], handle[1],
+                                          sqf(DT_GUI_MOUSE_EFFECT_RADIUS)))
+    {
+      mask_gui->gamma_handle_hovered = TRUE;
+    }
+  }
+
+  return result;
 }
 
 static void _circle_get_creation_values(const dt_masks_form_t *form, float *radius, float *border)
@@ -125,6 +174,7 @@ static void _circle_init_new(dt_masks_form_t *form, dt_masks_form_gui_t *gui, dt
 {
   dt_masks_gui_cursor_to_raw_norm(darktable.develop, gui, circle->center);
   _circle_get_creation_values(form, &circle->radius, &circle->border);
+  circle->gamma = 1.0f;
 
   if(dt_masks_form_is_clone(form))
     dt_masks_set_source_pos_initial_value(gui, form);
@@ -213,6 +263,8 @@ static float _circle_get_interaction_value(const dt_masks_form_t *form, dt_masks
       return circle->radius;
     case DT_MASKS_INTERACTION_HARDNESS:
       return circle->border;
+    case DT_MASKS_INTERACTION_GAMMA:
+      return circle->gamma;
     default:
       return NAN;
   }
@@ -233,6 +285,8 @@ static int _change_hardness(dt_masks_form_t *form, dt_masks_form_gui_t *gui, str
                             int index, const float amount, const dt_masks_increment_t increment, const int flow);
 static int _change_size(dt_masks_form_t *form, dt_masks_form_gui_t *gui, struct dt_iop_module_t *module,
                         int index, const float amount, const dt_masks_increment_t increment, const int flow);
+static int _change_gamma(dt_masks_form_t *form, dt_masks_form_gui_t *gui, struct dt_iop_module_t *module,
+                         int index, const float amount, const dt_masks_increment_t increment, const int flow);
 
 static float _circle_set_interaction_value(dt_masks_form_t *form, dt_masks_interaction_t interaction, float value,
                                            dt_masks_increment_t increment, int flow,
@@ -249,6 +303,9 @@ static float _circle_set_interaction_value(dt_masks_form_t *form, dt_masks_inter
     case DT_MASKS_INTERACTION_HARDNESS:
       if(!_change_hardness(form, gui, module, index, value, increment, flow)) return NAN;
       return _circle_get_interaction_value(form, interaction);
+    case DT_MASKS_INTERACTION_GAMMA:
+      if(!_change_gamma(form, gui, module, index, value, increment, flow)) return NAN;
+      return _circle_get_interaction_value(form, interaction);
     default:
       return NAN;
   }
@@ -264,6 +321,21 @@ static int _change_hardness(dt_masks_form_t *form, dt_masks_form_gui_t *gui, str
                           HARDNESS_MIN, HARDNESS_MAX);
 
   _init_hardness(form, amount, increment, flow);
+
+  // we recreate the form points
+  dt_masks_gui_form_create(form, gui, index, module);
+
+  return 1;
+}
+
+static int _change_gamma(dt_masks_form_t *form, dt_masks_form_gui_t *gui, struct dt_iop_module_t *module, int index, const float amount, const dt_masks_increment_t increment, const int flow)
+{
+  if(IS_NULL_PTR(form) || IS_NULL_PTR(form->points)) return 0;
+  dt_masks_node_circle_t *circle = (dt_masks_node_circle_t *)(form->points)->data;
+  if(IS_NULL_PTR(circle)) return 0;
+
+  circle->gamma = CLAMPF(dt_masks_apply_increment(circle->gamma, amount, increment, flow),
+                         GAMMA_MIN, GAMMA_MAX);
 
   // we recreate the form points
   dt_masks_gui_form_create(form, gui, index, module);
@@ -361,7 +433,13 @@ static int _circle_events_button_pressed(struct dt_iop_module_t *module, double 
       dt_masks_form_gui_points_t *gpt = (dt_masks_form_gui_points_t *)g_list_nth_data(gui->points, index);
       if(IS_NULL_PTR(gpt)) return 0;
 
-      if(gui->source_selected && gui->edit_mode == DT_MASKS_EDIT_FULL)
+      if(gui->gamma_handle_hovered && gui->edit_mode == DT_MASKS_EDIT_FULL)
+      {
+        // we start dragging the gamma falloff handle
+        gui->gamma_dragging = TRUE;
+        return 1;
+      }
+      else if(gui->source_selected && gui->edit_mode == DT_MASKS_EDIT_FULL)
       {
         // we start the source dragging
         gui->delta[0] = gpt->source[0] - gui->pos[0];
@@ -403,6 +481,12 @@ static int _circle_events_button_released(struct dt_iop_module_t *module, double
   }
   else if(gui->source_dragging)
   {
+    return 1;
+  }
+  else if(gui->gamma_dragging)
+  {
+    // we end the gamma handle dragging
+    gui->gamma_dragging = FALSE;
     return 1;
   }
   return 0;
@@ -449,6 +533,30 @@ static int _circle_events_mouse_moved(struct dt_iop_module_t *module, double x, 
 
     // we recreate the form points
     dt_masks_gui_form_create(form, gui, index, module);
+
+    return 1;
+  }
+  else if(gui->gamma_dragging)
+  {
+    dt_masks_node_circle_t *circle = (dt_masks_node_circle_t *)((form->points)->data);
+    dt_masks_form_gui_points_t *gpt = (dt_masks_form_gui_points_t *)g_list_nth_data(gui->points, index);
+    if(IS_NULL_PTR(circle) || IS_NULL_PTR(gpt)) return 0;
+
+    float edge[2], border_pt[2], handle[2];
+    if(_circle_gamma_handle_points(gpt, circle, edge, border_pt, handle))
+    {
+      // project the cursor onto the [edge, border_pt] segment to get t in [0,1]
+      const float seg_x = border_pt[0] - edge[0];
+      const float seg_y = border_pt[1] - edge[1];
+      const float seg_len2 = sqf(seg_x) + sqf(seg_y);
+      float t = 0.0f;
+      if(seg_len2 > 1e-6f)
+        t = CLAMPF(((gui->pos[0] - edge[0]) * seg_x + (gui->pos[1] - edge[1]) * seg_y) / seg_len2, 0.0f, 1.0f);
+
+      circle->gamma = CLAMPF(dt_masks_t_to_gamma_quadratic(t, circle->radius, circle->radius + circle->border),
+                             GAMMA_MIN, GAMMA_MAX);
+      dt_masks_gui_form_create(form, gui, index, module);
+    }
 
     return 1;
   }
@@ -616,6 +724,15 @@ static void _circle_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks_f
     if(gpt->border && gpt->border_count > 1)
       dt_draw_shape_lines(DT_MASKS_DASH_STICK, FALSE, cr, num_points, (gui->border_selected), zoom_scale, gpt->border,
                           gpt->border_count, &dt_masks_functions_circle.draw_shape, CAIRO_LINE_CAP_ROUND);
+
+    // draw the gamma falloff handle, on the invisible radial line between the shape edge
+    // and the outer border edge
+    dt_masks_form_t *drawn_form = dt_masks_get_drawn_form(index);
+    const dt_masks_node_circle_t *circle
+        = (drawn_form && drawn_form->points) ? (const dt_masks_node_circle_t *)drawn_form->points->data : NULL;
+    float edge[2], border_pt[2], handle[2];
+    if(circle && _circle_gamma_handle_points(gpt, circle, edge, border_pt, handle))
+      dt_draw_handle(cr, edge, zoom_scale, handle, gui->gamma_handle_hovered || gui->gamma_dragging, FALSE);
   }
 
   // draw the source if any
@@ -822,7 +939,7 @@ static int _circle_get_mask(const dt_iop_module_t *const restrict module, dt_dev
     const float ratio = (total2 - l2) / border2;
     // enforce 1.0 inside the circle and 0.0 outside the feathering
     const float f = CLIP(ratio);
-    ptbuffer[i] = sqf(f);
+    ptbuffer[i] = powf(sqf(f), circle->gamma);
   }
 
   dt_pixelpipe_cache_free_align(points);
@@ -1020,7 +1137,7 @@ static int _circle_get_mask_roi(const dt_iop_module_t *const restrict module, dt
       const float ratio = (sqr_total - l2) / sqr_border;
       // enforce 1.0 inside the circle and 0.0 outside the feathering
       const float f = CLAMP(ratio, 0.0f, 1.0f);
-      points[2*index] = f * f;
+      points[2*index] = powf(f * f, circle->gamma);
     }
 
   if(darktable.unmuted & DT_DEBUG_PERF)

--- a/src/develop/masks/ellipse.c
+++ b/src/develop/masks/ellipse.c
@@ -46,6 +46,9 @@
 #define HARDNESS_MIN 0.0005f
 #define HARDNESS_MAX 1.0f
 
+#define GAMMA_MIN 0.1f
+#define GAMMA_MAX 10.0f
+
 #define BORDER_MIN 0.00005f
 #define BORDER_MAX 0.5f
 
@@ -265,6 +268,7 @@ static void _ellipse_init_new(dt_masks_form_t *form, dt_masks_form_gui_t *gui, d
   ellipse->border = values.border;
   ellipse->rotation = values.rotation;
   ellipse->flags = values.flags;
+  ellipse->gamma = 1.0f;
 
   if(dt_masks_form_is_clone(form))
     dt_masks_set_source_pos_initial_value(gui, form);
@@ -527,12 +531,58 @@ static void _ellipse_post_select_cb(dt_masks_form_gui_t *mask_gui, int inside, i
   mask_gui->pivot_selected = inside_border ? TRUE : FALSE; // cast to strict gboolean
 }
 
+/**
+ * @brief Locate the shape-edge point, border-edge point and gamma handle point at the
+ * ellipse-local "north" control point (minor-axis, "-b" side, control point 4), in the same
+ * absolute screen space as gpt->points/gpt->border. This point rotates with the ellipse.
+ */
+static gboolean _ellipse_gamma_handle_points(const dt_masks_form_gui_points_t *gpt,
+                                             const dt_masks_node_ellipse_t *ellipse,
+                                             float edge[2], float border_pt[2], float handle[2])
+{
+  if(IS_NULL_PTR(gpt->points) || gpt->points_count < 5 || IS_NULL_PTR(gpt->border) || gpt->border_count < 5)
+    return FALSE;
+
+  edge[0] = gpt->points[8];
+  edge[1] = gpt->points[9];
+  border_pt[0] = gpt->border[8];
+  border_pt[1] = gpt->border[9];
+
+  const int prop = ellipse->flags & DT_MASKS_ELLIPSE_PROPORTIONAL;
+  const float inner_r = ellipse->radius[1];
+  const float total_r = prop ? inner_r * (1.0f + ellipse->border) : inner_r + ellipse->border;
+
+  const float t = dt_masks_gamma_to_t_quadratic(ellipse->gamma, inner_r, total_r);
+  handle[0] = edge[0] + t * (border_pt[0] - edge[0]);
+  handle[1] = edge[1] + t * (border_pt[1] - edge[1]);
+  return TRUE;
+}
+
 static int _find_closest_handle(dt_masks_form_t *mask_form, dt_masks_form_gui_t *mask_gui, int form_index)
 {
   if(mask_gui) mask_gui->pivot_selected = FALSE;
-  return dt_masks_find_closest_handle_common(mask_form, mask_gui, form_index, 5,
+  const int result = dt_masks_find_closest_handle_common(mask_form, mask_gui, form_index, 5,
                                              NULL, NULL, _ellipse_node_position_cb,
                                              _ellipse_distance_cb, _ellipse_post_select_cb, NULL);
+
+  mask_gui->gamma_handle_hovered = FALSE;
+  if(!mask_gui->creation && mask_gui->group_selected == form_index && mask_gui->node_dragging < 0
+     && !mask_gui->form_rotating && !mask_gui->gamma_dragging)
+  {
+    const dt_masks_node_ellipse_t *ellipse = (const dt_masks_node_ellipse_t *)mask_form->points->data;
+    const dt_masks_form_gui_points_t *gpt
+        = (const dt_masks_form_gui_points_t *)g_list_nth_data(mask_gui->points, form_index);
+    float edge[2], border_pt[2], handle[2];
+    if(ellipse && gpt && _ellipse_gamma_handle_points(gpt, ellipse, edge, border_pt, handle)
+       && dt_masks_point_is_within_radius(mask_gui->pos[0], mask_gui->pos[1], handle[0], handle[1],
+                                          sqf(DT_GUI_MOUSE_EFFECT_RADIUS)))
+    {
+      mask_gui->gamma_handle_hovered = TRUE;
+      mask_gui->pivot_selected = FALSE; // gamma handle takes priority over rotation here
+    }
+  }
+
+  return result;
 }
 
 static int _init_hardness(dt_masks_form_t *form, const float amount, const dt_masks_increment_t increment, const int flow)
@@ -576,6 +626,8 @@ static float _ellipse_get_interaction_value(const dt_masks_form_t *form, dt_mask
       return fmaxf(ellipse->radius[0], ellipse->radius[1]);
     case DT_MASKS_INTERACTION_HARDNESS:
       return ellipse->border;
+    case DT_MASKS_INTERACTION_GAMMA:
+      return ellipse->gamma;
     default:
       return NAN;
   }
@@ -596,6 +648,8 @@ static int _change_hardness(dt_masks_form_t *form, dt_masks_form_gui_t *gui, str
                             int index, const float amount, const dt_masks_increment_t increment, const int flow);
 static int _change_size(dt_masks_form_t *form, dt_masks_form_gui_t *gui, struct dt_iop_module_t *module,
                         int index, const float amount, const dt_masks_increment_t increment, const int flow);
+static int _change_gamma(dt_masks_form_t *form, dt_masks_form_gui_t *gui, struct dt_iop_module_t *module,
+                         int index, const float amount, const dt_masks_increment_t increment, const int flow);
 
 static float _ellipse_set_interaction_value(dt_masks_form_t *form, dt_masks_interaction_t interaction, float value,
                                             dt_masks_increment_t increment, int flow,
@@ -612,6 +666,9 @@ static float _ellipse_set_interaction_value(dt_masks_form_t *form, dt_masks_inte
     case DT_MASKS_INTERACTION_HARDNESS:
       if(!_change_hardness(form, gui, module, index, value, increment, flow)) return NAN;
       return _ellipse_get_interaction_value(form, interaction);
+    case DT_MASKS_INTERACTION_GAMMA:
+      if(!_change_gamma(form, gui, module, index, value, increment, flow)) return NAN;
+      return _ellipse_get_interaction_value(form, interaction);
     default:
       return NAN;
   }
@@ -627,6 +684,21 @@ static int _change_hardness(dt_masks_form_t *form, dt_masks_form_gui_t *gui, str
                            HARDNESS_MIN, HARDNESS_MAX);
 
   _init_hardness(form, amount, increment, flow);
+
+  // we recreate the form points
+  dt_masks_gui_form_create(form, gui, index, module);
+
+  return 1;
+}
+
+static int _change_gamma(dt_masks_form_t *form, dt_masks_form_gui_t *gui, struct dt_iop_module_t *module, int index, const float amount, const dt_masks_increment_t increment, const int flow)
+{
+  if(IS_NULL_PTR(form) || IS_NULL_PTR(form->points)) return 0;
+  dt_masks_node_ellipse_t *ellipse = (dt_masks_node_ellipse_t *)(form->points)->data;
+  if(IS_NULL_PTR(ellipse)) return 0;
+
+  ellipse->gamma = CLAMPF(dt_masks_apply_increment(ellipse->gamma, amount, increment, flow),
+                          GAMMA_MIN, GAMMA_MAX);
 
   // we recreate the form points
   dt_masks_gui_form_create(form, gui, index, module);
@@ -746,8 +818,14 @@ static int _ellipse_events_button_pressed(struct dt_iop_module_t *module, double
     {
       dt_masks_form_gui_points_t *gpt = (dt_masks_form_gui_points_t *)g_list_nth_data(gui->points, index);
       if(IS_NULL_PTR(gpt)) return 0;
-      
-      if(gui->source_selected && gui->edit_mode == DT_MASKS_EDIT_FULL)
+
+      if(gui->gamma_handle_hovered && gui->edit_mode == DT_MASKS_EDIT_FULL)
+      {
+        // we start dragging the gamma falloff handle
+        gui->gamma_dragging = TRUE;
+        return 1;
+      }
+      else if(gui->source_selected && gui->edit_mode == DT_MASKS_EDIT_FULL)
       {
         // we start the source dragging
         gui->delta[0] = gpt->source[0] - gui->pos[0];
@@ -868,6 +946,12 @@ static int _ellipse_events_button_released(struct dt_iop_module_t *module, doubl
   {
     return 1;
   }
+  else if(gui->gamma_dragging)
+  {
+    // we end the gamma handle dragging
+    gui->gamma_dragging = FALSE;
+    return 1;
+  }
   return 0;
 }
 
@@ -976,7 +1060,30 @@ static int _ellipse_events_mouse_moved(struct dt_iop_module_t *module, double x,
 
     return 1;
   }
-  
+
+  else if(gui->gamma_dragging)
+  {
+    float edge[2], border_pt[2], handle[2];
+    if(_ellipse_gamma_handle_points(gpt, ellipse, edge, border_pt, handle))
+    {
+      // project the cursor onto the [edge, border_pt] segment to get t in [0,1]
+      const float seg_x = border_pt[0] - edge[0];
+      const float seg_y = border_pt[1] - edge[1];
+      const float seg_len2 = sqf(seg_x) + sqf(seg_y);
+      float t = 0.0f;
+      if(seg_len2 > 1e-6f)
+        t = CLAMPF(((gui->pos[0] - edge[0]) * seg_x + (gui->pos[1] - edge[1]) * seg_y) / seg_len2, 0.0f, 1.0f);
+
+      const int prop = ellipse->flags & DT_MASKS_ELLIPSE_PROPORTIONAL;
+      const float inner_r = ellipse->radius[1];
+      const float total_r = prop ? inner_r * (1.0f + ellipse->border) : inner_r + ellipse->border;
+      ellipse->gamma = CLAMPF(dt_masks_t_to_gamma_quadratic(t, inner_r, total_r), GAMMA_MIN, GAMMA_MAX);
+      dt_masks_gui_form_create(form, gui, index, module);
+    }
+
+    return 1;
+  }
+
   //if(gui->edit_mode != DT_MASKS_EDIT_FULL) return 0;
   return 0;
 }
@@ -1065,6 +1172,14 @@ static void _ellipse_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks_
 
     // draw handles
     _ellipse_draw_handles(gui, cr, zoom_scale, gpt, index);
+
+    // draw the gamma falloff handle
+    dt_masks_form_t *drawn_form = dt_masks_get_drawn_form(index);
+    const dt_masks_node_ellipse_t *ellipse
+        = (drawn_form && drawn_form->points) ? (const dt_masks_node_ellipse_t *)drawn_form->points->data : NULL;
+    float edge[2], border_pt[2], handle[2];
+    if(ellipse && _ellipse_gamma_handle_points(gpt, ellipse, edge, border_pt, handle))
+      dt_draw_handle(cr, edge, zoom_scale, handle, gui->gamma_handle_hovered || gui->gamma_dragging, FALSE);
   }
 
   //draw the center point
@@ -1101,7 +1216,7 @@ static void _bounding_box(const float *const points, int num_points, int *width,
 
 static void _fill_mask(const size_t numpoints, float *const bufptr, const float *const points,
                        const float *const center, const float a, const float b, const float ta, const float tb,
-                       const float alpha, const size_t out_scale)
+                       const float alpha, const size_t out_scale, const float gamma)
 {
   const float a2 = a * a;
   const float b2 = b * b;
@@ -1143,7 +1258,7 @@ static void _fill_mask(const size_t numpoints, float *const bufptr, const float 
       const float ratio = (total2 - l2) / (total2 - radius2);
       // enforce 1.0 inside the ellipse and 0.0 outside the feathering
       const float f = CLIP(ratio);
-      bufptr[i << out_scale] = f * f;
+      bufptr[i << out_scale] = powf(f * f, gamma);
     }
 }
 
@@ -1365,7 +1480,7 @@ static int _ellipse_get_mask(const dt_iop_module_t *const module, dt_dev_pixelpi
 
   float *const bufptr = *buffer;
 
-  _fill_mask((size_t)(h)*w, bufptr, points, center, a, b, ta, tb, alpha, 0);
+  _fill_mask((size_t)(h)*w, bufptr, points, center, a, b, ta, tb, alpha, 0, ellipse->gamma);
 
   dt_pixelpipe_cache_free_align(points);
 
@@ -1539,7 +1654,7 @@ static int _ellipse_get_mask_roi(const dt_iop_module_t *const module, dt_dev_pix
 
   // we calculate the mask values at the transformed points;
   // re-use the points array for results; this requires out_scale==1 to double the offsets at which they are stored
-  _fill_mask((size_t)(bbh)*bbw, points, points, center, a, b, ta, tb, alpha, 1);
+  _fill_mask((size_t)(bbh)*bbw, points, points, center, a, b, ta, tb, alpha, 1, ellipse->gamma);
 
   if(darktable.unmuted & DT_DEBUG_PERF)
   {

--- a/src/develop/masks/gradient.c
+++ b/src/develop/masks/gradient.c
@@ -43,6 +43,8 @@
 #define extent_MAX 1.0f
 #define CURVATURE_MIN -2.0f
 #define CURVATURE_MAX 2.0f
+#define GAMMA_MIN 0.1f
+#define GAMMA_MAX 10.0f
 
 #define BORDER_MIN 0.00005f
 #define BORDER_MAX 0.5f
@@ -177,6 +179,108 @@ static float _gradient_get_border_len_sq(const dt_masks_form_gui_points_t *gpt)
   return gradient_dx * gradient_dx + gradient_dy * gradient_dy;
 }
 
+// Falloff formula (see the render loop below): u = clip(0.5 + 0.5*raw) in [0,1], u=0 at the
+// 0%-opacity border, u=1 at the 100%-opacity border (matching circle/ellipse's convention
+// where the "shape" edge holds 100% and the "border" edge holds 0%). gamma=1 reproduces the
+// original 0.5+0.5*raw curve exactly (required for backward compatibility: existing gradient
+// masks must not change appearance). For gamma!=1 the exponent actually applied is E = gamma^2
+// (gamma >= 1) or E = 1/gamma^2 (gamma < 1, the reciprocal branch), not gamma itself: a linear
+// rate-of-2 match to circle/ellipse's f^(2*gamma) (tried first) still left the transition
+// visibly less crushed against the border than circle/ellipse at the same slider value, so the
+// exponent grows quadratically instead (E=100 at gamma=10, vs. circle/ellipse's own E=20) while
+// still anchoring E=1 (linear) at gamma=1, since gradient's own pre-existing base exponent is 1
+// (linear), not circle/ellipse's 2 (quadratic).
+//   value = u^E                          (gamma >= 1: steepens toward the 100% edge)
+//   value = 1 - (1-u)^E                  (gamma < 1: steepens toward the 0% edge, mirrors the
+//                                         other branch so the slope stays finite at both u=0
+//                                         and u=1 for every gamma instead of shooting to
+//                                         infinity, which reads as a hard cut)
+//
+// The on-canvas handle position must solve the *exact same* equation (value(u)=0.5) so that
+// dragging it to a given spot always matches what gamma actually produces in the image.
+static float _gradient_gamma_to_u(const float gamma)
+{
+  const float g = CLAMPF(gamma, GAMMA_MIN, GAMMA_MAX);
+  // value(u) = 0.5  =>  u = 0.5^(1/E) (g>=1 branch, E=g^2) or u = 1 - 0.5^(1/E) (g<1 branch,
+  // E=1/g^2, so 1/E=g^2); both give u=0.5 at g=1 (E=1 either way), confirming the two pieces
+  // meet continuously.
+  return (g >= 1.0f) ? powf(0.5f, 1.0f / (g * g)) : 1.0f - powf(0.5f, g * g);
+}
+
+// Inverse of _gradient_gamma_to_u: returns the gamma value directly.
+static float _gradient_u_to_gamma(const float u)
+{
+  const float uu = CLAMPF(u, 1e-4f, 1.0f - 1e-4f);
+  if(uu >= 0.5f)
+  {
+    const float e = logf(0.5f) / logf(uu); // e = g^2  =>  g = sqrt(e)
+    return CLAMPF(sqrtf(fmaxf(e, 0.0f)), GAMMA_MIN, GAMMA_MAX);
+  }
+  else
+  {
+    const float e = logf(0.5f) / logf(1.0f - uu); // e = 1/g^2  =>  g = 1/sqrt(e)
+    return CLAMPF(1.0f / sqrtf(fmaxf(e, 1e-6f)), GAMMA_MIN, GAMMA_MAX);
+  }
+}
+
+/**
+ * @brief Locate the border2 point, the border1 point and the gamma handle point along the
+ * segment between them, in the same absolute screen space as gpt->points/gpt->border. The
+ * segment is offset sideways along the gradient's own axis so it doesn't overlap the
+ * rotation pivot drawn at the anchor.
+ */
+static gboolean _gradient_gamma_handle_points(const dt_masks_form_gui_points_t *gpt,
+                                              const dt_masks_anchor_gradient_t *gradient,
+                                              float border2_pt[2], float border1_pt[2], float handle[2])
+{
+  if(IS_NULL_PTR(gpt->points) || gpt->points_count < 2 || IS_NULL_PTR(gpt->border) || gpt->border_count < 2)
+    return FALSE;
+
+  const float center[2] = { gpt->points[0], gpt->points[1] };
+
+  const int separator_idx = _find_border_separator(gpt->border, gpt->border_count);
+  const int end_idx = (separator_idx > 0) ? separator_idx : gpt->border_count;
+
+  // first curve (before the separator) is the border2 (u=0, low-gamma) side
+  float dist1_sq = FLT_MAX, dist2_sq = FLT_MAX;
+  _closest_point_on_line(center[0], center[1], gpt->border, 0, end_idx, &border2_pt[0], &border2_pt[1], &dist1_sq);
+  if(dist1_sq >= FLT_MAX) return FALSE;
+
+  if(separator_idx > 0 && separator_idx < gpt->border_count - 1)
+  {
+    _closest_point_on_line(center[0], center[1], gpt->border, separator_idx + 1, gpt->border_count,
+                           &border1_pt[0], &border1_pt[1], &dist2_sq);
+  }
+  if(dist2_sq >= FLT_MAX)
+  {
+    // only one border line is valid (e.g. near an image edge): mirror the anchor around it
+    border1_pt[0] = 2.0f * center[0] - border2_pt[0];
+    border1_pt[1] = 2.0f * center[1] - border2_pt[1];
+  }
+
+  // gpt->points[2,3] points toward one of the border lines (same axis as border1<->border2,
+  // per _gradient_get_border_len_sq/_gradient_get_distance), so it is *not* usable as an offset
+  // direction here. Derive the true perpendicular (the gradient's actual transition axis) by
+  // rotating the border1<->border2 segment 90 degrees, and slide the whole segment sideways
+  // along it, away from the rotation pivot drawn at the anchor.
+  const float seg_dx = border1_pt[0] - border2_pt[0];
+  const float seg_dy = border1_pt[1] - border2_pt[1];
+  const float seg_len = sqrtf(sqf(seg_dx) + sqf(seg_dy));
+  if(seg_len > 1e-3f)
+  {
+    const float offset = seg_len * 0.15f;
+    const float offset_x = -seg_dy / seg_len * offset;
+    const float offset_y = seg_dx / seg_len * offset;
+    border1_pt[0] += offset_x; border1_pt[1] += offset_y;
+    border2_pt[0] += offset_x; border2_pt[1] += offset_y;
+  }
+
+  const float u = _gradient_gamma_to_u(gradient->gamma);
+  handle[0] = border2_pt[0] + u * (border1_pt[0] - border2_pt[0]);
+  handle[1] = border2_pt[1] + u * (border1_pt[1] - border2_pt[1]);
+  return TRUE;
+}
+
 typedef struct dt_masks_gradient_creation_values_t
 {
   float extent;
@@ -202,6 +306,7 @@ static void _gradient_init_new(dt_masks_form_gui_t *gui, dt_masks_anchor_gradien
   gradient->extent = values.extent;
   gradient->curvature = values.curvature;
   gradient->rotation = values.rotation;
+  gradient->gamma = 1.0f;
 }
 
 static int _gradient_get_points(dt_develop_t *dev, float x, float y, float rotation, float curvature,
@@ -355,9 +460,28 @@ static void _gradient_post_select_cb(dt_masks_form_gui_t *mask_gui, int inside, 
 static int _find_closest_handle(dt_masks_form_t *mask_form, dt_masks_form_gui_t *mask_gui, int index)
 {
   if(mask_gui) mask_gui->pivot_selected = FALSE;
-  return dt_masks_find_closest_handle_common(mask_form, mask_gui, index, 1,
+  const int result = dt_masks_find_closest_handle_common(mask_form, mask_gui, index, 1,
                                              NULL, NULL, _gradient_node_position_cb,
                                              _gradient_distance_cb, _gradient_post_select_cb, NULL);
+
+  mask_gui->gamma_handle_hovered = FALSE;
+  if(!mask_gui->creation && mask_gui->group_selected == index && !mask_gui->form_rotating
+     && !mask_gui->form_dragging && !mask_gui->gamma_dragging)
+  {
+    const dt_masks_anchor_gradient_t *gradient = (const dt_masks_anchor_gradient_t *)mask_form->points->data;
+    const dt_masks_form_gui_points_t *gpt
+        = (const dt_masks_form_gui_points_t *)g_list_nth_data(mask_gui->points, index);
+    float edge[2], border_pt[2], handle[2];
+    if(gradient && gpt && _gradient_gamma_handle_points(gpt, gradient, edge, border_pt, handle)
+       && dt_masks_point_is_within_radius(mask_gui->pos[0], mask_gui->pos[1], handle[0], handle[1],
+                                          sqf(DT_GUI_MOUSE_EFFECT_RADIUS)))
+    {
+      mask_gui->gamma_handle_hovered = TRUE;
+      mask_gui->pivot_selected = FALSE; // gamma handle takes priority over rotation here
+    }
+  }
+
+  return result;
 }
 
 
@@ -401,6 +525,8 @@ static float _gradient_get_interaction_value(const dt_masks_form_t *form, dt_mas
       return gradient->extent;
     case DT_MASKS_INTERACTION_HARDNESS:
       return gradient->curvature;
+    case DT_MASKS_INTERACTION_GAMMA:
+      return gradient->gamma;
     default:
       return NAN;
   }
@@ -421,6 +547,8 @@ static int _change_extent(dt_masks_form_t *form, dt_masks_form_gui_t *gui, struc
                           int index, const float amount, const dt_masks_increment_t increment, const int flow);
 static int _change_curvature(dt_masks_form_t *form, dt_masks_form_gui_t *gui, struct dt_iop_module_t *module,
                              int index, const float amount, const dt_masks_increment_t increment, const int flow);
+static int _change_gamma(dt_masks_form_t *form, dt_masks_form_gui_t *gui, struct dt_iop_module_t *module,
+                         int index, const float amount, const dt_masks_increment_t increment, const int flow);
 
 static float _gradient_set_interaction_value(dt_masks_form_t *form, dt_masks_interaction_t interaction, float value,
                                              dt_masks_increment_t increment, int flow,
@@ -436,6 +564,9 @@ static float _gradient_set_interaction_value(dt_masks_form_t *form, dt_masks_int
       return _gradient_get_interaction_value(form, interaction);
     case DT_MASKS_INTERACTION_HARDNESS:
       if(!_change_curvature(form, gui, module, index, value, increment, flow)) return NAN;
+      return _gradient_get_interaction_value(form, interaction);
+    case DT_MASKS_INTERACTION_GAMMA:
+      if(!_change_gamma(form, gui, module, index, value, increment, flow)) return NAN;
       return _gradient_get_interaction_value(form, interaction);
     default:
       return NAN;
@@ -479,6 +610,21 @@ static int _change_curvature(dt_masks_form_t *form, dt_masks_form_gui_t *gui, st
   }
 
   _init_curvature(form, amount, DT_MASKS_INCREMENT_SCALE, flow);
+
+  // we recreate the form points
+  dt_masks_gui_form_create(form, gui, index, module);
+
+  return 1;
+}
+
+static int _change_gamma(dt_masks_form_t *form, dt_masks_form_gui_t *gui, struct dt_iop_module_t *module, int index, const float amount, const dt_masks_increment_t increment, const int flow)
+{
+  if(IS_NULL_PTR(form) || IS_NULL_PTR(form->points)) return 0;
+  dt_masks_anchor_gradient_t *gradient = (dt_masks_anchor_gradient_t *)(form->points)->data;
+  if(IS_NULL_PTR(gradient)) return 0;
+
+  gradient->gamma = CLAMPF(dt_masks_apply_increment(gradient->gamma, amount, increment, flow),
+                           GAMMA_MIN, GAMMA_MAX);
 
   // we recreate the form points
   dt_masks_gui_form_create(form, gui, index, module);
@@ -583,6 +729,12 @@ static int _gradient_events_button_pressed(struct dt_iop_module_t *module, doubl
     const dt_masks_form_gui_points_t *gpt = (dt_masks_form_gui_points_t *)g_list_nth_data(gui->points, index);
     if(IS_NULL_PTR(gpt)) return 0;
 
+    else if(gui->gamma_handle_hovered && gui->edit_mode == DT_MASKS_EDIT_FULL)
+    {
+      // we start dragging the gamma falloff handle
+      gui->gamma_dragging = TRUE;
+      return 1;
+    }
     else if((gui->form_selected || gui->seg_hovered >= 0 || gui->seg_selected)
             && gui->edit_mode == DT_MASKS_EDIT_FULL)
     {
@@ -651,12 +803,18 @@ static int _gradient_events_button_released(struct dt_iop_module_t *module, doub
       gradient->state = DT_MASKS_GRADIENT_STATE_LINEAR;
 
     dt_conf_set_int("plugins/darkroom/masks/gradient/state", gradient->state);
-    
+
     // we recreate the form points
     dt_masks_gui_form_create(form, gui, index, module);
 
     // we save the new parameters
 
+    return 1;
+  }
+  else if(gui->gamma_dragging)
+  {
+    // we end the gamma handle dragging
+    gui->gamma_dragging = FALSE;
     return 1;
   }
   return 0;
@@ -712,6 +870,27 @@ static int _gradient_events_mouse_moved(struct dt_iop_module_t *module, double x
 
     // we recreate the form points
     dt_masks_gui_form_create(form, gui, index, module);
+
+    return 1;
+  }
+
+  if(gui->gamma_dragging)
+  {
+    float border2_pt[2], border1_pt[2], handle[2];
+    if(_gradient_gamma_handle_points(gpt, gradient, border2_pt, border1_pt, handle))
+    {
+      // project the cursor onto the [border2, border1] segment to get u in [0,1]
+      const float seg_x = border1_pt[0] - border2_pt[0];
+      const float seg_y = border1_pt[1] - border2_pt[1];
+      const float seg_len2 = sqf(seg_x) + sqf(seg_y);
+      float u = 0.5f;
+      if(seg_len2 > 1e-6f)
+        u = CLAMPF(((gui->pos[0] - border2_pt[0]) * seg_x + (gui->pos[1] - border2_pt[1]) * seg_y) / seg_len2,
+                   0.0f, 1.0f);
+
+      gradient->gamma = CLAMPF(_gradient_u_to_gamma(u), GAMMA_MIN, GAMMA_MAX);
+      dt_masks_gui_form_create(form, gui, index, module);
+    }
 
     return 1;
   }
@@ -1089,6 +1268,21 @@ static void _gradient_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks
     if(gpt->border && gpt->border_count > 0)
       dt_draw_shape_lines(DT_MASKS_DASH_STICK, FALSE, cr, nb, (gui->border_selected), zoom_scale, gpt->border,
                           gpt->border_count, &dt_masks_functions_gradient.draw_shape, CAIRO_LINE_CAP_ROUND);
+
+    // draw the gamma falloff handle, sliding along the full border2<->border1 span
+    dt_masks_form_t *drawn_form = dt_masks_get_drawn_form(index);
+    const dt_masks_anchor_gradient_t *gradient
+        = (drawn_form && drawn_form->points) ? (const dt_masks_anchor_gradient_t *)drawn_form->points->data : NULL;
+    float border2_pt[2], border1_pt[2], handle[2];
+    if(gradient && _gradient_gamma_handle_points(gpt, gradient, border2_pt, border1_pt, handle))
+    {
+      cairo_move_to(cr, border2_pt[0], border2_pt[1]);
+      cairo_line_to(cr, border1_pt[0], border1_pt[1]);
+      dt_draw_stroke_line(DT_MASKS_DASH_ROUND, FALSE, cr, FALSE, zoom_scale, CAIRO_LINE_CAP_ROUND);
+
+      dt_draw_node(cr, FALSE, FALSE, gui->gamma_handle_hovered || gui->gamma_dragging, zoom_scale,
+                  handle[0], handle[1]);
+    }
   }
 
   if(gpt->points && gpt->points_count >= 3)
@@ -1231,8 +1425,12 @@ static int _gradient_get_mask(const dt_iop_module_t *const module, dt_dev_pixelp
   const float normf = 1.0f / extent;
   const float curvature = gradient->curvature;
   const dt_masks_gradient_states_t state = gradient->state;
+  const float gamma = gradient->gamma;
 
-  const int lutmax = ceilf(4 * extent * ihwscale);
+  // gamma/gradient falloff must stay confined strictly between the two border lines
+  // (distance = +-extent): u already clips to [0,1] there, so shrink the LUT and the
+  // outer hard-clamp to match instead of extrapolating out to 4x the extent.
+  const int lutmax = ceilf(extent * ihwscale);
   const int lutsize = 2 * lutmax + 2;
   float *lut = dt_pixelpipe_cache_alloc_align_float_cache((size_t)lutsize, 0);
   if(IS_NULL_PTR(lut))
@@ -1244,7 +1442,20 @@ static int _gradient_get_mask(const dt_iop_module_t *const module, dt_dev_pixelp
   for(int n = 0; n < lutsize; n++)
   {
     const float distance = (n - lutmax) * hwscale;
-    const float value = 0.5f + 0.5f * ((state == DT_MASKS_GRADIENT_STATE_LINEAR) ? normf * distance: erff(distance / extent));
+    // normalize erf by erff(2) so the sigmoid state also reaches exactly +-1 at distance=+-extent
+    // (raw erff(distance/extent) only reaches ~0.84 there), matching the linear state's exact
+    // boundary and avoiding a visible jump against the hard clamp at the border.
+    const float raw = (state == DT_MASKS_GRADIENT_STATE_LINEAR) ? normf * distance
+                                                                 : erff(2.0f * distance / extent) / erff(2.0f);
+    const float u = CLAMPF(0.5f + 0.5f * raw, 0.0f, 1.0f);
+    // Effective exponent E (see the comment above _gradient_gamma_to_u) grows quadratically
+    // with gamma, while still giving E=1 (linear) at gamma=1 for backward compatibility. u=1 is
+    // the 100%-opacity "shape" edge, so gamma>=1 steepens the curve toward it. Mirroring for
+    // gamma<1 (ease in from 0, flatten toward 1) keeps the slope finite at both ends instead of
+    // shooting to infinity, which reads as a hard cut right off the 0%-opacity border. The two
+    // branches agree exactly at gamma == 1 (E=1 either way), so there is no seam.
+    const float value = (gamma >= 1.0f) ? powf(u, gamma * gamma)
+                                        : 1.0f - powf(1.0f - u, 1.0f / (gamma * gamma));
     lut[n] = (value < 0.0f) ? 0.0f : ((value > 1.0f) ? 1.0f : value);
   }
 
@@ -1265,8 +1476,8 @@ static int _gradient_get_mask(const dt_iop_module_t *const module, dt_dev_pixelp
 
       const float distance = y0 - curvature * x0 * x0;
 
-      points[(j * gw + i) * 2] = (distance <= -4.0f * extent) ? 0.0f :
-                                    ((distance >= 4.0f * extent) ? 1.0f : dt_gradient_lookup(clut, distance * ihwscale));
+      points[(j * gw + i) * 2] = (distance <= -extent) ? 0.0f :
+                                    ((distance >= extent) ? 1.0f : dt_gradient_lookup(clut, distance * ihwscale));
     }
   }
 
@@ -1397,8 +1608,12 @@ static int _gradient_get_mask_roi(const dt_iop_module_t *const module, dt_dev_pi
   const float normf = 1.0f / extent;
   const float curvature = gradient->curvature;
   const dt_masks_gradient_states_t state = gradient->state;
+  const float gamma = gradient->gamma;
 
-  const int lutmax = ceilf(4 * extent * ihwscale);
+  // gamma/gradient falloff must stay confined strictly between the two border lines
+  // (distance = +-extent): u already clips to [0,1] there, so shrink the LUT and the
+  // outer hard-clamp to match instead of extrapolating out to 4x the extent.
+  const int lutmax = ceilf(extent * ihwscale);
   const int lutsize = 2 * lutmax + 2;
   float *lut = dt_pixelpipe_cache_alloc_align_float_cache((size_t)lutsize, 0);
   if(IS_NULL_PTR(lut))
@@ -1410,7 +1625,20 @@ static int _gradient_get_mask_roi(const dt_iop_module_t *const module, dt_dev_pi
   for(int n = 0; n < lutsize; n++)
   {
     const float distance = (n - lutmax) * hwscale;
-    const float value = 0.5f + 0.5f * ((state == DT_MASKS_GRADIENT_STATE_LINEAR) ? normf * distance: erff(distance / extent));
+    // normalize erf by erff(2) so the sigmoid state also reaches exactly +-1 at distance=+-extent
+    // (raw erff(distance/extent) only reaches ~0.84 there), matching the linear state's exact
+    // boundary and avoiding a visible jump against the hard clamp at the border.
+    const float raw = (state == DT_MASKS_GRADIENT_STATE_LINEAR) ? normf * distance
+                                                                 : erff(2.0f * distance / extent) / erff(2.0f);
+    const float u = CLAMPF(0.5f + 0.5f * raw, 0.0f, 1.0f);
+    // Effective exponent E (see the comment above _gradient_gamma_to_u) grows quadratically
+    // with gamma, while still giving E=1 (linear) at gamma=1 for backward compatibility. u=1 is
+    // the 100%-opacity "shape" edge, so gamma>=1 steepens the curve toward it. Mirroring for
+    // gamma<1 (ease in from 0, flatten toward 1) keeps the slope finite at both ends instead of
+    // shooting to infinity, which reads as a hard cut right off the 0%-opacity border. The two
+    // branches agree exactly at gamma == 1 (E=1 either way), so there is no seam.
+    const float value = (gamma >= 1.0f) ? powf(u, gamma * gamma)
+                                        : 1.0f - powf(1.0f - u, 1.0f / (gamma * gamma));
     lut[n] = (value < 0.0f) ? 0.0f : ((value > 1.0f) ? 1.0f : value);
   }
 
@@ -1431,7 +1659,7 @@ static int _gradient_get_mask_roi(const dt_iop_module_t *const module, dt_dev_pi
 
       const float distance = y0 - curvature * x0 * x0;
 
-      points[index * 2] = (distance <= -4.0f * extent) ? 0.0f : ((distance >= 4.0f * extent) ? 1.0f : dt_gradient_lookup(clut, distance * ihwscale));
+      points[index * 2] = (distance <= -extent) ? 0.0f : ((distance >= extent) ? 1.0f : dt_gradient_lookup(clut, distance * ihwscale));
     }
   }
 

--- a/src/develop/masks/masks.c
+++ b/src/develop/masks/masks.c
@@ -412,13 +412,14 @@ void dt_masks_gui_reset_dragging(dt_masks_form_gui_t *gui)
   gui->seg_dragging = -1;
   gui->form_dragging = FALSE;
   gui->source_dragging = FALSE;
+  gui->gamma_dragging = FALSE;
 }
 
 gboolean dt_masks_gui_is_dragging(const dt_masks_form_gui_t *gui)
 {
   if(IS_NULL_PTR(gui)) return FALSE;
   const gboolean dragging = (gui->form_dragging || gui->source_dragging || gui->seg_dragging >= 0 || gui->node_dragging >= 0
-                              || gui->handle_dragging >= 0 || gui->handle_border_dragging >= 0);
+                              || gui->handle_dragging >= 0 || gui->handle_border_dragging >= 0 || gui->gamma_dragging);
   dt_control_mouse_is_dragging(dragging);
   return dragging;
 }
@@ -1880,6 +1881,44 @@ static int dt_masks_legacy_params_v5_to_v6(dt_develop_t *develop, void *params)
   return 0;
 }
 
+static int dt_masks_legacy_params_v6_to_v7(dt_develop_t *develop, void *params)
+{
+  /*
+   * difference affecting every shape
+   * up to v6: fixed falloff curve between the shape and the outer border edge
+   *           (quadratic for circle/ellipse, linear for path/brush,
+   *           linear-or-sigmoidal for gradient)
+   * after v6: that curve is reshaped by a per-shape "gamma" exponent; 1.0
+   *           reproduces the pre-v7 curve exactly, so every existing shape
+   *           must be seeded with 1.0 explicitly (uninitialized on disk
+   *           otherwise, for gradient's repurposed field in particular)
+   */
+
+  dt_masks_form_t *mask_form = (dt_masks_form_t *)params;
+
+  GList *point_node = mask_form->points;
+
+  if(IS_NULL_PTR(point_node)) return 1;
+
+  for(GList *node = point_node; node; node = g_list_next(node))
+  {
+    if(mask_form->type & DT_MASKS_CIRCLE)
+      ((dt_masks_node_circle_t *)node->data)->gamma = 1.0f;
+    else if(mask_form->type & DT_MASKS_ELLIPSE)
+      ((dt_masks_node_ellipse_t *)node->data)->gamma = 1.0f;
+    else if(mask_form->type & DT_MASKS_POLYGON)
+      ((dt_masks_node_polygon_t *)node->data)->gamma = 1.0f;
+    else if(mask_form->type & DT_MASKS_BRUSH)
+      ((dt_masks_node_brush_t *)node->data)->gamma = 1.0f;
+    else if(mask_form->type & DT_MASKS_GRADIENT)
+      ((dt_masks_anchor_gradient_t *)node->data)->gamma = 1.0f;
+  }
+
+  mask_form->version = 7;
+
+  return 0;
+}
+
 
 int dt_masks_legacy_params(dt_develop_t *develop, void *params, const int old_version, const int new_version)
 {
@@ -1891,35 +1930,44 @@ int dt_masks_legacy_params(dt_develop_t *develop, void *params, const int old_ve
   }
 #endif
 
-  if(old_version == 1 && new_version == 6)
+  if(old_version == 1 && new_version == 7)
   {
     result = dt_masks_legacy_params_v1_to_v2(develop, params);
     if(!result) result = dt_masks_legacy_params_v2_to_v3(develop, params);
     if(!result) result = dt_masks_legacy_params_v3_to_v4(develop, params);
     if(!result) result = dt_masks_legacy_params_v4_to_v5(develop, params);
     if(!result) result = dt_masks_legacy_params_v5_to_v6(develop, params);
+    if(!result) result = dt_masks_legacy_params_v6_to_v7(develop, params);
   }
-  else if(old_version == 2 && new_version == 6)
+  else if(old_version == 2 && new_version == 7)
   {
     result = dt_masks_legacy_params_v2_to_v3(develop, params);
     if(!result) result = dt_masks_legacy_params_v3_to_v4(develop, params);
     if(!result) result = dt_masks_legacy_params_v4_to_v5(develop, params);
     if(!result) result = dt_masks_legacy_params_v5_to_v6(develop, params);
+    if(!result) result = dt_masks_legacy_params_v6_to_v7(develop, params);
   }
-  else if(old_version == 3 && new_version == 6)
+  else if(old_version == 3 && new_version == 7)
   {
     result = dt_masks_legacy_params_v3_to_v4(develop, params);
     if(!result) result = dt_masks_legacy_params_v4_to_v5(develop, params);
     if(!result) result = dt_masks_legacy_params_v5_to_v6(develop, params);
+    if(!result) result = dt_masks_legacy_params_v6_to_v7(develop, params);
   }
-  else if(old_version == 4 && new_version == 6)
+  else if(old_version == 4 && new_version == 7)
   {
     result = dt_masks_legacy_params_v4_to_v5(develop, params);
     if(!result) result = dt_masks_legacy_params_v5_to_v6(develop, params);
+    if(!result) result = dt_masks_legacy_params_v6_to_v7(develop, params);
   }
-  else if(old_version == 5 && new_version == 6)
+  else if(old_version == 5 && new_version == 7)
   {
     result = dt_masks_legacy_params_v5_to_v6(develop, params);
+    if(!result) result = dt_masks_legacy_params_v6_to_v7(develop, params);
+  }
+  else if(old_version == 6 && new_version == 7)
+  {
+    result = dt_masks_legacy_params_v6_to_v7(develop, params);
   }
 
   return result;
@@ -2263,7 +2311,8 @@ gboolean dt_masks_is_anything_hovered(const dt_masks_form_gui_t *mask_gui)
   return mask_gui->node_hovered >= 0
           || mask_gui->handle_hovered >= 0
           || mask_gui->handle_border_hovered >= 0
-          || mask_gui->seg_hovered >= 0;
+          || mask_gui->seg_hovered >= 0
+          || mask_gui->gamma_handle_hovered;
 }
 
 static void _set_cursor_shape(dt_masks_form_gui_t *mask_gui)
@@ -2344,7 +2393,7 @@ static void _apply_gui_button_pressed_state(dt_masks_form_gui_t *mask_gui, const
     mask_gui->source_selected = prev_source_selected;
   }
 
-  if(mask_gui->form_rotating || mask_gui->border_toggling || mask_gui->gradient_toggling) return;
+  if(mask_gui->form_rotating || mask_gui->border_toggling || mask_gui->gradient_toggling || mask_gui->gamma_dragging) return;
   if(dt_modifier_is(state, GDK_CONTROL_MASK)) return;
   if(!shape_was_selected) return;
 

--- a/src/develop/masks/masks_gui.c
+++ b/src/develop/masks/masks_gui.c
@@ -297,10 +297,14 @@ static void _masks_gui_menu_item_block_activate(GtkWidget *widget, gpointer user
   g_signal_stop_emission_by_name(widget, "activate");
 }
 
+// Forwards a menu item's pointer/scroll events onto an interactive child widget (bauhaus
+// slider or checkbox) embedded inside it: GTK menus otherwise swallow these events before the
+// child ever sees them. `user_data` is the target widget directly, not a wrapper struct, so
+// this is reusable for any embedded control, not just the interaction sliders.
 static gboolean _masks_gui_menu_item_forward_event(GtkWidget *widget, GdkEvent *event, gpointer user_data)
 {
-  dt_masks_gui_interaction_slider_t *data = (dt_masks_gui_interaction_slider_t *)user_data;
-  if(IS_NULL_PTR(data) || !data->slider) return FALSE;
+  GtkWidget *target = GTK_WIDGET(user_data);
+  if(IS_NULL_PTR(target)) return FALSE;
 
   GdkEvent *copy = gdk_event_copy(event);
   if(IS_NULL_PTR(copy)) return FALSE;
@@ -334,7 +338,7 @@ static gboolean _masks_gui_menu_item_forward_event(GtkWidget *widget, GdkEvent *
   if(has_coords)
   {
     int sx = 0, sy = 0;
-    if(gtk_widget_translate_coordinates(widget, data->slider, (int)x, (int)y, &sx, &sy))
+    if(gtk_widget_translate_coordinates(widget, target, (int)x, (int)y, &sx, &sy))
     {
       switch(copy->type)
       {
@@ -359,15 +363,15 @@ static gboolean _masks_gui_menu_item_forward_event(GtkWidget *widget, GdkEvent *
     }
   }
 
-  GdkWindow *slider_window = gtk_widget_get_window(data->slider);
-  if(slider_window)
+  GdkWindow *target_window = gtk_widget_get_window(target);
+  if(target_window)
   {
     if(copy->any.window) g_object_unref(copy->any.window);
-    copy->any.window = g_object_ref(slider_window);
+    copy->any.window = g_object_ref(target_window);
     copy->any.send_event = TRUE;
   }
 
-  gtk_widget_event(data->slider, copy);
+  gtk_widget_event(target, copy);
   gdk_event_free(copy);
   return TRUE;
 }
@@ -421,13 +425,13 @@ static GtkWidget *_masks_gui_add_interaction_slider(GtkWidget *menu, const char 
                         G_CALLBACK(_masks_gui_interaction_slider_changed),
                         data, (GClosureNotify)g_free, 0);
   g_signal_connect(G_OBJECT(menu_item), "button-press-event",
-                   G_CALLBACK(_masks_gui_menu_item_forward_event), data);
+                   G_CALLBACK(_masks_gui_menu_item_forward_event), slider);
   g_signal_connect(G_OBJECT(menu_item), "button-release-event",
-                   G_CALLBACK(_masks_gui_menu_item_forward_event), data);
+                   G_CALLBACK(_masks_gui_menu_item_forward_event), slider);
   g_signal_connect(G_OBJECT(menu_item), "motion-notify-event",
-                   G_CALLBACK(_masks_gui_menu_item_forward_event), data);
+                   G_CALLBACK(_masks_gui_menu_item_forward_event), slider);
   g_signal_connect(G_OBJECT(menu_item), "scroll-event",
-                   G_CALLBACK(_masks_gui_menu_item_forward_event), data);
+                   G_CALLBACK(_masks_gui_menu_item_forward_event), slider);
 
   gtk_box_pack_start(GTK_BOX(box), slider, TRUE, TRUE, 0);
   gtk_container_add(GTK_CONTAINER(menu_item), box);
@@ -743,6 +747,7 @@ GtkWidget *dt_masks_create_menu(dt_masks_form_gui_t *gui, dt_masks_form_t *form,
   {
     const float opacity = dt_masks_form_get_interaction_value(op_form, DT_MASKS_INTERACTION_OPACITY);
     const float hardness = dt_masks_form_get_interaction_value(op_form, DT_MASKS_INTERACTION_HARDNESS);
+    const float gamma = dt_masks_form_get_interaction_value(op_form, DT_MASKS_INTERACTION_GAMMA);
 
     _masks_gui_add_interaction_slider(menu, _("Size"), op_form, DT_MASKS_INTERACTION_SIZE,
                                       DT_MASKS_INCREMENT_SCALE, -4.f, 4.0f, 0.01f, 0.0f, 2, "x", 1.0f,
@@ -754,6 +759,10 @@ GtkWidget *dt_masks_create_menu(dt_masks_form_gui_t *gui, dt_masks_form_t *form,
     _masks_gui_add_interaction_slider(menu, _("Opacity"), op_form, DT_MASKS_INTERACTION_OPACITY,
                                       DT_MASKS_INCREMENT_ABSOLUTE, 0.0f, 1.0f, 0.01f,
                                       isfinite(opacity) ? opacity : 1.0f, 3, "%", 100.0f,
+                                      gui, darktable.develop->gui_module);
+    _masks_gui_add_interaction_slider(menu, _("Progression"), op_form, DT_MASKS_INTERACTION_GAMMA,
+                                      DT_MASKS_INCREMENT_ABSOLUTE, 0.1f, 10.0f, 0.05f,
+                                      isfinite(gamma) ? gamma : 1.0f, 2, "", 1.0f,
                                       gui, darktable.develop->gui_module);
 
     gtk_menu_shell_append(GTK_MENU_SHELL(menu), gtk_separator_menu_item_new());

--- a/src/develop/masks/polygon.c
+++ b/src/develop/masks/polygon.c
@@ -55,6 +55,9 @@
 #define HARDNESS_MIN 0.0005f
 #define HARDNESS_MAX 1.0f
 
+#define GAMMA_MIN 0.1f
+#define GAMMA_MAX 10.0f
+
 #define BORDER_MIN 0.00005f
 #define BORDER_MAX 0.5f
 
@@ -1122,6 +1125,7 @@ static void _add_node_to_segment(struct dt_iop_module_t *module,
   dt_masks_node_polygon_t *point1 = (dt_masks_node_polygon_t *)next_pt->data;
   new_node->border[0] = point0->border[0] * (1.0f - t) + point1->border[0] * t;
   new_node->border[1] = point0->border[1] * (1.0f - t) + point1->border[1] * t;
+  new_node->gamma = point0->gamma * (1.0f - t) + point1->gamma * t;
 
   mask_form->points = g_list_insert(mask_form->points, new_node, selected_segment + 1);
   _polygon_init_ctrl_points(mask_form);
@@ -1245,6 +1249,21 @@ static float _polygon_get_interaction_value(const dt_masks_form_t *mask_form,
 
       return hardness_count > 0 ? hardness_sum / (float)hardness_count : NAN;
     }
+    case DT_MASKS_INTERACTION_GAMMA:
+    {
+      float gamma_sum = 0.0f;
+      int gamma_count = 0;
+
+      for(const GList *point_node = mask_form->points; point_node; point_node = g_list_next(point_node))
+      {
+        const dt_masks_node_polygon_t *node = (const dt_masks_node_polygon_t *)point_node->data;
+        if(IS_NULL_PTR(node)) continue;
+        gamma_sum += node->gamma;
+        gamma_count++;
+      }
+
+      return gamma_count > 0 ? gamma_sum / (float)gamma_count : NAN;
+    }
     default:
       return NAN;
   }
@@ -1282,6 +1301,9 @@ static int _change_size(dt_masks_form_t *mask_form, int parent_id, dt_masks_form
 static int _change_hardness(dt_masks_form_t *mask_form, int parent_id, dt_masks_form_gui_t *mask_gui,
                             struct dt_iop_module_t *module, int form_index, const float amount,
                             const dt_masks_increment_t increment, int flow);
+static int _change_gamma(dt_masks_form_t *mask_form, int parent_id, dt_masks_form_gui_t *mask_gui,
+                         struct dt_iop_module_t *module, int form_index, const float amount,
+                         const dt_masks_increment_t increment, int flow);
 
 static float _polygon_set_interaction_value(dt_masks_form_t *mask_form,
                                             dt_masks_interaction_t interaction, float value,
@@ -1298,6 +1320,9 @@ static float _polygon_set_interaction_value(dt_masks_form_t *mask_form,
       return _polygon_get_interaction_value(mask_form, interaction);
     case DT_MASKS_INTERACTION_HARDNESS:
       if(!_change_hardness(mask_form, 0, mask_gui, module, index, value, increment, flow)) return NAN;
+      return _polygon_get_interaction_value(mask_form, interaction);
+    case DT_MASKS_INTERACTION_GAMMA:
+      if(!_change_gamma(mask_form, 0, mask_gui, module, index, value, increment, flow)) return NAN;
       return _polygon_get_interaction_value(mask_form, interaction);
     default:
       return NAN;
@@ -1660,6 +1685,30 @@ static int _change_hardness(dt_masks_form_t *mask_form, int parent_id, dt_masks_
   return 1;
 }
 
+static int _change_gamma(dt_masks_form_t *mask_form, int parent_id, dt_masks_form_gui_t *mask_gui,
+                         struct dt_iop_module_t *module, int form_index, const float amount,
+                         const dt_masks_increment_t increment, int flow)
+{
+  int node_index = 0;
+
+  for(GList *node_iter = mask_form->points; node_iter; node_iter = g_list_next(node_iter), node_index++)
+  {
+    if(dt_masks_gui_change_affects_selected_node_or_all(mask_gui, node_index))
+    {
+      dt_masks_node_polygon_t *node = (dt_masks_node_polygon_t *)node_iter->data;
+      if(!node) continue;
+
+      node->gamma = CLAMPF(dt_masks_apply_increment(node->gamma, amount, increment, flow),
+                           GAMMA_MIN, GAMMA_MAX);
+    }
+  }
+
+  // Rebuild the cached GUI geometry.
+  dt_masks_gui_form_create(mask_form, mask_gui, form_index, module);
+
+  return 1;
+}
+
 /**
  * @brief Handle mouse wheel updates for polygon size/hardness/opacity.
  */
@@ -1758,7 +1807,8 @@ static int _polygon_events_button_pressed(struct dt_iop_module_t *module, double
         polygon_node->ctrl1[0] = polygon_node->ctrl1[1] = polygon_node->ctrl2[0] = polygon_node->ctrl2[1] = -1.0;
         polygon_node->border[0] = polygon_node->border[1] = MAX(HARDNESS_MIN, masks_border);
         polygon_node->state = DT_MASKS_POINT_STATE_NORMAL;
-  
+        polygon_node->gamma = 1.0f;
+
         if(node_count == 0)
         {
           // create the first node
@@ -1768,6 +1818,7 @@ static int _polygon_events_button_pressed(struct dt_iop_module_t *module, double
           polygon_first_node->ctrl1[0] = polygon_first_node->ctrl1[1] = polygon_first_node->ctrl2[0] = polygon_first_node->ctrl2[1] = -1.0;
           polygon_first_node->border[0] = polygon_first_node->border[1] = MAX(HARDNESS_MIN, masks_border);
           polygon_first_node->state = DT_MASKS_POINT_STATE_NORMAL;
+          polygon_first_node->gamma = 1.0f;
           mask_form->points = g_list_append(mask_form->points, polygon_first_node);
 
           if(mask_form->type & DT_MASKS_CLONE)
@@ -2421,7 +2472,7 @@ static int _polygon_get_area(const dt_iop_module_t *const module, dt_dev_pixelpi
  * @brief Write a falloff segment into the mask buffer.
  */
 /*static*/ void _polygon_falloff(float *const restrict buffer, int *p0, int *p1,
-                                 int posx, int posy, int buffer_width)
+                                 int posx, int posy, int buffer_width, const float gamma)
 {
   // segment length
   int l = sqrtf(sqf(p1[0] - p0[0]) + sqf(p1[1] - p0[1])) + 1;
@@ -2435,7 +2486,7 @@ static int _polygon_get_area(const dt_iop_module_t *const module, dt_dev_pixelpi
     // position
     const int x = (int)((float)i * lx * inv_l) + p0[0] - posx;
     const int y = (int)((float)i * ly * inv_l) + p0[1] - posy;
-    const float op = 1.0f - (float)i * inv_l;
+    const float op = powf(1.0f - (float)i * inv_l, gamma);
     const size_t idx = y * buffer_width + x;
     buffer[idx] = fmaxf(buffer[idx], op);
     if(x > 0)
@@ -2636,6 +2687,7 @@ static int _polygon_get_mask(const dt_iop_module_t *const module, dt_dev_pixelpi
   }
 
   // now we fill the falloff
+  const float gamma = ((dt_masks_node_polygon_t *)mask_form->points->data)->gamma;
   int p0[2] = { 0 }, p1[2] = { 0 };
   float pf1[2] = { 0.0f };
   int prev0[2] = { 0 }, prev1[2] = { 0 };
@@ -2675,14 +2727,14 @@ static int _polygon_get_mask(const dt_iop_module_t *const module, dt_dev_pixelpi
                        (int)floorf(prev0[1] + t * (p0[1] - prev0[1]) + 0.5f) };
         int mp1[2] = { (int)floorf(prev1[0] + t * (p1[0] - prev1[0]) + 0.5f),
                        (int)floorf(prev1[1] + t * (p1[1] - prev1[1]) + 0.5f) };
-        _polygon_falloff(bufptr, mp0, mp1, *posx, *posy, *width);
+        _polygon_falloff(bufptr, mp0, mp1, *posx, *posy, *width, gamma);
       }
     }
 
     // and we draw the falloff
     if(last0[0] != p0[0] || last0[1] != p0[1] || last1[0] != p1[0] || last1[1] != p1[1])
     {
-      _polygon_falloff(bufptr, p0, p1, *posx, *posy, *width);
+      _polygon_falloff(bufptr, p0, p1, *posx, *posy, *width, gamma);
       last0[0] = p0[0];
       last0[1] = p0[1];
       last1[0] = p1[0];
@@ -3015,7 +3067,7 @@ fallback_passes:
 }
 
 /** we write a falloff segment respecting limits of buffer */
-static inline void _polygon_falloff_roi(float *buffer, int *p0, int *p1, int bw, int bh)
+static inline void _polygon_falloff_roi(float *buffer, int *p0, int *p1, int bw, int bh, const float gamma)
 {
   // segment length
   const int l = sqrt((p1[0] - p0[0]) * (p1[0] - p0[0]) + (p1[1] - p0[1]) * (p1[1] - p0[1])) + 1;
@@ -3038,7 +3090,7 @@ static inline void _polygon_falloff_roi(float *buffer, int *p0, int *p1, int bw,
     // position
     const int x = (int)((float)i * lx * inv_l) + p0[0];
     const int y = (int)((float)i * ly * inv_l) + p0[1];
-    const float op = 1.0f - (float)i * inv_l;
+    const float op = powf(1.0f - (float)i * inv_l, gamma);
     if(!inside && (x < 0 || x >= bw || y < 0 || y >= bh)) continue;
     float *buf = buffer + (size_t)y * bw + x;
     if(inside)
@@ -3338,6 +3390,7 @@ static int _polygon_get_mask_roi(const dt_iop_module_t *const module, dt_dev_pix
       return 1;
     }
 
+    const float gamma = ((dt_masks_node_polygon_t *)mask_form->points->data)->gamma;
     int dindex = 0;
     int p0[2], p1[2];
     float pf1[2];
@@ -3427,7 +3480,7 @@ static int _polygon_get_mask_roi(const dt_iop_module_t *const module, dt_dev_pix
     }
     __OMP_PARALLEL_FOR__(if(dindex > 4096))
     for(int n = 0; n < dindex; n += 4)
-      _polygon_falloff_roi(buffer, dpoints + n, dpoints + n + 2, width, height);
+      _polygon_falloff_roi(buffer, dpoints + n, dpoints + n + 2, width, height, gamma);
 
     dt_pixelpipe_cache_free_align(dpoints);
 


### PR DESCRIPTION
<img width="1134" height="532" alt="image" src="https://github.com/user-attachments/assets/e54c8e13-8a1b-4cd1-b414-d04664f0cfe6" />


## Summary

Adds a "Progression" falloff exponent to all 5 drawn-mask shapes (circle, ellipse, path,
brush, gradient), plus an on-canvas draggable handle for circle, ellipse and gradient.

- Reuses an unused struct field per shape (gradient's dead `steepness` field; a new field on
  circle/ellipse/polygon/brush) instead of growing the save format, aside from the required
  `DEVELOP_MASKS_VERSION` bump (6 → 7) with a legacy converter so existing masks load
  unaffected.
- Progression = 1 reproduces every shape's exact pre-existing falloff curve bit-for-bit —
  no visual change to any existing mask.
- Circle/ellipse/polygon/brush apply the exponent directly on top of their existing falloff
  math (`f^(2·gamma)`-style). Gradient needed its own tuning: applying the exponent directly
  compressed the visible transition into a sliver of the border-to-border width at extreme
  values, so its exponent grows quadratically with Progression instead, while still equaling
  1 (linear) at Progression = 1.
- The on-canvas handle sits in the falloff band between a shape's edge and its outer border,
  along the shape's own perpendicular axis, in addition to the existing "Progression" slider
  in the shape's context menu. Path and brush are slider-only — they have no single
  well-defined perpendicular axis to anchor a handle on.

## Plan

- [x] Progression exponent implemented on all 5 shapes (circle, ellipse, path, brush, gradient), with `DEVELOP_MASKS_VERSION` bumped 6 → 7 and a legacy converter so pre-existing masks migrate automatically.
- [x] On-canvas draggable handle implemented and verified in the running app for circle, ellipse and gradient — drag behavior, positioning, and live falloff reshaping all confirmed correct.
- [x] Gradient's exponent formula iterated and tuned in the running app until Progression's effect at extreme values (0.1 and 10) produced the expected border-to-border crushing, with no hard cuts or overshoot.
- [x] Path and brush expose the Progression slider only (no on-canvas handle, by design — neither shape has a single well-defined perpendicular axis to anchor one on).
- [ ] Gradient's algo still needs some adjustment. Better find a way to use the same math as other shapes (`f^(2·gamma)`)
- [ ] Add a per nodes Progression ? (may be useless)