### PR TITLE
Memory: probe live system availability and shed the pixelpipe cache under pressure

### DIFF
--- a/data/anselconfig.xml.in
+++ b/data/anselconfig.xml.in
@@ -205,6 +205,13 @@
     <shortdescription>Memory reserved for pixelpipe (modules) cache (MiB)</shortdescription>
     <longdescription>This is the amount of memory that Ansel will use to keep intermediate module outputs for the pixelpipe</longdescription>
   </dtconfig>
+  <dtconfig>
+    <name>memory_pressure_floor</name>
+    <type>int</type>
+    <default>0</default>
+    <shortdescription>System memory pressure floor (MiB)</shortdescription>
+    <longdescription>When the system-wide available RAM drops below this, Ansel sheds its pixelpipe cache and returns the memory to the OS, regardless of the memory budgets above, to avoid being killed by the system out-of-memory watchdog. 0 = automatic (half the OS/apps headroom).</longdescription>
+  </dtconfig>
   <dtconfig prefs="processing" section="cpugpu" restart="true">
     <name>processing/timeout</name>
     <type min="0">int</type>

--- a/doc/pipeline-cache.md
+++ b/doc/pipeline-cache.md
@@ -581,3 +581,63 @@ the source.
   `dt_dev_pixelpipe_cache_get_writable()` has a single call site today (`pixelpipe_hb.c`), so this
   is not yet a reusable pattern — a second caller needing the same policy-aware-hit behavior should
   factor it into the cache layer instead of duplicating it.
+
+## 10. System memory pressure handling (issue #1083)
+
+The startup budgets (`dt_configure_runtime_performance()`: headroom / mipmap / pixelpipe split of
+the detected RAM, or of `host_memory_limit`) are only *plans*. They say nothing about what the
+system can actually back at any given moment, with other applications competing for the same
+physical pages. Historically three compounding problems turned that gap into OOM kills that users
+see as "Ansel crashed without message": the budgets were trusted blindly (a `host_memory_limit`
+above physical RAM was even honored as-is), freed arena runs never returned their physical pages
+to the OS (RSS was a permanent high-water mark), and nothing at runtime ever looked at the
+system-wide available memory.
+
+The defense has four layers, from planning to last resort:
+
+1. **Envelope-aware startup budgets** (`common/darktable.c`). The detected total RAM is clamped
+   by the physical RAM (so a misconfigured `host_memory_limit` can only shrink, never grow it) and
+   by the tightest cgroup-v2 `memory.max` on our own path (containers, Flatpak, systemd slices —
+   the kernel OOM-enforces that envelope no matter how much RAM the machine has). A **pressure
+   floor** is derived (conf key `memory_pressure_floor`, `0 = auto` = half the OS headroom,
+   bounded to the envelope): the system-wide available RAM under which we start shedding caches.
+
+2. **Lazy page release on every arena free** (`common/memory_arena.c`). `dt_cache_arena_free()`
+   marks the freed run `MADV_FREE`: the pages stay mapped and re-dirtying them before reclaim
+   costs nothing (the per-frame temp-buffer churn is unaffected), but the kernel may take them
+   back *at will* under pressure. Measured on a 24 Mpx export: ~44 % of the process RSS is
+   LazyFree at steady state — memory the kernel can have instantly, which starves the OOM killer
+   of a reason to pick us. `dt_cache_arena_trim()` is the hard variant (`MADV_DONTNEED` /
+   `VirtualFree(MEM_DECOMMIT)`) that hands all free runs back NOW; the 3-minute GC and the idle
+   shedder below call it so an idle Ansel doesn't sit on its high-water mark.
+
+3. **Allocation-time pressure valve** (`_system_memory_pressure_valve()`,
+   `develop/pixelpipe_cache.c`). Every arena allocation funnels through
+   `_arena_alloc_with_defrag()`, which first checks a rate-limited probe of the system-wide
+   available RAM (`dt_get_system_available_mem()`: MemAvailable on Linux — min'd with the cgroup
+   slack including its reclaimable `inactive_file`, where our own MADV_FREE'd pages land —
+   `ullAvailPhys` on Windows, free+inactive on macOS; `0` means "no information", which disables
+   the valve, not the allocation). If the allocation would push available RAM under the floor,
+   LRU entries are evicted until the deficit is covered. If even shedding everything cannot keep
+   HALF the floor, the allocation is refused: the pipeline fails with a clear message, which
+   beats a silent SIGKILL. A 5-second GUI timer (`_memory_pressure_shedder()`) covers the case
+   where *another* application creates the pressure while we sit idle and never allocate.
+
+4. **Pressure-aware tiling** (`dt_get_available_mem()`, `common/darktable.c`). The planning value
+   tiled modules size their working set from is capped by the live system availability (plus half
+   our own cache, which is LRU-evictable on demand — our own hoard must never force tiling), so
+   under pressure modules split into smaller tiles instead of planning allocations the valve
+   would refuse mid-pipe.
+
+Verified by running the same export with and without these layers inside
+`systemd-run --user --scope -p MemoryMax=1536M -p MemorySwapMax=0`: before, SIGKILL by the
+kernel OOM killer mid-export (journal: `Failed with result 'oom-kill'`), no output, no message;
+after, the envelope is detected at startup, budgets and floor scale to it, the cache sheds under
+pressure and the export completes — bit-identical pixels to the unconstrained run — down to a
+1280 MB envelope for a 24 Mpx image. Below that (1 GB) the *live working set* of a single
+pipeline pass (2–3 full-resolution float buffers that must coexist) simply doesn't fit, and no
+amount of eviction can compress it: that residual floor can only move with more aggressive
+tiling of the always-untiled modules, not with cache policy.
+
+Testing lever: the cgroup probe honors whatever limit `systemd-run -p MemoryMax=` sets, so
+pressure behavior is reproducible without actually starving the machine.

--- a/doc/pipeline-cache.md
+++ b/doc/pipeline-cache.md
@@ -618,10 +618,24 @@ The defense has four layers, from planning to last resort:
    slack including its reclaimable `inactive_file`, where our own MADV_FREE'd pages land —
    `ullAvailPhys` on Windows, free+inactive on macOS; `0` means "no information", which disables
    the valve, not the allocation). If the allocation would push available RAM under the floor,
-   LRU entries are evicted until the deficit is covered. If even shedding everything cannot keep
+   LRU entries are evicted until the deficit is covered, the arena is hard-trimmed, and the probe
+   is then **re-read from the OS** rather than credited with the bytes we think we released: how
+   much of an eviction actually reaches the system is not ours to guess (the per-free `MADV_FREE`
+   is a no-op on Windows, and elsewhere the kernel decides when those pages stop counting against
+   us), and an over-credit would wave the allocation through on a system that is still just as
+   full. If even shedding everything cannot keep
    HALF the floor, the allocation is refused: the pipeline fails with a clear message, which
    beats a silent SIGKILL. A 5-second GUI timer (`_memory_pressure_shedder()`) covers the case
    where *another* application creates the pressure while we sit idle and never allocate.
+
+   Two traps live in this valve. The probe costs ~61 µs (16 µs `/proc/meminfo` + 45 µs walking
+   the cgroup tree) — enough that the tiling planners alone would spend ~1.8 ms of a 16 ms
+   realtime frame on it — so `dt_get_system_available_mem()` caches its answer for 50 ms, and any
+   caller that just changed the situation itself must call `dt_invalidate_system_available_mem()`
+   first or it reads back its own pre-change snapshot. And the valve's running estimate (last
+   probe, minus our own allocations since) legitimately reaches 0 under sustained pressure, so
+   "does this platform answer at all" is a separate `sys_probe_valid` flag: deriving it from an
+   `est == 0` sentinel would silently disable the valve at exactly the moment it matters most.
 
 4. **Pressure-aware tiling** (`dt_get_available_mem()`, `common/darktable.c`). The planning value
    tiled modules size their working set from is capped by the live system availability (plus half

--- a/src/common/darktable.c
+++ b/src/common/darktable.c
@@ -1202,7 +1202,22 @@ int dt_init(int argc, char *argv[], const gboolean init_gui, const gboolean load
     return 1;
   }
 
-  darktable.pixelpipe_cache = dt_dev_pixelpipe_cache_init(darktable.dtresources.pixelpipe_memory);
+  // The arena is only a virtual-memory reservation (physical pages get committed on
+  // use), so init only fails on exhausted address space or a pathological requested
+  // size. Rather than aborting outright, retry smaller: a shrunken cache degrades
+  // performance, an abort loses the session.
+  size_t pipecache_size = darktable.dtresources.pixelpipe_memory;
+  darktable.pixelpipe_cache = dt_dev_pixelpipe_cache_init(pipecache_size);
+  while(IS_NULL_PTR(darktable.pixelpipe_cache) && pipecache_size / 2 >= (size_t)512 * 1024 * 1024)
+  {
+    pipecache_size /= 2;
+    fprintf(stderr,
+            "WARNING: can't reserve %" G_GSIZE_FORMAT " MiB of virtual memory for the pixelpipe cache, "
+            "retrying with %" G_GSIZE_FORMAT " MiB. Check your memory settings.\n",
+            2 * pipecache_size / (1024 * 1024), pipecache_size / (1024 * 1024));
+    darktable.pixelpipe_cache = dt_dev_pixelpipe_cache_init(pipecache_size);
+  }
+  darktable.dtresources.pixelpipe_memory = pipecache_size;
   if(IS_NULL_PTR(darktable.pixelpipe_cache))
   {
     fprintf(stderr, "ERROR: can't init pixelpipe cache, aborting.\n");
@@ -1666,7 +1681,7 @@ void dt_show_times_f(const dt_times_t *start, const char *prefix, const char *su
 #if defined(_WIN32)
 #include <windows.h>
 
-size_t get_usable_memory_bytes()
+static size_t _probe_system_available_mem(void)
 {
   MEMORYSTATUSEX status;
   status.dwLength = sizeof(status);
@@ -1679,7 +1694,7 @@ size_t get_usable_memory_bytes()
 #elif defined(__APPLE__)
 #include <mach/mach.h>
 
-size_t get_usable_memory_bytes()
+static size_t _probe_system_available_mem(void)
 {
   mach_port_t host = mach_host_self();
   vm_statistics64_data_t vmstat;
@@ -1696,33 +1711,158 @@ size_t get_usable_memory_bytes()
 #elif defined(__linux__)
 #include <string.h>
 
-size_t get_usable_memory_bytes()
+// A cgroup v2 memory.max limit (container, Flatpak sandbox, systemd slice) caps us
+// before the system-wide MemAvailable does: the kernel enforces it with a per-cgroup
+// OOM kill while /proc/meminfo still reports plenty of available RAM. Walk our own
+// cgroup path up to the root and report the tightest limit (out_limit) and the
+// tightest remaining slack including reclaimable pages (out_available), each
+// SIZE_MAX when no level sets a limit.
+static void _probe_cgroup_v2(size_t *out_limit, size_t *out_available)
+{
+  size_t tightest = SIZE_MAX;
+  size_t tightest_limit = SIZE_MAX;
+  *out_limit = SIZE_MAX;
+  *out_available = SIZE_MAX;
+
+  FILE *f = g_fopen("/proc/self/cgroup", "r");
+  if(IS_NULL_PTR(f)) return;
+
+  char line[512];
+  char path[512] = "";
+  while(fgets(line, sizeof(line), f))
+  {
+    // cgroup v2 unified hierarchy entry: "0::/user.slice/..."
+    if(!strncmp(line, "0::", 3))
+    {
+      g_strlcpy(path, line + 3, sizeof(path));
+      char *newline = strchr(path, '\n');
+      if(newline) *newline = '\0';
+      break;
+    }
+  }
+  fclose(f);
+  if(path[0] == '\0') return;
+
+  while(TRUE)
+  {
+    char file[1024];
+    snprintf(file, sizeof(file), "/sys/fs/cgroup%s/memory.max", path);
+    FILE *fmax = g_fopen(file, "r");
+    if(fmax)
+    {
+      // The file contains either a byte count or the literal "max" (no limit),
+      // which simply fails the numeric scan.
+      unsigned long long max_bytes = 0;
+      if(fscanf(fmax, "%llu", &max_bytes) == 1 && max_bytes > 0)
+      {
+        unsigned long long cur_bytes = max_bytes;
+        snprintf(file, sizeof(file), "/sys/fs/cgroup%s/memory.current", path);
+        FILE *fcur = g_fopen(file, "r");
+        if(fcur)
+        {
+          if(fscanf(fcur, "%llu", &cur_bytes) != 1) cur_bytes = max_bytes;
+          fclose(fcur);
+        }
+
+        // memory.current still charges pages the kernel could drop at will: the page
+        // cache and — critically for us — our own MADV_FREE'd arena pages, which land
+        // on the cgroup's inactive file LRU. Count that list as available, the same
+        // way system-wide MemAvailable does, or the slack of a busy cgroup would read
+        // ~0 even though our own freed cache is fully reclaimable.
+        unsigned long long inactive_file = 0;
+        snprintf(file, sizeof(file), "/sys/fs/cgroup%s/memory.stat", path);
+        FILE *fstat = g_fopen(file, "r");
+        if(fstat)
+        {
+          char stat_line[256];
+          while(fgets(stat_line, sizeof(stat_line), fstat))
+            if(sscanf(stat_line, "inactive_file %llu", &inactive_file) == 1) break;
+          fclose(fstat);
+        }
+
+        const size_t slack = (max_bytes > cur_bytes) ? (size_t)(max_bytes - cur_bytes) : 0;
+        const size_t available = slack + (size_t)inactive_file;
+        if(available < tightest) tightest = available;
+        if((size_t)max_bytes < tightest_limit) tightest_limit = (size_t)max_bytes;
+      }
+      fclose(fmax);
+    }
+
+    char *slash = strrchr(path, '/');
+    if(IS_NULL_PTR(slash) || slash == path) break;
+    *slash = '\0';
+  }
+
+  *out_limit = tightest_limit;
+  *out_available = tightest;
+}
+
+static size_t _probe_system_available_mem(void)
 {
   FILE *f = g_fopen("/proc/meminfo", "r");
   if(IS_NULL_PTR(f)) return 0;
 
   char line[256];
   size_t available_kb = 0;
+  size_t available = 0;
 
   while(fgets(line, sizeof(line), f))
   {
     if(sscanf(line, "MemAvailable: %" G_GSIZE_FORMAT " kB", &available_kb) == 1)
     {
-      fclose(f);
-      return available_kb * 1024; // kB to bytes
+      available = available_kb * 1024; // kB to bytes
+      break;
     }
   }
-
   fclose(f);
-  return 0;
+
+  size_t cgroup_limit = SIZE_MAX, cgroup_available = SIZE_MAX;
+  _probe_cgroup_v2(&cgroup_limit, &cgroup_available);
+  if(cgroup_available != SIZE_MAX) available = MIN(available, cgroup_available);
+
+  return available;
 }
 
 #else
-size_t get_usable_memory_bytes()
+static size_t _probe_system_available_mem(void)
 {
-  return 0; // Unsupported platform
+  return 0; // Unsupported platform: 0 = "no information", not "out of memory"
 }
 #endif
+
+size_t dt_get_system_available_mem(void)
+{
+  // The raw probe reads several /proc and /sys files; tiling planners and the
+  // pixelpipe pressure valve may call this dozens of times per pipeline run, so
+  // serve a short-lived cached value. Two threads racing a stale entry probe
+  // twice and store equivalent values — benign.
+  static gpointer cached_value = NULL;   // a size_t stored as pointer
+  static gpointer cached_time_us = NULL; // a gint64 stored as pointer
+
+  const gint64 now = g_get_monotonic_time();
+  const gint64 last = (gint64)(gintptr)g_atomic_pointer_get(&cached_time_us);
+  if(last != 0 && now - last < 50000) // 50 ms
+    return GPOINTER_TO_SIZE(g_atomic_pointer_get(&cached_value));
+
+  const size_t available = _probe_system_available_mem();
+  g_atomic_pointer_set(&cached_value, GSIZE_TO_POINTER(available));
+  g_atomic_pointer_set(&cached_time_us, (gpointer)(gintptr)now);
+  return available;
+}
+
+// Tightest container/cgroup memory limit this process runs under, SIZE_MAX when
+// uncontained. This is the envelope the kernel actually OOM-enforces on us,
+// regardless of how much RAM the machine has.
+static size_t _get_container_mem_limit(void)
+{
+#if defined(__linux__)
+  size_t cgroup_limit = SIZE_MAX, cgroup_available = SIZE_MAX;
+  _probe_cgroup_v2(&cgroup_limit, &cgroup_available);
+  return cgroup_limit;
+#else
+  return SIZE_MAX;
+#endif
+}
 
 
 int dt_worker_threads()
@@ -1732,7 +1872,21 @@ int dt_worker_threads()
 
 size_t dt_get_available_mem()
 {
-  return darktable.pixelpipe_cache->max_memory - darktable.pixelpipe_cache->current_memory;
+  const size_t budget_left = darktable.pixelpipe_cache->max_memory - darktable.pixelpipe_cache->current_memory;
+
+  // The budget is only a startup-time plan: cap it by what the system can actually
+  // back right now without dropping under the pressure floor (issue #1083), so
+  // tiled modules plan tile sizes that will survive the allocation-time pressure
+  // valve in pixelpipe_cache.c. Half of our own current cache usage counts as
+  // room too: it is LRU-evictable, and the valve will evict it on demand — our own
+  // cache must never be what forces a module into tiling.
+  const size_t sys_available = dt_get_system_available_mem();
+  if(sys_available == 0) return budget_left; // no information on this platform
+
+  const size_t pressure_floor = dt_get_memory_pressure_floor();
+  const size_t sys_room = ((sys_available > pressure_floor) ? sys_available - pressure_floor : 0)
+                          + darktable.pixelpipe_cache->current_memory / 2;
+  return MIN(budget_left, sys_room);
 }
 
 size_t dt_get_mipmap_mem()
@@ -1740,9 +1894,28 @@ size_t dt_get_mipmap_mem()
   return darktable.dtresources.mipmap_memory;
 }
 
+size_t dt_get_memory_pressure_floor(void)
+{
+  return darktable.dtresources.pressure_floor_memory;
+}
+
 void dt_configure_runtime_performance(dt_sys_resources_t *resources, gboolean init_gui)
 {
-  resources->total_memory = _get_total_memory() * 1000;
+  size_t physical_memory = _get_total_memory() * 1000;
+
+  // A container/cgroup memory limit (Flatpak sandbox, systemd slice, docker...) is
+  // the envelope the kernel actually OOM-enforces on us: inside it, the machine's
+  // physical RAM is irrelevant, so it IS our total memory for budgeting purposes.
+  const size_t container_limit = _get_container_mem_limit();
+  if(container_limit != SIZE_MAX && (physical_memory == 0 || container_limit < physical_memory))
+  {
+    dt_print(DT_DEBUG_MEMORY | DT_DEBUG_CACHE,
+             "[MEMORY CONFIGURATION] container/cgroup memory limit detected: %" G_GSIZE_FORMAT
+             " MiB — using it as the total RAM\n", container_limit / (1024 * 1024));
+    physical_memory = container_limit;
+  }
+
+  resources->total_memory = physical_memory;
 
   const size_t threads = darktable.num_openmp_threads;
   const size_t mem = resources->total_memory / (1024 * 1024);
@@ -1756,10 +1929,38 @@ void dt_configure_runtime_performance(dt_sys_resources_t *resources, gboolean in
   if(dt_conf_get_int64("host_memory_limit") > 0)
     resources->total_memory = dt_conf_get_int64("host_memory_limit") * 1024 * 1024;
 
+  // A host_memory_limit above the physical RAM would make us plan caches the system
+  // can never back: the OS OOM-killer, not us, would then enforce the difference by
+  // killing the app without a message (issue #1083). The user limit can only shrink
+  // the detected RAM, never grow it.
+  if(physical_memory > 0 && resources->total_memory > physical_memory)
+  {
+    fprintf(stderr,
+            "MEMORY WARNING: host_memory_limit (%" G_GSIZE_FORMAT " MiB) exceeds the physical RAM "
+            "(%" G_GSIZE_FORMAT " MiB) and was clamped to it.\n",
+            resources->total_memory / (1024 * 1024), physical_memory / (1024 * 1024));
+    resources->total_memory = physical_memory;
+  }
+
   // Keep OS headroom between 1 GB and a third of the system RAM
   resources->headroom_memory = dt_conf_get_int64("memory_os_headroom") * 1024 * 1024;
   resources->headroom_memory
       = CLAMP(resources->headroom_memory, 1024 * 1024 * 1024, resources->total_memory / 3);
+
+  // Runtime memory-pressure floor: while running, whenever the SYSTEM-wide available
+  // RAM drops below this — whether we or another application consumed it — the
+  // pixelpipe cache sheds entries and returns their pages to the OS instead of
+  // letting the system OOM-killer pick a victim (issue #1083). This is a live
+  // safety net on top of the static budgets below, which are only plans.
+  // Conf default 0 = auto: half the OS headroom.
+  // The bounds scale with the envelope: on a normal machine the floor stays within
+  // [512 MB, total/4], but inside a small container keeping 512 MB free would eat
+  // the whole allotment, so the lower bound relaxes to total/8 there.
+  int64_t pressure_floor = dt_conf_get_int64("memory_pressure_floor") * 1024 * 1024;
+  if(pressure_floor <= 0) pressure_floor = (int64_t)resources->headroom_memory / 2;
+  const int64_t floor_min = MIN((int64_t)512 * 1024 * 1024, (int64_t)resources->total_memory / 8);
+  const int64_t floor_max = MAX((int64_t)resources->total_memory / 4, floor_min);
+  resources->pressure_floor_memory = CLAMP(pressure_floor, floor_min, floor_max);
 
   // Keep mipmap cache between 256 MB and a sixth of the system RAM
   resources->mipmap_memory = dt_conf_get_int64("memory_mipmap_cache") * 1024 * 1024;
@@ -1800,6 +2001,9 @@ void dt_configure_runtime_performance(dt_sys_resources_t *resources, gboolean in
 
   dt_print(DT_DEBUG_MEMORY | DT_DEBUG_CACHE, _("[MEMORY CONFIGURATION] Pixelpipe cache size: %" G_GSIZE_FORMAT " MiB\n"),
            resources->pixelpipe_memory / (1024 * 1024));
+
+  dt_print(DT_DEBUG_MEMORY | DT_DEBUG_CACHE, _("[MEMORY CONFIGURATION] System memory pressure floor: %" G_GSIZE_FORMAT " MiB\n"),
+           resources->pressure_floor_memory / (1024 * 1024));
 
   dt_print(DT_DEBUG_MEMORY | DT_DEBUG_CACHE, _("[MEMORY CONFIGURATION] Worker threads: %i\n"), dt_worker_threads());
 
@@ -1851,7 +2055,7 @@ void dt_capabilities_cleanup()
 
 void dt_print_mem_usage()
 {
-  fprintf(stdout, "[memory] Currently-free and reclaimable memory detected: %lu MiB\n", get_usable_memory_bytes() / (1024 * 1024));
+  fprintf(stdout, "[memory] Currently-free and reclaimable memory detected: %lu MiB\n", dt_get_system_available_mem() / (1024 * 1024));
 
 #if defined(__linux__)
   char *line = NULL;

--- a/src/common/darktable.c
+++ b/src/common/darktable.c
@@ -1816,7 +1816,8 @@ static size_t _probe_system_available_mem(void)
   }
   fclose(f);
 
-  size_t cgroup_limit = SIZE_MAX, cgroup_available = SIZE_MAX;
+  size_t cgroup_limit = SIZE_MAX;
+  size_t cgroup_available = SIZE_MAX;
   _probe_cgroup_v2(&cgroup_limit, &cgroup_available);
   if(cgroup_available != SIZE_MAX) available = MIN(available, cgroup_available);
 
@@ -1830,24 +1831,43 @@ static size_t _probe_system_available_mem(void)
 }
 #endif
 
+/* Short-lived cache of the system probe. Measured at 61 µs per probe (16 µs for
+ * /proc/meminfo, 45 µs walking the cgroup tree), which the tiling planners alone
+ * would pay ~30 times per pipeline run — 1.8 ms of a 16 ms realtime frame. The
+ * cached value is at most DT_SYS_MEM_PROBE_PERIOD_US old; callers that just changed
+ * the situation themselves (the pixelpipe pressure valve, right after shedding
+ * cache) call dt_invalidate_system_available_mem() to force the next read to be
+ * ground truth. */
+#define DT_SYS_MEM_PROBE_PERIOD_US 50000 // 50 ms
+
+static GMutex _sys_mem_probe_lock;
+static size_t _sys_mem_probe_value = 0;
+static gint64 _sys_mem_probe_time_us = 0;
+
 size_t dt_get_system_available_mem(void)
 {
-  // The raw probe reads several /proc and /sys files; tiling planners and the
-  // pixelpipe pressure valve may call this dozens of times per pipeline run, so
-  // serve a short-lived cached value. Two threads racing a stale entry probe
-  // twice and store equivalent values — benign.
-  static gpointer cached_value = NULL;   // a size_t stored as pointer
-  static gpointer cached_time_us = NULL; // a gint64 stored as pointer
+  g_mutex_lock(&_sys_mem_probe_lock);
 
   const gint64 now = g_get_monotonic_time();
-  const gint64 last = (gint64)(gintptr)g_atomic_pointer_get(&cached_time_us);
-  if(last != 0 && now - last < 50000) // 50 ms
-    return GPOINTER_TO_SIZE(g_atomic_pointer_get(&cached_value));
+  if(_sys_mem_probe_time_us != 0 && now - _sys_mem_probe_time_us < DT_SYS_MEM_PROBE_PERIOD_US)
+  {
+    const size_t cached = _sys_mem_probe_value;
+    g_mutex_unlock(&_sys_mem_probe_lock);
+    return cached;
+  }
 
   const size_t available = _probe_system_available_mem();
-  g_atomic_pointer_set(&cached_value, GSIZE_TO_POINTER(available));
-  g_atomic_pointer_set(&cached_time_us, (gpointer)(gintptr)now);
+  _sys_mem_probe_value = available;
+  _sys_mem_probe_time_us = now;
+  g_mutex_unlock(&_sys_mem_probe_lock);
   return available;
+}
+
+void dt_invalidate_system_available_mem(void)
+{
+  g_mutex_lock(&_sys_mem_probe_lock);
+  _sys_mem_probe_time_us = 0;
+  g_mutex_unlock(&_sys_mem_probe_lock);
 }
 
 // Tightest container/cgroup memory limit this process runs under, SIZE_MAX when
@@ -1856,7 +1876,8 @@ size_t dt_get_system_available_mem(void)
 static size_t _get_container_mem_limit(void)
 {
 #if defined(__linux__)
-  size_t cgroup_limit = SIZE_MAX, cgroup_available = SIZE_MAX;
+  size_t cgroup_limit = SIZE_MAX;
+  size_t cgroup_available = SIZE_MAX;
   _probe_cgroup_v2(&cgroup_limit, &cgroup_available);
   return cgroup_limit;
 #else

--- a/src/common/darktable.h
+++ b/src/common/darktable.h
@@ -775,10 +775,11 @@ typedef enum dt_debug_thread_t
 
 typedef struct dt_sys_resources_t
 {
-  size_t total_memory;     // All RAM on system
-  size_t mipmap_memory;    // RAM allocated to mipmap cache
-  size_t headroom_memory;  // RAM left to OS & other Apps
-  size_t pixelpipe_memory; // RAM used by the pixelpipe cache (approx.)
+  size_t total_memory;          // All RAM on system
+  size_t mipmap_memory;         // RAM allocated to mipmap cache
+  size_t headroom_memory;       // RAM left to OS & other Apps
+  size_t pixelpipe_memory;      // RAM used by the pixelpipe cache (approx.)
+  size_t pressure_floor_memory; // System-wide available RAM under which we shed caches
 } dt_sys_resources_t;
 
 typedef struct darktable_t
@@ -933,6 +934,19 @@ size_t dt_get_available_mem();
 
 // Get the maximum size for the whole mipmap cache
 size_t dt_get_mipmap_mem();
+
+// Probe the system for currently-available (free + reclaimable) physical RAM, in bytes.
+// This is a live system-wide measurement, unrelated to our internal budgets: it shrinks
+// when OTHER applications allocate memory. On Linux it also honors a cgroup v2 memory
+// limit (containers, Flatpak, systemd slices) when one is set. Returns 0 when the
+// platform gives us no way to know — callers must treat 0 as "no information", not as
+// "out of memory".
+size_t dt_get_system_available_mem(void);
+
+// System-wide available RAM floor (bytes) under which caches must be shed to
+// keep the OS and other applications breathing, regardless of anselrc budgets.
+// See dt_configure_runtime_performance() for how it is derived.
+size_t dt_get_memory_pressure_floor(void);
 
 /**
  * @brief Set the memory buffer to zero as a pack of unsigned char

--- a/src/common/darktable.h
+++ b/src/common/darktable.h
@@ -941,7 +941,14 @@ size_t dt_get_mipmap_mem();
 // limit (containers, Flatpak, systemd slices) when one is set. Returns 0 when the
 // platform gives us no way to know — callers must treat 0 as "no information", not as
 // "out of memory".
+// The value is cached for a few tens of milliseconds (the probe reads several /proc and
+// /sys files), so it may lag reality by that much.
 size_t dt_get_system_available_mem(void);
+
+// Drop the cached probe value so the next dt_get_system_available_mem() re-reads the OS.
+// For callers that just changed the situation themselves (freeing caches) and need the
+// resulting number to be ground truth rather than a pre-change snapshot.
+void dt_invalidate_system_available_mem(void);
 
 // System-wide available RAM floor (bytes) under which caches must be shed to
 // keep the OS and other applications breathing, regardless of anselrc budgets.

--- a/src/common/memory_arena.c
+++ b/src/common/memory_arena.c
@@ -37,6 +37,27 @@ typedef struct dt_free_run_t
   uint32_t length;
 } dt_free_run_t;
 
+/* Lazily hand the physical pages backing a freed run back to the OS.
+ * MADV_FREE marks them reclaimable-at-will: the kernel only takes them under actual
+ * memory pressure, and re-dirtying them before that happens costs nothing — the right
+ * trade for the hot per-frame alloc/free churn of module temp buffers. Without this,
+ * the arena's RSS is a permanent high-water mark: LRU eviction and cache flushes never
+ * relieve the system, and on a loaded machine the OOM-killer fires (issue #1083).
+ * On Windows nothing is released per-free (a MEM_DECOMMIT here would force a zero-fill
+ * re-commit on every hot realloc); dt_cache_arena_trim() decommits free runs instead
+ * when pressure actually calls for it. */
+static inline void _arena_release_run_lazy(uint8_t *ptr, size_t size)
+{
+#if !defined(_WIN32) && defined(MADV_FREE)
+  if(madvise(ptr, size, MADV_FREE))
+    dt_print(DT_DEBUG_MEMORY, "[arena] MADV_FREE of %" G_GSIZE_FORMAT " bytes failed: %s\n",
+             size, strerror(errno));
+#else
+  (void)ptr;
+  (void)size;
+#endif
+}
+
 gboolean dt_cache_arena_calc(const dt_cache_arena_t *a,
                              size_t size,
                              uint32_t *out_pages,
@@ -172,6 +193,11 @@ void dt_cache_arena_free(dt_cache_arena_t *a,
 
   const uint32_t first = (uint32_t)first_sz;
 
+  /* Release the physical backing before the run is published to the free list:
+   * until the insert below, this range still belongs exclusively to the caller,
+   * so no concurrent alloc can be handed these pages while we drop them. */
+  _arena_release_run_lazy((uint8_t *)ptr, (size_t)pages * a->page_size);
+
   dt_pthread_mutex_lock(&a->lock);
 
   /* insert a new free run, keeping free_runs sorted by start page */
@@ -252,6 +278,41 @@ void dt_cache_arena_stats(dt_cache_arena_t *a,
 
   if(out_total_free_pages) *out_total_free_pages = total;
   if(out_largest_free_run_pages) *out_largest_free_run_pages = largest;
+}
+
+size_t dt_cache_arena_trim(dt_cache_arena_t *a)
+{
+  if(IS_NULL_PTR(a) || IS_NULL_PTR(a->base) || !a->free_runs || a->page_size == 0) return 0;
+
+  size_t released = 0;
+
+  /* The whole walk must hold the arena lock: a run released outside it could be
+   * carved out by a concurrent dt_cache_arena_alloc() and already written to by
+   * the time we drop its pages — silently destroying that consumer's pixels. */
+  dt_pthread_mutex_lock(&a->lock);
+  for(guint i = 0; i < a->free_runs->len; i++)
+  {
+    dt_free_run_t *r = &g_array_index(a->free_runs, dt_free_run_t, i);
+    uint8_t *ptr = a->base + (size_t)r->start * a->page_size;
+    const size_t size = (size_t)r->length * a->page_size;
+
+#if defined(_WIN32)
+    /* Decommitting an uncommitted page is documented as a no-op, so free runs never
+     * carved out yet are safe. dt_cache_arena_alloc() re-commits on the next use. */
+    if(VirtualFree(ptr, size, MEM_DECOMMIT)) released += size;
+#elif defined(__APPLE__) && defined(MADV_FREE)
+    /* On macOS MADV_DONTNEED doesn't actually release anonymous pages; MADV_FREE is
+     * the strongest sane option and feeds the system-wide memory-pressure machinery. */
+    if(!madvise(ptr, size, MADV_FREE)) released += size;
+#elif defined(MADV_DONTNEED)
+    if(!madvise(ptr, size, MADV_DONTNEED)) released += size;
+#endif
+  }
+  dt_pthread_mutex_unlock(&a->lock);
+
+  dt_print(DT_DEBUG_MEMORY, "[arena] trimmed %" G_GSIZE_FORMAT " MiB of free pages back to the OS\n",
+           released / (1024 * 1024));
+  return released;
 }
 
 void dt_cache_arena_cleanup(dt_cache_arena_t *a)

--- a/src/common/memory_arena.c
+++ b/src/common/memory_arena.c
@@ -37,27 +37,6 @@ typedef struct dt_free_run_t
   uint32_t length;
 } dt_free_run_t;
 
-/* Lazily hand the physical pages backing a freed run back to the OS.
- * MADV_FREE marks them reclaimable-at-will: the kernel only takes them under actual
- * memory pressure, and re-dirtying them before that happens costs nothing — the right
- * trade for the hot per-frame alloc/free churn of module temp buffers. Without this,
- * the arena's RSS is a permanent high-water mark: LRU eviction and cache flushes never
- * relieve the system, and on a loaded machine the OOM-killer fires (issue #1083).
- * On Windows nothing is released per-free (a MEM_DECOMMIT here would force a zero-fill
- * re-commit on every hot realloc); dt_cache_arena_trim() decommits free runs instead
- * when pressure actually calls for it. */
-static inline void _arena_release_run_lazy(uint8_t *ptr, size_t size)
-{
-#if !defined(_WIN32) && defined(MADV_FREE)
-  if(madvise(ptr, size, MADV_FREE))
-    dt_print(DT_DEBUG_MEMORY, "[arena] MADV_FREE of %" G_GSIZE_FORMAT " bytes failed: %s\n",
-             size, strerror(errno));
-#else
-  (void)ptr;
-  (void)size;
-#endif
-}
-
 gboolean dt_cache_arena_calc(const dt_cache_arena_t *a,
                              size_t size,
                              uint32_t *out_pages,
@@ -193,10 +172,23 @@ void dt_cache_arena_free(dt_cache_arena_t *a,
 
   const uint32_t first = (uint32_t)first_sz;
 
-  /* Release the physical backing before the run is published to the free list:
-   * until the insert below, this range still belongs exclusively to the caller,
-   * so no concurrent alloc can be handed these pages while we drop them. */
-  _arena_release_run_lazy((uint8_t *)ptr, (size_t)pages * a->page_size);
+#if !defined(_WIN32) && defined(MADV_FREE)
+  /* Lazily hand the physical pages back to the OS, BEFORE the run is published to the
+   * free list below: until then this range still belongs exclusively to the caller, so
+   * no concurrent alloc can be handed these pages while we are dropping them.
+   * MADV_FREE marks them reclaimable-at-will — the kernel only takes them under actual
+   * memory pressure, and re-dirtying them before that costs nothing, which is the right
+   * trade for the hot per-frame alloc/free churn of module temp buffers. Without this
+   * the arena's RSS is a permanent high-water mark: LRU eviction and cache flushes never
+   * relieve the system, and on a loaded machine the OOM-killer fires (issue #1083).
+   * Windows gets nothing here on purpose (a MEM_DECOMMIT would force a zero-fill
+   * re-commit on every hot realloc); dt_cache_arena_trim() decommits free runs there
+   * when pressure actually calls for it. */
+  const size_t release_size = (size_t)pages * a->page_size;
+  if(madvise(ptr, release_size, MADV_FREE))
+    dt_print(DT_DEBUG_MEMORY, "[arena] MADV_FREE of %" G_GSIZE_FORMAT " bytes failed: %s\n",
+             release_size, strerror(errno));
+#endif
 
   dt_pthread_mutex_lock(&a->lock);
 

--- a/src/common/memory_arena.h
+++ b/src/common/memory_arena.h
@@ -62,6 +62,13 @@ void dt_cache_arena_stats(dt_cache_arena_t *a,
                           uint32_t *out_total_free_pages,
                           uint32_t *out_largest_free_run_pages);
 
+// Hard-release the physical pages backing every currently-free run, so the OS
+// gets them back NOW (not lazily) while the virtual reservation stays intact.
+// Complements the lazy per-free release in dt_cache_arena_free(): call this when
+// the system is under memory pressure and other applications need the RAM.
+// Thread-safe. Returns the number of bytes released.
+size_t dt_cache_arena_trim(dt_cache_arena_t *a);
+
 int dt_cache_arena_init(dt_cache_arena_t *a, size_t total_size);
 void dt_cache_arena_cleanup(dt_cache_arena_t *a);
 

--- a/src/common/nn_model.c
+++ b/src/common/nn_model.c
@@ -617,24 +617,6 @@ static void _gelu(float *x, size_t n)
   for(size_t i = 0; i < n; i++) x[i] = 0.5f * x[i] * (1.0f + erff(x[i] * (float)M_SQRT1_2));
 }
 
-__DT_CLONE_TARGETS__
-static void _upsample2x(const float *in, int ch, int w, int h, float *out)
-{
-#ifdef _OPENMP
-#pragma omp parallel for schedule(static)
-#endif
-  for(int c = 0; c < ch; c++)
-  {
-    const float *const ip = in + (size_t)c * w * h;
-    float *const op = out + (size_t)c * 4 * w * h;
-    for(int y = 0; y < 2 * h; y++)
-    {
-      const float *const irow = ip + (size_t)(y >> 1) * w;
-      float *const orow = op + (size_t)y * 2 * w;
-      for(int x = 0; x < 2 * w; x++) orow[x] = irow[x >> 1];
-    }
-  }
-}
 
 /* Peak live scratch of one net's forward, in floats: the ledger of the EXACT
  * allocate/free sequence of the forwards. cl_variant selects which one:

--- a/src/develop/pixelpipe_cache.c
+++ b/src/develop/pixelpipe_cache.c
@@ -119,6 +119,7 @@ static gboolean _cache_entry_clmem_flush_device(dt_pixel_cache_entry_t *entry, c
 static gboolean _cache_entry_materialize_host_data_locked(dt_pixel_cache_entry_t *entry, int preferred_devid,
                                                           gboolean prefer_device_payload);
 static int dt_dev_pixelpipe_cache_flush_old(dt_dev_pixelpipe_cache_t *cache);
+static int _memory_pressure_shedder(dt_dev_pixelpipe_cache_t *cache);
 
 #ifdef HAVE_OPENCL
 static gboolean _cache_entry_clmem_flush_host_pinned_locked(dt_pixel_cache_entry_t *entry, void *host_ptr, int devid);
@@ -1452,11 +1453,109 @@ dt_pixel_cache_entry_t *dt_dev_pixelpipe_cache_ref_entry_for_host_ptr(dt_dev_pix
   return entry;
 }
 
+/* System memory-pressure valve (issue #1083).
+ *
+ * The internal budget (max_memory) is only a plan made at startup: it says nothing
+ * about what the system can actually back RIGHT NOW, with other applications competing
+ * for the same physical RAM. Before growing our committed footprint by `request_size`,
+ * make sure the system-wide available memory keeps the configured floor
+ * (dt_get_memory_pressure_floor()); when it doesn't, evict LRU entries to cover the
+ * deficit — their pages return to the OS through the arena's lazy release — so the
+ * system OOM-killer never has a reason to look at us.
+ *
+ * The probe is rate-limited and the cached value is decremented by our own
+ * allocations in between, so the hot path pays one probe per PROBE_PERIOD at most.
+ *
+ * Returns TRUE when the allocation may proceed. Returns FALSE when, even after
+ * shedding everything evictable, the system could not take `request_size` more bytes
+ * without dropping under HALF the floor: the caller must fail the allocation cleanly —
+ * a failed pipeline with a message beats a silent SIGKILL from the OOM-killer.
+ */
+static gboolean _system_memory_pressure_valve(dt_dev_pixelpipe_cache_t *cache, size_t request_size)
+{
+  const size_t pressure_floor = dt_get_memory_pressure_floor();
+  if(pressure_floor == 0) return TRUE;
+
+  dt_pthread_mutex_lock(&cache->lock);
+
+  const gint64 now = g_get_monotonic_time();
+  const gint64 PROBE_PERIOD_US = 100000; // 100 ms
+  if(cache->sys_probe_time_us == 0 || now - cache->sys_probe_time_us > PROBE_PERIOD_US)
+  {
+    cache->sys_available_est = dt_get_system_available_mem();
+    cache->sys_probe_time_us = now;
+  }
+
+  // 0 = the platform gives us no information: pressure handling disabled.
+  if(cache->sys_available_est == 0)
+  {
+    dt_pthread_mutex_unlock(&cache->lock);
+    return TRUE;
+  }
+
+  if(cache->sys_available_est < request_size + pressure_floor)
+  {
+    const size_t deficit = request_size + pressure_floor - cache->sys_available_est;
+    size_t freed = 0;
+    while(freed < deficit && g_hash_table_size(cache->entries) > 0)
+    {
+      const size_t before = cache->current_memory;
+      if(_non_thread_safe_pixel_pipe_cache_remove_lru(cache)) break;
+      freed += before - cache->current_memory;
+    }
+
+    // The freed pages are reclaimable by the kernel at will (MADV_FREE), so they
+    // count as available for our own next page touches.
+    cache->sys_available_est += freed;
+
+    if(freed)
+      dt_print(DT_DEBUG_MEMORY | DT_DEBUG_PIPECACHE,
+               "[pixelpipe_cache] system memory pressure: shed %" G_GSIZE_FORMAT " MiB of cache "
+               "(%" G_GSIZE_FORMAT " MiB available, floor %" G_GSIZE_FORMAT " MiB)\n",
+               freed / (1024 * 1024), cache->sys_available_est / (1024 * 1024),
+               pressure_floor / (1024 * 1024));
+  }
+
+  const gboolean allowed = cache->sys_available_est >= request_size + pressure_floor / 2;
+
+  if(allowed)
+  {
+    // Optimistically debit the estimate now that the caller will commit these pages;
+    // self-corrects at the next probe if the arena allocation fails afterwards.
+    cache->sys_available_est
+        = (cache->sys_available_est > request_size) ? cache->sys_available_est - request_size : 0;
+  }
+  else
+  {
+    // Warn the user at most every 10 s: this fires per failed allocation, on a
+    // system that is already drowning.
+    static gint64 last_warning_us = 0;
+    if(now - last_warning_us > 10000000)
+    {
+      last_warning_us = now;
+      dt_control_log(_("Your system is running out of memory. "
+                       "Close other applications or add more RAM to your system."));
+    }
+    fprintf(stdout,
+            "[pixelpipe_cache] refusing to allocate %" G_GSIZE_FORMAT " MiB: the system has only "
+            "%" G_GSIZE_FORMAT " MiB of available RAM left (pressure floor: %" G_GSIZE_FORMAT " MiB)\n",
+            request_size / (1024 * 1024), cache->sys_available_est / (1024 * 1024),
+            pressure_floor / (1024 * 1024));
+  }
+
+  dt_pthread_mutex_unlock(&cache->lock);
+  return allowed;
+}
+
 // Attempt to allocate from the arena; if fragmentation prevents it, evict LRU cache lines
 // until a sufficiently large contiguous run is available (or nothing remains to evict).
 static inline void *_arena_alloc_with_defrag(dt_dev_pixelpipe_cache_t *cache, size_t request_size,
                                              size_t *actual_size)
 {
+  // Never grow the committed footprint past what the system can actually take,
+  // whatever our internal budget still allows.
+  if(!_system_memory_pressure_valve(cache, request_size)) return NULL;
+
   void *buf = dt_cache_arena_alloc(&cache->arena, request_size, actual_size);
   if(!IS_NULL_PTR(buf)) return buf;
 
@@ -1880,6 +1979,7 @@ static void _free_cache_entry(dt_pixel_cache_entry_t *cache_entry)
 }
 
 static int garbage_collection = 0;
+static int pressure_shedding = 0;
 
 dt_dev_pixelpipe_cache_t * dt_dev_pixelpipe_cache_init(size_t max_memory)
 {
@@ -1891,6 +1991,8 @@ dt_dev_pixelpipe_cache_t * dt_dev_pixelpipe_cache_init(size_t max_memory)
   cache->current_memory = 0;
   cache->next_serial = 1;
   cache->queries = cache->hits = 0;
+  cache->sys_probe_time_us = 0;
+  cache->sys_available_est = 0;
 
   if(IS_NULL_PTR(cache->entries) || IS_NULL_PTR(cache->external_entries))
   {
@@ -1912,6 +2014,11 @@ dt_dev_pixelpipe_cache_t * dt_dev_pixelpipe_cache_init(size_t max_memory)
 
   // Run every 3 minutes
   garbage_collection = g_timeout_add(3 * 60 * 1000, (GSourceFunc)dt_dev_pixelpipe_cache_flush_old, cache);
+
+  // React within seconds when ANOTHER application's allocations push the system
+  // toward memory starvation while we sit idle (the alloc-time pressure valve only
+  // runs when we allocate). No-ops when the system has RAM to spare.
+  pressure_shedding = g_timeout_add_seconds(5, (GSourceFunc)_memory_pressure_shedder, cache);
   return cache;
 }
 
@@ -1929,6 +2036,12 @@ void dt_dev_pixelpipe_cache_cleanup(dt_dev_pixelpipe_cache_t *cache)
   {
     g_source_remove(garbage_collection);
     garbage_collection = 0;
+  }
+
+  if(pressure_shedding != 0)
+  {
+    g_source_remove(pressure_shedding);
+    pressure_shedding = 0;
   }
 }
 
@@ -2404,6 +2517,59 @@ static int dt_dev_pixelpipe_cache_flush_old(dt_dev_pixelpipe_cache_t *cache)
   if(dt_pthread_mutex_trylock(&cache->lock)) return G_SOURCE_CONTINUE;
   g_hash_table_foreach_remove(cache->entries, _for_each_remove_old, NULL);
   dt_pthread_mutex_unlock(&cache->lock);
+
+  // Hand free pages back to the OS while we're at it, but only when the system
+  // actually runs lowish: the per-free MADV_FREE already makes them reclaimable
+  // (they count as available), and a hard trim of a large resident free set is
+  // O(resident pages) under the arena lock — a needless stall of this (GUI)
+  // thread when RAM is plentiful.
+  const size_t available = dt_get_system_available_mem();
+  const size_t pressure_floor = dt_get_memory_pressure_floor();
+  if(available > 0 && pressure_floor > 0 && available < 2 * pressure_floor)
+    dt_cache_arena_trim(&cache->arena);
+  return G_SOURCE_CONTINUE;
+}
+
+/* Periodic system memory-pressure shedder (issue #1083), the idle-time counterpart of
+ * the alloc-time _system_memory_pressure_valve(): when OTHER applications push the
+ * system toward starvation while we are not allocating anything, nobody runs the valve,
+ * so watch the system-wide available RAM here and shed cache below the floor. The
+ * hard trim matters: the per-free lazy release (MADV_FREE) technically keeps the pages
+ * ours until the kernel scavenges them, while decommitting hands them over NOW. */
+static int _memory_pressure_shedder(dt_dev_pixelpipe_cache_t *cache)
+{
+  const size_t pressure_floor = dt_get_memory_pressure_floor();
+  if(pressure_floor == 0) return G_SOURCE_CONTINUE;
+
+  const size_t available = dt_get_system_available_mem();
+  if(available == 0 || available >= pressure_floor) return G_SOURCE_CONTINUE;
+
+  // Don't hang the GUI thread if the cache is locked by a pipeline.
+  // The valve covers pressure handling while pipelines are allocating anyway.
+  if(dt_pthread_mutex_trylock(&cache->lock)) return G_SOURCE_CONTINUE;
+
+  const size_t deficit = pressure_floor - available;
+  size_t freed = 0;
+  while(freed < deficit && g_hash_table_size(cache->entries) > 0)
+  {
+    const size_t before = cache->current_memory;
+    if(_non_thread_safe_pixel_pipe_cache_remove_lru(cache)) break;
+    freed += before - cache->current_memory;
+  }
+
+  // Refresh the valve's probe cache while we hold the lock and the data.
+  cache->sys_available_est = available + freed;
+  cache->sys_probe_time_us = g_get_monotonic_time();
+  dt_pthread_mutex_unlock(&cache->lock);
+
+  const size_t trimmed = dt_cache_arena_trim(&cache->arena);
+
+  dt_print(DT_DEBUG_MEMORY | DT_DEBUG_PIPECACHE,
+           "[pixelpipe_cache] system memory pressure while idle: %" G_GSIZE_FORMAT " MiB available "
+           "under the %" G_GSIZE_FORMAT " MiB floor — shed %" G_GSIZE_FORMAT " MiB of cache, "
+           "returned %" G_GSIZE_FORMAT " MiB to the OS\n",
+           available / (1024 * 1024), pressure_floor / (1024 * 1024), freed / (1024 * 1024),
+           trimmed / (1024 * 1024));
   return G_SOURCE_CONTINUE;
 }
 

--- a/src/develop/pixelpipe_cache.c
+++ b/src/develop/pixelpipe_cache.c
@@ -1460,11 +1460,15 @@ dt_pixel_cache_entry_t *dt_dev_pixelpipe_cache_ref_entry_for_host_ptr(dt_dev_pix
  * for the same physical RAM. Before growing our committed footprint by `request_size`,
  * make sure the system-wide available memory keeps the configured floor
  * (dt_get_memory_pressure_floor()); when it doesn't, evict LRU entries to cover the
- * deficit — their pages return to the OS through the arena's lazy release — so the
- * system OOM-killer never has a reason to look at us.
+ * deficit, hand their pages back to the OS for real, and re-read what that actually
+ * bought — so the system OOM-killer never has a reason to look at us.
  *
  * The probe is rate-limited and the cached value is decremented by our own
  * allocations in between, so the hot path pays one probe per PROBE_PERIOD at most.
+ * That running estimate legitimately reaches 0 under sustained pressure, which is why
+ * "the platform answers at all" is tracked separately (`sys_probe_valid`) instead of
+ * being read off a 0 estimate: conflating the two would disable the valve at exactly
+ * the moment it matters.
  *
  * Returns TRUE when the allocation may proceed. Returns FALSE when, even after
  * shedding everything evictable, the system could not take `request_size` more bytes
@@ -1482,12 +1486,14 @@ static gboolean _system_memory_pressure_valve(dt_dev_pixelpipe_cache_t *cache, s
   const gint64 PROBE_PERIOD_US = 100000; // 100 ms
   if(cache->sys_probe_time_us == 0 || now - cache->sys_probe_time_us > PROBE_PERIOD_US)
   {
-    cache->sys_available_est = dt_get_system_available_mem();
+    const size_t probed = dt_get_system_available_mem();
+    cache->sys_probe_valid = (probed > 0);
+    cache->sys_available_est = probed;
     cache->sys_probe_time_us = now;
   }
 
-  // 0 = the platform gives us no information: pressure handling disabled.
-  if(cache->sys_available_est == 0)
+  // The platform gives us no way to know: pressure handling disabled, never refuse.
+  if(!cache->sys_probe_valid)
   {
     dt_pthread_mutex_unlock(&cache->lock);
     return TRUE;
@@ -1504,19 +1510,37 @@ static gboolean _system_memory_pressure_valve(dt_dev_pixelpipe_cache_t *cache, s
       freed += before - cache->current_memory;
     }
 
-    // The freed pages are reclaimable by the kernel at will (MADV_FREE), so they
-    // count as available for our own next page touches.
-    cache->sys_available_est += freed;
-
     if(freed)
+    {
+      /* Evicting only returns the pages to the ARENA. How much of that reaches the OS
+       * is not ours to guess: the per-free lazy release is a no-op on Windows until a
+       * decommit runs, and even where MADV_FREE applies, the kernel decides when those
+       * pages stop counting against us. So hand them over for real, then take the new
+       * number from the OS instead of crediting what we think we released — an
+       * over-credit here would let the allocation through on a system that is still
+       * just as full, which is precisely the OOM this valve exists to prevent.
+       * Ordering note: cache->lock is held and dt_cache_arena_trim() takes arena.lock,
+       * matching the cache->lock → arena.lock order the rest of this file already uses
+       * (see the defrag path below). */
+      dt_cache_arena_trim(&cache->arena);
+      dt_invalidate_system_available_mem();
+      const size_t probed = dt_get_system_available_mem();
+      cache->sys_probe_valid = (probed > 0);
+      cache->sys_available_est = probed;
+      cache->sys_probe_time_us = g_get_monotonic_time();
+
       dt_print(DT_DEBUG_MEMORY | DT_DEBUG_PIPECACHE,
                "[pixelpipe_cache] system memory pressure: shed %" G_GSIZE_FORMAT " MiB of cache "
-               "(%" G_GSIZE_FORMAT " MiB available, floor %" G_GSIZE_FORMAT " MiB)\n",
+               "(%" G_GSIZE_FORMAT " MiB available after trim, floor %" G_GSIZE_FORMAT " MiB)\n",
                freed / (1024 * 1024), cache->sys_available_est / (1024 * 1024),
                pressure_floor / (1024 * 1024));
+    }
   }
 
-  const gboolean allowed = cache->sys_available_est >= request_size + pressure_floor / 2;
+  // The post-trim re-probe can itself come back unanswered; absence of information is
+  // never a reason to refuse (see the dt_get_system_available_mem() header contract).
+  const gboolean allowed = !cache->sys_probe_valid
+                           || (cache->sys_available_est >= request_size + pressure_floor / 2);
 
   if(allowed)
   {
@@ -1993,6 +2017,7 @@ dt_dev_pixelpipe_cache_t * dt_dev_pixelpipe_cache_init(size_t max_memory)
   cache->queries = cache->hits = 0;
   cache->sys_probe_time_us = 0;
   cache->sys_available_est = 0;
+  cache->sys_probe_valid = FALSE;
 
   if(IS_NULL_PTR(cache->entries) || IS_NULL_PTR(cache->external_entries))
   {
@@ -2557,19 +2582,23 @@ static int _memory_pressure_shedder(dt_dev_pixelpipe_cache_t *cache)
     freed += before - cache->current_memory;
   }
 
-  // Refresh the valve's probe cache while we hold the lock and the data.
-  cache->sys_available_est = available + freed;
+  // Same reasoning as in the valve: hand the freed pages over for real, then let the
+  // OS — not our own bookkeeping — say what that bought, and seed the valve's probe
+  // cache with that ground truth.
+  const size_t trimmed = dt_cache_arena_trim(&cache->arena);
+  dt_invalidate_system_available_mem();
+  const size_t available_after = dt_get_system_available_mem();
+  cache->sys_probe_valid = (available_after > 0);
+  cache->sys_available_est = available_after;
   cache->sys_probe_time_us = g_get_monotonic_time();
   dt_pthread_mutex_unlock(&cache->lock);
-
-  const size_t trimmed = dt_cache_arena_trim(&cache->arena);
 
   dt_print(DT_DEBUG_MEMORY | DT_DEBUG_PIPECACHE,
            "[pixelpipe_cache] system memory pressure while idle: %" G_GSIZE_FORMAT " MiB available "
            "under the %" G_GSIZE_FORMAT " MiB floor — shed %" G_GSIZE_FORMAT " MiB of cache, "
-           "returned %" G_GSIZE_FORMAT " MiB to the OS\n",
+           "returned %" G_GSIZE_FORMAT " MiB to the OS, now %" G_GSIZE_FORMAT " MiB available\n",
            available / (1024 * 1024), pressure_floor / (1024 * 1024), freed / (1024 * 1024),
-           trimmed / (1024 * 1024));
+           trimmed / (1024 * 1024), available_after / (1024 * 1024));
   return G_SOURCE_CONTINUE;
 }
 

--- a/src/develop/pixelpipe_cache.h
+++ b/src/develop/pixelpipe_cache.h
@@ -64,9 +64,12 @@ typedef struct dt_dev_pixelpipe_cache_t
   size_t current_memory;
   // System memory-pressure probe cache, guarded by `lock` (see the pressure valve
   // in pixelpipe_cache.c): last probed system-wide available RAM, decremented by
-  // our own allocations between two rate-limited probes.
+  // our own allocations between two rate-limited probes. The estimate legitimately
+  // reaches 0 under pressure, so whether the platform answers at all is a separate
+  // flag rather than an `est == 0` sentinel.
   gint64 sys_probe_time_us;
   size_t sys_available_est;
+  gboolean sys_probe_valid;
   dt_pthread_mutex_t lock; // mutex to protect the cache entries
   dt_cache_arena_t arena;
 } dt_dev_pixelpipe_cache_t;

--- a/src/develop/pixelpipe_cache.h
+++ b/src/develop/pixelpipe_cache.h
@@ -62,6 +62,11 @@ typedef struct dt_dev_pixelpipe_cache_t
   uint64_t hits;
   size_t max_memory;
   size_t current_memory;
+  // System memory-pressure probe cache, guarded by `lock` (see the pressure valve
+  // in pixelpipe_cache.c): last probed system-wide available RAM, decremented by
+  // our own allocations between two rate-limited probes.
+  gint64 sys_probe_time_us;
+  size_t sys_available_est;
   dt_pthread_mutex_t lock; // mutex to protect the cache entries
   dt_cache_arena_t arena;
 } dt_dev_pixelpipe_cache_t;

--- a/src/develop/tiling.c
+++ b/src/develop/tiling.c
@@ -1463,9 +1463,10 @@ int dt_tiling_piece_fits_host_memory(const size_t width, const size_t height, co
      * dt_get_available_mem() (issue #1083), which eviction cannot reliably
      * raise — freed pages reach the OS asynchronously. Draining the whole
      * cache would not change the answer; the caller tiles instead. */
-    size_t current = 0, max = 0;
-    dt_dev_pixelpipe_cache_get_usage(darktable.pixelpipe_cache, &current, &max);
-    if(max - current >= total && (size_t)(0.9f * largest_run) >= total) break;
+    size_t cache_current = 0;
+    size_t cache_max = 0;
+    dt_dev_pixelpipe_cache_get_usage(darktable.pixelpipe_cache, &cache_current, &cache_max);
+    if(cache_max - cache_current >= total && (size_t)(0.9f * largest_run) >= total) break;
 
     error = dt_dev_pixel_pipe_cache_remove_lru(darktable.pixelpipe_cache);
     available = dt_get_available_mem();

--- a/src/develop/tiling.c
+++ b/src/develop/tiling.c
@@ -273,7 +273,13 @@ static int _default_process_tiling_ptp(struct dt_iop_module_t *self, const struc
 
   /* calculate optimal size of tiles */
   float available = dt_get_available_mem();
-  assert(available >= 500.0f * 1024.0f * 1024.0f);
+  // Less than 500 MB of planning room is a legitimate runtime state now that
+  // dt_get_available_mem() is capped by live system availability (issue #1083):
+  // tiles just get small. Not an invariant, so no assert.
+  if(available < 500.0f * 1024.0f * 1024.0f)
+    dt_print(DT_DEBUG_TILING | DT_DEBUG_MEMORY,
+             "[tiling] low memory (%.0f MiB): tiling '%s' aggressively\n",
+             available / (1024.0f * 1024.0f), self->op);
   /* correct for size of ivoid and ovoid which are needed on top of tiling */
   available = fmaxf(available - ((float)roi_out->width * roi_out->height * out_bpp)
                    - ((float)roi_in->width * roi_in->height * in_bpp) - tiling.overhead,
@@ -527,7 +533,13 @@ static int _default_process_tiling_roi(struct dt_iop_module_t *self, const struc
 
   /* calculate optimal size of tiles */
   float available = dt_get_available_mem();
-  assert(available >= 500.0f * 1024.0f * 1024.0f);
+  // Less than 500 MB of planning room is a legitimate runtime state now that
+  // dt_get_available_mem() is capped by live system availability (issue #1083):
+  // tiles just get small. Not an invariant, so no assert.
+  if(available < 500.0f * 1024.0f * 1024.0f)
+    dt_print(DT_DEBUG_TILING | DT_DEBUG_MEMORY,
+             "[tiling] low memory (%.0f MiB): tiling '%s' aggressively\n",
+             available / (1024.0f * 1024.0f), self->op);
   /* correct for size of ivoid and ovoid which are needed on top of tiling */
   available = fmaxf(available - ((float)roi_out->width * roi_out->height * out_bpp)
                    - ((float)roi_in->width * roi_in->height * in_bpp) - tiling.overhead,
@@ -1446,6 +1458,15 @@ int dt_tiling_piece_fits_host_memory(const size_t width, const size_t height, co
   int error = 0;
   while(!error && (available < total || (size_t)(0.9f * largest_run) < total))
   {
+    /* Stop evicting once the internal budget headroom already fits: past that
+     * point the blocker is the system-availability cap inside
+     * dt_get_available_mem() (issue #1083), which eviction cannot reliably
+     * raise — freed pages reach the OS asynchronously. Draining the whole
+     * cache would not change the answer; the caller tiles instead. */
+    size_t current = 0, max = 0;
+    dt_dev_pixelpipe_cache_get_usage(darktable.pixelpipe_cache, &current, &max);
+    if(max - current >= total && (size_t)(0.9f * largest_run) >= total) break;
+
     error = dt_dev_pixel_pipe_cache_remove_lru(darktable.pixelpipe_cache);
     available = dt_get_available_mem();
     largest_run = dt_pixelpipe_cache_get_largest_free_run(darktable.pixelpipe_cache);

--- a/src/iop/rawdenoiseai.c
+++ b/src/iop/rawdenoiseai.c
@@ -437,8 +437,8 @@ static void *_region_alloc(nn_region_t *r, size_t bytes, int long_lived)
       gap = r->blocks[i].off + r->blocks[i].len;
     }
     dt_print(DT_DEBUG_ALWAYS,
-             "[rawdenoiseai] region alloc failed: %zu bytes (%s), region %zu, live %zu in %d blocks, "
-             "largest gap %zu\n",
+             "[rawdenoiseai] region alloc failed: %" G_GSIZE_FORMAT " bytes (%s), region %" G_GSIZE_FORMAT
+             ", live %" G_GSIZE_FORMAT " in %d blocks, largest gap %" G_GSIZE_FORMAT "\n",
              bytes, long_lived ? "long-lived" : "churn", r->size, live, r->n_blocks, largest_gap);
     return NULL;
   }


### PR DESCRIPTION
Fixes #1083 — the "Ansel crashed without message" OOM kills.

## Root cause

Three compounding problems turned the startup memory *plans* into OOM kills on loaded or scarce-RAM systems:

1. **Budgets ignored reality.** The arena was sized from `total RAM − headroom − mipmap` (or from a user `host_memory_limit` that could even exceed physical RAM), and nothing ever checked what the system could actually back with other applications competing for the same pages.
2. **Freed memory never returned to the OS.** `dt_cache_arena_free()` only put pages back in the free-run list — process RSS was a permanent high-water mark, so even LRU eviction and the 3-minute GC never relieved the system.
3. **No runtime pressure response.** Eviction only triggered on our own budget and arena fragmentation; system-wide memory pressure was invisible, so the kernel OOM killer fired first — `SIGKILL`, no message, nothing we could catch.

The issue said "there is no cross-platform way of probing available memory" — but `get_usable_memory_bytes()` already existed for Linux/macOS/Windows; it was just only used in a debug printf. This PR promotes it to a load-bearing part of the memory system.

## The four layers

1. **Envelope-aware startup budgets** (`common/darktable.c`): `host_memory_limit` can only shrink, never exceed, physical RAM; a cgroup v2 `memory.max` (container, Flatpak, systemd slice) is detected and used as the total RAM — the kernel OOM-enforces that envelope regardless of the machine's RAM. A **pressure floor** is derived (new hidden conf key `memory_pressure_floor`, `0 = auto` = half the OS headroom, bounded to the envelope).
2. **Arena returns pages** (`common/memory_arena.c`): `MADV_FREE` on every free — lazy, costless for the hot per-frame temp-buffer churn, and the kernel may reclaim those pages at will under pressure. Measured: **~44 % of export-time RSS is LazyFree** at steady state, i.e. pre-offered to the kernel, starving the OOM killer of a reason to pick us. `dt_cache_arena_trim()` is the hard variant (`MADV_DONTNEED` / `VirtualFree(MEM_DECOMMIT)`) for when pressure actually calls for it.
3. **Allocation-time valve** (`develop/pixelpipe_cache.c`): every arena allocation passes a rate-limited probe of system-wide available RAM (Linux: `MemAvailable` min'd with cgroup slack including its reclaimable `inactive_file`, where our own MADV_FREE'd pages land; Windows: `ullAvailPhys`; macOS: free+inactive). Below the floor, LRU entries are evicted to cover the deficit; if even shedding everything cannot keep half the floor, the allocation **fails cleanly with a message** instead of the process dying. A 5 s timer covers pressure created by *other* applications while Ansel idles.
4. **Pressure-aware tiling** (`dt_get_available_mem()`): tile planning is capped by live availability (plus half our own evictable cache), so modules tile smaller under pressure instead of planning working sets the valve would refuse mid-pipe.

Also: cache init retries at half size instead of aborting when the virtual reservation fails, and the tiling fit-check no longer drains the whole cache when the system cap (not the budget) is the blocker.

## Verification

Reproducible without starving the machine, thanks to the cgroup probe: `systemd-run --user --scope -p MemoryMax=1536M -p MemorySwapMax=0 -- ansel-cli <24 Mpx NEF> out.tif` (unconstrained peak RSS of this export: 1.83 GB).

| | master | this PR |
|---|---|---|
| 1536 MB cap | **SIGKILL by OOM killer** mid-export, no output, no message (journal: `Failed with result 'oom-kill'`) | export completes; envelope detected at startup, budgets/floor scaled to it |
| 1280 MB cap | — | export completes |
| 1024 MB cap | killed | pipeline fails (below the intrinsic ~1.2 GB live working set of a 24 Mpx pipe — 2–3 coexisting full-res float buffers; a tiling matter, not a cache one) |
| 4-image sequential export @1536 MB | killed on image 1 | all valid images exported, shed events logged |
| pixels under pressure | — | **bit-identical** to unconstrained, which is bit-identical to master |
| unconstrained wall time | 28.35 s | 28.38 s (no overhead; RSS peak unchanged) |

LazyFree sampled mid-export via `/proc/<pid>/smaps_rollup`: RSS 1297 MB / LazyFree 565 MB.

Not covered by automated testing: the GUI shedder timer path (same eviction internals as the valve, exercised via CLI). Worth a real darkroom session on a scarce-RAM machine — the scenario this issue reports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)