### PR TITLE
iop: fix the no-OpenCL build of colorprimaries and colorequal

### DIFF
--- a/src/iop/colorequal.c
+++ b/src/iop/colorequal.c
@@ -2455,8 +2455,8 @@ void init_global(dt_iop_module_so_t *module)
 
 void cleanup_global(dt_iop_module_so_t *module)
 {
-  dt_iop_colorequal_global_data_t *gd = (dt_iop_colorequal_global_data_t *)module->data;
 #ifdef HAVE_OPENCL
+  dt_iop_colorequal_global_data_t *gd = (dt_iop_colorequal_global_data_t *)module->data;
   dt_opencl_free_kernel(gd->kernel_lut3d_tetrahedral);
   dt_opencl_free_kernel(gd->kernel_lut3d_trilinear);
   dt_opencl_free_kernel(gd->kernel_lut3d_pyramid);

--- a/src/iop/colorprimaries.c
+++ b/src/iop/colorprimaries.c
@@ -1335,8 +1335,8 @@ void init_global(dt_iop_module_so_t *module)
 
 void cleanup_global(dt_iop_module_so_t *module)
 {
-  dt_iop_colorprimaries_global_data_t *gd = (dt_iop_colorprimaries_global_data_t *)module->data;
 #ifdef HAVE_OPENCL
+  dt_iop_colorprimaries_global_data_t *gd = (dt_iop_colorprimaries_global_data_t *)module->data;
   dt_opencl_free_kernel(gd->kernel_lut3d_tetrahedral);
   dt_opencl_free_kernel(gd->kernel_lut3d_trilinear);
   dt_opencl_free_kernel(gd->kernel_lut3d_pyramid);


### PR DESCRIPTION
`cleanup_global()` in both modules declares its global-data pointer outside the `#ifdef HAVE_OPENCL` that is its only user — the `dt_free()` below goes through `module->data` directly.

A build configured without OpenCL therefore trips `-Werror=unused-variable`:

```
colorprimaries.c:1338: error: unused variable 'gd' [-Werror=unused-variable]
colorequal.c:2458:     error: unused variable 'gd' [-Werror=unused-variable]
```

That is every **nofeatures** job on Linux, Windows and macOS, so master is currently red and every open PR inherits the failure through the merge commit CI builds — including #1022, which is how I found it.

Moved each declaration inside the guard where it is used. Verified both files compile warning-free with `HAVE_OPENCL` defined and undefined.

🤖 Generated with [Claude Code](https://claude.com/claude-code)