### PR TITLE
build: replace deprecated jsonschema CLI with a direct API call

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -560,15 +560,33 @@ elseif(USE_OPENCL)
   message(STATUS "Test-compilation of OpenCL programs is disabled.")
 endif()
 
-# we need jsonschema to check noiseprofiles.json
-find_program(jsonschema_BIN jsonschema)
-if(${jsonschema_BIN} STREQUAL "jsonschema_BIN-NOTFOUND")
-  message(STATUS "Missing jsonschema, problems in noiseprofiles.json might go unnoticed")
-  set(VALIDATE_JSON 0)
-else(${jsonschema_BIN} STREQUAL "jsonschema_BIN-NOTFOUND")
-  message(STATUS "Found jsonschema")
-  set(VALIDATE_JSON 1)
-endif(${jsonschema_BIN} STREQUAL "jsonschema_BIN-NOTFOUND")
+# we need the jsonschema python library to check noiseprofiles.json.
+# We call its validation API ourselves (tools/validate_json_schema.py) instead
+# of the `jsonschema` command-line tool, which is deprecated upstream in favor
+# of the separate, not-universally-packaged `check-jsonschema`.
+# On Windows/MSYS2, CMake's Python3 finder prefers registry-registered
+# installs (the standalone Windows python.org/Store build) over whatever
+# `python3` is on PATH inside the MSYS2 shell build.sh runs from — that
+# registry Python never has the MSYS2-packaged jsonschema module. Make PATH
+# win so we pick up the same interpreter the MSYS2 package manager provides.
+set(Python3_FIND_REGISTRY "LAST")
+find_package(Python3 COMPONENTS Interpreter)
+set(VALIDATE_JSON 0)
+if(Python3_Interpreter_FOUND)
+  execute_process(
+    COMMAND ${Python3_EXECUTABLE} -c "import jsonschema"
+    RESULT_VARIABLE jsonschema_import_result
+    OUTPUT_QUIET ERROR_QUIET
+  )
+  if(jsonschema_import_result EQUAL 0)
+    message(STATUS "Found jsonschema")
+    set(VALIDATE_JSON 1)
+  else()
+    message(STATUS "Missing jsonschema, problems in noiseprofiles.json might go unnoticed")
+  endif()
+else()
+  message(STATUS "Missing Python3, problems in noiseprofiles.json might go unnoticed")
+endif()
 
 # we need an XSLT interpreter to generate preferences_gen.h and anselrc
 find_program(Xsltproc_BIN xsltproc)

--- a/data/CMakeLists.txt
+++ b/data/CMakeLists.txt
@@ -123,8 +123,8 @@ install(FILES gdb_commands DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/ansel COMPON
 if(${VALIDATE_JSON})
   add_custom_target(
     validate_noiseprofiles_json ALL
-    COMMAND ${jsonschema_BIN} -i ${CMAKE_CURRENT_SOURCE_DIR}/noiseprofiles.json ${CMAKE_CURRENT_SOURCE_DIR}/noiseprofiles.schema
-    DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/noiseprofiles.json ${CMAKE_CURRENT_SOURCE_DIR}/noiseprofiles.schema
+    COMMAND ${Python3_EXECUTABLE} ${CMAKE_SOURCE_DIR}/tools/validate_json_schema.py ${CMAKE_CURRENT_SOURCE_DIR}/noiseprofiles.json ${CMAKE_CURRENT_SOURCE_DIR}/noiseprofiles.schema
+    DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/noiseprofiles.json ${CMAKE_CURRENT_SOURCE_DIR}/noiseprofiles.schema ${CMAKE_SOURCE_DIR}/tools/validate_json_schema.py
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/
     COMMENT "Checking validity of noiseprofiles.json"
   )

--- a/tools/validate_json_schema.py
+++ b/tools/validate_json_schema.py
@@ -1,0 +1,74 @@
+#!/usr/bin/python3
+#   This file is part of darktable,
+#   Copyright (C) 2026 Ansel contributors.
+#
+#   darktable is free software: you can redistribute it and/or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation, either version 3 of the License, or
+#   (at your option) any later version.
+#
+#   darktable is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with darktable.  If not, see <http://www.gnu.org/licenses/>.
+#
+# Validate a JSON instance file against a JSON schema file.
+#
+# Replaces the `jsonschema` command-line tool, which the jsonschema library
+# itself deprecated in favor of the separate `check-jsonschema` package
+# (not packaged for every distro we build on). Calling the validation API
+# directly avoids the CLI's deprecation warning and the extra dependency.
+
+import json
+import os
+import sys
+
+
+def _validated_path(path_str):
+    base_dir = os.path.realpath(os.getcwd())
+    path = os.path.realpath(os.path.join(base_dir, path_str))
+    try:
+        confined = os.path.commonpath([path, base_dir]) == base_dir
+    except ValueError:
+        # raised on Windows when the two paths are on different drives
+        confined = False
+    if not confined:
+        print(f"error: path escapes the working directory: {path_str}", file=sys.stderr)
+        sys.exit(2)
+    if not os.path.isfile(path):
+        print(f"error: not a file: {path_str}", file=sys.stderr)
+        sys.exit(2)
+    return path
+
+
+def main():
+    if len(sys.argv) != 3:
+        print(f"usage: {sys.argv[0]} <instance.json> <schema.json>", file=sys.stderr)
+        return 2
+
+    import jsonschema
+
+    instance_path = _validated_path(sys.argv[1])
+    schema_path = _validated_path(sys.argv[2])
+
+    with open(instance_path, encoding="utf-8") as f:
+        instance = json.load(f)
+    with open(schema_path, encoding="utf-8") as f:
+        schema = json.load(f)
+
+    validator_cls = jsonschema.validators.validator_for(schema)
+    validator_cls.check_schema(schema)
+    validator = validator_cls(schema)
+
+    errors = sorted(validator.iter_errors(instance), key=str)
+    for error in errors:
+        print(error, file=sys.stderr)
+
+    return 1 if errors else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Stop invoking the `jsonschema` command-line tool, which emits a DeprecationWarning on every build (upstream now recommends the separate check-jsonschema package, which isn't reliably packaged across our target distros/MSYS2). tools/validate_json_schema.py calls the jsonschema library's validation API directly instead, same pass/fail semantics.

Also make CMake's Python3 detection prefer PATH over the Windows registry (Python3_FIND_REGISTRY LAST), so the MSYS2-provided interpreter — the one with the jsonschema module actually installed — gets picked over a registry-registered Windows Python.

Fixes #718