### PR TITLE
Masks: expurge the darktable.develop global from the whole masks subsystem

### DIFF
--- a/src/common/history_merge_gui.c
+++ b/src/common/history_merge_gui.c
@@ -360,8 +360,11 @@ static gboolean _hm_history_masks_match(const dt_dev_history_item_t *a, const dt
   {
     dt_masks_form_t *a_form = dt_masks_get_from_id_ext(a->forms, a_mask_id);
     dt_masks_form_t *b_form = dt_masks_get_from_id_ext(b->forms, b_mask_id);
-    const uint64_t a_hash = dt_masks_group_get_hash(0, a_form);
-    const uint64_t b_hash = dt_masks_group_get_hash(0, b_form);
+    // Each snapshot is hashed against its OWN forms list: resolving children from the live
+    // dev->forms (what the old dt_masks_group_get_hash() wrapper did) compared two hybrid
+    // states and could declare different snapshots equal.
+    const uint64_t a_hash = dt_masks_group_get_hash_ext(0, a->forms, a_form);
+    const uint64_t b_hash = dt_masks_group_get_hash_ext(0, b->forms, b_form);
     if(a_hash != b_hash) return FALSE;
   }
 

--- a/src/develop/blend_gui.c
+++ b/src/develop/blend_gui.c
@@ -1928,7 +1928,7 @@ static void _blendop_masks_all_selection_changed(GtkTreeSelection *selection, dt
   // That handler rebuilds the visible mask GUI and can be re-entered while this
   // blend list selection is still being processed.
   dt_dev_masks_selection_change(darktable.develop, NULL, formid, FALSE);
-  dt_masks_change_form_gui(mask_form);
+  dt_masks_change_form_gui(module->dev, mask_form);
   if(module->dev && module->dev->form_gui)
   {
     module->dev->form_gui->group_selected = 0;
@@ -1969,7 +1969,7 @@ static void _blendop_masks_all_toggled(GtkCellRendererToggle *cell, gchar *path_
   if(active)
   {
     if(!IS_NULL_PTR(group_form))
-      dt_masks_form_delete(module, group_form, mask_form);
+      dt_masks_form_delete(module->dev, module, group_form, mask_form);
   }
   else
   {
@@ -1980,7 +1980,7 @@ static void _blendop_masks_all_toggled(GtkCellRendererToggle *cell, gchar *path_
     if(!_blendop_masks_find_group_entry(group_form, mask_form->formid, NULL))
     {
       group_form = dt_masks_cow_touch(darktable.develop, group_form);
-      dt_masks_group_add_form(group_form, mask_form);
+      dt_masks_group_add_form(module->dev, group_form, mask_form);
       dt_masks_set_edit_mode(module, DT_MASKS_EDIT_FULL);
     }
   }
@@ -2028,8 +2028,8 @@ static void _blendop_masks_all_delete(dt_iop_module_t *module, const int formid)
 
   if(!dt_masks_gui_confirm_permanent_delete(mask_form->name)) return;
 
-  dt_masks_change_form_gui(NULL);
-  dt_masks_form_delete(module, NULL, mask_form);
+  dt_masks_change_form_gui(module->dev, NULL);
+  dt_masks_form_delete(module->dev, module, NULL, mask_form);
   _blendop_masks_apply_and_commit(module);
   DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_MASK_CHANGED, formid, 0, DT_MASKS_EVENT_DELETE);
 }
@@ -2318,7 +2318,7 @@ static void _blendop_masks_group_move_callback(GtkWidget *menu_item, dt_iop_modu
   dt_masks_form_t *group_form = dt_masks_get_from_id(darktable.develop, parentid);
   if(!_blendop_masks_group_move_by_index(group_form, index, move_up)) return;
 
-  dt_masks_change_form_gui(NULL);
+  dt_masks_change_form_gui(module->dev, NULL);
   _blendop_masks_apply_and_commit(module);
   DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_MASK_CHANGED, 0, parentid, DT_MASKS_EVENT_UPDATE);
 }
@@ -2351,6 +2351,7 @@ static GtkWidget *_blendop_masks_create_shape_buttons(dt_iop_module_t *module, d
   if(IS_NULL_PTR(module) || IS_NULL_PTR(bd)) return NULL;
 
   const dt_masks_shape_buttons_config_t config = {
+    .dev = module->dev,
     .owner_module = module,
     .creation_module = module,
     .buttons = bd->masks_shapes,
@@ -2460,10 +2461,10 @@ static void _blendop_masks_group_unlink(dt_iop_module_t *module, const int formi
   if(IS_NULL_PTR(parent_group) || !(parent_group->type & DT_MASKS_GROUP) || IS_NULL_PTR(form)) return;
 
   // Discard any visible overlay before mutating the group.
-  dt_masks_change_form_gui(NULL);
+  dt_masks_change_form_gui(module->dev, NULL);
 
   // Passing the parent group only detaches the form from this group.
-  dt_masks_form_delete(module, parent_group, form);
+  dt_masks_form_delete(module->dev, module, parent_group, form);
 
   _blendop_masks_apply_and_commit(module);
   _blendop_masks_refresh_lists(module);
@@ -2481,10 +2482,10 @@ static void _blendop_masks_group_delete(dt_iop_module_t *module, const int formi
   if(!dt_masks_gui_confirm_permanent_delete(form->name)) return;
 
   // Discard any visible overlay before mutating the masks.
-  dt_masks_change_form_gui(NULL);
+  dt_masks_change_form_gui(module->dev, NULL);
 
   // Passing no group permanently deletes the form from every module and dev->forms.
-  dt_masks_form_delete(module, NULL, form);
+  dt_masks_form_delete(module->dev, module, NULL, form);
 
   _blendop_masks_apply_and_commit(module);
   _blendop_masks_refresh_lists(module);

--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -1753,7 +1753,7 @@ void dt_dev_masks_update_hash(dt_develop_t *dev)
   for(GList *form = g_list_first(dev->forms); form; form = g_list_next(form))
   {
     dt_masks_form_t *shape = (dt_masks_form_t *)form->data;
-    hash = dt_masks_form_get_own_hash(hash, shape);
+    hash = dt_masks_form_get_own_hash(hash, dev->forms, shape);
   }
 
   dt_pthread_rwlock_unlock(&dev->masks_mutex);

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -2187,9 +2187,9 @@ static void _gui_reset_callback(GtkButton *button, GdkEventButton *event, dt_iop
     // if a drawn mask is set, remove it from the list
     if(module->blend_params->mask_id > 0)
     {
-      dt_masks_form_t *grp = dt_masks_get_from_id(darktable.develop, module->blend_params->mask_id);
+      dt_masks_form_t *grp = dt_masks_get_from_id(module->dev, module->blend_params->mask_id);
       // FIXME: ask the user if he wants to delete the mask, or just unlink them.
-      if(grp) dt_masks_form_delete(module, NULL, grp);
+      if(grp) dt_masks_form_delete(module->dev, module, NULL, grp);
       DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_MASK_CHANGED, -1, -1, DT_MASKS_EVENT_RESET);
     }
     /* reset to default params */
@@ -2267,7 +2267,7 @@ void dt_iop_request_focus(dt_iop_module_t *module)
     gtk_widget_set_state_flags(dt_iop_gui_get_pluginui(out_focus_module), GTK_STATE_FLAG_NORMAL, TRUE);
 
     /* reset mask view */
-    dt_masks_reset_form_gui();
+    dt_masks_reset_form_gui(out_focus_module->dev);
 
     /* do stuff needed in the blending gui */
     dt_iop_gui_blending_lose_focus(out_focus_module);

--- a/src/develop/masks.h
+++ b/src/develop/masks.h
@@ -36,7 +36,7 @@
 /*
 Typical forms tree structure :
 
-GList darktable.develop->forms
+GList dev->forms
   |
   0) dt_masks_form_t  circle --------------------> ID 1771813676,  "circle #2"
   |    { GList *points
@@ -319,7 +319,7 @@ typedef struct dt_masks_functions_t
   void (*set_hint_message)(const struct dt_masks_form_gui_t *const gui, const struct dt_masks_form_t *const form,
                            const int opacity, char *const __restrict__ msgbuf, const size_t msgbuf_len);
   void (*duplicate_points)(struct dt_develop_t *const dev, struct dt_masks_form_t *base, struct dt_masks_form_t *dest);
-  void (*initial_source_pos)(const float iwd, const float iht, float *x, float *y);
+  void (*initial_source_pos)(struct dt_develop_t *dev, const float iwd, const float iht, float *x, float *y);
   // input coordinates are in absolute output-image space, dist is squared in the same space
   void (*get_distance)(float x, float y, float as, struct dt_masks_form_gui_t *gui, int index, int num_points,
                        int *inside, int *inside_border, int *near, int *inside_source, float *dist);
@@ -342,7 +342,7 @@ typedef struct dt_masks_functions_t
   int (*get_source_area)(dt_iop_module_t *module, struct dt_dev_pixelpipe_t *pipe,
                          dt_dev_pixelpipe_iop_t *piece, struct dt_masks_form_t *form,
                          int *width, int *height, int *posx, int *posy);
-  gboolean (*get_gravity_center)(const struct dt_masks_form_t *form, float center[2], float *area);
+  gboolean (*get_gravity_center)(struct dt_develop_t *dev, const struct dt_masks_form_t *form, float center[2], float *area);
   float (*get_interaction_value)(const struct dt_masks_form_t *form, dt_masks_interaction_t interaction);
   float (*set_interaction_value)(struct dt_masks_form_t *form, dt_masks_interaction_t interaction, float value,
                                  dt_masks_increment_t increment, int flow,
@@ -366,8 +366,8 @@ typedef struct dt_masks_functions_t
   /* Key event */
   int (*key_pressed)(struct dt_iop_module_t *module, GdkEventKey *event, struct dt_masks_form_t *form, int parentid, struct dt_masks_form_gui_t *gui, int index);
   void (*post_expose)(cairo_t *cr, float zoom_scale, struct dt_masks_form_gui_t *gui, int index, int num_points);
-  // The function to draw the shape in question.
-  void (*draw_shape)(cairo_t *cr, const float *points, const int points_count, const int nb, const gboolean border, const gboolean source);
+  // The function to draw the shape in question. Signature must match shape_draw_function_t.
+  shape_draw_function_t draw_shape;
   /** initialise all control points to eventually match a catmull-rom like spline */
   void (*init_ctrl_points)(struct dt_masks_form_t *form);
   int (*populate_context_menu)(GtkWidget *menu, struct dt_masks_form_t *form, struct dt_masks_form_gui_t *gui, const float pzx, const float pzy);
@@ -439,6 +439,12 @@ typedef struct dt_masks_dynbuf_t
 /** structure used to display a form */
 typedef struct dt_masks_form_gui_t
 {
+  // Owning develop instance, set once at init. Mask GUI code must use this (or an explicit
+  // dev/module argument) instead of the darktable.develop global: shape handlers can run with
+  // module == NULL (mask-manager editing), and reaching for the global both couples every
+  // shape file to the whole application and hides which develop instance the code mutates.
+  struct dt_develop_t *dev;
+
   dt_masks_type_t type;
   // currently visible form when editing masks (GUI-only; may be a temporary copy)
   dt_masks_form_t *form_visible;
@@ -784,13 +790,11 @@ static inline float dt_masks_border_from_projected_handle(dt_develop_t *dev, con
 
 // Circle, ellipse and gradient creation previews all follow the same drawing sequence:
 // optional save/restore, draw the shape, then draw the border preview if present.
-static inline void dt_masks_draw_preview_shape(cairo_t *cr, const float zoom_scale, const int num_points,
+static inline void dt_masks_draw_preview_shape(struct dt_develop_t *dev, cairo_t *cr, const float zoom_scale,
+                                               const int num_points,
                                                float *points, const int points_count,
                                                float *border, const int border_count,
-                                               void (*const *draw_shape)(cairo_t *cr, const float *points,
-                                                                         const int points_count, const int nb,
-                                                                         const gboolean border,
-                                                                         const gboolean source),
+                                               const shape_draw_function_t *draw_shape,
                                                const cairo_line_cap_t shape_cap,
                                                const cairo_line_cap_t border_cap,
                                                const gboolean save_restore,
@@ -798,10 +802,10 @@ static inline void dt_masks_draw_preview_shape(cairo_t *cr, const float zoom_sca
 {
   if(save_restore) cairo_save(cr);
   if(points && points_count > 0)
-    dt_draw_shape_lines(DT_MASKS_NO_DASH, source, cr, num_points, FALSE, zoom_scale, points, points_count,
+    dt_draw_shape_lines(dev, DT_MASKS_NO_DASH, source, cr, num_points, FALSE, zoom_scale, points, points_count,
                         draw_shape, shape_cap);
   if(border && border_count > 0)
-    dt_draw_shape_lines(DT_MASKS_DASH_STICK, source, cr, num_points, FALSE, zoom_scale, border, border_count,
+    dt_draw_shape_lines(dev, DT_MASKS_DASH_STICK, source, cr, num_points, FALSE, zoom_scale, border, border_count,
                         draw_shape, border_cap);
   if(save_restore) cairo_restore(cr);
 }
@@ -849,7 +853,8 @@ extern const dt_masks_functions_t dt_masks_functions_gradient;
 extern const dt_masks_functions_t dt_masks_functions_group;
 
 /** init dt_masks_form_gui_t struct with default values */
-void dt_masks_init_form_gui(dt_masks_form_gui_t *gui);
+/** Reset a form GUI state and bind it to its owning develop instance (gui->dev). */
+void dt_masks_init_form_gui(dt_develop_t *dev, dt_masks_form_gui_t *gui);
 
 /** get points in real space with respect of distortion dx and dy are used to eventually move the center of
  * the circle */
@@ -908,8 +913,8 @@ int dt_masks_legacy_params(dt_develop_t *dev, void *params, const int old_versio
 
 /** we create a completely new form. */
 dt_masks_form_t *dt_masks_create(dt_masks_type_t type);
-/** we create a completely new form and add it to darktable.develop->allforms. */
-dt_masks_form_t *dt_masks_create_ext(dt_masks_type_t type);
+/** we create a completely new form and add it to dev->allforms. */
+dt_masks_form_t *dt_masks_create_ext(dt_develop_t *dev, dt_masks_type_t type);
 /** returns a form with formid == id from a list of forms */
 dt_masks_form_t *dt_masks_get_from_id_ext(GList *forms, int id);
 /** returns a form with formid == id from dev->forms */
@@ -928,11 +933,11 @@ void dt_masks_free_form(dt_masks_form_t *form);
 void dt_masks_cleanup_unused(dt_develop_t *dev);
 
 /** function used to manipulate forms for masks */
-void dt_masks_change_form_gui(dt_masks_form_t *newform);
+void dt_masks_change_form_gui(dt_develop_t *dev, dt_masks_form_t *newform);
 void dt_masks_clear_form_gui(dt_develop_t *dev);
-void dt_masks_reset_form_gui(void);
+void dt_masks_reset_form_gui(dt_develop_t *dev);
 void dt_masks_soft_reset_form_gui(dt_masks_form_gui_t *gui);
-void dt_masks_reset_show_masks_icons(void);
+void dt_masks_reset_show_masks_icons(dt_develop_t *dev);
 
 #define DEVELOP_MASKS_NB_SHAPES 5
 
@@ -976,6 +981,9 @@ typedef void (*dt_masks_shape_buttons_notify_f)(GtkWidget *button, dt_iop_module
 
 typedef struct dt_masks_shape_buttons_config_t
 {
+  // Owning develop instance. Mandatory: the GTK button callbacks have no other context when
+  // creation_module is NULL (the shape-manager toolbar case).
+  struct dt_develop_t *dev;
   dt_iop_module_t *owner_module;
   dt_iop_module_t *creation_module;
   GtkWidget **buttons;
@@ -994,15 +1002,15 @@ typedef struct dt_masks_shape_buttons_config_t
 GtkWidget *dt_masks_shape_buttons_create(const dt_masks_shape_buttons_config_t *config);
 void dt_masks_shape_buttons_deactivate_all(GtkWidget *active_button);
 
-int dt_masks_events_mouse_moved(struct dt_iop_module_t *module, double x, double y, double pressure,
+int dt_masks_events_mouse_moved(dt_develop_t *dev, struct dt_iop_module_t *module, double x, double y, double pressure,
                                 int which);
-int dt_masks_events_button_released(struct dt_iop_module_t *module, double x, double y, int which,
+int dt_masks_events_button_released(dt_develop_t *dev, struct dt_iop_module_t *module, double x, double y, int which,
                                     uint32_t state);
-int dt_masks_events_button_pressed(struct dt_iop_module_t *module, double x, double y, double pressure,
+int dt_masks_events_button_pressed(dt_develop_t *dev, struct dt_iop_module_t *module, double x, double y, double pressure,
                                    int which, int type, uint32_t state);
-int dt_masks_events_mouse_scrolled(struct dt_iop_module_t *module, double x, double y, int up, uint32_t state, int delta_y);
+int dt_masks_events_mouse_scrolled(dt_develop_t *dev, struct dt_iop_module_t *module, double x, double y, int up, uint32_t state, int delta_y);
 
-int dt_masks_events_key_pressed(struct dt_iop_module_t *module, GdkEventKey *event);
+int dt_masks_events_key_pressed(dt_develop_t *dev, struct dt_iop_module_t *module, GdkEventKey *event);
 /**
  * @brief returns wether a node is a corner or not.
  * A node is a corner if its 2 control handles are at the same position, else it's a curve.
@@ -1031,7 +1039,7 @@ void dt_masks_draw_source(cairo_t *cr, dt_masks_form_gui_t *gui, const int index
 void dt_masks_draw_path_seg_by_seg(cairo_t *cr, dt_masks_form_gui_t *gui, const int index, const float *points,
                                    const int points_count, const int node_count, const float zoom_scale);
 
-void dt_masks_events_post_expose(struct dt_iop_module_t *module, cairo_t *cr, int32_t width, int32_t height,
+void dt_masks_events_post_expose(dt_develop_t *dev, struct dt_iop_module_t *module, cairo_t *cr, int32_t width, int32_t height,
                                  int32_t pointerx, int32_t pointery);
 int dt_masks_events_mouse_leave(struct dt_iop_module_t *module);
 int dt_masks_events_mouse_enter(struct dt_iop_module_t *module);
@@ -1103,9 +1111,9 @@ void dt_masks_gui_form_test_create(dt_masks_form_t *form, dt_masks_form_gui_t *g
  */
 void dt_masks_gui_form_save_creation(dt_develop_t *dev, struct dt_iop_module_t *module, dt_masks_form_t *form,
                                      dt_masks_form_gui_t *gui);
-void dt_masks_group_ungroup(dt_masks_form_t *dest_grp, dt_masks_form_t *grp);
+void dt_masks_group_ungroup(dt_develop_t *dev, dt_masks_form_t *dest_grp, dt_masks_form_t *grp);
 void dt_masks_group_update_name(dt_iop_module_t *module);
-dt_masks_form_group_t *dt_masks_group_add_form(dt_masks_form_t *grp, dt_masks_form_t *form);
+dt_masks_form_group_t *dt_masks_group_add_form(dt_develop_t *dev, dt_masks_form_t *grp, dt_masks_form_t *form);
 
 void dt_masks_iop_value_changed_callback(GtkWidget *widget, struct dt_iop_module_t *module);
 dt_masks_edit_mode_t dt_masks_get_edit_mode(struct dt_iop_module_t *module);
@@ -1113,18 +1121,17 @@ void dt_masks_set_edit_mode(struct dt_iop_module_t *module, dt_masks_edit_mode_t
 void dt_masks_iop_update(struct dt_iop_module_t *module);
 void dt_masks_iop_combo_populate(GtkWidget *w, void *module);
 void dt_masks_iop_use_same_as(struct dt_iop_module_t *module, struct dt_iop_module_t *src);
-uint64_t dt_masks_group_get_hash(uint64_t hash, dt_masks_form_t *form);
-/** Same as dt_masks_group_get_hash(), but resolves grouped children from the given forms list
- * instead of the live dev->forms — mandatory when hashing a history/pipe snapshot, so the hash
- * describes one coherent state instead of mixing the snapshot's group with live children. */
+/** Hash a group's full content (recursing into members). Children are resolved from the given
+ * forms list — pass the same list the group came from (live dev->forms or a snapshot), so the
+ * hash describes one coherent state instead of mixing the group with foreign children. */
 uint64_t dt_masks_group_get_hash_ext(uint64_t hash, GList *masks, dt_masks_form_t *form);
-/** Same as dt_masks_group_get_hash(), but hashes only the form's own content: for a group,
+/** Same as dt_masks_group_get_hash_ext(), but hashes only the form's own content: for a group,
  * member references (id/state/opacity) instead of recursing into each member's content.
  * Meant for walking a flat list where every member already gets its own top-level call. */
-uint64_t dt_masks_form_get_own_hash(uint64_t hash, const dt_masks_form_t *form);
+uint64_t dt_masks_form_get_own_hash(uint64_t hash, GList *masks, const dt_masks_form_t *form);
 
-void dt_masks_form_delete(struct dt_iop_module_t *module, dt_masks_form_t *grp, dt_masks_form_t *form);
-int dt_masks_form_change_opacity(dt_masks_form_t *form, int parentid, int up, const int flow);
+void dt_masks_form_delete(dt_develop_t *dev, struct dt_iop_module_t *module, dt_masks_form_t *grp, dt_masks_form_t *form);
+int dt_masks_form_change_opacity(dt_develop_t *dev, dt_masks_form_t *form, int parentid, int up, const int flow);
 void dt_masks_form_move(dt_masks_form_t *grp, int formid, int up);
 int dt_masks_form_duplicate(dt_develop_t *dev, int formid);
 /* returns a duplicate tof form, including the formid */
@@ -1134,7 +1141,7 @@ dt_masks_form_t *dt_masks_dup_masks_form(const dt_masks_form_t *form);
 int dt_masks_point_in_form_exact(const float *pts, int num_pts, const float *points, int points_start, int points_count);
 
 /** allow to select a shape inside an iop */
-void dt_masks_select_form(struct dt_iop_module_t *module, dt_masks_form_t *sel);
+void dt_masks_select_form(dt_develop_t *dev, struct dt_iop_module_t *module, dt_masks_form_t *sel);
 
 /** utils for selecting the source of a clone mask while creating it */
 void dt_masks_set_source_pos_initial_state(dt_masks_form_gui_t *gui, const uint32_t state);
@@ -1164,7 +1171,7 @@ static inline void dt_masks_draw_source_preview(cairo_t *cr, const float zoom_sc
 float dt_masks_rotate_with_anchor(dt_develop_t *dev, const float anchor[2], const float center[2], dt_masks_form_gui_t *gui);
 
 /** Getters and setters for direct GUI interaction */
-dt_masks_form_group_t *dt_masks_form_group_from_parentid(int parentid, int formid);
+dt_masks_form_group_t *dt_masks_form_group_from_parentid(dt_develop_t *dev, int parentid, int formid);
 int dt_masks_group_index_from_formid(const dt_masks_form_t *group_form, int formid);
 dt_masks_form_group_t *dt_masks_form_get_selected_group(const struct dt_masks_form_t *form,
                                                         const struct dt_masks_form_gui_t *gui);
@@ -1185,10 +1192,10 @@ gboolean dt_masks_is_anything_hovered(const dt_masks_form_gui_t *mask_gui);
  */
 dt_masks_form_group_t *dt_masks_form_get_selected_group_live(const struct dt_masks_form_t *form,
                                                              const struct dt_masks_form_gui_t *gui);
-float dt_masks_form_get_interaction_value(dt_masks_form_group_t *form_group,
+float dt_masks_form_get_interaction_value(dt_develop_t *dev, dt_masks_form_group_t *form_group,
                                           dt_masks_interaction_t interaction);
-gboolean dt_masks_form_get_gravity_center(const struct dt_masks_form_t *form, float center[2], float *area);
-void dt_masks_form_update_gravity_center(struct dt_masks_form_t *form);
+gboolean dt_masks_form_get_gravity_center(dt_develop_t *dev, const struct dt_masks_form_t *form, float center[2], float *area);
+void dt_masks_form_update_gravity_center(dt_develop_t *dev, struct dt_masks_form_t *form);
 /** Marks gravity_center/area stale instead of recomputing them right away. Use for bulk
  * paths (loading history, undo/redo) that swap in many forms at once; the one GUI
  * hit-testing read site recomputes lazily on first actual use. */
@@ -1552,7 +1559,7 @@ int dt_masks_find_closest_handle_common(dt_masks_form_t *mask_form, dt_masks_for
                                         void *user_data);
 
 void dt_masks_creation_mode_quit(dt_masks_form_gui_t *gui);
-gboolean dt_masks_creation_mode_enter(dt_iop_module_t *module, const dt_masks_type_t type);
+gboolean dt_masks_creation_mode_enter(dt_develop_t *dev, dt_iop_module_t *module, const dt_masks_type_t type);
 void apply_operation(struct dt_masks_form_group_t *pt, const dt_masks_state_t apply_state);
 
 /** Contextual menu */

--- a/src/develop/masks/brush.c
+++ b/src/develop/masks/brush.c
@@ -730,7 +730,7 @@ static int _brush_get_pts_border(dt_develop_t *develop, dt_masks_form_t *mask_fo
 
   const float iwd = pipe->iwidth;
   const float iht = pipe->iheight;
-  const int pixel_threshold = (dt_dev_pixelpipe_has_preview_output(darktable.develop, pipe, NULL)
+  const int pixel_threshold = (dt_dev_pixelpipe_has_preview_output(develop, pipe, NULL)
                                || pipe->type == DT_DEV_PIXELPIPE_THUMBNAIL) ? 3 : 1;
 
   dt_masks_dynbuf_t *dpoints = NULL, *dborder = NULL, *dpayload = NULL;
@@ -1386,7 +1386,7 @@ static float _brush_get_interaction_value(const dt_masks_form_t *mask_form, dt_m
   }
 }
 
-static gboolean _brush_get_gravity_center(const dt_masks_form_t *mask_form, float center[2], float *area)
+static gboolean _brush_get_gravity_center(dt_develop_t *dev, const dt_masks_form_t *mask_form, float center[2], float *area)
 {
   if(IS_NULL_PTR(mask_form) || IS_NULL_PTR(mask_form->points)) return FALSE;
 
@@ -1545,7 +1545,7 @@ static int _brush_events_mouse_scrolled(struct dt_iop_module_t *module, double w
     }
 
     if(dt_modifier_is(state, GDK_CONTROL_MASK))
-      return dt_masks_form_change_opacity(mask_form, parentid, scroll_up, flow);
+      return dt_masks_form_change_opacity(mask_gui->dev, mask_form, parentid, scroll_up, flow);
     else if(dt_modifier_is(state, GDK_SHIFT_MASK))
       return _change_hardness(mask_form, parentid, mask_gui, module, index, scroll_up ? -0.01f : 0.01f,
                               DT_MASKS_INCREMENT_OFFSET, flow);
@@ -1589,7 +1589,7 @@ static void _add_node_to_segment(struct dt_iop_module_t *module, dt_masks_form_t
   if(IS_NULL_PTR(new_node)) return;
 
   // set coordinates
-  dt_masks_gui_cursor_to_raw_norm(darktable.develop, mask_gui, new_node->node);
+  dt_masks_gui_cursor_to_raw_norm(mask_gui->dev, mask_gui, new_node->node);
   new_node->ctrl1[0] = new_node->ctrl1[1] = new_node->ctrl2[0] = new_node->ctrl2[1] = -1.0;
   new_node->state = DT_MASKS_POINT_STATE_NORMAL;
 
@@ -1886,7 +1886,7 @@ static int _brush_events_button_released(struct dt_iop_module_t *module, double 
       float *guipoints_payload = dt_masks_dynbuf_buffer(mask_gui->guipoints_payload);
 
       // we transform the points
-      dt_dev_coordinates_image_abs_to_raw_norm(darktable.develop, guipoints, mask_gui->guipoints_count);
+      dt_dev_coordinates_image_abs_to_raw_norm(mask_gui->dev, guipoints, mask_gui->guipoints_count);
 
       // we consolidate pen pressure readings into payload
       _apply_pen_pressure(mask_gui, guipoints_payload);
@@ -1908,11 +1908,11 @@ static int _brush_events_button_released(struct dt_iop_module_t *module, double 
       mask_gui->guipoints_payload = NULL;
       mask_gui->guipoints_count = 0;
 
-      dt_masks_gui_form_save_creation(darktable.develop, creation_module, mask_form, mask_gui);
+      dt_masks_gui_form_save_creation(mask_gui->dev, creation_module, mask_form, mask_gui);
 
       if(mask_form->type & (DT_MASKS_CLONE | DT_MASKS_NON_CLONE))
       {
-        dt_masks_form_t *grp = dt_masks_get_visible_form(darktable.develop);
+        dt_masks_form_t *grp = dt_masks_get_visible_form(mask_gui->dev);
         if(IS_NULL_PTR(grp) || !(grp->type & DT_MASKS_GROUP)) return 1;
         int group_index = 0;
         int selected_index = -1;
@@ -1927,11 +1927,11 @@ static int _brush_events_button_released(struct dt_iop_module_t *module, double 
           group_index++;
         }
         if(selected_index < 0) return 1;
-        dt_masks_form_gui_t *visible_gui = darktable.develop->form_gui;
+        dt_masks_form_gui_t *visible_gui = mask_gui->dev->form_gui;
         if(IS_NULL_PTR(visible_gui)) return 1;
         visible_gui->group_selected = selected_index;
 
-        dt_masks_select_form(creation_module, dt_masks_get_from_id(darktable.develop, mask_form->formid));
+        dt_masks_select_form(mask_gui->dev, creation_module, dt_masks_get_from_id(mask_gui->dev, mask_form->formid));
       }
     }
     else
@@ -1946,7 +1946,7 @@ static int _brush_events_button_released(struct dt_iop_module_t *module, double 
       dt_masks_set_edit_mode(module, DT_MASKS_EDIT_FULL);
       dt_masks_iop_update(module);
 
-      dt_masks_change_form_gui(NULL);
+      dt_masks_change_form_gui(mask_gui->dev, NULL);
     }
     return 1;
   }
@@ -1978,9 +1978,9 @@ static int _brush_events_mouse_moved(struct dt_iop_module_t *module, double widg
                                      double pressure, int which, dt_masks_form_t *mask_form, int parentid,
                                      dt_masks_form_gui_t *mask_gui, int index)
 {
-  dt_develop_t *dev = (dt_develop_t *)darktable.develop;
-  const int iwidth = darktable.develop->roi.raw_width;
-  const int iheight = darktable.develop->roi.raw_height;
+  dt_develop_t *dev = mask_gui->dev;
+  const int iwidth = dev->roi.raw_width;
+  const int iheight = dev->roi.raw_height;
 
   if(mask_gui->creation)
   {
@@ -2063,7 +2063,7 @@ static int _brush_events_mouse_moved(struct dt_iop_module_t *module, double widg
                           cursor_pos[1], &control_points[0], &control_points[1], &control_points[2],
                           &control_points[3], TRUE);
 
-    dt_dev_coordinates_image_abs_to_raw_norm(darktable.develop, control_points, 2);
+    dt_dev_coordinates_image_abs_to_raw_norm(dev, control_points, 2);
 
     // set new ctrl points
     dt_masks_set_ctrl_points(node->ctrl1, node->ctrl2, control_points);
@@ -2117,7 +2117,7 @@ static int _brush_events_mouse_moved(struct dt_iop_module_t *module, double widg
     else
     {
       float raw_pos[2];
-      dt_masks_gui_delta_to_raw_norm(darktable.develop, mask_gui, raw_pos);
+      dt_masks_gui_delta_to_raw_norm(dev, mask_gui, raw_pos);
       mask_form->source[0] = raw_pos[0];
       mask_form->source[1] = raw_pos[1];
     }
@@ -2129,8 +2129,9 @@ static int _brush_events_mouse_moved(struct dt_iop_module_t *module, double widg
   return 0;
 }
 
-static void _brush_draw_shape(cairo_t *cr, const float *points, const int points_count, const int node_nb, const gboolean border, const gboolean source)
+static void _brush_draw_shape(struct dt_develop_t *dev, cairo_t *cr, const float *points, const int points_count, const int node_nb, const gboolean border, const gboolean source)
 {
+   // unused arg, keep compiler from complaining
  // Find the first valid non-NaN point to start drawing
  // FIXME: Why not just avoid having NaN points in the array?
   int start_idx = -1;
@@ -2269,13 +2270,13 @@ static void _brush_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks_fo
   // in creation mode
   if(mask_gui->creation)
   {
-    const float iwd = darktable.develop->roi.raw_width;
-    const float iht = darktable.develop->roi.raw_height;
+    const float iwd = mask_gui->dev->roi.raw_width;
+    const float iht = mask_gui->dev->roi.raw_height;
     const float min_iwd_iht = MIN(iwd, iht);
 
     if(mask_gui->guipoints_count == 0)
     {
-      dt_masks_form_t *mask_form = dt_masks_get_visible_form(darktable.develop);
+      dt_masks_form_t *mask_form = dt_masks_get_visible_form(mask_gui->dev);
       if(IS_NULL_PTR(mask_form)) return;
 
       const float masks_border = dt_masks_get_set_conf_value(mask_form, "border", 1.0f, BORDER_MIN, BORDER_MAX,
@@ -2424,7 +2425,7 @@ static void _brush_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks_fo
                 2.0 * M_PI);
       cairo_stroke(cr);
 
-      dt_masks_form_t *visible_form = dt_masks_get_visible_form(darktable.develop);
+      dt_masks_form_t *visible_form = dt_masks_get_visible_form(mask_gui->dev);
       if(visible_form && (visible_form->type & DT_MASKS_CLONE))
       {
         const int i = mask_gui->guipoints_count - 1;
@@ -2509,7 +2510,7 @@ static void _brush_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks_fo
     // draw borders
     if(gui_points->border && gui_points->border_count > node_count * 3 + 2)
     {
-      dt_draw_shape_lines(DT_MASKS_DASH_STICK, FALSE, cr, node_count, (mask_gui->border_selected), zoom_scale,
+      dt_draw_shape_lines(mask_gui->dev, DT_MASKS_DASH_STICK, FALSE, cr, node_count, (mask_gui->border_selected), zoom_scale,
                           gui_points->border, gui_points->border_count, &dt_masks_functions_brush.draw_shape,
                           CAIRO_LINE_CAP_ROUND);
     }
@@ -3104,12 +3105,12 @@ static void _brush_duplicate_points(dt_develop_t *const dev, dt_masks_form_t *co
   dt_masks_duplicate_points(base, dest, sizeof(dt_masks_node_brush_t));
 }
 
-static void _brush_initial_source_pos(const float iwd, const float iht, float *x, float *y)
+static void _brush_initial_source_pos(struct dt_develop_t *dev, const float iwd, const float iht, float *x, float *y)
 {
-  
-  
+
+
   float offset[2] = { 0.01f, 0.01f };
-  dt_dev_coordinates_raw_norm_to_raw_abs(darktable.develop, offset, 1);
+  dt_dev_coordinates_raw_norm_to_raw_abs(dev, offset, 1);
   *x = offset[0];
   *y = offset[1];
 }
@@ -3119,14 +3120,14 @@ static void _brush_switch_node_callback(GtkWidget *widget, gpointer user_data)
   dt_masks_form_gui_t *mask_gui = (dt_masks_form_gui_t *)user_data;
   if(IS_NULL_PTR(mask_gui)) return;
 
-  dt_iop_module_t *module = darktable.develop->gui_module;
+  dt_iop_module_t *module = mask_gui->dev->gui_module;
   if(IS_NULL_PTR(module)) return;
 
   mask_gui->node_selected = TRUE;
   mask_gui->node_selected_idx = mask_gui->node_hovered;
 
   const int form_id = mask_gui->formid;
-  dt_masks_form_t *selected_form = dt_masks_get_from_id(darktable.develop, form_id);
+  dt_masks_form_t *selected_form = dt_masks_get_from_id(mask_gui->dev, form_id);
   if(IS_NULL_PTR(selected_form)) return;
   dt_masks_form_gui_points_t *gui_points
       = (dt_masks_form_gui_points_t *)g_list_nth_data(mask_gui->points, mask_gui->group_selected);
@@ -3143,14 +3144,14 @@ static void _brush_reset_round_node_callback(GtkWidget *widget, gpointer user_da
   dt_masks_form_gui_t *mask_gui = (dt_masks_form_gui_t *)user_data;
   if(IS_NULL_PTR(mask_gui)) return;
 
-  dt_iop_module_t *module = darktable.develop->gui_module;
+  dt_iop_module_t *module = mask_gui->dev->gui_module;
   if(IS_NULL_PTR(module)) return;
 
   mask_gui->node_selected = TRUE;
   mask_gui->node_selected_idx = mask_gui->node_hovered;
 
   const int form_id = mask_gui->formid;
-  dt_masks_form_t *selected_form = dt_masks_get_from_id(darktable.develop, form_id);
+  dt_masks_form_t *selected_form = dt_masks_get_from_id(mask_gui->dev, form_id);
   if(IS_NULL_PTR(selected_form)) return;
   dt_masks_form_gui_points_t *gui_points
       = (dt_masks_form_gui_points_t *)g_list_nth_data(mask_gui->points, mask_gui->group_selected);
@@ -3167,21 +3168,21 @@ static void _brush_add_node_callback(GtkWidget *menu, gpointer user_data)
 {
   dt_masks_form_gui_t *mask_gui = (dt_masks_form_gui_t *)user_data;
   if(IS_NULL_PTR(mask_gui)) return;
-  dt_masks_form_t *visible_forms = dt_masks_get_visible_form(darktable.develop);
+  dt_masks_form_t *visible_forms = dt_masks_get_visible_form(mask_gui->dev);
   if(IS_NULL_PTR(visible_forms)) return;
 
-  dt_iop_module_t *module = darktable.develop->gui_module;
+  dt_iop_module_t *module = mask_gui->dev->gui_module;
   if(IS_NULL_PTR(module)) return;
 
   dt_masks_form_group_t *group_entry = dt_masks_form_get_selected_group(visible_forms, mask_gui);
   if(IS_NULL_PTR(group_entry)) return;
-  dt_masks_form_t *selected_form = dt_masks_get_from_id(darktable.develop, group_entry->formid);
+  dt_masks_form_t *selected_form = dt_masks_get_from_id(mask_gui->dev, group_entry->formid);
   if(selected_form)
   {
     _add_node_to_segment(module, selected_form, group_entry->parentid, mask_gui, mask_gui->group_selected);
   }
-    
-  dt_dev_add_history_item(darktable.develop, module, TRUE, TRUE);
+
+  dt_dev_add_history_item(mask_gui->dev, module, TRUE, TRUE);
 }
 
 static int _brush_populate_context_menu(GtkWidget *menu, struct dt_masks_form_t *mask_form,

--- a/src/develop/masks/circle.c
+++ b/src/develop/masks/circle.c
@@ -123,7 +123,7 @@ static void _circle_get_creation_values(const dt_masks_form_t *form, float *radi
 
 static void _circle_init_new(dt_masks_form_t *form, dt_masks_form_gui_t *gui, dt_masks_node_circle_t *circle)
 {
-  dt_masks_gui_cursor_to_raw_norm(darktable.develop, gui, circle->center);
+  dt_masks_gui_cursor_to_raw_norm(gui->dev, gui, circle->center);
   _circle_get_creation_values(form, &circle->radius, &circle->border);
 
   if(dt_masks_form_is_clone(form))
@@ -146,13 +146,13 @@ static int _circle_get_creation_preview(dt_masks_form_t *form, dt_masks_form_gui
   radius_border += radius_shape;
 
   float center[2];
-  dt_masks_gui_cursor_to_raw_norm(darktable.develop, gui, center);
+  dt_masks_gui_cursor_to_raw_norm(gui->dev, gui, center);
 
   *preview = (dt_masks_preview_buffers_t){ 0 };
-  int err = _circle_get_points(darktable.develop, center[0], center[1], radius_shape, 0.0f, 0.0f,
+  int err = _circle_get_points(gui->dev, center[0], center[1], radius_shape, 0.0f, 0.0f,
                                &preview->points, &preview->points_count);
   if(!err && radius_shape != radius_border)
-    err = _circle_get_points(darktable.develop, center[0], center[1], radius_border, 0.0f, 0.0f,
+    err = _circle_get_points(gui->dev, center[0], center[1], radius_border, 0.0f, 0.0f,
                              &preview->border, &preview->border_count);
 
   if(!err && dt_masks_form_is_clone(form))
@@ -218,7 +218,7 @@ static float _circle_get_interaction_value(const dt_masks_form_t *form, dt_masks
   }
 }
 
-static gboolean _circle_get_gravity_center(const dt_masks_form_t *form, float center[2], float *area)
+static gboolean _circle_get_gravity_center(dt_develop_t *dev, const dt_masks_form_t *form, float center[2], float *area)
 {
   if(IS_NULL_PTR(form) || IS_NULL_PTR(form->points) || IS_NULL_PTR(center) || IS_NULL_PTR(area)) return FALSE;
   const dt_masks_node_circle_t *circle = (const dt_masks_node_circle_t *)(form->points)->data;
@@ -324,7 +324,7 @@ static int _circle_events_mouse_scrolled(struct dt_iop_module_t *module, double 
   else if(gui->form_selected)
   {
     if(dt_modifier_is(state, GDK_CONTROL_MASK))
-      return dt_masks_form_change_opacity(form, parentid, up, flow);
+      return dt_masks_form_change_opacity(gui->dev, form, parentid, up, flow);
     else if(dt_modifier_is(state, GDK_SHIFT_MASK))
       return _change_hardness(form, gui, module, index, up ? +1.02f : 0.98f, DT_MASKS_INCREMENT_SCALE, flow);
     else
@@ -355,7 +355,7 @@ static int _circle_events_button_pressed(struct dt_iop_module_t *module, double 
 
       _circle_init_new(form, gui, circle);
       form->points = g_list_append(form->points, circle);
-      dt_masks_gui_form_save_creation(darktable.develop, crea_module, form, gui);
+      dt_masks_gui_form_save_creation(gui->dev, crea_module, form, gui);
 
       return 1;
     }
@@ -431,7 +431,7 @@ static int _circle_events_mouse_moved(struct dt_iop_module_t *module, double x, 
 
   if(gui->form_dragging || gui->source_dragging)
   {
-    dt_develop_t *dev = (dt_develop_t *)darktable.develop;
+    dt_develop_t *dev = gui->dev;
     // apply delta to the current mouse position
     float pts[2];
     dt_masks_gui_delta_to_raw_norm(dev, gui, pts);
@@ -458,15 +458,16 @@ static int _circle_events_mouse_moved(struct dt_iop_module_t *module, double x, 
   return 0;
 }
 
-static void _circle_draw_shape(cairo_t *cr, const float *points, const int points_count, const int coord_nb, const gboolean border, const gboolean source)
+static void _circle_draw_shape(dt_develop_t *dev, cairo_t *cr, const float *points, const int points_count, const int coord_nb, const gboolean border, const gboolean source)
 {
+   // unused arg, keep compiler from complaining
   cairo_move_to(cr, points[coord_nb * 2 + 2], points[coord_nb * 2 + 3]);
   for(int i = 2; i < points_count; i++)
     cairo_line_to(cr, points[i * 2], points[i * 2 + 1]);
   cairo_close_path(cr);
 }
 
-static float *_points_to_transform(float x, float y, float radius, float wd, float ht, int *points_count)
+static float *_points_to_transform(dt_develop_t *dev, float x, float y, float radius, float wd, float ht, int *points_count)
 {
   // how many points do we need?
   const float r = radius * MIN(wd, ht);
@@ -482,7 +483,7 @@ static float *_points_to_transform(float x, float y, float radius, float wd, flo
 
   // now we set the points, first the center, then the circumference
   float center[2] = { x, y };
-  dt_dev_coordinates_raw_norm_to_raw_abs(darktable.develop, center, 1);
+  dt_dev_coordinates_raw_norm_to_raw_abs(dev, center, 1);
   const float center_x = center[0];
   const float center_y = center[1];
   points[0] = center_x;
@@ -508,7 +509,7 @@ static int _circle_get_points_source(dt_develop_t *dev, float x, float y, float 
 
   // compute the points of the target (center and circumference of circle)
   // we get the point in RAW image reference
-  *points = _points_to_transform(x, y, radius, wd, ht, points_count);
+  *points = _points_to_transform(dev, x, y, radius, wd, ht, points_count);
   if(IS_NULL_PTR(*points)) return 1;
 
   // we transform with all distortion that happen *before* the module
@@ -561,7 +562,7 @@ static int _circle_get_points(dt_develop_t *dev, float x, float y, float radius,
   const float ht = dev->roi.raw_height;
 
   // compute the points we need to transform (center and circumference of circle)
-  *points = _points_to_transform(x, y, radius, wd, ht, points_count);
+  *points = _points_to_transform(dev, x, y, radius, wd, ht, points_count);
   if(IS_NULL_PTR(*points)) return 1;
 
   // and transform them with all distorted modules
@@ -583,11 +584,11 @@ static void _circle_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks_f
   // in creation mode
   if(gui->creation)
   {
-    dt_masks_form_t *form = dt_masks_get_visible_form(darktable.develop);
+    dt_masks_form_t *form = dt_masks_get_visible_form(gui->dev);
     dt_masks_preview_buffers_t preview;
     if(_circle_get_creation_preview(form, gui, &preview)) return;
 
-    dt_masks_draw_preview_shape(cr, zoom_scale, num_points, preview.points, preview.points_count,
+    dt_masks_draw_preview_shape(gui->dev, cr, zoom_scale, num_points, preview.points, preview.points_count,
                                 preview.border, preview.border_count,
                                 &dt_masks_functions_circle.draw_shape, CAIRO_LINE_CAP_BUTT,
                                 CAIRO_LINE_CAP_ROUND, FALSE, FALSE);
@@ -596,7 +597,7 @@ static void _circle_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks_f
     if(dt_masks_form_is_clone(form))
     {
       dt_masks_draw_source_preview(cr, zoom_scale, gui, gui->pos[0], gui->pos[1], gui->pos[0], gui->pos[1], FALSE);
-      dt_masks_draw_preview_shape(cr, zoom_scale, num_points, preview.source_points, preview.points_count,
+      dt_masks_draw_preview_shape(gui->dev, cr, zoom_scale, num_points, preview.source_points, preview.points_count,
                                 NULL, 0, &dt_masks_functions_circle.draw_shape, CAIRO_LINE_CAP_BUTT,
                                 CAIRO_LINE_CAP_ROUND, FALSE, TRUE);
     }
@@ -611,13 +612,13 @@ static void _circle_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks_f
   // we draw the main shape
   const gboolean selected = (gui->group_selected == index) && (gui->form_selected || gui->form_dragging);
   if(gpt->points && gpt->points_count > 1)
-    dt_draw_shape_lines(DT_MASKS_NO_DASH, FALSE, cr, num_points, selected, zoom_scale, gpt->points,
+    dt_draw_shape_lines(gui->dev, DT_MASKS_NO_DASH, FALSE, cr, num_points, selected, zoom_scale, gpt->points,
                         gpt->points_count, &dt_masks_functions_circle.draw_shape, CAIRO_LINE_CAP_BUTT);
   // we draw the borders
   if(gui->group_selected == index)
   { 
     if(gpt->border && gpt->border_count > 1)
-      dt_draw_shape_lines(DT_MASKS_DASH_STICK, FALSE, cr, num_points, (gui->border_selected), zoom_scale, gpt->border,
+      dt_draw_shape_lines(gui->dev, DT_MASKS_DASH_STICK, FALSE, cr, num_points, (gui->border_selected), zoom_scale, gpt->border,
                           gpt->border_count, &dt_masks_functions_circle.draw_shape, CAIRO_LINE_CAP_ROUND);
   }
 
@@ -692,7 +693,7 @@ static int _circle_get_source_area(dt_iop_module_t *module, dt_dev_pixelpipe_t *
   const float outer_radius = circle->radius + circle->border;
   int num_points;
   float *const restrict points =
-    _points_to_transform(form->source[0], form->source[1], outer_radius, wd, ht, &num_points);
+    _points_to_transform(pipe->dev, form->source[0], form->source[1], outer_radius, wd, ht, &num_points);
   if(IS_NULL_PTR(points))
     return 1;
 
@@ -723,7 +724,7 @@ static int _circle_get_area(const dt_iop_module_t *const restrict module, dt_dev
   const float outer_radius = circle->radius + circle->border;
   int num_points;
   float *const restrict points =
-    _points_to_transform(circle->center[0], circle->center[1], outer_radius, wd, ht, &num_points);
+    _points_to_transform(pipe->dev, circle->center[0], circle->center[1], outer_radius, wd, ht, &num_points);
   if(IS_NULL_PTR(points))
     return 1;
 
@@ -1119,11 +1120,11 @@ static void _circle_duplicate_points(dt_develop_t *dev, dt_masks_form_t *const b
   dt_masks_duplicate_points(base, dest, sizeof(dt_masks_node_circle_t));
 }
 
-static void _circle_initial_source_pos(const float iwd, const float iht, float *x, float *y)
+static void _circle_initial_source_pos(dt_develop_t *dev, const float iwd, const float iht, float *x, float *y)
 {
   const float radius = MIN(0.5f, dt_conf_get_float("plugins/darkroom/spots/circle/size"));
   float offset[2] = { radius, -radius };
-  dt_dev_coordinates_raw_norm_to_raw_abs(darktable.develop, offset, 1);
+  dt_dev_coordinates_raw_norm_to_raw_abs(dev, offset, 1);
   *x = offset[0];
   *y = offset[1];
 }

--- a/src/develop/masks/ellipse.c
+++ b/src/develop/masks/ellipse.c
@@ -257,7 +257,7 @@ static void _ellipse_get_creation_values(const dt_masks_form_t *form, dt_masks_e
 static void _ellipse_init_new(dt_masks_form_t *form, dt_masks_form_gui_t *gui, dt_masks_node_ellipse_t *ellipse)
 {
   dt_masks_ellipse_creation_values_t values;
-  dt_masks_gui_cursor_to_raw_norm(darktable.develop, gui, ellipse->center);
+  dt_masks_gui_cursor_to_raw_norm(gui->dev, gui, ellipse->center);
   _ellipse_get_creation_values(form, &values);
 
   ellipse->radius[0] = values.radius_a;
@@ -291,13 +291,13 @@ static int _ellipse_get_creation_preview(dt_masks_form_t *form, dt_masks_form_gu
                              : values.radius_b + values.border;
 
   float center[2];
-  dt_masks_gui_cursor_to_raw_norm(darktable.develop, gui, center);
+  dt_masks_gui_cursor_to_raw_norm(gui->dev, gui, center);
 
   *preview = (dt_masks_preview_buffers_t){ 0 };
-  int err = _ellipse_get_points(darktable.develop, center[0], center[1], values.radius_a, values.radius_b,
+  int err = _ellipse_get_points(gui->dev, center[0], center[1], values.radius_a, values.radius_b,
                                 values.rotation, &preview->points, &preview->points_count);
   if(!err && values.border > 0.0f)
-    err = _ellipse_get_points(darktable.develop, center[0], center[1], border_a, border_b, values.rotation,
+    err = _ellipse_get_points(gui->dev, center[0], center[1], border_a, border_b, values.rotation,
                               &preview->border, &preview->border_count);
   
   if(!err && dt_masks_form_is_clone(form))
@@ -324,8 +324,8 @@ static int _ellipse_get_creation_preview(dt_masks_form_t *form, dt_masks_form_gu
   return err;
 }
 
-static float *_points_to_transform(float xx, float yy, float radius_a, float radius_b, float rotation, float wd,
-                                   float ht, int *points_count)
+static float *_points_to_transform(dt_develop_t *dev, float xx, float yy, float radius_a, float radius_b,
+                                   float rotation, float wd, float ht, int *points_count)
 {
   // Calculate the rotation angle in radians
   const float v = (rotation / 180.0f) * M_PI;
@@ -355,7 +355,7 @@ static float *_points_to_transform(float xx, float yy, float radius_a, float rad
 
   // Center of the ellipse
   float center[2] = { xx, yy };
-  dt_dev_coordinates_raw_norm_to_raw_abs(darktable.develop, center, 1);
+  dt_dev_coordinates_raw_norm_to_raw_abs(dev, center, 1);
   const float x = points[0] = center[0];
   const float y = points[1] = center[1];
 
@@ -389,7 +389,7 @@ static int _ellipse_get_points_source(dt_develop_t *dev, float xx, float yy, flo
 
   // compute the points of the target (center and circumference of ellipse)
   // we get the point in RAW image reference
-  *points = _points_to_transform(xx, yy, radius_a, radius_b, rotation, wd, ht, points_count);
+  *points = _points_to_transform(dev, xx, yy, radius_a, radius_b, rotation, wd, ht, points_count);
   if(IS_NULL_PTR(*points)) return 1;
 
   // we transform with all distortion that happen *before* the module
@@ -441,7 +441,7 @@ static int _ellipse_get_points(dt_develop_t *dev, float xx, float yy, float radi
   const float wd = dev->roi.raw_width;
   const float ht = dev->roi.raw_height;
 
-  *points = _points_to_transform(xx, yy, radius_a, radius_b, rotation, wd, ht, points_count);
+  *points = _points_to_transform(dev, xx, yy, radius_a, radius_b, rotation, wd, ht, points_count);
   if(IS_NULL_PTR(*points)) return 1;
 
   // and we transform them with all distorted modules
@@ -583,7 +583,7 @@ static float _ellipse_get_interaction_value(const dt_masks_form_t *form, dt_mask
   }
 }
 
-static gboolean _ellipse_get_gravity_center(const dt_masks_form_t *form, float center[2], float *area)
+static gboolean _ellipse_get_gravity_center(dt_develop_t *dev, const dt_masks_form_t *form, float center[2], float *area)
 {
   if(IS_NULL_PTR(form) || IS_NULL_PTR(form->points) || IS_NULL_PTR(center) || IS_NULL_PTR(area)) return FALSE;
   const dt_masks_node_ellipse_t *ellipse = (const dt_masks_node_ellipse_t *)(form->points)->data;
@@ -714,7 +714,7 @@ static int _ellipse_events_mouse_scrolled(struct dt_iop_module_t *module, double
     if(dt_modifier_is(state, GDK_SHIFT_MASK | GDK_CONTROL_MASK))
       return _change_rotation(form, gui, module, index, (up ? +0.2f : -0.2f), DT_MASKS_INCREMENT_OFFSET, flow);
     else if(dt_modifier_is(state, GDK_CONTROL_MASK))
-      return dt_masks_form_change_opacity(form, parentid, up, flow);
+      return dt_masks_form_change_opacity(gui->dev, form, parentid, up, flow);
     else if(dt_modifier_is(state, GDK_SHIFT_MASK))
       return _change_hardness(form, gui, module, index, (up ? 1.02f : 0.98f), DT_MASKS_INCREMENT_SCALE, flow);
     else
@@ -747,7 +747,7 @@ static int _ellipse_events_button_pressed(struct dt_iop_module_t *module, double
       if(IS_NULL_PTR(ellipse)) return 0;
       _ellipse_init_new(form, gui, ellipse);
       form->points = g_list_append(form->points, ellipse);
-      dt_masks_gui_form_save_creation(darktable.develop, crea_module, form, gui);
+      dt_masks_gui_form_save_creation(gui->dev, crea_module, form, gui);
       
       return 1;
     }
@@ -908,7 +908,7 @@ static int _ellipse_events_mouse_moved(struct dt_iop_module_t *module, double x,
   
   if(gui->form_dragging || gui->source_dragging)
     {
-    dt_develop_t *dev = (dt_develop_t *)darktable.develop;
+    dt_develop_t *dev = gui->dev;
     // apply delta to the current mouse position
     float pts[2];
     dt_masks_gui_delta_to_raw_norm(dev, gui, pts);
@@ -977,7 +977,7 @@ static int _ellipse_events_mouse_moved(struct dt_iop_module_t *module, double x,
   {
 
     const float origin_point[2] = { gpt->points[0], gpt->points[1] };
-    const float angle = dt_masks_rotate_with_anchor(darktable.develop, gui->pos, origin_point, gui);
+    const float angle = dt_masks_rotate_with_anchor(gui->dev, gui->pos, origin_point, gui);
 
     _change_rotation(form, gui, module, index, angle , DT_MASKS_INCREMENT_OFFSET, 1);
 
@@ -991,8 +991,9 @@ static int _ellipse_events_mouse_moved(struct dt_iop_module_t *module, double x,
   return 0;
 }
 
-static void _ellipse_draw_shape(cairo_t *cr, const float *points, const int points_count, const int nb, const gboolean border, const gboolean source)
+static void _ellipse_draw_shape(dt_develop_t *dev, cairo_t *cr, const float *points, const int points_count, const int nb, const gboolean border, const gboolean source)
 {
+  // dev unused, kept for shape_draw_function_t signature
   cairo_move_to(cr, points[10], points[11]);
   for(int t = 6; t < points_count; t++)
   {
@@ -1033,11 +1034,11 @@ static void _ellipse_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks_
   // in creation mode
   if(gui->creation)
   {
-    dt_masks_form_t *form = dt_masks_get_visible_form(darktable.develop);
+    dt_masks_form_t *form = dt_masks_get_visible_form(gui->dev);
     dt_masks_preview_buffers_t preview;
     if(_ellipse_get_creation_preview(form, gui, &preview)) return;
 
-    dt_masks_draw_preview_shape(cr, zoom_scale, num_points, preview.points, preview.points_count,
+    dt_masks_draw_preview_shape(gui->dev, cr, zoom_scale, num_points, preview.points, preview.points_count,
                                 preview.border, preview.border_count,
                                 &dt_masks_functions_ellipse.draw_shape, CAIRO_LINE_CAP_BUTT,
                                 CAIRO_LINE_CAP_ROUND, TRUE, FALSE);
@@ -1047,7 +1048,7 @@ static void _ellipse_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks_
     if(dt_masks_form_is_clone(form))
     {
       dt_masks_draw_source_preview(cr, zoom_scale, gui, gui->pos[0], gui->pos[1], gui->pos[0], gui->pos[1], FALSE);
-      dt_masks_draw_preview_shape(cr, zoom_scale, num_points, preview.source_points, preview.points_count,
+      dt_masks_draw_preview_shape(gui->dev, cr, zoom_scale, num_points, preview.source_points, preview.points_count,
                                 NULL, 0, &dt_masks_functions_ellipse.draw_shape, CAIRO_LINE_CAP_BUTT,
                                 CAIRO_LINE_CAP_ROUND, FALSE, TRUE);
     }
@@ -1063,14 +1064,14 @@ static void _ellipse_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks_
   // we draw the main shape
   const gboolean selected = (gui->group_selected == index) && (gui->form_selected || gui->form_dragging);
   if(gpt->points && gpt->points_count > 5)
-    dt_draw_shape_lines(DT_MASKS_NO_DASH, FALSE, cr, num_points, selected, zoom_scale, gpt->points,
+    dt_draw_shape_lines(gui->dev, DT_MASKS_NO_DASH, FALSE, cr, num_points, selected, zoom_scale, gpt->points,
                         gpt->points_count, &dt_masks_functions_ellipse.draw_shape, CAIRO_LINE_CAP_BUTT);
   
   if(gui->group_selected == index)
   {
     // we draw the borders
     if(gpt->border && gpt->border_count > 5)
-      dt_draw_shape_lines(DT_MASKS_DASH_STICK, FALSE, cr, num_points, (gui->border_selected), zoom_scale, gpt->border,
+      dt_draw_shape_lines(gui->dev, DT_MASKS_DASH_STICK, FALSE, cr, num_points, (gui->border_selected), zoom_scale, gpt->border,
                           gpt->border_count, &dt_masks_functions_ellipse.draw_shape, CAIRO_LINE_CAP_ROUND);
 
     // draw handles
@@ -1157,7 +1158,7 @@ static void _fill_mask(const size_t numpoints, float *const bufptr, const float 
     }
 }
 
-static float *const _ellipse_points_to_transform(const float center_x, const float center_y, const float dim1, const float dim2,
+static float *const _ellipse_points_to_transform(dt_develop_t *dev, const float center_x, const float center_y, const float dim1, const float dim2,
                                                  const float rotation, const float wd, const float ht, size_t *point_count)
 {
 
@@ -1194,7 +1195,7 @@ static float *const _ellipse_points_to_transform(const float center_x, const flo
 
   // now we set the points - first the center
   float center[2] = { center_x, center_y };
-  dt_dev_coordinates_raw_norm_to_raw_abs(darktable.develop, center, 1);
+  dt_dev_coordinates_raw_norm_to_raw_abs(dev, center, 1);
   const float x = points[0] = center[0];
   const float y = points[1] = center[1];
   // then the control node points (ends of semimajor/semiminor axes)
@@ -1232,7 +1233,7 @@ static int _ellipse_get_source_area(dt_iop_module_t *module, dt_dev_pixelpipe_t 
   // next we compute the points to be transformed
   size_t point_count = 0;
   float *const restrict points
-    = _ellipse_points_to_transform(form->source[0], form->source[1], total[0], total[1], ellipse->rotation, wd, ht, &point_count);
+    = _ellipse_points_to_transform(module->dev, form->source[0], form->source[1], total[0], total[1], ellipse->rotation, wd, ht, &point_count);
   if (IS_NULL_PTR(points))
     return 1;
 
@@ -1266,7 +1267,7 @@ static int _ellipse_get_area(const dt_iop_module_t *const module, dt_dev_pixelpi
   // next we compute the points to be transformed
   size_t point_count = 0;
   float *const restrict points
-    = _ellipse_points_to_transform(ellipse->center[0], ellipse->center[1], total[0], total[1], ellipse->rotation, wd, ht, &point_count);
+    = _ellipse_points_to_transform(module->dev, ellipse->center[0], ellipse->center[1], total[0], total[1], ellipse->rotation, wd, ht, &point_count);
   if (IS_NULL_PTR(points))
     return 1;
 
@@ -1620,14 +1621,14 @@ static void _ellipse_duplicate_points(dt_develop_t *const dev, dt_masks_form_t *
   dt_masks_duplicate_points(base, dest, sizeof(dt_masks_node_ellipse_t));
 }
 
-static void _ellipse_initial_source_pos(const float iwd, const float iht, float *x, float *y)
+static void _ellipse_initial_source_pos(dt_develop_t *dev, const float iwd, const float iht, float *x, float *y)
 {
-  
-  
+
+
   const float radius_a = dt_conf_get_float("plugins/darkroom/spots/ellipse/radius_a");
   const float radius_b = dt_conf_get_float("plugins/darkroom/spots/ellipse/radius_b");
   float offset[2] = { radius_a, -radius_b };
-  dt_dev_coordinates_raw_norm_to_raw_abs(darktable.develop, offset, 1);
+  dt_dev_coordinates_raw_norm_to_raw_abs(dev, offset, 1);
   *x = offset[0];
   *y = offset[1];
 }

--- a/src/develop/masks/gradient.c
+++ b/src/develop/masks/gradient.c
@@ -197,7 +197,7 @@ static void _gradient_get_creation_values(dt_masks_gradient_creation_values_t *v
 static void _gradient_init_new(dt_masks_form_gui_t *gui, dt_masks_anchor_gradient_t *gradient)
 {
   dt_masks_gradient_creation_values_t values;
-  dt_masks_gui_cursor_to_raw_norm(darktable.develop, gui, gradient->center);
+  dt_masks_gui_cursor_to_raw_norm(gui->dev, gui, gradient->center);
   _gradient_get_creation_values(&values);
   gradient->extent = values.extent;
   gradient->curvature = values.curvature;
@@ -217,13 +217,13 @@ static int _gradient_get_creation_preview(dt_masks_form_gui_t *gui, dt_masks_pre
   _gradient_get_creation_values(&values);
 
   float center[2];
-  dt_masks_gui_cursor_to_raw_norm(darktable.develop, gui, center);
+  dt_masks_gui_cursor_to_raw_norm(gui->dev, gui, center);
 
   *preview = (dt_masks_preview_buffers_t){ 0 };
-  int err = _gradient_get_points(darktable.develop, center[0], center[1], values.rotation,
+  int err = _gradient_get_points(gui->dev, center[0], center[1], values.rotation,
                                  values.curvature, &preview->points, &preview->points_count);
   if(!err && values.extent > 0.0f)
-    err = _gradient_get_pts_border(darktable.develop, center[0], center[1], values.rotation,
+    err = _gradient_get_pts_border(gui->dev, center[0], center[1], values.rotation,
                                    values.extent, values.curvature, &preview->border,
                                    &preview->border_count);
   return err;
@@ -408,7 +408,7 @@ static float _gradient_get_interaction_value(const dt_masks_form_t *form, dt_mas
   }
 }
 
-static gboolean _gradient_get_gravity_center(const dt_masks_form_t *form, float center[2], float *area)
+static gboolean _gradient_get_gravity_center(dt_develop_t *dev, const dt_masks_form_t *form, float center[2], float *area)
 {
   if(IS_NULL_PTR(form) || IS_NULL_PTR(form->points) || IS_NULL_PTR(center) || IS_NULL_PTR(area)) return FALSE;
   const dt_masks_anchor_gradient_t *gradient = (const dt_masks_anchor_gradient_t *)(form->points)->data;
@@ -544,7 +544,7 @@ static int _gradient_events_mouse_scrolled(struct dt_iop_module_t *module, doubl
     if(dt_modifier_is(state, GDK_SHIFT_MASK | GDK_CONTROL_MASK))
       return _change_rotation(form, gui, module, index, (up ? +0.2f : -0.2f), DT_MASKS_INCREMENT_OFFSET, flow);
     else if(dt_modifier_is(state, GDK_CONTROL_MASK))
-      return dt_masks_form_change_opacity(form, parentid, up, flow);
+      return dt_masks_form_change_opacity(gui->dev, form, parentid, up, flow);
     else if(dt_modifier_is(state, GDK_SHIFT_MASK))
       return _change_curvature(form, gui, module, index, (up ? +0.02f : -0.02f), DT_MASKS_INCREMENT_OFFSET, flow);
     else
@@ -574,7 +574,7 @@ static int _gradient_events_button_pressed(struct dt_iop_module_t *module, doubl
       _gradient_init_new(gui, gradient);
 
       form->points = g_list_append(form->points, gradient);
-      dt_masks_gui_form_save_creation(darktable.develop, crea_module, form, gui);
+      dt_masks_gui_form_save_creation(gui->dev, crea_module, form, gui);
       
       return 1;
     }
@@ -702,7 +702,7 @@ static int _gradient_events_mouse_moved(struct dt_iop_module_t *module, double x
   {
     // we change the center value
     float pts[2];
-    dt_masks_gui_delta_to_raw_norm(darktable.develop, gui, pts);
+    dt_masks_gui_delta_to_raw_norm(gui->dev, gui, pts);
 
     gradient->center[0] = pts[0];
     gradient->center[1] = pts[1];
@@ -717,7 +717,7 @@ static int _gradient_events_mouse_moved(struct dt_iop_module_t *module, double x
   if(gui->form_rotating)
   {
     const float origin_point[2] = { gpt->points[0], gpt->points[1] };
-    const float angle = - dt_masks_rotate_with_anchor(darktable.develop, gui->pos, origin_point, gui);
+    const float angle = - dt_masks_rotate_with_anchor(gui->dev, gui->pos, origin_point, gui);
     _change_rotation(form, gui, module, index, angle , DT_MASKS_INCREMENT_OFFSET, 1);
 
     // we recreate the form points
@@ -951,7 +951,7 @@ cleanup:
   return err;
 }
 
-static void _gradient_draw_shape(cairo_t *cr, const float *pts_line, const int pts_line_count, const int nb, const gboolean border, const gboolean source)
+static void _gradient_draw_shape(struct dt_develop_t *dev, cairo_t *cr, const float *pts_line, const int pts_line_count, const int nb, const gboolean border, const gboolean source)
 {
   // safeguard in case of malformed arrays of points
   if(border && pts_line_count <= 3) return;
@@ -959,9 +959,9 @@ static void _gradient_draw_shape(cairo_t *cr, const float *pts_line, const int p
 
   const float *points = (border) ? pts_line : pts_line + 6;
   const int points_count = (border) ? pts_line_count : pts_line_count - 3;
-  
-  const float wd = darktable.develop->roi.raw_width;
-  const float ht = darktable.develop->roi.raw_height;
+
+  const float wd = dev->roi.raw_width;
+  const float ht = dev->roi.raw_height;
 
   int i = 0;
   while(i < points_count)
@@ -1074,7 +1074,7 @@ static void _gradient_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks
     dt_masks_preview_buffers_t preview;
     if(_gradient_get_creation_preview(gui, &preview)) return;
 
-    dt_masks_draw_preview_shape(cr, zoom_scale, nb, preview.points, preview.points_count,
+    dt_masks_draw_preview_shape(gui->dev, cr, zoom_scale, nb, preview.points, preview.points_count,
                                 preview.border, preview.border_count,
                                 &dt_masks_functions_gradient.draw_shape, CAIRO_LINE_CAP_ROUND,
                                 CAIRO_LINE_CAP_ROUND, FALSE, FALSE);
@@ -1091,13 +1091,13 @@ static void _gradient_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks
   const gboolean all_selected = (gui->group_selected == index) && (gui->form_selected || gui->form_dragging); 
   // draw main line
   if(gpt->points && gpt->points_count > 0)
-    dt_draw_shape_lines(DT_MASKS_NO_DASH, FALSE, cr, nb, (seg_selected), zoom_scale, gpt->points,
+    dt_draw_shape_lines(gui->dev, DT_MASKS_NO_DASH, FALSE, cr, nb, (seg_selected), zoom_scale, gpt->points,
                         gpt->points_count, &dt_masks_functions_gradient.draw_shape, CAIRO_LINE_CAP_ROUND);
   // draw borders
   if(gui->group_selected == index)
   {
     if(gpt->border && gpt->border_count > 0)
-      dt_draw_shape_lines(DT_MASKS_DASH_STICK, FALSE, cr, nb, (gui->border_selected), zoom_scale, gpt->border,
+      dt_draw_shape_lines(gui->dev, DT_MASKS_DASH_STICK, FALSE, cr, nb, (gui->border_selected), zoom_scale, gpt->border,
                           gpt->border_count, &dt_masks_functions_gradient.draw_shape, CAIRO_LINE_CAP_ROUND);
   }
 

--- a/src/develop/masks/group.c
+++ b/src/develop/masks/group.c
@@ -45,20 +45,20 @@
  * coordinates come from `gui->pos`. */
 // Centralize group child lookup so all dispatchers and expose code resolve the same
 // selected child the same way.
-static dt_masks_form_t *_group_get_child_at(dt_masks_form_t *form, const int group_index,
+static dt_masks_form_t *_group_get_child_at(dt_develop_t *dev, dt_masks_form_t *form, const int group_index,
                                             dt_masks_form_group_t **group_entry)
 {
   dt_masks_form_group_t *entry = (dt_masks_form_group_t *)g_list_nth_data(form->points, group_index);
   if(IS_NULL_PTR(entry)) return NULL;
   if(group_entry) *group_entry = entry;
-  return dt_masks_get_from_id(darktable.develop, entry->formid);
+  return dt_masks_get_from_id(dev, entry->formid);
 }
 
 static dt_masks_form_t *_group_get_selected_child(dt_masks_form_t *form, dt_masks_form_gui_t *gui,
                                                   dt_masks_form_group_t **group_entry)
 {
   if(gui->group_selected < 0) return NULL;
-  return _group_get_child_at(form, gui->group_selected, group_entry);
+  return _group_get_child_at(gui->dev, form, gui->group_selected, group_entry);
 }
 
 static int _group_events_mouse_scrolled(struct dt_iop_module_t *module, double x, double y, int up, const int flow,
@@ -127,7 +127,7 @@ static int _group_events_mouse_moved(struct dt_iop_module_t *module, double x, d
 static void _group_events_post_expose_draw(cairo_t *cr, float zoom_scale, dt_masks_form_t *form,
                                           dt_masks_form_gui_t *gui, int pos)
 {
-  dt_masks_form_t *selected_form = _group_get_child_at(form, pos, NULL);
+  dt_masks_form_t *selected_form = _group_get_child_at(gui->dev, form, pos, NULL);
   if(selected_form && selected_form->functions && selected_form->functions->post_expose)
   {
     gui->type = selected_form->type;
@@ -690,7 +690,7 @@ static void _group_duplicate_points(dt_develop_t *const dev, dt_masks_form_t *co
   }
 }
 
-static gboolean _group_get_gravity_center(const dt_masks_form_t *form, float center[2], float *area)
+static gboolean _group_get_gravity_center(dt_develop_t *dev, const dt_masks_form_t *form, float center[2], float *area)
 {
   if(IS_NULL_PTR(form) || IS_NULL_PTR(form->points) || IS_NULL_PTR(center) || IS_NULL_PTR(area)) return FALSE;
 
@@ -703,12 +703,12 @@ static gboolean _group_get_gravity_center(const dt_masks_form_t *form, float cen
   {
     const dt_masks_form_group_t *pt = (const dt_masks_form_group_t *)l->data;
     if(IS_NULL_PTR(pt)) continue;
-    dt_masks_form_t *child = dt_masks_get_from_id(darktable.develop, pt->formid);
+    dt_masks_form_t *child = dt_masks_get_from_id(dev, pt->formid);
     if(IS_NULL_PTR(child)) continue;
 
     float child_center[2] = { 0.0f, 0.0f };
     float child_area = 0.0f;
-    if(!dt_masks_form_get_gravity_center(child, child_center, &child_area)) continue;
+    if(!dt_masks_form_get_gravity_center(dev, child, child_center, &child_area)) continue;
 
     const float w = (child_area > 0.0f) ? child_area : 1.0f;
     sum_x += child_center[0] * w;

--- a/src/develop/masks/masks.c
+++ b/src/develop/masks/masks.c
@@ -366,7 +366,7 @@ void dt_masks_gui_init(dt_develop_t *dev)
   if(IS_NULL_PTR(dev->form_gui))
   {
     dev->form_gui = (dt_masks_form_gui_t *)calloc(1, sizeof(dt_masks_form_gui_t));
-    dt_masks_init_form_gui(dev->form_gui);
+    dt_masks_init_form_gui(dev, dev->form_gui);
   }
 
   dt_masks_clear_form_gui(dev);
@@ -428,9 +428,9 @@ gboolean dt_masks_gui_is_dragging(const dt_masks_form_gui_t *gui)
  *
  * Caveat: returns NULL if parent isn't a group or the entry is missing.
  */
-dt_masks_form_group_t *dt_masks_form_group_from_parentid(int parent_id, int form_id)
+dt_masks_form_group_t *dt_masks_form_group_from_parentid(dt_develop_t *dev, int parent_id, int form_id)
 {
-  dt_masks_form_t *group_form = dt_masks_get_from_id(darktable.develop, parent_id);
+  dt_masks_form_t *group_form = dt_masks_get_from_id(dev, parent_id);
   if(IS_NULL_PTR(group_form) || !(group_form->type & DT_MASKS_GROUP)) return NULL;
   return _masks_group_find_form(group_form, form_id);
 }
@@ -486,7 +486,8 @@ dt_masks_form_group_t *dt_masks_form_get_selected_group_live(const dt_masks_form
   {
     // Re-resolve via parentid to ensure the pointer is still current.
     dt_masks_form_group_t *resolved_group_entry
-        = dt_masks_form_group_from_parentid(selected_group_entry->parentid, selected_group_entry->formid);
+        = dt_masks_form_group_from_parentid(mask_gui->dev, selected_group_entry->parentid,
+                                            selected_group_entry->formid);
     if(resolved_group_entry) return resolved_group_entry;
   }
 
@@ -515,7 +516,7 @@ static dt_masks_form_t *_dt_masks_events_get_dispatch_form(dt_masks_form_t *visi
       = dt_masks_form_get_selected_group_live(visible_form, mask_gui);
   if(IS_NULL_PTR(selected_group_entry)) return NULL;
 
-  dt_masks_form_t *selected_form = dt_masks_get_from_id(darktable.develop, selected_group_entry->formid);
+  dt_masks_form_t *selected_form = dt_masks_get_from_id(mask_gui->dev, selected_group_entry->formid);
   if(IS_NULL_PTR(selected_form)) return NULL;
 
   if(group_entry) *group_entry = selected_group_entry;
@@ -536,7 +537,7 @@ static gboolean _dt_masks_events_group_update_selection(dt_masks_form_t *group_f
 {
   if(IS_NULL_PTR(group_form) || IS_NULL_PTR(mask_gui)) return FALSE;
 
-  dt_develop_t *const dev = darktable.develop;
+  dt_develop_t *const dev = mask_gui->dev;
   const float radius = DT_GUI_MOUSE_EFFECT_RADIUS;
   const float cursor_x = mask_gui->pos[0];
   const float cursor_y = mask_gui->pos[1];
@@ -611,7 +612,7 @@ static gboolean _dt_masks_events_group_update_selection(dt_masks_form_t *group_f
     {
       // Lazily computed: only shapes actually hit by this click need it, not every member
       // of the group on every mouse event.
-      if(!form->gravity_center_valid) dt_masks_form_update_gravity_center(form);
+      if(!form->gravity_center_valid) dt_masks_form_update_gravity_center(mask_gui->dev, form);
       const float dx = mask_gui->raw_pos[0] - form->gravity_center[0];
       const float dy = mask_gui->raw_pos[1] - form->gravity_center[1];
       const float center_dist2 = dx * dx + dy * dy;
@@ -705,7 +706,7 @@ static gboolean _dt_masks_events_flush_rebuild_if_needed(struct dt_iop_module_t 
     {
       dt_masks_gui_form_create(dispatch_form, mask_gui, form_index, module);
 
-      dt_develop_t *const dev = darktable.develop;
+      dt_develop_t *const dev = mask_gui->dev;
       if(!IS_NULL_PTR(dev))
       {
         mask_gui->last_rebuild_ts = dt_get_wtime();
@@ -755,8 +756,8 @@ static gboolean _set_hinter_message(dt_masks_form_gui_t *mask_gui, const dt_mask
     if(!IS_NULL_PTR(selected_group_entry))
     {
       opacity_percent
-          = dt_masks_form_get_interaction_value(selected_group_entry, DT_MASKS_INTERACTION_OPACITY) * 100.f;
-      selected_form = dt_masks_get_from_id(darktable.develop, selected_group_entry->formid);
+          = dt_masks_form_get_interaction_value(mask_gui->dev, selected_group_entry, DT_MASKS_INTERACTION_OPACITY) * 100.f;
+      selected_form = dt_masks_get_from_id(mask_gui->dev, selected_group_entry->formid);
       if(IS_NULL_PTR(selected_form)) return FALSE;
     }
   }
@@ -779,10 +780,11 @@ static gboolean _set_hinter_message(dt_masks_form_gui_t *mask_gui, const dt_mask
   return message[0] != '\0';
 }
 
-void dt_masks_init_form_gui(dt_masks_form_gui_t *mask_gui)
+void dt_masks_init_form_gui(dt_develop_t *dev, dt_masks_form_gui_t *mask_gui)
 {
   memset(mask_gui, 0, sizeof(dt_masks_form_gui_t));
 
+  mask_gui->dev = dev;
   mask_gui->pos[0] = mask_gui->pos[1] = -1.0f;
   mask_gui->rel_pos[0] = mask_gui->rel_pos[1] = -1.0f;
   mask_gui->raw_pos[0] = mask_gui->raw_pos[1] = -1.0f;
@@ -848,23 +850,23 @@ void dt_masks_gui_form_create(dt_masks_form_t *mask_form, dt_masks_form_gui_t *m
 
   dt_masks_form_gui_points_t *gui_points
       = (dt_masks_form_gui_points_t *)g_list_nth_data(mask_gui->points, form_index);
-  if(dt_masks_get_points_border(darktable.develop, mask_form, &gui_points->points, &gui_points->points_count,
+  if(dt_masks_get_points_border(mask_gui->dev, mask_form, &gui_points->points, &gui_points->points_count,
                                 &gui_points->border, &gui_points->border_count, 0, NULL) == 0)
   {
     if(mask_form->type & DT_MASKS_CLONE)
     {
-      if(dt_masks_get_points_border(darktable.develop, mask_form, &gui_points->source, &gui_points->source_count,
+      if(dt_masks_get_points_border(mask_gui->dev, mask_form, &gui_points->source, &gui_points->source_count,
                                     NULL, NULL, TRUE, module)
          != 0)
         return;
     }
-    mask_gui->pipe_hash = dt_dev_backbuf_get_hash(&darktable.develop->preview_pipe->backbuf);
+    mask_gui->pipe_hash = dt_dev_backbuf_get_hash(&mask_gui->dev->preview_pipe->backbuf);
     mask_gui->formid = mask_form->formid;
     mask_gui->type = mask_form->type;
 
   }
 
-  dt_masks_form_update_gravity_center(mask_form);
+  dt_masks_form_update_gravity_center(mask_gui->dev, mask_form);
 }
 
 gboolean dt_masks_gui_form_create_throttled(dt_masks_form_t *mask_form, dt_masks_form_gui_t *mask_gui,
@@ -873,7 +875,7 @@ gboolean dt_masks_gui_form_create_throttled(dt_masks_form_t *mask_form, dt_masks
 {
   if(IS_NULL_PTR(mask_form) || IS_NULL_PTR(mask_gui)) return FALSE;
 
-  dt_develop_t *const develop = darktable.develop;
+  dt_develop_t *const develop = mask_gui->dev;
   if(IS_NULL_PTR(develop))
   {
     dt_masks_gui_form_create(mask_form, mask_gui, form_index, module);
@@ -923,7 +925,7 @@ void dt_masks_remove_node(struct dt_iop_module_t *module, dt_masks_form_t *mask_
                           dt_masks_form_gui_t *mask_gui, int form_index, int node_index)
 {
   if(IS_NULL_PTR(mask_form) || IS_NULL_PTR(mask_form->points)) return;
-  mask_form = dt_masks_cow_touch(darktable.develop, mask_form);
+  mask_form = dt_masks_cow_touch(mask_gui->dev, mask_form);
   dt_masks_node_brush_t *brush_node = (dt_masks_node_brush_t *)g_list_nth_data(mask_form->points, node_index);
   if(IS_NULL_PTR(brush_node)) return;
   mask_form->points = g_list_remove(mask_form->points, brush_node);
@@ -956,17 +958,17 @@ static gboolean _masks_remove_shape(struct dt_iop_module_t *module, dt_masks_for
   if(parent_id <= 0) return 1;
 
   // we hide the form
-  dt_masks_form_t *visible_form = dt_masks_get_visible_form(darktable.develop);
+  dt_masks_form_t *visible_form = dt_masks_get_visible_form(mask_gui->dev);
   if(IS_NULL_PTR(visible_form) || !(visible_form->type & DT_MASKS_GROUP))
-    dt_masks_change_form_gui(NULL);
+    dt_masks_change_form_gui(mask_gui->dev, NULL);
   else if(g_list_shorter_than(visible_form->points, 2))
-    dt_masks_change_form_gui(NULL);
+    dt_masks_change_form_gui(mask_gui->dev, NULL);
   else
   {
     const int edit_mode = mask_gui->edit_mode;
 
-    dt_masks_clear_form_gui(darktable.develop);
-    visible_form = dt_masks_cow_touch(darktable.develop, visible_form);
+    dt_masks_clear_form_gui(mask_gui->dev);
+    visible_form = dt_masks_cow_touch(mask_gui->dev, visible_form);
     // Remove the selected shape copy from the visible group before deleting the
     // real group entry below.
     for(GList *forms = visible_form->points; forms; forms = g_list_next(forms))
@@ -987,7 +989,7 @@ static gboolean _masks_remove_shape(struct dt_iop_module_t *module, dt_masks_for
   // that's how this was called:
   // dt_masks_form_remove(module, NULL, form);
   // Called from shape removal, this is how it was called:
-  dt_masks_form_delete(module, dt_masks_get_from_id(darktable.develop, parent_id), mask_form);
+  dt_masks_form_delete(mask_gui->dev, module, dt_masks_get_from_id(mask_gui->dev, parent_id), mask_form);
   // Not sure what difference it makes.
 
   return 1;
@@ -1025,7 +1027,7 @@ done:
 static gboolean _masks_remove_or_delete_finish(struct dt_iop_module_t *module, dt_masks_form_t *sel, int parent_id,
                                                dt_masks_form_gui_t *mask_gui, int form_id, gboolean keep_unused)
 {
-  dt_masks_form_t *visible_form = dt_masks_get_visible_form(darktable.develop);
+  dt_masks_form_t *visible_form = dt_masks_get_visible_form(mask_gui->dev);
   int next_form_index = -1;
   int next_formid = 0;
   if(!IS_NULL_PTR(visible_form) && (visible_form->type & DT_MASKS_GROUP)
@@ -1066,14 +1068,14 @@ static gboolean _masks_remove_or_delete_finish(struct dt_iop_module_t *module, d
   else // Permanent delete.
   {
     if(IS_NULL_PTR(visible_form) || !(visible_form->type & DT_MASKS_GROUP))
-      dt_masks_change_form_gui(NULL);
+      dt_masks_change_form_gui(mask_gui->dev, NULL);
     else if(g_list_shorter_than(visible_form->points, 2))
-      dt_masks_change_form_gui(NULL);
+      dt_masks_change_form_gui(mask_gui->dev, NULL);
     else
     {
       const int edit_mode = mask_gui->edit_mode;
-      dt_masks_clear_form_gui(darktable.develop);
-      visible_form = dt_masks_cow_touch(darktable.develop, visible_form);
+      dt_masks_clear_form_gui(mask_gui->dev);
+      visible_form = dt_masks_cow_touch(mask_gui->dev, visible_form);
       // Remove the selected shape copy from the visible group before deleting
       // the real form from the develop mask list below.
       for(GList *forms = visible_form->points; forms; forms = g_list_next(forms))
@@ -1094,10 +1096,10 @@ static gboolean _masks_remove_or_delete_finish(struct dt_iop_module_t *module, d
       }
     }
 
-    dt_masks_form_delete(module, NULL, sel);
+    dt_masks_form_delete(mask_gui->dev, module, NULL, sel);
   }
 
-  dt_dev_add_history_item(darktable.develop, module, TRUE, TRUE);
+  dt_dev_add_history_item(mask_gui->dev, module, TRUE, TRUE);
   DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_MASK_CHANGED, form_id, signal_parent_id,
                                 signal_event);
 
@@ -1107,8 +1109,8 @@ static gboolean _masks_remove_or_delete_finish(struct dt_iop_module_t *module, d
     // the replacement selection after the signal has finished refreshing lists.
     mask_gui->group_selected = next_form_index;
     mask_gui->form_selected = TRUE;
-    dt_dev_masks_selection_change(darktable.develop, module, next_formid, FALSE);
-    dt_masks_select_form(module, dt_masks_get_from_id(darktable.develop, next_formid));
+    dt_dev_masks_selection_change(mask_gui->dev, module, next_formid, FALSE);
+    dt_masks_select_form(mask_gui->dev, module, dt_masks_get_from_id(mask_gui->dev, next_formid));
   }
   return res;
 }
@@ -1116,7 +1118,7 @@ static gboolean _masks_remove_or_delete_finish(struct dt_iop_module_t *module, d
 gboolean dt_masks_remove_or_delete(struct dt_iop_module_t *module, dt_masks_form_t *sel, int parent_id,
                                     dt_masks_form_gui_t *mask_gui, int form_id)
 {
-  const int use_count = _masks_gui_form_group_use_count(darktable.develop, form_id);
+  const int use_count = _masks_gui_form_group_use_count(mask_gui->dev, form_id);
 
   // We don't ask for confirmation if the module uses internal masks,
   // just delete the form as it won't be visible in the shape manager.
@@ -1157,7 +1159,8 @@ gboolean dt_masks_form_exit_creation(dt_iop_module_t *module, dt_masks_form_gui_
   {
     const int last_formid = mask_gui->creation_last_formid;
     dt_iop_module_t *creation_module = mask_gui->creation_module ? mask_gui->creation_module : module;
-    dt_masks_form_t *temporary_form = dt_masks_get_visible_form(darktable.develop);
+    dt_develop_t *dev = mask_gui->dev;
+    dt_masks_form_t *temporary_form = dt_masks_get_visible_form(dev);
 
     if(mask_gui->guipoints)
     {
@@ -1171,9 +1174,9 @@ gboolean dt_masks_form_exit_creation(dt_iop_module_t *module, dt_masks_form_gui_
     // The visible form is the current unfinished shape while creation is active.
     // If it was never appended to develop->forms, drop it before selecting the
     // last completed shape from this creation session.
-    if(!IS_NULL_PTR(temporary_form) && IS_NULL_PTR(dt_masks_get_from_id(darktable.develop, temporary_form->formid)))
+    if(!IS_NULL_PTR(temporary_form) && IS_NULL_PTR(dt_masks_get_from_id(dev, temporary_form->formid)))
     {
-      dt_masks_set_visible_form(darktable.develop, NULL);
+      dt_masks_set_visible_form(dev, NULL);
       dt_masks_free_form(temporary_form);
     }
 
@@ -1191,13 +1194,13 @@ gboolean dt_masks_form_exit_creation(dt_iop_module_t *module, dt_masks_form_gui_
       {
         // Keep the shape manager selection in sync without letting its selection
         // handler replace the visible module group with the standalone shape.
-        dt_dev_masks_selection_change(darktable.develop, creation_module, last_formid, FALSE);
+        dt_dev_masks_selection_change(dev, creation_module, last_formid, FALSE);
       }
 
       dt_masks_iop_update(creation_module);
       dt_iop_gui_blend_data_t *blend_data = (dt_iop_gui_blend_data_t *)creation_module->blend_data;
-      if(!IS_NULL_PTR(darktable.develop) && !IS_NULL_PTR(darktable.develop->form_gui))
-        darktable.develop->form_gui->edit_mode = DT_MASKS_EDIT_FULL;
+      if(!IS_NULL_PTR(dev) && !IS_NULL_PTR(dev->form_gui))
+        dev->form_gui->edit_mode = DT_MASKS_EDIT_FULL;
       if(!IS_NULL_PTR(blend_data) && GTK_IS_TOGGLE_BUTTON(blend_data->masks_edit))
       {
         // Creation mode keeps the edit button visually inactive while a shape
@@ -1208,10 +1211,10 @@ gboolean dt_masks_form_exit_creation(dt_iop_module_t *module, dt_masks_form_gui_
         gtk_widget_queue_draw(blend_data->masks_edit);
       }
 
-      if(last_formid > 0 && !IS_NULL_PTR(darktable.develop) && !IS_NULL_PTR(darktable.develop->form_gui))
+      if(last_formid > 0 && !IS_NULL_PTR(dev) && !IS_NULL_PTR(dev->form_gui))
       {
-        dt_masks_form_gui_t *current_gui = darktable.develop->form_gui;
-        dt_masks_form_t *visible_form = dt_masks_get_visible_form(darktable.develop);
+        dt_masks_form_gui_t *current_gui = dev->form_gui;
+        dt_masks_form_t *visible_form = dt_masks_get_visible_form(dev);
         const int selected_index = dt_masks_group_index_from_formid(visible_form, last_formid);
         if(selected_index >= 0)
         {
@@ -1236,18 +1239,18 @@ gboolean dt_masks_form_exit_creation(dt_iop_module_t *module, dt_masks_form_gui_
     }
     else if(last_formid > 0)
     {
-      dt_masks_change_form_gui(dt_masks_get_from_id(darktable.develop, last_formid));
-      dt_dev_masks_selection_change(darktable.develop, NULL, last_formid, TRUE);
-      if(!IS_NULL_PTR(darktable.develop) && !IS_NULL_PTR(darktable.develop->form_gui))
+      dt_masks_change_form_gui(dev, dt_masks_get_from_id(dev, last_formid));
+      dt_dev_masks_selection_change(dev, NULL, last_formid, TRUE);
+      if(!IS_NULL_PTR(dev) && !IS_NULL_PTR(dev->form_gui))
       {
         // A standalone visible form is rendered at index 0.
-        darktable.develop->form_gui->group_selected = 0;
-        darktable.develop->form_gui->form_selected = TRUE;
+        dev->form_gui->group_selected = 0;
+        dev->form_gui->form_selected = TRUE;
       }
     }
     else
     {
-      dt_masks_change_form_gui(NULL);
+      dt_masks_change_form_gui(dev, NULL);
     }
 
     return TRUE;
@@ -1310,7 +1313,7 @@ void dt_masks_gui_form_test_create(dt_masks_form_t *mask_form, dt_masks_form_gui
   // we test if the image has changed
   if(mask_gui->pipe_hash != DT_PIXELPIPE_CACHE_HASH_INVALID)
   {
-    if(mask_gui->pipe_hash != dt_dev_backbuf_get_hash(&darktable.develop->preview_pipe->backbuf))
+    if(mask_gui->pipe_hash != dt_dev_backbuf_get_hash(&mask_gui->dev->preview_pipe->backbuf))
     {
       mask_gui->pipe_hash = DT_PIXELPIPE_CACHE_HASH_INVALID;
       mask_gui->formid = 0;
@@ -1328,7 +1331,7 @@ void dt_masks_gui_form_test_create(dt_masks_form_t *mask_form, dt_masks_form_gui
       for(GList *group_node = mask_form->points; group_node; group_node = g_list_next(group_node))
       {
         dt_masks_form_group_t *group_entry = (dt_masks_form_group_t *)group_node->data;
-        dt_masks_form_t *child_form = dt_masks_get_from_id(darktable.develop, group_entry->formid);
+        dt_masks_form_t *child_form = dt_masks_get_from_id(mask_gui->dev, group_entry->formid);
         if(IS_NULL_PTR(child_form)) return;
         dt_masks_gui_form_create(child_form, mask_gui, form_index, module);
         form_index++;
@@ -1341,16 +1344,16 @@ void dt_masks_gui_form_test_create(dt_masks_form_t *mask_form, dt_masks_form_gui
   }
 }
 
-static void _check_id(dt_masks_form_t *mask_form)
+static void _check_id(dt_develop_t *dev, dt_masks_form_t *mask_form)
 {
   int new_form_id = 100;
-  for(GList *form_node = darktable.develop->forms; form_node; )
+  for(GList *form_node = dev->forms; form_node; )
   {
     dt_masks_form_t *existing_form = (dt_masks_form_t *)form_node->data;
     if(existing_form->formid == mask_form->formid)
     {
       mask_form->formid = new_form_id++;
-      form_node = darktable.develop->forms; // jump back to start of list
+      form_node = dev->forms; // jump back to start of list
     }
     else
     {
@@ -1370,7 +1373,7 @@ static dt_masks_form_t *_group_create(dt_develop_t *develop, dt_iop_module_t *mo
 {
   dt_masks_form_t *group_form = dt_masks_create(group_type);
   _set_group_name_from_module(module, group_form);
-  _check_id(group_form);
+  _check_id(develop, group_form);
   dt_masks_append_form(develop, group_form);
   module->blend_params->mask_id = group_form->formid;
   return group_form;
@@ -1406,7 +1409,7 @@ void dt_masks_gui_form_save_creation(dt_develop_t *develop, dt_iop_module_t *mod
                                      dt_masks_form_gui_t *mask_gui)
 {
   // we check if the id is already registered
-  _check_id(mask_form);
+  _check_id(develop, mask_form);
 
   // mask nb will be at least the length of the list
   guint form_count = 0;
@@ -1446,7 +1449,7 @@ void dt_masks_gui_form_save_creation(dt_develop_t *develop, dt_iop_module_t *mod
 
   } while(name_exists);
 
-  dt_masks_form_update_gravity_center(mask_form);
+  dt_masks_form_update_gravity_center(develop, mask_form);
 
   dt_masks_form_group_t *group_entry = NULL;
   if(!IS_NULL_PTR(module))
@@ -1530,7 +1533,7 @@ int dt_masks_form_duplicate(dt_develop_t *develop, int form_id)
   dt_masks_form_t *base_form = dt_masks_get_from_id(develop, form_id);
   if(IS_NULL_PTR(base_form)) return -1;
   dt_masks_form_t *dest_form = dt_masks_create(base_form->type);
-  _check_id(dest_form);
+  _check_id(develop, dest_form);
 
   // we copy the base values
   dest_form->source[0] = base_form->source[0];
@@ -1985,16 +1988,16 @@ dt_masks_form_t *dt_masks_create(dt_masks_type_t type)
   return mask_form;
 }
 
-dt_masks_form_t *dt_masks_create_ext(dt_masks_type_t type)
+dt_masks_form_t *dt_masks_create_ext(dt_develop_t *dev, dt_masks_type_t type)
 {
-  dt_pthread_rwlock_wrlock(&darktable.develop->masks_mutex);
+  dt_pthread_rwlock_wrlock(&dev->masks_mutex);
   dt_masks_form_t *mask_form = dt_masks_create(type);
 
-  // all forms created here are registered in darktable.develop->allforms for later cleanup
+  // all forms created here are registered in dev->allforms for later cleanup
   if(mask_form)
-    darktable.develop->allforms = g_list_append(darktable.develop->allforms, mask_form);
+    dev->allforms = g_list_append(dev->allforms, mask_form);
 
-  dt_pthread_rwlock_unlock(&darktable.develop->masks_mutex);
+  dt_pthread_rwlock_unlock(&dev->masks_mutex);
 
   return mask_form;
 }
@@ -2389,25 +2392,25 @@ static void _dt_masks_events_set_current_pos(const double x, const double y, dt_
   if(IS_NULL_PTR(mask_gui)) return;
 
   float point[2] = { (float)x, (float)y };
-  dt_dev_coordinates_widget_to_image_norm(darktable.develop, point, 1);
+  dt_dev_coordinates_widget_to_image_norm(mask_gui->dev, point, 1);
   mask_gui->rel_pos[0] = point[0];
   mask_gui->rel_pos[1] = point[1];
 
-  dt_dev_coordinates_image_norm_to_image_abs(darktable.develop, point, 1);
+  dt_dev_coordinates_image_norm_to_image_abs(mask_gui->dev, point, 1);
   mask_gui->pos[0] = point[0];
   mask_gui->pos[1] = point[1];
 
   mask_gui->raw_pos[0] = point[0];
   mask_gui->raw_pos[1] = point[1];
-  dt_dev_coordinates_image_abs_to_raw_abs(darktable.develop, mask_gui->raw_pos, 1);
+  dt_dev_coordinates_image_abs_to_raw_abs(mask_gui->dev, mask_gui->raw_pos, 1);
 }
 
-int dt_masks_events_mouse_moved(struct dt_iop_module_t *module, double x, double y, double pressure, int which)
+int dt_masks_events_mouse_moved(dt_develop_t *dev, struct dt_iop_module_t *module, double x, double y, double pressure, int which)
 {
   // This assume that if this event is generated, the mouse is over the center window.
   // record mouse position even if there are no masks visible
-  dt_masks_form_gui_t *mask_gui = darktable.develop->form_gui;
-  dt_masks_form_t *mask_form = dt_masks_get_visible_form(darktable.develop);
+  dt_masks_form_gui_t *mask_gui = dev->form_gui;
+  dt_masks_form_t *mask_form = dt_masks_get_visible_form(dev);
   if(IS_NULL_PTR(mask_gui)) return 0;
   _dt_masks_events_set_current_pos(x, y, mask_gui);
 
@@ -2415,7 +2418,7 @@ int dt_masks_events_mouse_moved(struct dt_iop_module_t *module, double x, double
   if(IS_NULL_PTR(mask_form)) return 0;
 
   // add an option to allow skip mouse events while editing masks
-  if(darktable.develop->darkroom_skip_mouse_events) return 0;
+  if(dev->darkroom_skip_mouse_events) return 0;
 
   int result = 0;
   if((mask_form->type & DT_MASKS_GROUP) && _dt_masks_events_group_blocks_motion(mask_gui))
@@ -2429,7 +2432,7 @@ int dt_masks_events_mouse_moved(struct dt_iop_module_t *module, double x, double
     int form_index = 0;
     dt_masks_form_t *dispatch_form
         = _dt_masks_events_get_dispatch_form(mask_form, mask_gui, &group_entry, &parent_id, &form_index);
-    dispatch_form = dt_masks_cow_touch(darktable.develop, dispatch_form);
+    dispatch_form = dt_masks_cow_touch(dev, dispatch_form);
 
     if(_dt_masks_events_should_update_hover_on_move(mask_gui))
       result = _dt_masks_events_update_hover(dispatch_form, mask_gui, form_index);
@@ -2447,14 +2450,14 @@ int dt_masks_events_mouse_moved(struct dt_iop_module_t *module, double x, double
   return result;
 }
 
-int dt_masks_events_button_released(struct dt_iop_module_t *module, double x, double y, int button,
+int dt_masks_events_button_released(dt_develop_t *dev, struct dt_iop_module_t *module, double x, double y, int button,
                                     uint32_t state)
 {
   // add an option to allow skip mouse events while editing masks
-  if(darktable.develop->darkroom_skip_mouse_events) return 0;
+  if(dev->darkroom_skip_mouse_events) return 0;
 
-  dt_masks_form_t *mask_form = dt_masks_get_visible_form(darktable.develop);
-  dt_masks_form_gui_t *mask_gui = darktable.develop->form_gui;
+  dt_masks_form_t *mask_form = dt_masks_get_visible_form(dev);
+  dt_masks_form_gui_t *mask_gui = dev->form_gui;
   if(IS_NULL_PTR(mask_gui)) return 0;
   _dt_masks_events_set_current_pos(x, y, mask_gui);
   if(IS_NULL_PTR(mask_form)) return 0;
@@ -2464,7 +2467,7 @@ int dt_masks_events_button_released(struct dt_iop_module_t *module, double x, do
   int form_index = 0;
   dt_masks_form_t *dispatch_form
       = _dt_masks_events_get_dispatch_form(mask_form, mask_gui, &group_entry, &parent_id, &form_index);
-  dispatch_form = dt_masks_cow_touch(darktable.develop, dispatch_form);
+  dispatch_form = dt_masks_cow_touch(dev, dispatch_form);
 
   int result = 0;
   if(!IS_NULL_PTR(dispatch_form) && dispatch_form->functions && dispatch_form->functions->button_released)
@@ -2479,7 +2482,7 @@ int dt_masks_events_button_released(struct dt_iop_module_t *module, double x, do
     const dt_masks_form_group_t *selected_group_entry
         = dt_masks_form_get_selected_group_live(mask_form, mask_gui);
     if(selected_group_entry)
-      dt_dev_masks_selection_change(darktable.develop, module,
+      dt_dev_masks_selection_change(dev, module,
                                     selected_group_entry->formid, FALSE);
   }
 
@@ -2495,14 +2498,14 @@ int dt_masks_events_button_released(struct dt_iop_module_t *module, double x, do
   return result;
 }
 
-int dt_masks_events_button_pressed(struct dt_iop_module_t *module, double x, double y, double pressure,
+int dt_masks_events_button_pressed(dt_develop_t *dev, struct dt_iop_module_t *module, double x, double y, double pressure,
                                    int button, int event_type, uint32_t state)
 {
   // add an option to allow skip mouse events while editing masks
-  if(darktable.develop->darkroom_skip_mouse_events) return 0;
+  if(dev->darkroom_skip_mouse_events) return 0;
 
-  dt_masks_form_t *mask_form = dt_masks_get_visible_form(darktable.develop);
-  dt_masks_form_gui_t *mask_gui = darktable.develop->form_gui;
+  dt_masks_form_t *mask_form = dt_masks_get_visible_form(dev);
+  dt_masks_form_gui_t *mask_gui = dev->form_gui;
   if(IS_NULL_PTR(mask_gui)) return 0;
 
   _dt_masks_events_set_current_pos(x, y, mask_gui);
@@ -2520,7 +2523,7 @@ int dt_masks_events_button_pressed(struct dt_iop_module_t *module, double x, dou
   int form_index = 0;
   dt_masks_form_t *dispatch_form
       = _dt_masks_events_get_dispatch_form(mask_form, mask_gui, &group_entry, &parent_id, &form_index);
-  dispatch_form = dt_masks_cow_touch(darktable.develop, dispatch_form);
+  dispatch_form = dt_masks_cow_touch(dev, dispatch_form);
   _dt_masks_events_update_hover(dispatch_form, mask_gui, form_index);
 
   gboolean return_val = FALSE;
@@ -2530,7 +2533,7 @@ int dt_masks_events_button_pressed(struct dt_iop_module_t *module, double x, dou
                                                           dispatch_form, parent_id, mask_gui, form_index);
   // Throw a selection change event.
   // `dispatch_form` can pass NULL in case of deselection.
-  dt_masks_select_form(module, dispatch_form);
+  dt_masks_select_form(dev, module, dispatch_form);
 
   const gboolean shape_was_selected = (mask_form->type & DT_MASKS_GROUP)
                                           ? (prev_group_selected >= 0 && prev_group_selected == form_index)
@@ -2557,11 +2560,11 @@ int dt_masks_events_button_pressed(struct dt_iop_module_t *module, double x, dou
   return return_val;
 }
 
-int dt_masks_events_key_pressed(struct dt_iop_module_t *module, GdkEventKey *event)
+int dt_masks_events_key_pressed(dt_develop_t *dev, struct dt_iop_module_t *module, GdkEventKey *event)
 {
-  dt_masks_form_t *mask_form = dt_masks_get_visible_form(darktable.develop);
+  dt_masks_form_t *mask_form = dt_masks_get_visible_form(dev);
   if(IS_NULL_PTR(mask_form)) return 0;
-  dt_masks_form_gui_t *mask_gui = darktable.develop->form_gui;
+  dt_masks_form_gui_t *mask_gui = dev->form_gui;
   if(IS_NULL_PTR(mask_gui)) return 0;
 
   gboolean return_value = FALSE;
@@ -2572,20 +2575,20 @@ int dt_masks_events_key_pressed(struct dt_iop_module_t *module, GdkEventKey *eve
     int form_index = 0;
     dt_masks_form_t *dispatch_form
         = _dt_masks_events_get_dispatch_form(mask_form, mask_gui, &group_entry, &parent_id, &form_index);
-    dispatch_form = dt_masks_cow_touch(darktable.develop, dispatch_form);
+    dispatch_form = dt_masks_cow_touch(dev, dispatch_form);
     if(dispatch_form && dispatch_form->functions && dispatch_form->functions->key_pressed)
       return_value = dispatch_form->functions->key_pressed(module, event, dispatch_form,
                                                            parent_id, mask_gui, form_index);
 
     if(!return_value && mask_form->functions->key_pressed)
     {
-      mask_form = dt_masks_cow_touch(darktable.develop, mask_form);
+      mask_form = dt_masks_cow_touch(dev, mask_form);
       return_value = mask_form->functions->key_pressed(module, event, mask_form, 0, mask_gui, 0);
     }
   }
   else if(mask_form->functions->key_pressed)
   {
-    mask_form = dt_masks_cow_touch(darktable.develop, mask_form);
+    mask_form = dt_masks_cow_touch(dev, mask_form);
     return_value = mask_form->functions->key_pressed(module, event, mask_form, 0, mask_gui, 0);
   }
   
@@ -2606,7 +2609,7 @@ int dt_masks_events_key_pressed(struct dt_iop_module_t *module, GdkEventKey *eve
           // Delete shape from current group
           dt_masks_form_group_t *selected_group = dt_masks_form_get_selected_group(mask_form, mask_gui);
           if(IS_NULL_PTR(selected_group)) return 0;
-          dt_masks_form_t *selected_form = dt_masks_get_from_id(darktable.develop, selected_group->formid);
+          dt_masks_form_t *selected_form = dt_masks_get_from_id(dev, selected_group->formid);
           if(selected_form)
             return_value = dt_masks_gui_remove(module, selected_form, mask_gui, selected_group->parentid);
           break;
@@ -2618,14 +2621,14 @@ int dt_masks_events_key_pressed(struct dt_iop_module_t *module, GdkEventKey *eve
   return return_value;
 }
 
-int dt_masks_events_mouse_scrolled(struct dt_iop_module_t *module, double x, double y,
+int dt_masks_events_mouse_scrolled(dt_develop_t *dev, struct dt_iop_module_t *module, double x, double y,
                                    int scroll_up, uint32_t key_state, int scrolling_delta)
 {
   // add an option to allow skip mouse events while editing masks
-  if(darktable.develop->darkroom_skip_mouse_events) return 0;
+  if(dev->darkroom_skip_mouse_events) return 0;
 
-  dt_masks_form_t *mask_form = dt_masks_get_visible_form(darktable.develop);
-  dt_masks_form_gui_t *mask_gui = darktable.develop->form_gui;
+  dt_masks_form_t *mask_form = dt_masks_get_visible_form(dev);
+  dt_masks_form_gui_t *mask_gui = dev->form_gui;
   if(IS_NULL_PTR(mask_gui)) return 0;
 
   _dt_masks_events_set_current_pos(x, y, mask_gui);
@@ -2642,7 +2645,7 @@ int dt_masks_events_mouse_scrolled(struct dt_iop_module_t *module, double x, dou
   int form_index = 0;
   dt_masks_form_t *dispatch_form
       = _dt_masks_events_get_dispatch_form(mask_form, mask_gui, &group_entry, &parent_id, &form_index);
-  dispatch_form = dt_masks_cow_touch(darktable.develop, dispatch_form);
+  dispatch_form = dt_masks_cow_touch(dev, dispatch_form);
 
   if(!mask_gui->creation && !dt_masks_is_anything_selected(mask_gui))
     return 0;
@@ -2867,7 +2870,7 @@ void dt_masks_draw_source(cairo_t *cr, dt_masks_form_gui_t *mask_gui, const int 
   const gboolean shape_selected = (mask_gui->group_selected == form_index)
                                   && (mask_gui->form_selected || mask_gui->form_dragging);
 
-  dt_draw_source_shape(cr, zoom_scale, shape_selected, gui_points->source, gui_points->source_count,
+  dt_draw_source_shape(mask_gui->dev, cr, zoom_scale, shape_selected, gui_points->source, gui_points->source_count,
                        rendered_node_count, draw_shape_func);
   
 }
@@ -2940,7 +2943,7 @@ static void _masks_draw_creation_session_forms(dt_develop_t *develop, dt_iop_mod
   if(!creation_gui->creation || IS_NULL_PTR(creation_gui->creation_formids)) return;
 
   dt_masks_form_gui_t draw_gui;
-  dt_masks_init_form_gui(&draw_gui);
+  dt_masks_init_form_gui(develop, &draw_gui);
   draw_gui.edit_mode = creation_gui->edit_mode;
   draw_gui.group_selected = -1;
   draw_gui.pipe_hash = DT_PIXELPIPE_CACHE_HASH_INVALID;
@@ -2971,10 +2974,10 @@ static void _masks_draw_creation_session_forms(dt_develop_t *develop, dt_iop_mod
   }
 }
 
-void dt_masks_events_post_expose(struct dt_iop_module_t *module, cairo_t *cr, int32_t width, int32_t height,
+void dt_masks_events_post_expose(dt_develop_t *dev, struct dt_iop_module_t *module, cairo_t *cr, int32_t width, int32_t height,
                                  int32_t pointerx, int32_t pointery)
 {
-  dt_develop_t *develop = darktable.develop;
+  dt_develop_t *develop = dev;
   if(IS_NULL_PTR(develop)) return;
   dt_masks_form_t *mask_form = dt_masks_get_visible_form(develop);
   dt_masks_form_gui_t *mask_gui = develop->form_gui;
@@ -3092,18 +3095,18 @@ void dt_masks_clear_form_gui(dt_develop_t *develop)
   develop->form_gui->rebuild_pending = FALSE;
   develop->form_gui->last_hit_test_pos[0] = develop->form_gui->last_hit_test_pos[1] = -1.0f;
   // allow to select a shape inside an iop
-  dt_masks_select_form(NULL, NULL);
+  dt_masks_select_form(develop, NULL, NULL);
 }
 
-void dt_masks_change_form_gui(dt_masks_form_t *new_form)
+void dt_masks_change_form_gui(dt_develop_t *dev, dt_masks_form_t *new_form)
 {
-  dt_masks_form_t *old_form = dt_masks_get_visible_form(darktable.develop);
+  dt_masks_form_t *old_form = dt_masks_get_visible_form(dev);
   if(!IS_NULL_PTR(old_form))
   {
     gboolean is_registered = FALSE;
     gboolean is_registered_for_cleanup = FALSE;
-    dt_pthread_rwlock_rdlock(&darktable.develop->masks_mutex);
-    for(const GList *form_node = darktable.develop->forms; form_node; form_node = g_list_next(form_node))
+    dt_pthread_rwlock_rdlock(&dev->masks_mutex);
+    for(const GList *form_node = dev->forms; form_node; form_node = g_list_next(form_node))
     {
       if(form_node->data == old_form)
       {
@@ -3112,7 +3115,7 @@ void dt_masks_change_form_gui(dt_masks_form_t *new_form)
       }
     }
 
-    for(const GList *form_node = darktable.develop->allforms; form_node; form_node = g_list_next(form_node))
+    for(const GList *form_node = dev->allforms; form_node; form_node = g_list_next(form_node))
     {
       if(form_node->data == old_form)
       {
@@ -3120,22 +3123,22 @@ void dt_masks_change_form_gui(dt_masks_form_t *new_form)
         break;
       }
     }
-    dt_pthread_rwlock_unlock(&darktable.develop->masks_mutex);
+    dt_pthread_rwlock_unlock(&dev->masks_mutex);
 
     // Free only fully orphan temporary previews. Forms tracked in either list
     // are owned by develop and will be released by its teardown path.
     if(!is_registered && !is_registered_for_cleanup) dt_masks_free_form(old_form);
   }
 
-  dt_masks_clear_form_gui(darktable.develop);
-  dt_masks_set_visible_form(darktable.develop, new_form);
+  dt_masks_clear_form_gui(dev);
+  dt_masks_set_visible_form(dev, new_form);
 }
 
-void dt_masks_reset_form_gui(void)
+void dt_masks_reset_form_gui(dt_develop_t *dev)
 {
-  dt_masks_change_form_gui(NULL);
+  dt_masks_change_form_gui(dev, NULL);
   dt_masks_shape_buttons_deactivate_all(NULL);
-  dt_iop_module_t *module = darktable.develop->gui_module;
+  dt_iop_module_t *module = dev->gui_module;
   if(!IS_NULL_PTR(module) && (module->flags() & IOP_FLAGS_SUPPORTS_BLENDING) && !(module->flags() & IOP_FLAGS_NO_MASKS)
     && !IS_NULL_PTR(module->blend_data))
   {
@@ -3146,10 +3149,10 @@ void dt_masks_reset_form_gui(void)
   }
 }
 
-void dt_masks_reset_show_masks_icons(void)
+void dt_masks_reset_show_masks_icons(dt_develop_t *dev)
 {
   dt_masks_shape_buttons_deactivate_all(NULL);
-  for(GList *module_node = darktable.develop->iop; module_node; module_node = g_list_next(module_node))
+  for(GList *module_node = dev->iop; module_node; module_node = g_list_next(module_node))
   {
     dt_iop_module_t *module = (dt_iop_module_t *)module_node->data;
     if(module && (module->flags() & IOP_FLAGS_SUPPORTS_BLENDING) && !(module->flags() & IOP_FLAGS_NO_MASKS)
@@ -3168,8 +3171,9 @@ void dt_masks_reset_show_masks_icons(void)
 
 dt_masks_edit_mode_t dt_masks_get_edit_mode(struct dt_iop_module_t *module)
 {
-  return darktable.develop->form_gui
-    ? darktable.develop->form_gui->edit_mode
+  if(IS_NULL_PTR(module) || IS_NULL_PTR(module->dev)) return DT_MASKS_EDIT_OFF;
+  return module->dev->form_gui
+    ? module->dev->form_gui->edit_mode
     : DT_MASKS_EDIT_OFF;
 }
 
@@ -3183,19 +3187,19 @@ void dt_masks_set_edit_mode(struct dt_iop_module_t *module, dt_masks_edit_mode_t
   dt_masks_form_t *mask_form = dt_masks_get_from_id(module->dev, module->blend_params->mask_id);
   if(value && !IS_NULL_PTR(mask_form))
   {
-    group_form = dt_masks_create_ext(DT_MASKS_GROUP);
+    group_form = dt_masks_create_ext(module->dev, DT_MASKS_GROUP);
     group_form->formid = 0;
-    dt_masks_group_ungroup(group_form, mask_form);
+    dt_masks_group_ungroup(module->dev, group_form, mask_form);
   }
 
   if(blend_data) blend_data->masks_shown = value;
 
-  dt_masks_change_form_gui(group_form);
-  darktable.develop->form_gui->edit_mode = value;
+  dt_masks_change_form_gui(module->dev, group_form);
+  module->dev->form_gui->edit_mode = value;
   if(value && mask_form)
-    dt_dev_masks_selection_change(darktable.develop, NULL, mask_form->formid, FALSE);
+    dt_dev_masks_selection_change(module->dev, NULL, mask_form->formid, FALSE);
   else
-    dt_dev_masks_selection_change(darktable.develop, NULL, 0, FALSE);
+    dt_dev_masks_selection_change(module->dev, NULL, 0, FALSE);
 
   if(blend_data->masks_support)
     gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(blend_data->masks_edit),
@@ -3207,8 +3211,8 @@ void dt_masks_set_edit_mode(struct dt_iop_module_t *module, dt_masks_edit_mode_t
 static void _menu_no_masks(struct dt_iop_module_t *module)
 {
   // we drop all the forms in the iop
-  dt_masks_form_t *group_form = _group_from_module(darktable.develop, module);
-  if(group_form) dt_masks_form_delete(module, NULL, group_form);
+  dt_masks_form_t *group_form = _group_from_module(module->dev, module);
+  if(group_form) dt_masks_form_delete(module->dev, module, NULL, group_form);
   module->blend_params->mask_id = 0;
 
   // and we update the iop
@@ -3218,24 +3222,24 @@ static void _menu_no_masks(struct dt_iop_module_t *module)
 
 static void _menu_add_shape(struct dt_iop_module_t *module, dt_masks_type_t type)
 {
-  dt_masks_creation_mode_enter(module, type);
+  dt_masks_creation_mode_enter(module->dev, module, type);
 }
 
 static void _menu_add_exist(dt_iop_module_t *module, int form_id)
 {
   if(IS_NULL_PTR(module)) return;
-  dt_masks_form_t *mask_form = dt_masks_get_from_id(darktable.develop, form_id);
+  dt_masks_form_t *mask_form = dt_masks_get_from_id(module->dev, form_id);
   if(IS_NULL_PTR(mask_form)) return;
 
   // is there already a masks group for this module ?
-  dt_masks_form_t *group_form = _group_from_module(darktable.develop, module);
+  dt_masks_form_t *group_form = _group_from_module(module->dev, module);
   if(IS_NULL_PTR(group_form))
   {
-    group_form = _group_create(darktable.develop, module, DT_MASKS_GROUP);
+    group_form = _group_create(module->dev, module, DT_MASKS_GROUP);
   }
-  group_form = dt_masks_cow_touch(darktable.develop, group_form);
+  group_form = dt_masks_cow_touch(module->dev, group_form);
   // we add the form in this group
-  dt_masks_group_add_form(group_form, mask_form);
+  dt_masks_group_add_form(module->dev, group_form, mask_form);
   // we save the group
   // and we ensure that we are in edit mode
 
@@ -3245,7 +3249,8 @@ static void _menu_add_exist(dt_iop_module_t *module, int form_id)
 
 void dt_masks_group_update_name(dt_iop_module_t *module)
 {
-  dt_masks_form_t *group_form = _group_from_module(darktable.develop, module);
+  if(IS_NULL_PTR(module)) return;
+  dt_masks_form_t *group_form = _group_from_module(module->dev, module);
   if (IS_NULL_PTR(group_form))
     return;
 
@@ -3260,27 +3265,27 @@ void dt_masks_iop_use_same_as(dt_iop_module_t *module, dt_iop_module_t *source_m
 
   // we get the source group
   int source_id = source_module->blend_params->mask_id;
-  dt_masks_form_t *source_group = dt_masks_get_from_id(darktable.develop, source_id);
+  dt_masks_form_t *source_group = dt_masks_get_from_id(module->dev, source_id);
   if(IS_NULL_PTR(source_group) || source_group->type != DT_MASKS_GROUP) return;
 
   // is there already a masks group for this module ?
-  dt_masks_form_t *group_form = _group_from_module(darktable.develop, module);
+  dt_masks_form_t *group_form = _group_from_module(module->dev, module);
   if(IS_NULL_PTR(group_form))
   {
-    group_form = _group_create(darktable.develop, module, DT_MASKS_GROUP);
+    group_form = _group_create(module->dev, module, DT_MASKS_GROUP);
   }
   // Touch once, before the loop: dt_masks_group_add_form mutates group_form->points on every
   // iteration, so it must already be private by the first call, or later iterations would
   // append to an orphaned clone instead of the object actually in dev->forms.
-  group_form = dt_masks_cow_touch(darktable.develop, group_form);
+  group_form = dt_masks_cow_touch(module->dev, group_form);
   // we copy the src group in this group
   for(GList *group_node = source_group->points; group_node; group_node = g_list_next(group_node))
   {
     dt_masks_form_group_t *group_entry = (dt_masks_form_group_t *)group_node->data;
-    dt_masks_form_t *mask_form = dt_masks_get_from_id(darktable.develop, group_entry->formid);
+    dt_masks_form_t *mask_form = dt_masks_get_from_id(module->dev, group_entry->formid);
     if(mask_form)
     {
-      dt_masks_form_group_t *new_entry = dt_masks_group_add_form(group_form, mask_form);
+      dt_masks_form_group_t *new_entry = dt_masks_group_add_form(module->dev, group_form, mask_form);
       if(new_entry)
       {
         new_entry->state = group_entry->state;
@@ -3363,7 +3368,7 @@ void dt_masks_iop_combo_populate(GtkWidget *widget, void *data)
     if((other_module != module) && (other_module->flags() & IOP_FLAGS_SUPPORTS_BLENDING)
        && !(other_module->flags() & IOP_FLAGS_NO_MASKS))
     {
-      dt_masks_form_t *group_form = _group_from_module(darktable.develop, other_module);
+      dt_masks_form_t *group_form = _group_from_module(module->dev, other_module);
       if(group_form)
       {
         gchar *module_label = dt_history_item_get_name(other_module);
@@ -3447,7 +3452,7 @@ void dt_masks_iop_value_changed_callback(GtkWidget *widget, struct dt_iop_module
   dt_dev_add_history_item(module->dev, module, TRUE, TRUE);
 }
 
-void dt_masks_form_delete(struct dt_iop_module_t *module, dt_masks_form_t *group_form,
+void dt_masks_form_delete(dt_develop_t *dev, struct dt_iop_module_t *module, dt_masks_form_t *group_form,
                           dt_masks_form_t *mask_form)
 {
   if(IS_NULL_PTR(mask_form)) return;
@@ -3456,7 +3461,7 @@ void dt_masks_form_delete(struct dt_iop_module_t *module, dt_masks_form_t *group
 
   if(!(mask_form->type & (DT_MASKS_CLONE | DT_MASKS_NON_CLONE)) && !IS_NULL_PTR(group_form))
   {
-    group_form = dt_masks_cow_touch(darktable.develop, group_form);
+    group_form = dt_masks_cow_touch(dev, group_form);
     // we try to remove the form from the masks group
     int removed = 0;
     for(GList *group_node = group_form->points; group_node; group_node = g_list_next(group_node))
@@ -3476,8 +3481,8 @@ void dt_masks_form_delete(struct dt_iop_module_t *module, dt_masks_form_t *group
       dt_masks_iop_update(module);
 
     }
-    if(removed) dt_masks_form_update_gravity_center(group_form);
-    if(removed && IS_NULL_PTR(group_form->points)) dt_masks_form_delete(module, NULL, group_form);
+    if(removed) dt_masks_form_update_gravity_center(dev, group_form);
+    if(removed && IS_NULL_PTR(group_form->points)) dt_masks_form_delete(dev, module, NULL, group_form);
     return;
   }
 
@@ -3488,19 +3493,19 @@ void dt_masks_form_delete(struct dt_iop_module_t *module, dt_masks_form_t *group
     while(mask_form->points)
     {
       dt_masks_form_group_t *group_child = (dt_masks_form_group_t *)mask_form->points->data;
-      dt_masks_form_t *child = dt_masks_get_from_id(darktable.develop, group_child->formid);
-      dt_masks_form_delete(module, mask_form, child);
+      dt_masks_form_t *child = dt_masks_get_from_id(dev, group_child->formid);
+      dt_masks_form_delete(dev, module, mask_form, child);
       // The recursive call passes mask_form as its own group_form parameter and may have
       // COW-cloned it (see the touch above): re-fetch the live object so this loop keeps
       // observing the mutation instead of spinning on a stale, now-orphaned copy.
-      mask_form = dt_masks_get_from_id(darktable.develop, form_id);
+      mask_form = dt_masks_get_from_id(dev, form_id);
       if(IS_NULL_PTR(mask_form)) break;
     }
   }
 
   // if we are here that mean we have to permanently delete this form
   // we drop the form from all modules
-  for(GList *iop_node = darktable.develop->iop; iop_node; iop_node = g_list_next(iop_node))
+  for(GList *iop_node = dev->iop; iop_node; iop_node = g_list_next(iop_node))
   {
     dt_iop_module_t *iop_module = (dt_iop_module_t *)iop_node->data;
     if(iop_module->flags() & IOP_FLAGS_SUPPORTS_BLENDING)
@@ -3513,10 +3518,10 @@ void dt_masks_form_delete(struct dt_iop_module_t *module, dt_masks_form_t *group
       }
       else
       {
-        dt_masks_form_t *iop_group = _group_from_module(darktable.develop, iop_module);
+        dt_masks_form_t *iop_group = _group_from_module(dev, iop_module);
         if(iop_group && (iop_group->type & DT_MASKS_GROUP))
         {
-          iop_group = dt_masks_cow_touch(darktable.develop, iop_group);
+          iop_group = dt_masks_cow_touch(dev, iop_group);
           int removed = 0;
           GList *shapes = iop_group->points;
           while(shapes)
@@ -3537,25 +3542,25 @@ void dt_masks_form_delete(struct dt_iop_module_t *module, dt_masks_form_t *group
           {
             dt_masks_iop_update(iop_module);
 
-            if(IS_NULL_PTR(iop_group->points)) dt_masks_form_delete(iop_module, NULL, iop_group);
+            if(IS_NULL_PTR(iop_group->points)) dt_masks_form_delete(dev, iop_module, NULL, iop_group);
           }
         }
       }
     }
   }
   // we drop the form from the general list
-  for(GList *form_node = darktable.develop->forms; form_node; form_node = g_list_next(form_node))
+  for(GList *form_node = dev->forms; form_node; form_node = g_list_next(form_node))
   {
     dt_masks_form_t *existing_form = (dt_masks_form_t *)form_node->data;
     if(existing_form->formid == form_id)
     {
-      dt_masks_remove_form(darktable.develop, existing_form);
+      dt_masks_remove_form(dev, existing_form);
       break;
     }
   }
 }
 
-float dt_masks_form_get_interaction_value(dt_masks_form_group_t *form_group,
+float dt_masks_form_get_interaction_value(dt_develop_t *dev, dt_masks_form_group_t *form_group,
                                           dt_masks_interaction_t interaction)
 {
   if(IS_NULL_PTR(form_group)) return NAN;
@@ -3565,29 +3570,29 @@ float dt_masks_form_get_interaction_value(dt_masks_form_group_t *form_group,
     return form_group->opacity;
   }
 
-  dt_masks_form_t *target_form = dt_masks_get_from_id(darktable.develop, form_group->formid);
+  dt_masks_form_t *target_form = dt_masks_get_from_id(dev, form_group->formid);
   if(IS_NULL_PTR(target_form) || IS_NULL_PTR(target_form->functions) || IS_NULL_PTR(target_form->functions->get_interaction_value)) return NAN;
 
   return target_form->functions->get_interaction_value(target_form, interaction);
 }
 
-gboolean dt_masks_form_get_gravity_center(const dt_masks_form_t *mask_form, float center[2], float *area)
+gboolean dt_masks_form_get_gravity_center(dt_develop_t *dev, const dt_masks_form_t *mask_form, float center[2], float *area)
 {
   center[0] = 0.0f;
   center[1] = 0.0f;
   if(!IS_NULL_PTR(area)) *area = 0.0f;
 
   if(IS_NULL_PTR(mask_form) || IS_NULL_PTR(mask_form->functions) || IS_NULL_PTR(mask_form->functions->get_gravity_center) || IS_NULL_PTR(center)) return FALSE;
-  return mask_form->functions->get_gravity_center(mask_form, center, area);
+  return mask_form->functions->get_gravity_center(dev, mask_form, center, area);
 }
 
-void dt_masks_form_update_gravity_center(dt_masks_form_t *mask_form)
+void dt_masks_form_update_gravity_center(dt_develop_t *dev, dt_masks_form_t *mask_form)
 {
   if(IS_NULL_PTR(mask_form)) return;
 
   float center_point[2];
   float area = 0.0f;
-  const gboolean ok = dt_masks_form_get_gravity_center(mask_form, center_point, &area);
+  const gboolean ok = dt_masks_form_get_gravity_center(dev, mask_form, center_point, &area);
   mask_form->gravity_center[0] = center_point[0];
   mask_form->gravity_center[1] = center_point[1];
   mask_form->area = area;
@@ -3622,7 +3627,7 @@ int dt_masks_center_view_on_form(dt_develop_t *dev, const dt_masks_form_t *mask_
 
   float center[2] = { 0.0f, 0.0f };
   float area = 0.0f;
-  if(!dt_masks_form_get_gravity_center(mask_form, center, &area)) return 1;
+  if(!dt_masks_form_get_gravity_center(dev, mask_form, center, &area)) return 1;
 
   dt_dev_coordinates_raw_norm_to_raw_abs(dev, center, 1);
   if(!dt_dev_coordinates_raw_abs_to_image_abs(dev, center, 1)) return 1;
@@ -3659,15 +3664,16 @@ float dt_masks_form_set_interaction_value(dt_masks_form_group_t *form_group,
     return result;
   }
 
-  dt_masks_form_t *target_form = dt_masks_get_from_id(darktable.develop, form_group->formid);
+  dt_develop_t *dev = !IS_NULL_PTR(mask_gui) ? mask_gui->dev : (!IS_NULL_PTR(module) ? module->dev : NULL);
+  if(IS_NULL_PTR(dev)) return NAN;
+  dt_masks_form_t *target_form = dt_masks_get_from_id(dev, form_group->formid);
   if(IS_NULL_PTR(target_form) || !target_form->functions
      || !target_form->functions->set_interaction_value) return NAN;
 
   const float result = target_form->functions->set_interaction_value(target_form, interaction, value, increment,
                                                                      flow, mask_gui, module);
   if(isnan(result)) return NAN;
-  dt_masks_form_update_gravity_center(target_form);
-  //dt_dev_add_history_item(darktable.develop, module, TRUE, TRUE);
+  dt_masks_form_update_gravity_center(dev, target_form);
   return result;
 }
 
@@ -3787,7 +3793,7 @@ void dt_masks_duplicate_points(const dt_masks_form_t *base_form, dt_masks_form_t
   }
 }
 
-int dt_masks_form_change_opacity(dt_masks_form_t *mask_form, int parent_id, int scroll_up,
+int dt_masks_form_change_opacity(dt_develop_t *dev, dt_masks_form_t *mask_form, int parent_id, int scroll_up,
                                  const int flow)
 {
   if(IS_NULL_PTR(mask_form)) return 0;
@@ -3796,9 +3802,9 @@ int dt_masks_form_change_opacity(dt_masks_form_t *mask_form, int parent_id, int 
   // memory owned by the parent group, not by mask_form -- touch the parent (not mask_form)
   // before resolving the entry, or a shared parent's group_entry gets mutated behind the back
   // of a snapshot that still references it.
-  dt_masks_form_t *parent_form = dt_masks_get_from_id(darktable.develop, parent_id);
+  dt_masks_form_t *parent_form = dt_masks_get_from_id(dev, parent_id);
   if(IS_NULL_PTR(parent_form) || !(parent_form->type & DT_MASKS_GROUP)) return 0;
-  parent_form = dt_masks_cow_touch(darktable.develop, parent_form);
+  parent_form = dt_masks_cow_touch(dev, parent_form);
 
   dt_masks_form_group_t *form_group = _masks_group_find_form(parent_form, mask_form->formid);
   if(IS_NULL_PTR(form_group)) return 0;
@@ -3844,7 +3850,7 @@ void dt_masks_form_move(dt_masks_form_t *group_form, int form_id, int move_up)
   }
 }
 
-static int _find_in_group(dt_masks_form_t *group_form, int form_id)
+static int _find_in_group(dt_develop_t *dev, dt_masks_form_t *group_form, int form_id)
 {
   if(!(group_form->type & DT_MASKS_GROUP)) return 0;
   if(group_form->formid == form_id) return 1;
@@ -3852,23 +3858,23 @@ static int _find_in_group(dt_masks_form_t *group_form, int form_id)
   for(GList *group_node = group_form->points; group_node; group_node = g_list_next(group_node))
   {
     const dt_masks_form_group_t *group_entry = (dt_masks_form_group_t *)group_node->data;
-    dt_masks_form_t *mask_form = dt_masks_get_from_id(darktable.develop, group_entry->formid);
+    dt_masks_form_t *mask_form = dt_masks_get_from_id(dev, group_entry->formid);
     if(mask_form)
     {
-      if(mask_form->type & DT_MASKS_GROUP) nested_count += _find_in_group(mask_form, form_id);
+      if(mask_form->type & DT_MASKS_GROUP) nested_count += _find_in_group(dev, mask_form, form_id);
     }
   }
   return nested_count;
 }
 
-dt_masks_form_group_t *dt_masks_group_add_form(dt_masks_form_t *group_form, dt_masks_form_t *mask_form)
+dt_masks_form_group_t *dt_masks_group_add_form(dt_develop_t *dev, dt_masks_form_t *group_form, dt_masks_form_t *mask_form)
 {
   // add a form to group and check for self inclusion
 
   if(!(group_form->type & DT_MASKS_GROUP)) return NULL;
   // either the form to add is not a group, so no risk
   // or we go through all points of form to see if we find a ref to grp->formid
-  if(!(mask_form->type & DT_MASKS_GROUP) || _find_in_group(mask_form, group_form->formid) == 0)
+  if(!(mask_form->type & DT_MASKS_GROUP) || _find_in_group(dev, mask_form, group_form->formid) == 0)
   {
     dt_masks_form_group_t *group_entry = malloc(sizeof(dt_masks_form_group_t));
     group_entry->formid = mask_form->formid;
@@ -3876,7 +3882,7 @@ dt_masks_form_group_t *dt_masks_group_add_form(dt_masks_form_t *group_form, dt_m
     group_entry->state = DT_MASKS_STATE_SHOW | DT_MASKS_STATE_USE | DT_MASKS_STATE_UNION;
     group_entry->opacity = dt_conf_get_float("plugins/darkroom/masks/opacity");
     group_form->points = g_list_append(group_form->points, group_entry);
-    dt_masks_form_update_gravity_center(group_form);
+    dt_masks_form_update_gravity_center(dev, group_form);
     return group_entry;
   }
 
@@ -3884,7 +3890,7 @@ dt_masks_form_group_t *dt_masks_group_add_form(dt_masks_form_t *group_form, dt_m
   return NULL;
 }
 
-void dt_masks_group_ungroup(dt_masks_form_t *dest_group, dt_masks_form_t *group_form)
+void dt_masks_group_ungroup(dt_develop_t *dev, dt_masks_form_t *dest_group, dt_masks_form_t *group_form)
 {
   if(IS_NULL_PTR(group_form) || IS_NULL_PTR(dest_group)) return;
   if(!(group_form->type & DT_MASKS_GROUP) || !(dest_group->type & DT_MASKS_GROUP)) return;
@@ -3892,17 +3898,17 @@ void dt_masks_group_ungroup(dt_masks_form_t *dest_group, dt_masks_form_t *group_
   // dest_group->points is mutated below (also across recursive calls, which all receive this
   // same touched pointer by value): safe to self-touch here, unlike group_form which is only
   // ever read/recursed into, never mutated.
-  dest_group = dt_masks_cow_touch(darktable.develop, dest_group);
+  dest_group = dt_masks_cow_touch(dev, dest_group);
 
   for(GList *group_node = group_form->points; group_node; group_node = g_list_next(group_node))
   {
     dt_masks_form_group_t *group_entry = (dt_masks_form_group_t *)group_node->data;
-    dt_masks_form_t *mask_form = dt_masks_get_from_id(darktable.develop, group_entry->formid);
+    dt_masks_form_t *mask_form = dt_masks_get_from_id(dev, group_entry->formid);
     if(mask_form)
     {
       if(mask_form->type & DT_MASKS_GROUP)
       {
-        dt_masks_group_ungroup(dest_group, mask_form);
+        dt_masks_group_ungroup(dev, dest_group, mask_form);
       }
       else
       {
@@ -3916,7 +3922,7 @@ void dt_masks_group_ungroup(dt_masks_form_t *dest_group, dt_masks_form_t *group_
     }
   }
 
-  dt_masks_form_update_gravity_center(dest_group);
+  dt_masks_form_update_gravity_center(dev, dest_group);
 }
 
 uint64_t dt_masks_group_get_hash_ext(uint64_t hash, GList *masks, dt_masks_form_t *mask_form)
@@ -3957,12 +3963,7 @@ uint64_t dt_masks_group_get_hash_ext(uint64_t hash, GList *masks, dt_masks_form_
   return hash;
 }
 
-uint64_t dt_masks_group_get_hash(uint64_t hash, dt_masks_form_t *mask_form)
-{
-  return dt_masks_group_get_hash_ext(hash, darktable.develop ? darktable.develop->forms : NULL, mask_form);
-}
-
-uint64_t dt_masks_form_get_own_hash(uint64_t hash, const dt_masks_form_t *mask_form)
+uint64_t dt_masks_form_get_own_hash(uint64_t hash, GList *masks, const dt_masks_form_t *mask_form)
 {
   if(IS_NULL_PTR(mask_form)) return hash;
 
@@ -3980,7 +3981,7 @@ uint64_t dt_masks_form_get_own_hash(uint64_t hash, const dt_masks_form_t *mask_f
       // Membership only (id + state/opacity): the referenced form's own content is hashed
       // once, separately, when dev->forms reaches that form's own top-level entry. Recursing
       // into it here would re-hash every grouped shape's full point list a second time.
-      if(dt_masks_get_from_id(darktable.develop, group_entry->formid))
+      if(dt_masks_get_from_id_ext(masks, group_entry->formid))
       {
         hash = dt_hash(hash, (const char *)&group_entry->formid, sizeof(int));
         hash = dt_hash(hash, (const char *)&group_entry->state, sizeof(int));
@@ -4024,7 +4025,7 @@ static void _cleanup_unused_recurs(GList *form_list, int form_id, int *used_form
 }
 
 // removes from _forms all forms that are not used in history_list up to history_end
-static int _masks_cleanup_unused(GList **forms_list, GList *history_list, const int history_end)
+static int _masks_cleanup_unused(dt_develop_t *dev, GList **forms_list, GList *history_list, const int history_end)
 {
   int masks_removed = 0;
   GList *forms = *forms_list;
@@ -4073,7 +4074,7 @@ static int _masks_cleanup_unused(GList **forms_list, GList *history_list, const 
     {
       forms = g_list_remove(forms, mask_form);
       // and add it to allforms for cleanup
-      darktable.develop->allforms = g_list_append(darktable.develop->allforms, mask_form);
+      dev->allforms = g_list_append(dev->allforms, mask_form);
       masks_removed = 1;
     }
   }
@@ -4092,7 +4093,7 @@ static int _masks_cleanup_unused(GList **forms_list, GList *history_list, const 
  * Caveat: if multiple history entries reference masks, some unused masks may remain.
  *         This is intentional so users can still jump back in history.
  */
-void dt_masks_cleanup_unused_from_list(GList *history_list)
+void dt_masks_cleanup_unused_from_list(dt_develop_t *dev, GList *history_list)
 {
   // a mask is used in a given hist->forms entry if it is used up to the next hist->forms
   // so we are going to remove for each hist->forms from the top
@@ -4104,7 +4105,7 @@ void dt_masks_cleanup_unused_from_list(GList *history_list)
     dt_dev_history_item_t *history_item = (dt_dev_history_item_t *)history_node->data;
     if(!IS_NULL_PTR(history_item->forms)) //&& strcmp(history_item->op_name, "mask_manager") == 0)
     {
-      _masks_cleanup_unused(&history_item->forms, history_list, history_end);
+      _masks_cleanup_unused(dev, &history_item->forms, history_list, history_end);
       history_end = history_count - 1;
     }
     history_count--;
@@ -4118,10 +4119,10 @@ void dt_masks_cleanup_unused_from_list(GList *history_list)
  */
 void dt_masks_cleanup_unused(dt_develop_t *develop)
 {
-  dt_masks_change_form_gui(NULL);
+  dt_masks_change_form_gui(develop, NULL);
 
   // we remove the forms from history
-  dt_masks_cleanup_unused_from_list(develop->history);
+  dt_masks_cleanup_unused_from_list(develop, develop->history);
 
   // and we save all that
   GList *forms = NULL;
@@ -4207,12 +4208,12 @@ int dt_masks_point_in_form_exact(const float *test_points, int test_point_count,
  *
  * Passing NULL clears the selection.
  */
-void dt_masks_select_form(struct dt_iop_module_t *module, dt_masks_form_t *selected_form)
+void dt_masks_select_form(dt_develop_t *dev, struct dt_iop_module_t *module, dt_masks_form_t *selected_form)
 {
   const int selected_formid = IS_NULL_PTR(selected_form) ? 0 : selected_form->formid;
 
-  if(IS_NULL_PTR(module) && selected_formid == 0)
-    module = darktable.develop->gui_module;
+  if(IS_NULL_PTR(module) && selected_formid == 0 && !IS_NULL_PTR(dev))
+    module = dev->gui_module;
 
   if(!IS_NULL_PTR(module) && module->masks_selection_changed)
     module->masks_selection_changed(module, selected_formid);
@@ -4252,8 +4253,9 @@ void dt_masks_set_source_pos_initial_state(dt_masks_form_gui_t *mask_gui, const 
  */
 void dt_masks_set_source_pos_initial_value(dt_masks_form_gui_t *mask_gui, dt_masks_form_t *mask_form)
 {
-  const float raw_width = darktable.develop->roi.raw_width;
-  const float raw_height = darktable.develop->roi.raw_height;
+  dt_develop_t *dev = mask_gui->dev;
+  const float raw_width = dev->roi.raw_width;
+  const float raw_height = dev->roi.raw_height;
 
   const float xx = mask_gui->pos[0];
   const float yy = mask_gui->pos[1];
@@ -4266,7 +4268,7 @@ void dt_masks_set_source_pos_initial_value(dt_masks_form_gui_t *mask_gui, dt_mas
     {
       if(mask_form->functions && mask_form->functions->initial_source_pos)
       {
-        mask_form->functions->initial_source_pos(raw_width, raw_height,
+        mask_form->functions->initial_source_pos(dev, raw_width, raw_height,
                                                  &mask_gui->pos_source[0], &mask_gui->pos_source[1]);
       }
       else
@@ -4275,16 +4277,16 @@ void dt_masks_set_source_pos_initial_value(dt_masks_form_gui_t *mask_gui, dt_mas
       // set offset to form->source
       mask_form->source[0] = mask_gui->pos[0] + mask_gui->pos_source[0];
       mask_form->source[1] = mask_gui->pos[1] + mask_gui->pos_source[1];
-      dt_dev_coordinates_image_abs_to_raw_abs(darktable.develop, mask_form->source, 1);
+      dt_dev_coordinates_image_abs_to_raw_abs(dev, mask_form->source, 1);
       // normalize backbuf points
-      dt_dev_coordinates_raw_abs_to_raw_norm(darktable.develop, mask_form->source, 1);
+      dt_dev_coordinates_raw_abs_to_raw_norm(dev, mask_form->source, 1);
 
     }
     else
     {
       // if a position was defined by the user, use the absolute value the first time
       float source_points[2] = { mask_gui->pos_source[0], mask_gui->pos_source[1] };
-      dt_dev_coordinates_image_abs_to_raw_norm(darktable.develop, source_points, 1);
+      dt_dev_coordinates_image_abs_to_raw_norm(dev, source_points, 1);
 
       mask_form->source[0] = source_points[0];
       mask_form->source[1] = source_points[1];
@@ -4300,13 +4302,13 @@ void dt_masks_set_source_pos_initial_value(dt_masks_form_gui_t *mask_gui, dt_mas
     // original pos was already defined and relative value calculated, just use it
     mask_form->source[0] = mask_gui->pos[0] + mask_gui->pos_source[0];
     mask_form->source[1] = mask_gui->pos[1] + mask_gui->pos_source[1];
-    dt_dev_coordinates_image_abs_to_raw_norm(darktable.develop, mask_form->source, 1);
+    dt_dev_coordinates_image_abs_to_raw_norm(dev, mask_form->source, 1);
   }
   else if(mask_gui->source_pos_type == DT_MASKS_SOURCE_POS_ABSOLUTE)
   {
     // an absolute position was defined by the user
     float source_points[2] = { mask_gui->pos_source[0], mask_gui->pos_source[1] };
-    dt_dev_coordinates_image_abs_to_raw_norm(darktable.develop, source_points, 1);
+    dt_dev_coordinates_image_abs_to_raw_norm(dev, source_points, 1);
 
     mask_form->source[0] = source_points[0];
     mask_form->source[1] = source_points[1];
@@ -4326,8 +4328,8 @@ void dt_masks_calculate_source_pos_origin(dt_masks_form_gui_t *mask_gui, const f
 {
   float source_x = 0.0f;
   float source_y = 0.0f;
-  const float raw_width = darktable.develop->roi.raw_width;
-  const float raw_height = darktable.develop->roi.raw_height;
+  const float raw_width = mask_gui->dev->roi.raw_width;
+  const float raw_height = mask_gui->dev->roi.raw_height;
   if(mask_gui->source_pos_type == DT_MASKS_SOURCE_POS_RELATIVE)
   {
     source_x = xpos + mask_gui->pos_source[0];
@@ -4337,10 +4339,10 @@ void dt_masks_calculate_source_pos_origin(dt_masks_form_gui_t *mask_gui, const f
   {
     if(mask_gui->pos_source[0] == -1.0f && mask_gui->pos_source[1] == -1.0f)
     {
-      const dt_masks_form_t *visible_form = dt_masks_get_visible_form(darktable.develop);
+      const dt_masks_form_t *visible_form = dt_masks_get_visible_form(mask_gui->dev);
       if(!IS_NULL_PTR(visible_form) && visible_form->functions && visible_form->functions->initial_source_pos)
       {
-        visible_form->functions->initial_source_pos(raw_width, raw_height, &source_x, &source_y);
+        visible_form->functions->initial_source_pos(mask_gui->dev, raw_width, raw_height, &source_x, &source_y);
         source_x += xpos;
         source_y += ypos;
       }
@@ -4439,21 +4441,22 @@ void dt_masks_creation_mode_quit(dt_masks_form_gui_t *mask_gui)
  *
  * NOTE: this does quite the same as _menu_add_shape.
  */
-gboolean dt_masks_creation_mode_enter(dt_iop_module_t *module, const dt_masks_type_t type)
+gboolean dt_masks_creation_mode_enter(dt_develop_t *dev, dt_iop_module_t *module, const dt_masks_type_t type)
 {
   if((type & DT_MASKS_ALL) == 0) return FALSE;
+  if(IS_NULL_PTR(dev) || IS_NULL_PTR(dev->form_gui)) return FALSE;
   // we want to be sure that the iop has focus
   if(!IS_NULL_PTR(module)) dt_iop_request_focus(module);
 
   dt_masks_form_t *mask_form = dt_masks_create(type);
   if(IS_NULL_PTR(mask_form)) return FALSE;
 
-  dt_masks_change_form_gui(mask_form);
-  darktable.develop->form_gui->creation = TRUE;
-  darktable.develop->form_gui->creation_module = module;
-  darktable.develop->form_gui->creation_type = type;
-  darktable.develop->form_gui->creation_formids = NULL;
-  darktable.develop->form_gui->creation_last_formid = 0;
+  dt_masks_change_form_gui(dev, mask_form);
+  dev->form_gui->creation = TRUE;
+  dev->form_gui->creation_module = module;
+  dev->form_gui->creation_type = type;
+  dev->form_gui->creation_formids = NULL;
+  dev->form_gui->creation_last_formid = 0;
 
   // Give focus to central view to allow using shortcuts for mask creation right after selecting a mask type in the manager
   gtk_widget_grab_focus(dt_ui_center(darktable.gui->ui));

--- a/src/develop/masks/masks_gui.c
+++ b/src/develop/masks/masks_gui.c
@@ -100,11 +100,12 @@ static int _masks_shape_button_index(const dt_masks_shape_buttons_data_t *data, 
   return -1;
 }
 
-static gboolean _masks_shape_button_is_current_creation(const dt_masks_shape_buttons_data_t *data,
+static gboolean _masks_shape_button_is_current_creation(dt_develop_t *dev,
+                                                        const dt_masks_shape_buttons_data_t *data,
                                                         const int button_index)
 {
-  dt_masks_form_gui_t *mask_gui = darktable.develop->form_gui;
-  dt_masks_form_t *visible_form = dt_masks_get_visible_form(darktable.develop);
+  dt_masks_form_gui_t *mask_gui = dev->form_gui;
+  dt_masks_form_t *visible_form = dt_masks_get_visible_form(dev);
 
   return !IS_NULL_PTR(mask_gui) && mask_gui->creation
          && mask_gui->creation_module == data->config.creation_module
@@ -123,9 +124,11 @@ static gboolean _masks_shape_button_pressed(GtkWidget *button, GdkEventButton *e
 
   dt_masks_type_t type = data->types[button_index];
   dt_iop_module_t *module = data->config.creation_module;
-  dt_masks_form_gui_t *mask_gui = darktable.develop->form_gui;
+  dt_develop_t *dev = !IS_NULL_PTR(module) ? module->dev : data->config.dev;
+  if(IS_NULL_PTR(dev)) return FALSE;
+  dt_masks_form_gui_t *mask_gui = dev->form_gui;
 
-  if(_masks_shape_button_is_current_creation(data, button_index))
+  if(_masks_shape_button_is_current_creation(dev, data, button_index))
   {
     dt_masks_shape_buttons_deactivate_all(NULL);
     dt_masks_form_exit_creation(module, mask_gui);
@@ -146,7 +149,7 @@ static gboolean _masks_shape_button_pressed(GtkWidget *button, GdkEventButton *e
   dt_masks_shape_buttons_deactivate_all(button);
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(button), TRUE);
 
-  if(dt_masks_creation_mode_enter(module, type))
+  if(dt_masks_creation_mode_enter(dev, module, type))
   {
     if(data->config.started)
     {
@@ -261,9 +264,9 @@ typedef struct dt_masks_gui_interaction_slider_t
 // renders, yet the image updates without waiting for the context menu to be closed.
 static void _masks_gui_interaction_commit(dt_masks_gui_interaction_slider_t *data)
 {
-  if(IS_NULL_PTR(data) || IS_NULL_PTR(data->form_group)) return;
+  if(IS_NULL_PTR(data) || IS_NULL_PTR(data->form_group) || IS_NULL_PTR(data->gui)) return;
 
-  dt_dev_add_history_item(darktable.develop, data->module, TRUE, TRUE);
+  dt_dev_add_history_item(data->gui->dev, data->module, TRUE, TRUE);
   DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_MASK_CHANGED,
                                 data->form_group->formid, data->form_group->parentid,
                                 DT_MASKS_EVENT_UPDATE);
@@ -497,14 +500,14 @@ static gboolean _masks_gui_resolve_selected_shape(dt_masks_form_gui_t *gui, dt_i
                                                    dt_masks_form_t **sel, int *parentid, int *formid)
 {
   if(IS_NULL_PTR(gui) || gui->group_selected < 0) return FALSE;
-  dt_masks_form_t *forms = dt_masks_get_visible_form(darktable.develop);
+  dt_masks_form_t *forms = dt_masks_get_visible_form(gui->dev);
   if(IS_NULL_PTR(forms)) return FALSE;
 
   dt_masks_form_group_t *fpt = dt_masks_form_get_selected_group(forms, gui);
   if(IS_NULL_PTR(fpt)) return FALSE;
-  dt_iop_module_t *mod = darktable.develop->gui_module;
+  dt_iop_module_t *mod = gui->dev->gui_module;
   if(IS_NULL_PTR(mod)) return FALSE;
-  dt_masks_form_t *form = dt_masks_get_from_id(darktable.develop, fpt->formid);
+  dt_masks_form_t *form = dt_masks_get_from_id(gui->dev, fpt->formid);
   if(IS_NULL_PTR(form)) return FALSE;
 
   *module = mod;
@@ -542,10 +545,10 @@ void _masks_gui_delete_node_callback(GtkWidget *menu, gpointer user_data)
 {
   dt_masks_form_gui_t *gui = (dt_masks_form_gui_t *)user_data;
   if(IS_NULL_PTR(gui)) return;
-  dt_masks_form_t *forms = dt_masks_get_visible_form(darktable.develop);
+  dt_masks_form_t *forms = dt_masks_get_visible_form(gui->dev);
   if(IS_NULL_PTR(forms)) return;
 
-  dt_iop_module_t *module = darktable.develop->gui_module;
+  dt_iop_module_t *module = gui->dev->gui_module;
   if(IS_NULL_PTR(module)) return;
 
   if(gui->creation)
@@ -556,7 +559,7 @@ void _masks_gui_delete_node_callback(GtkWidget *menu, gpointer user_data)
       dt_masks_form_exit_creation(module, gui);
       return;
     }
-    dt_masks_form_t *sel = dt_masks_get_visible_form(darktable.develop);
+    dt_masks_form_t *sel = dt_masks_get_visible_form(gui->dev);
     if(sel)
       dt_masks_remove_node(module, sel, 0, gui, 0, gui->node_dragging);
     gui->node_dragging -= 1;
@@ -567,18 +570,19 @@ void _masks_gui_delete_node_callback(GtkWidget *menu, gpointer user_data)
 
     dt_masks_form_group_t *fpt = dt_masks_form_get_selected_group(forms, gui);
     if(IS_NULL_PTR(fpt)) return;
-    dt_masks_form_t *sel = dt_masks_get_from_id(darktable.develop, fpt->formid);
+    dt_masks_form_t *sel = dt_masks_get_from_id(gui->dev, fpt->formid);
     if(sel)
       dt_masks_remove_node(module, sel, fpt->parentid, gui, gui->group_selected, gui->node_hovered);
 
-    dt_dev_add_history_item(darktable.develop, module, TRUE, TRUE);
+    dt_dev_add_history_item(gui->dev, module, TRUE, TRUE);
   }
 }
 
 static void _masks_gui_exit_creation_callback(GtkWidget *menu, gpointer user_data)
 {
   dt_masks_form_gui_t *gui = (dt_masks_form_gui_t *)user_data;
-  dt_iop_module_t *module = darktable.develop->gui_module;
+  if(IS_NULL_PTR(gui)) return;
+  dt_iop_module_t *module = gui->dev->gui_module;
   dt_masks_form_exit_creation(module, gui);
 }
 
@@ -588,16 +592,16 @@ static void _masks_move_up_down_callback(gpointer user_data, const int up)
   if(IS_NULL_PTR(gui)) return;
   if(gui->group_selected < 0) return;
 
-  dt_iop_module_t *module = darktable.develop->gui_module;
+  dt_iop_module_t *module = gui->dev->gui_module;
   if(IS_NULL_PTR(module)) return;
 
-  dt_masks_form_t *forms = dt_masks_get_visible_form(darktable.develop);
+  dt_masks_form_t *forms = dt_masks_get_visible_form(gui->dev);
   if(IS_NULL_PTR(forms)) return;
   dt_masks_form_group_t *fpt = dt_masks_form_get_selected_group(forms, gui);
   if(IS_NULL_PTR(fpt)) return;
-  dt_masks_form_t *grp = dt_masks_get_from_id(darktable.develop, fpt->parentid);
+  dt_masks_form_t *grp = dt_masks_get_from_id(gui->dev, fpt->parentid);
   if(IS_NULL_PTR(grp) || !(grp->type & DT_MASKS_GROUP)) return;
-  grp = dt_masks_cow_touch(darktable.develop, grp);
+  grp = dt_masks_cow_touch(gui->dev, grp);
 
   dt_masks_form_move(grp, fpt->formid, up);
 
@@ -675,9 +679,9 @@ GtkWidget *dt_masks_create_menu(dt_masks_form_gui_t *gui, dt_masks_form_t *form,
 
   // Get the current group to apply operations on it if needed
   dt_masks_form_group_t *op_form = NULL;
-  dt_masks_form_t *grp = formgroup ? dt_masks_get_from_id(darktable.develop, formgroup->parentid) : NULL;
+  dt_masks_form_t *grp = formgroup ? dt_masks_get_from_id(gui->dev, formgroup->parentid) : NULL;
   if(grp && (grp->type & DT_MASKS_GROUP))
-    op_form = dt_masks_form_group_from_parentid(grp->formid, form->formid);
+    op_form = dt_masks_form_group_from_parentid(gui->dev, grp->formid, form->formid);
   if(IS_NULL_PTR(op_form) && !gui->creation)
   {
     for(size_t k = 0; k < G_N_ELEMENTS(op_icon); k++)
@@ -794,60 +798,60 @@ GtkWidget *dt_masks_create_menu(dt_masks_form_gui_t *gui, dt_masks_form_t *form,
     // Common menu items
   if(!gui->creation && (gui->form_selected || gui->node_selected) && op_form)
   {
-    const float opacity = dt_masks_form_get_interaction_value(op_form, DT_MASKS_INTERACTION_OPACITY);
+    const float opacity = dt_masks_form_get_interaction_value(gui->dev, op_form, DT_MASKS_INTERACTION_OPACITY);
 
     if(form->type & DT_MASKS_GRADIENT)
     {
       // For gradients, DT_MASKS_INTERACTION_HARDNESS is the shape curvature and
       // DT_MASKS_INTERACTION_SIZE is the fade extent -- expose them under their actual names.
-      const float curvature = dt_masks_form_get_interaction_value(op_form, DT_MASKS_INTERACTION_HARDNESS);
-      const float fade = dt_masks_form_get_interaction_value(op_form, DT_MASKS_INTERACTION_SIZE);
-      float rotation = dt_masks_form_get_interaction_value(op_form, DT_MASKS_INTERACTION_ROTATION);
+      const float curvature = dt_masks_form_get_interaction_value(gui->dev, op_form, DT_MASKS_INTERACTION_HARDNESS);
+      const float fade = dt_masks_form_get_interaction_value(gui->dev, op_form, DT_MASKS_INTERACTION_SIZE);
+      float rotation = dt_masks_form_get_interaction_value(gui->dev, op_form, DT_MASKS_INTERACTION_ROTATION);
       if(!isfinite(rotation)) rotation = 0.0f;
       if(rotation > 180.0f) rotation -= 360.0f;
 
       _masks_gui_add_interaction_slider(menu, _("Curvature"), op_form, DT_MASKS_INTERACTION_HARDNESS,
                                         DT_MASKS_INCREMENT_ABSOLUTE, -2.0f, 2.0f, 0.01f,
                                         isfinite(curvature) ? curvature : 0.0f, 3, "%", 50.0f,
-                                        gui, darktable.develop->gui_module);
+                                        gui, gui->dev->gui_module);
       _masks_gui_add_interaction_slider(menu, _("Fade"), op_form, DT_MASKS_INTERACTION_SIZE,
                                         DT_MASKS_INCREMENT_ABSOLUTE, 0.0f, 1.0f, 0.001f,
                                         isfinite(fade) ? fade : 1.0f, 3, "%", 100.0f,
-                                        gui, darktable.develop->gui_module);
+                                        gui, gui->dev->gui_module);
       _masks_gui_add_interaction_slider(menu, _("Rotation"), op_form, DT_MASKS_INTERACTION_ROTATION,
                                         DT_MASKS_INCREMENT_ABSOLUTE, -180.0f, 180.0f, 1.0f,
                                         rotation, 1, "\302\260", 1.0f,
-                                        gui, darktable.develop->gui_module);
+                                        gui, gui->dev->gui_module);
     }
     else
     {
-      const float hardness = dt_masks_form_get_interaction_value(op_form, DT_MASKS_INTERACTION_HARDNESS);
+      const float hardness = dt_masks_form_get_interaction_value(gui->dev, op_form, DT_MASKS_INTERACTION_HARDNESS);
 
       _masks_gui_add_interaction_slider(menu, _("Size"), op_form, DT_MASKS_INTERACTION_SIZE,
                                         DT_MASKS_INCREMENT_SCALE, -4.f, 4.0f, 0.01f, 0.0f, 2, "x", 1.0f,
-                                        gui, darktable.develop->gui_module);
+                                        gui, gui->dev->gui_module);
       _masks_gui_add_interaction_slider(menu, _("Fading"), op_form, DT_MASKS_INTERACTION_HARDNESS,
                                         DT_MASKS_INCREMENT_ABSOLUTE, 0.f, 1.0f, 0.01f,
                                         isfinite(hardness) ? hardness : 1.0f, 3, "%", 100.0f,
-                                        gui, darktable.develop->gui_module);
+                                        gui, gui->dev->gui_module);
 
       if(form->type & DT_MASKS_ELLIPSE)
       {
-        float rotation = dt_masks_form_get_interaction_value(op_form, DT_MASKS_INTERACTION_ROTATION);
+        float rotation = dt_masks_form_get_interaction_value(gui->dev, op_form, DT_MASKS_INTERACTION_ROTATION);
         if(!isfinite(rotation)) rotation = 0.0f;
         if(rotation > 180.0f) rotation -= 360.0f;
 
         _masks_gui_add_interaction_slider(menu, _("Rotation"), op_form, DT_MASKS_INTERACTION_ROTATION,
                                           DT_MASKS_INCREMENT_ABSOLUTE, -180.0f, 180.0f, 1.0f,
                                           rotation, 1, "\302\260", 1.0f,
-                                          gui, darktable.develop->gui_module);
+                                          gui, gui->dev->gui_module);
       }
     }
 
     _masks_gui_add_interaction_slider(menu, _("Opacity"), op_form, DT_MASKS_INTERACTION_OPACITY,
                                       DT_MASKS_INCREMENT_ABSOLUTE, 0.0f, 1.0f, 0.01f,
                                       isfinite(opacity) ? opacity : 1.0f, 3, "%", 100.0f,
-                                      gui, darktable.develop->gui_module);
+                                      gui, gui->dev->gui_module);
 
     gtk_menu_shell_append(GTK_MENU_SHELL(menu), gtk_separator_menu_item_new());
   }
@@ -862,7 +866,7 @@ GtkWidget *dt_masks_create_menu(dt_masks_form_gui_t *gui, dt_masks_form_t *form,
 
   /* Module specific */
   {
-    dt_iop_module_t *module = darktable.develop->gui_module;
+    dt_iop_module_t *module = gui->dev->gui_module;
     if(!IS_NULL_PTR(module) && module->populate_masks_context_menu)
       if(module->populate_masks_context_menu(module, menu, form->formid, pzx, pzy))
       {

--- a/src/develop/masks/polygon.c
+++ b/src/develop/masks/polygon.c
@@ -707,7 +707,7 @@ static int _polygon_get_pts_border(dt_develop_t *develop, dt_masks_form_t *mask_
 
   const float input_width = pipe->iwidth;
   const float input_height = pipe->iheight;
-  const int pixel_threshold = (dt_dev_pixelpipe_has_preview_output(darktable.develop, pipe, NULL)
+  const int pixel_threshold = (dt_dev_pixelpipe_has_preview_output(develop, pipe, NULL)
                                || pipe->type == DT_DEV_PIXELPIPE_THUMBNAIL) ? 3 : 1;
   const guint node_count = g_list_length(mask_form->points);
 
@@ -1097,7 +1097,7 @@ static void _add_node_to_segment(struct dt_iop_module_t *module,
   if(IS_NULL_PTR(new_node)) return;
 
   // set coordinates
-  dt_masks_gui_cursor_to_raw_norm(darktable.develop, mask_gui, new_node->node);
+  dt_masks_gui_cursor_to_raw_norm(mask_gui->dev, mask_gui, new_node->node);
   new_node->ctrl1[0] = new_node->ctrl1[1] = new_node->ctrl2[0] = new_node->ctrl2[1] = -1.0;
   new_node->state = DT_MASKS_POINT_STATE_NORMAL;
 
@@ -1203,13 +1203,13 @@ static void _polygon_get_sizes(struct dt_iop_module_t *module, dt_masks_form_t *
   }
 
   float mask_span[2] = { p2[0] - p1[0], p2[1] - p1[1] };
-  dt_dev_coordinates_preview_abs_to_image_norm(darktable.develop, mask_span, 1);
+  dt_dev_coordinates_preview_abs_to_image_norm(mask_gui->dev, mask_span, 1);
   *mask_size = fmaxf(mask_span[0], mask_span[1]);
 
   if(!IS_NULL_PTR(border_size))
   {
     float border_span[2] = { fp2[0] - fp1[0], fp2[1] - fp1[1] };
-    dt_dev_coordinates_preview_abs_to_image_norm(darktable.develop, border_span, 1);
+    dt_dev_coordinates_preview_abs_to_image_norm(mask_gui->dev, border_span, 1);
     *border_size = fmaxf(border_span[0], border_span[1]);
   }
 }
@@ -1250,7 +1250,7 @@ static float _polygon_get_interaction_value(const dt_masks_form_t *mask_form,
   }
 }
 
-static gboolean _polygon_get_gravity_center(const dt_masks_form_t *mask_form,
+static gboolean _polygon_get_gravity_center(dt_develop_t *dev, const dt_masks_form_t *mask_form,
                                             float center[2], float *area)
 {
   if(IS_NULL_PTR(mask_form) || IS_NULL_PTR(mask_form->points) || IS_NULL_PTR(center)) return FALSE;
@@ -1686,7 +1686,7 @@ static int _polygon_events_mouse_scrolled(struct dt_iop_module_t *module, double
   if(mask_gui->edit_mode == DT_MASKS_EDIT_FULL && dt_masks_is_anything_selected(mask_gui))
   {
     if(dt_modifier_is(state, GDK_CONTROL_MASK))
-      return dt_masks_form_change_opacity(mask_form, parent_id, up, flow);
+      return dt_masks_form_change_opacity(mask_gui->dev, mask_form, parent_id, up, flow);
     if(dt_modifier_is(state, GDK_SHIFT_MASK) || mask_gui->node_selected)
       return _change_hardness(mask_form, parent_id, mask_gui, module, form_index, up ? +0.01f : -0.01f,
                               DT_MASKS_INCREMENT_OFFSET, flow);
@@ -1718,7 +1718,7 @@ static int _polygon_creation_closing_form(dt_masks_form_t *mask_form, dt_masks_f
   mask_gui->node_dragging = -1;
   _polygon_init_ctrl_points(mask_form);
 
-  dt_masks_gui_form_save_creation(darktable.develop, creation_module, mask_form, mask_gui);
+  dt_masks_gui_form_save_creation(mask_gui->dev, creation_module, mask_form, mask_gui);
 
   return 1;
 }
@@ -1756,7 +1756,7 @@ static int _polygon_events_button_pressed(struct dt_iop_module_t *module, double
         dt_masks_node_polygon_t *polygon_node = (dt_masks_node_polygon_t *)(malloc(sizeof(dt_masks_node_polygon_t)));
         if(IS_NULL_PTR(polygon_node)) return 0;
 
-        dt_masks_gui_cursor_to_raw_norm(darktable.develop, mask_gui, polygon_node->node);
+        dt_masks_gui_cursor_to_raw_norm(mask_gui->dev, mask_gui, polygon_node->node);
 
         polygon_node->ctrl1[0] = polygon_node->ctrl1[1] = polygon_node->ctrl2[0] = polygon_node->ctrl2[1] = -1.0;
         polygon_node->border[0] = polygon_node->border[1] = MAX(HARDNESS_MIN, masks_border);
@@ -1950,7 +1950,7 @@ static int _polygon_events_key_pressed(struct dt_iop_module_t *module, GdkEventK
         // Decrease the current dragging node index
         mask_gui->node_dragging -= 1;
 
-        dt_dev_pixelpipe_update_history_preview(darktable.develop);
+        dt_dev_pixelpipe_update_history_preview(mask_gui->dev);
         return 1;
       }
       case GDK_KEY_Return:
@@ -1973,13 +1973,13 @@ static int _polygon_events_mouse_moved(struct dt_iop_module_t *module, double x,
                                        dt_masks_form_gui_t *mask_gui, int form_index)
 {
   // centre view will have zoom_scale * backbuf_width pixels, we want the handle offset to scale with DPI:
-  dt_develop_t *const dev = (dt_develop_t *)darktable.develop;
+  dt_develop_t *const dev = mask_gui->dev;
   dt_masks_form_gui_points_t *gui_points
       = (dt_masks_form_gui_points_t *)g_list_nth_data(mask_gui->points, form_index);
   if(IS_NULL_PTR(gui_points)) return 0;
 
-  const int iwidth = darktable.develop->roi.raw_width;
-  const int iheight = darktable.develop->roi.raw_height;
+  const int iwidth = dev->roi.raw_width;
+  const int iheight = dev->roi.raw_height;
 
   if(mask_gui->node_dragging >= 0)
   {
@@ -2069,7 +2069,7 @@ static int _polygon_events_mouse_moved(struct dt_iop_module_t *module, double x,
                             gui_points->points[mask_gui->handle_dragging * 6 + 3],
                             pts[0], pts[1], &p[0], &p[1], &p[2], &p[3], gui_points->clockwise);
 
-    dt_dev_coordinates_image_abs_to_raw_norm(darktable.develop, p, 2);
+    dt_dev_coordinates_image_abs_to_raw_norm(dev, p, 2);
 
     // set new ctrl points
     dt_masks_set_ctrl_points(node->ctrl1, node->ctrl2, p);
@@ -2139,10 +2139,10 @@ static int _polygon_events_mouse_moved(struct dt_iop_module_t *module, double x,
 /**
  * @brief Draw a polygon or border polyline, skipping NaN points.
  */
-static void _polygon_draw_shape(cairo_t *cr, const float *point_buffer, const int point_count,
+static void _polygon_draw_shape(struct dt_develop_t *dev, cairo_t *cr, const float *point_buffer, const int point_count,
                                 const int node_count, const gboolean draw_border, const gboolean draw_source)
 {
-  
+
   // Find the first valid non-NaN point to start drawing
   // FIXME: Why not just avoid having NaN points in the array?
   int start_idx = -1;
@@ -2183,7 +2183,7 @@ static void _polygon_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks_
   if(mask_gui->creation)
   {
     // draw a cross where the source will be created
-    dt_masks_form_t *visible_form = dt_masks_get_visible_form(darktable.develop);
+    dt_masks_form_t *visible_form = dt_masks_get_visible_form(mask_gui->dev);
     if(visible_form && (visible_form->type & DT_MASKS_CLONE))
     {
       const gboolean have_first_node = node_count && gui_points->points && gui_points->points_count > 1;
@@ -2198,12 +2198,12 @@ static void _polygon_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks_
   else if((mask_gui->type & DT_MASKS_IS_RETOUCHE) != 0 || mask_gui->node_selected || mask_gui->node_dragging >= 0
           || mask_gui->handle_selected)
   {
-    dt_masks_form_t *group_form = dt_masks_get_visible_form(darktable.develop);
+    dt_masks_form_t *group_form = dt_masks_get_visible_form(mask_gui->dev);
     if(!IS_NULL_PTR(group_form) && (group_form->type & DT_MASKS_GROUP))
     {
       dt_masks_form_group_t *group_entry = g_list_nth_data(group_form->points, form_index);
       dt_masks_form_t *polygon_form = group_entry
-                                          ? dt_masks_get_from_id(darktable.develop, group_entry->formid)
+                                          ? dt_masks_get_from_id(mask_gui->dev, group_entry->formid)
                                           : NULL;
       if(!IS_NULL_PTR(polygon_form)) gui_points->clockwise = _polygon_is_clockwise(polygon_form);
     }
@@ -2221,7 +2221,7 @@ static void _polygon_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks_
     // draw borders
     if(gui_points->border_count > node_count * 3 + 2)
     {
-      dt_draw_shape_lines(DT_MASKS_DASH_STICK, FALSE, cr, node_count, (mask_gui->border_selected), zoom_scale,
+      dt_draw_shape_lines(mask_gui->dev, DT_MASKS_DASH_STICK, FALSE, cr, node_count, (mask_gui->border_selected), zoom_scale,
                           gui_points->border, gui_points->border_count, &dt_masks_functions_polygon.draw_shape,
                           CAIRO_LINE_CAP_ROUND);
     }
@@ -3499,12 +3499,12 @@ static void _polygon_duplicate_points(dt_develop_t *const dev, dt_masks_form_t *
   dt_masks_duplicate_points(base, dest, sizeof(dt_masks_node_polygon_t));
 }
 
-static void _polygon_initial_source_pos(const float iwd, const float iht, float *x, float *y)
+static void _polygon_initial_source_pos(struct dt_develop_t *dev, const float iwd, const float iht, float *x, float *y)
 {
-  
-  
+
+
   float offset[2] = { 0.1f, 0.1f };
-  dt_dev_coordinates_raw_norm_to_raw_abs(darktable.develop, offset, 1);
+  dt_dev_coordinates_raw_norm_to_raw_abs(dev, offset, 1);
   *x = offset[0];
   *y = offset[1];
 }
@@ -3513,7 +3513,7 @@ static void _polygon_creation_closing_form_callback(GtkWidget *widget, gpointer 
 {
   dt_masks_form_gui_t *mask_gui = (dt_masks_form_gui_t *)user_data;
   // This is a temp form on creation mode
-  dt_masks_form_t *mask_form = dt_masks_get_visible_form(darktable.develop);
+  dt_masks_form_t *mask_form = dt_masks_get_visible_form(mask_gui->dev);
   if(IS_NULL_PTR(mask_form)) return;
 
   _polygon_creation_closing_form(mask_form, mask_gui);
@@ -3523,10 +3523,10 @@ static void _polygon_switch_node_callback(GtkWidget *widget, gpointer user_data)
 {
   dt_masks_form_gui_t *mask_gui = (dt_masks_form_gui_t *)user_data;
   if(IS_NULL_PTR(mask_gui)) return;
-  dt_iop_module_t *module = darktable.develop->gui_module;
+  dt_iop_module_t *module = mask_gui->dev->gui_module;
   if(IS_NULL_PTR(module)) return;
   const int form_id = mask_gui->formid;
-  dt_masks_form_t *selected_form = dt_masks_get_from_id(darktable.develop, form_id);
+  dt_masks_form_t *selected_form = dt_masks_get_from_id(mask_gui->dev, form_id);
   if(IS_NULL_PTR(selected_form)) return;
 
   mask_gui->node_selected = TRUE;
@@ -3545,10 +3545,10 @@ static void _polygon_reset_round_node_callback(GtkWidget *widget, gpointer user_
 {
   dt_masks_form_gui_t *mask_gui = (dt_masks_form_gui_t *)user_data;
   if(IS_NULL_PTR(mask_gui)) return;
-  dt_iop_module_t *module = darktable.develop->gui_module;
+  dt_iop_module_t *module = mask_gui->dev->gui_module;
   if(IS_NULL_PTR(module)) return;
   const int form_id = mask_gui->formid;
-  dt_masks_form_t *selected_form = dt_masks_get_from_id(darktable.develop, form_id);
+  dt_masks_form_t *selected_form = dt_masks_get_from_id(mask_gui->dev, form_id);
   if(IS_NULL_PTR(selected_form)) return;
 
   mask_gui->node_selected = TRUE;
@@ -3569,22 +3569,22 @@ static void _polygon_add_node_callback(GtkWidget *menu, gpointer user_data)
 {
   dt_masks_form_gui_t *mask_gui = (dt_masks_form_gui_t *)user_data;
   if(IS_NULL_PTR(mask_gui)) return;
-  dt_masks_form_t *visible_forms = dt_masks_get_visible_form(darktable.develop);
+  dt_masks_form_t *visible_forms = dt_masks_get_visible_form(mask_gui->dev);
   if(IS_NULL_PTR(visible_forms)) return;
 
-  dt_iop_module_t *module = darktable.develop->gui_module;
+  dt_iop_module_t *module = mask_gui->dev->gui_module;
   if(IS_NULL_PTR(module)) return;
 
   dt_masks_form_group_t *group_entry = dt_masks_form_get_selected_group(visible_forms, mask_gui);
   if(IS_NULL_PTR(group_entry)) return;
-  dt_masks_form_t *selected_form = dt_masks_get_from_id(darktable.develop, group_entry->formid);
+  dt_masks_form_t *selected_form = dt_masks_get_from_id(mask_gui->dev, group_entry->formid);
 
   if(selected_form)
   {
     _add_node_to_segment(module, selected_form, group_entry->parentid, mask_gui, mask_gui->group_selected);
   }
 
-  //dt_dev_add_history_item(darktable.develop, module, TRUE, TRUE);
+  //dt_dev_add_history_item(mask_gui->dev, module, TRUE, TRUE);
 }
 
 static int _polygon_populate_context_menu(GtkWidget *menu, struct dt_masks_form_t *mask_form,

--- a/src/gui/draw.h
+++ b/src/gui/draw.h
@@ -716,7 +716,10 @@ static inline void dt_draw_handle(cairo_t *cr, const float pt[2], const float zo
   cairo_restore(cr);
 }
 
-typedef void (*shape_draw_function_t)(cairo_t *cr, const float *points, const int points_count, const int nb, const gboolean border, const gboolean source);
+// dev is the develop instance owning the shape being drawn. It is threaded explicitly so shape
+// drawing code never has to reach for the darktable.develop global (which would couple every
+// shape file to the whole application and hide which instance is read).
+typedef void (*shape_draw_function_t)(struct dt_develop_t *dev, cairo_t *cr, const float *points, const int points_count, const int nb, const gboolean border, const gboolean source);
 
 /**
  * @brief Draw the lines of a mask shape.
@@ -731,18 +734,18 @@ typedef void (*shape_draw_function_t)(cairo_t *cr, const float *points, const in
  * @param points_count the number of points in the shape
  * @param functions the functions table of the shape
  */
-static inline void dt_draw_shape_lines(const dt_draw_dash_type_t dash_type, const gboolean source, cairo_t *cr, const int nb, const gboolean selected,
+static inline void dt_draw_shape_lines(struct dt_develop_t *dev, const dt_draw_dash_type_t dash_type, const gboolean source, cairo_t *cr, const int nb, const gboolean selected,
                 const float zoom_scale, const float *points, const int points_count, const shape_draw_function_t *draw_shape_func, const cairo_line_cap_t line_cap)
 {
   cairo_save(cr);
-  
+
   cairo_set_line_cap(cr, line_cap);
   // Are we drawing a border ?
-  const gboolean border = (dash_type != DT_MASKS_NO_DASH);  
+  const gboolean border = (dash_type != DT_MASKS_NO_DASH);
 
   // Draw the shape from the integrated function if any
   if(points && points_count >= 2 && draw_shape_func)
-    (*draw_shape_func)(cr, points, points_count, nb, border, FALSE);
+    (*draw_shape_func)(dev, cr, points, points_count, nb, border, FALSE);
 
   const dt_draw_dash_type_t dash = (dash_type && !source)
                                   ? dash_type : DT_MASKS_NO_DASH;
@@ -784,7 +787,7 @@ static inline void dt_draw_shape_lines(const dt_draw_dash_type_t dash_type, cons
 static inline void dt_draw_stroke_line(const dt_draw_dash_type_t dash_type, const gboolean source, cairo_t *cr,
                           const gboolean selected, const float zoom_scale, const cairo_line_cap_t line_cap)
 {
-  dt_draw_shape_lines(dash_type, source, cr, 0, selected, zoom_scale, NULL, 0, NULL, line_cap);
+  dt_draw_shape_lines(NULL, dash_type, source, cr, 0, selected, zoom_scale, NULL, 0, NULL, line_cap);
 }
 
 static void _draw_arrow_head(cairo_t *cr, const float arrow[2], const float arrow_x_a, const float arrow_y_a,
@@ -914,16 +917,16 @@ static inline void dt_draw_cross(cairo_t *cr, const float zoom_scale, const floa
   cairo_restore(cr);
 }
 
-static inline void dt_draw_source_shape(cairo_t *cr, const float zoom_scale, const gboolean selected, 
+static inline void dt_draw_source_shape(struct dt_develop_t *dev, cairo_t *cr, const float zoom_scale, const gboolean selected,
   const float *source_pts, const int source_pts_count, const int nodes_nb, const shape_draw_function_t *draw_shape_func)
 {
   cairo_save(cr);
 
   cairo_set_line_cap(cr, CAIRO_LINE_CAP_ROUND);
   dt_draw_set_dash_style(cr, DT_MASKS_NO_DASH, zoom_scale);
-  
+
   if(draw_shape_func)
-    (*draw_shape_func)(cr, source_pts, source_pts_count, nodes_nb, FALSE, TRUE);
+    (*draw_shape_func)(dev, cr, source_pts, source_pts_count, nodes_nb, FALSE, TRUE);
 
   //dark line
   if(selected)

--- a/src/iop/retouch.c
+++ b/src/iop/retouch.c
@@ -643,7 +643,7 @@ static void rt_show_forms_for_current_scale(dt_iop_module_t *self)
   // if no shapes on this scale, we hide all
   if(bd->masks_shown == DT_MASKS_EDIT_OFF || count == 0)
   {
-    dt_masks_change_form_gui(NULL);
+    dt_masks_change_form_gui(self->dev, NULL);
 
     if(g)
       gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->bt_edit_masks),
@@ -655,7 +655,7 @@ static void rt_show_forms_for_current_scale(dt_iop_module_t *self)
   }
 
   // else, we create a new from group with the shapes and display it
-  dt_masks_form_t *grp = dt_masks_create_ext(DT_MASKS_GROUP);
+  dt_masks_form_t *grp = dt_masks_create_ext(self->dev, DT_MASKS_GROUP);
   const int grid = self->blend_params->mask_id;
 
   for(int i = 0; i < RETOUCH_NO_FORMS; i++)
@@ -675,10 +675,10 @@ static void rt_show_forms_for_current_scale(dt_iop_module_t *self)
     }
   }
 
-  dt_masks_form_t *grp2 = dt_masks_create_ext(DT_MASKS_GROUP);
+  dt_masks_form_t *grp2 = dt_masks_create_ext(self->dev, DT_MASKS_GROUP);
   grp2->formid = 0;
-  dt_masks_group_ungroup(grp2, grp);
-  dt_masks_change_form_gui(grp2);
+  dt_masks_group_ungroup(self->dev, grp2, grp);
+  dt_masks_change_form_gui(self->dev, grp2);
   self->dev->form_gui->edit_mode = bd->masks_shown;
 
   if(g)
@@ -1728,7 +1728,7 @@ static gboolean rt_edit_masks_callback(GtkWidget *widget, GdkEventButton *event,
 
   //hide all shapes and free if some are in creation
   if(self->dev->form_gui->creation && self->dev->form_gui->creation_module == self)
-    dt_masks_change_form_gui(NULL);
+    dt_masks_change_form_gui(self->dev, NULL);
 
   dt_masks_shape_buttons_deactivate_all(NULL);
 
@@ -1858,7 +1858,7 @@ static gboolean rt_select_algorithm_callback(GtkToggleButton *togglebutton, GdkE
     else
       masks_type = (type | DT_MASKS_NON_CLONE);
 
-    dt_masks_creation_mode_enter(self, masks_type);
+    dt_masks_creation_mode_enter(self->dev, self, masks_type);
 
     dt_control_queue_redraw_center();
   }
@@ -2054,7 +2054,7 @@ void gui_focus(struct dt_iop_module_t *self, gboolean in)
     {
       // lost focus, hide all shapes and free if some are in creation
       if(self->dev->form_gui->creation && self->dev->form_gui->creation_module == self)
-        dt_masks_change_form_gui(NULL);
+        dt_masks_change_form_gui(self->dev, NULL);
 
       dt_masks_shape_buttons_deactivate_all(NULL);
       gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->bt_edit_masks), FALSE);
@@ -2244,6 +2244,7 @@ void gui_init(dt_iop_module_t *self)
 
   GtkWidget *shape_buttons[DEVELOP_MASKS_NB_SHAPES] = { 0 };
   const dt_masks_shape_buttons_config_t shape_buttons_config = {
+    .dev = self->dev,
     .owner_module = self,
     .creation_module = self,
     .buttons = shape_buttons,
@@ -2514,7 +2515,7 @@ void gui_init(dt_iop_module_t *self)
 void gui_reset(struct dt_iop_module_t *self)
 {
   // hide the previous masks
-  dt_masks_reset_form_gui();
+  dt_masks_reset_form_gui(self->dev);
   // set the algo to the default one
   dt_iop_retouch_params_t *p = (dt_iop_retouch_params_t *)self->params;
   p->algorithm = dt_conf_get_int("plugins/darkroom/retouch/default_algo");

--- a/src/iop/spots.c
+++ b/src/iop/spots.c
@@ -253,7 +253,7 @@ static gboolean _reset_form_creation(GtkWidget *widget, dt_iop_module_t *self)
          || gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(g->bt_ellipse))))
   {
     // we unset the creation mode
-    dt_masks_change_form_gui(NULL);
+    dt_masks_change_form_gui(self->dev, NULL);
   }
   if(widget != g->bt_path || nb >= 64) gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->bt_path), FALSE);
   if(widget != g->bt_circle || nb >= 64) gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->bt_circle), FALSE);
@@ -316,7 +316,7 @@ static gboolean _add_shape(GtkWidget *widget, dt_iop_module_t *self)
 
 
   const dt_masks_type_t masks_type = (type | DT_MASKS_CLONE);
-  dt_masks_creation_mode_enter(self, masks_type);
+  dt_masks_creation_mode_enter(self->dev, self, masks_type);
 
 
   dt_control_queue_redraw_center();
@@ -354,7 +354,7 @@ static gboolean _edit_masks(GtkWidget *widget, GdkEventButton *e, dt_iop_module_
 
   //hide all shapes and free if some are in creation
   if(self->dev->form_gui->creation && self->dev->form_gui->creation_module == self)
-    dt_masks_change_form_gui(NULL);
+    dt_masks_change_form_gui(self->dev, NULL);
 
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->bt_path), FALSE);
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->bt_circle), FALSE);
@@ -762,7 +762,7 @@ void gui_focus(struct dt_iop_module_t *self, gboolean in)
     {
       // lost focus, hide all shapes
       if (self->dev->form_gui->creation && self->dev->form_gui->creation_module == self)
-        dt_masks_change_form_gui(NULL);
+        dt_masks_change_form_gui(self->dev, NULL);
       gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->bt_path), FALSE);
       gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->bt_circle), FALSE);
       gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->bt_ellipse), FALSE);
@@ -860,7 +860,7 @@ void gui_init(dt_iop_module_t *self)
 void gui_reset(struct dt_iop_module_t *self)
 {
   // hide the previous masks
-  dt_masks_reset_form_gui();
+  dt_masks_reset_form_gui(self->dev);
 }
 
 // clang-format off

--- a/src/libs/masks.c
+++ b/src/libs/masks.c
@@ -268,7 +268,7 @@ static void _lib_masks_blending_gui_changed_callback(gpointer instance, dt_lib_m
 static void _tree_add_circle(GtkButton *button, dt_iop_module_t *module)
 {
   // we create the new form
-  dt_masks_creation_mode_enter(module, DT_MASKS_CIRCLE);
+  dt_masks_creation_mode_enter(darktable.develop, module, DT_MASKS_CIRCLE);
   darktable.develop->form_gui->group_selected = 0;
   dt_control_queue_redraw_center();
 }
@@ -276,7 +276,7 @@ static void _tree_add_circle(GtkButton *button, dt_iop_module_t *module)
 static void _tree_add_ellipse(GtkButton *button, dt_iop_module_t *module)
 {
   // we create the new form
-  dt_masks_creation_mode_enter(module, DT_MASKS_ELLIPSE);
+  dt_masks_creation_mode_enter(darktable.develop, module, DT_MASKS_ELLIPSE);
   darktable.develop->form_gui->group_selected = 0;
   dt_control_queue_redraw_center();
 }
@@ -284,7 +284,7 @@ static void _tree_add_ellipse(GtkButton *button, dt_iop_module_t *module)
 static void _tree_add_polygon(GtkButton *button, dt_iop_module_t *module)
 {
   // we create the new form
-  dt_masks_creation_mode_enter(module, DT_MASKS_POLYGON);
+  dt_masks_creation_mode_enter(darktable.develop, module, DT_MASKS_POLYGON);
   darktable.develop->form_gui->group_selected = 0;
   dt_control_queue_redraw_center();
 }
@@ -292,7 +292,7 @@ static void _tree_add_polygon(GtkButton *button, dt_iop_module_t *module)
 static void _tree_add_gradient(GtkButton *button, dt_iop_module_t *module)
 {
   // we create the new form
-  dt_masks_creation_mode_enter(module, DT_MASKS_GRADIENT);
+  dt_masks_creation_mode_enter(darktable.develop, module, DT_MASKS_GRADIENT);
   darktable.develop->form_gui->group_selected = 0;
   dt_control_queue_redraw_center();
 }
@@ -300,7 +300,7 @@ static void _tree_add_gradient(GtkButton *button, dt_iop_module_t *module)
 static void _tree_add_brush(GtkButton *button, dt_iop_module_t *module)
 {
   // we create the new form
-  dt_masks_creation_mode_enter(module, DT_MASKS_BRUSH);
+  dt_masks_creation_mode_enter(darktable.develop, module, DT_MASKS_BRUSH);
   darktable.develop->form_gui->group_selected = 0;
   dt_control_queue_redraw_center();
 }
@@ -321,7 +321,7 @@ static void _tree_add_exist(GtkButton *button, dt_masks_form_t *grp)
   // we add the form in this group
   dt_masks_form_t *form = dt_masks_get_from_id(darktable.develop, id);
   grp = dt_masks_cow_touch(darktable.develop, grp);
-  if(form && dt_masks_group_add_form(grp, form))
+  if(form && dt_masks_group_add_form(darktable.develop, grp, form))
   {
     // we save the group
     dt_dev_add_history_item(darktable.develop, NULL, FALSE, TRUE);
@@ -374,7 +374,7 @@ static void _tree_group(GtkButton *button, dt_lib_module_t *self)
   // add we save
   dt_dev_add_history_item(darktable.develop, NULL, FALSE, TRUE);
   _lib_masks_recreate_list(self);
-  // dt_masks_change_form_gui(grp);
+  // dt_masks_change_form_gui(darktable.develop, grp);
 }
 
 static int _tree_format_form_usage_label(char *str, const size_t str_size,
@@ -745,7 +745,7 @@ static void _tree_moveup(GtkButton *button, dt_lib_module_t *self)
   dt_lib_masks_t *lm = (dt_lib_masks_t *)self->data;
 
   // we first discard all visible shapes
-  dt_masks_change_form_gui(NULL);
+  dt_masks_change_form_gui(darktable.develop, NULL);
 
   // now we go through all selected nodes
   GtkTreeModel *model = gtk_tree_view_get_model(GTK_TREE_VIEW(lm->treeview));
@@ -783,7 +783,7 @@ static void _tree_movedown(GtkButton *button, dt_lib_module_t *self)
   dt_lib_masks_t *lm = (dt_lib_masks_t *)self->data;
 
   // we first discard all visible shapes
-  dt_masks_change_form_gui(NULL);
+  dt_masks_change_form_gui(darktable.develop, NULL);
 
   // now we go through all selected nodes
   GtkTreeModel *model = gtk_tree_view_get_model(GTK_TREE_VIEW(lm->treeview));
@@ -821,7 +821,7 @@ static void _tree_delete_shape(GtkButton *button, dt_lib_module_t *self)
   dt_lib_masks_t *lm = (dt_lib_masks_t *)self->data;
 
   // we first discard all visible shapes
-  dt_masks_change_form_gui(NULL);
+  dt_masks_change_form_gui(darktable.develop, NULL);
 
   // now we go through all selected nodes
   GtkTreeModel *model = gtk_tree_view_get_model(GTK_TREE_VIEW(lm->treeview));
@@ -839,7 +839,7 @@ static void _tree_delete_shape(GtkButton *button, dt_lib_module_t *self)
       int id = -1;
       _lib_masks_get_values(model, &iter, &module, &grid, &id);
 
-      dt_masks_form_delete(module, dt_masks_get_from_id(darktable.develop, grid),
+      dt_masks_form_delete(darktable.develop, module, dt_masks_get_from_id(darktable.develop, grid),
                            dt_masks_get_from_id(darktable.develop, id));
     }
   }
@@ -893,7 +893,7 @@ static void _tree_duplicate_shape(GtkButton *button, dt_lib_module_t *self)
         }
 
         dt_masks_form_t *dup_form = dt_masks_get_from_id(darktable.develop, nid);
-        dt_masks_form_group_t *new_entry = dup_form ? dt_masks_group_add_form(grp, dup_form) : NULL;
+        dt_masks_form_group_t *new_entry = dup_form ? dt_masks_group_add_form(darktable.develop, grp, dup_form) : NULL;
         if(new_entry && orig_entry)
         {
           new_entry->state = orig_entry->state;
@@ -951,13 +951,13 @@ static void _tree_selection_change(GtkTreeSelection *selection, dt_lib_masks_t *
   if(!IS_NULL_PTR(creation_gui) && creation_gui->creation) return;
 
   // we reset all "show mask" icon of iops
-  dt_masks_reset_show_masks_icons();
+  dt_masks_reset_show_masks_icons(darktable.develop);
 
   // if selection empty, we hide all
   const int nb = gtk_tree_selection_count_selected_rows(selection);
   if(nb == 0)
   {
-    dt_masks_change_form_gui(NULL);
+    dt_masks_change_form_gui(darktable.develop, NULL);
     dt_control_queue_redraw_center();
     return;
   }
@@ -1011,8 +1011,8 @@ static void _tree_selection_change(GtkTreeSelection *selection, dt_lib_masks_t *
 
   dt_masks_form_t *grp2 = dt_masks_create(DT_MASKS_GROUP);
   grp2->formid = 0;
-  dt_masks_group_ungroup(grp2, grp);
-  dt_masks_change_form_gui(grp2);
+  dt_masks_group_ungroup(darktable.develop, grp2, grp);
+  dt_masks_change_form_gui(darktable.develop, grp2);
   darktable.develop->form_gui->edit_mode = DT_MASKS_EDIT_FULL;
   if(nb == 1 && !IS_NULL_PTR(selected_form))
     dt_masks_center_view_on_form(darktable.develop, selected_form);
@@ -2048,6 +2048,7 @@ void gui_init(dt_lib_module_t *self)
   // so there is no child added to self->widget from here.
   GtkWidget *shape_buttons[DEVELOP_MASKS_NB_SHAPES] = { 0 };
   const dt_masks_shape_buttons_config_t shape_buttons_config = {
+    .dev = darktable.develop,
     .owner_module = NULL,
     .creation_module = NULL,
     .buttons = shape_buttons,

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -1046,7 +1046,7 @@ void expose(
                                  || dt_lib_gui_get_expanded(dt_lib_get_module("masks"));
 
     if(dt_masks_get_visible_form(dev) && display_masks)
-      dt_masks_events_post_expose(dev->gui_module, cri, width, height, pointerx, pointery);
+      dt_masks_events_post_expose(dev, dev->gui_module, cri, width, height, pointerx, pointery);
       
     // module
     if(dev->gui_module && dev->gui_module->enabled && dev->gui_module->gui_post_expose)
@@ -2455,7 +2455,7 @@ void mouse_moved(dt_view_t *self, double x, double y, double pressure, int which
 
   // masks
   else if(dt_masks_get_visible_form(dev)
-          && dt_masks_events_mouse_moved(dev->gui_module, x, y, pressure, which))
+          && dt_masks_events_mouse_moved(dev, dev->gui_module, x, y, pressure, which))
   {
     // There is no shape dragging in creation mode, so no need to commit history.
     if(!dev->form_gui->creation)
@@ -2598,7 +2598,7 @@ int button_released(dt_view_t *self, double x, double y, int which, uint32_t sta
   }
   // masks
   if(dt_masks_get_visible_form(dev)
-     && dt_masks_events_button_released(dev->gui_module, x, y, which, state))
+     && dt_masks_events_button_released(dev, dev->gui_module, x, y, which, state))
   {
     // Change on mask parameters and image output.
     _queue_delayed_history_commit(dev);
@@ -2768,7 +2768,7 @@ int button_pressed(dt_view_t *self, double x, double y, double pressure, int whi
 
   // masks
   if(dt_masks_get_visible_form(dev)
-     && dt_masks_events_button_pressed(dev->gui_module, x, y, pressure, which, type, state))
+     && dt_masks_events_button_pressed(dev, dev->gui_module, x, y, pressure, which, type, state))
   {
     if(!darktable.develop->form_gui->creation)
       _queue_delayed_history_commit(dev);
@@ -2875,7 +2875,7 @@ int scrolled(dt_view_t *self, double x, double y, int up, int state, int delta_y
 
   // masks
   if(dt_masks_get_visible_form(dev)
-     && dt_masks_events_mouse_scrolled(dev->gui_module, x, y, up, state, delta_y))
+     && dt_masks_events_mouse_scrolled(dev, dev->gui_module, x, y, up, state, delta_y))
   {
     dt_control_queue_redraw_center();
     if(!dev->form_gui->creation)
@@ -2909,7 +2909,7 @@ int key_pressed(dt_view_t *self, GdkEventKey *event)
 
   dt_develop_t *dev = (dt_develop_t *)self->data;
 
-  if(dt_masks_get_visible_form(dev) && dt_masks_events_key_pressed(dev->gui_module, event))
+  if(dt_masks_get_visible_form(dev) && dt_masks_events_key_pressed(dev, dev->gui_module, event))
   {
     _queue_delayed_history_commit(dev);
     return 1;


### PR DESCRIPTION
First tranche of expurging the `darktable.develop` global from libraries/modules (942 uses across ~80 files at start; 720 after this PR). The masks subsystem was chosen first: it was the densest offender (~240 uses) and the subsystem where the #1069/#1060 desync class lived — ambient-state access is exactly what made those bugs hard to reason about.

**Stacked on #1091** (base branch `fix/gui-cache-desync-1069`): it extends `dt_masks_group_get_hash_ext()` introduced there. Merge #1091 first, then rebase/merge this.

## Design

- `dt_masks_form_gui_t` gains a `dev` back-pointer bound at `dt_masks_init_form_gui(dev, gui)`. Every GUI path now has an explicit develop handle even when `module == NULL` (mask-manager editing) — previously the reason shape handlers reached for the global.
- Everything else is plain dependency threading: `dev` parameters on the vtable entries that need one (`draw_shape` via `shape_draw_function_t`, `initial_source_pos`, `get_gravity_center`), on the generic draw helpers, and on the public masks API that had no context (`dt_masks_create_ext`, `dt_masks_change_form_gui`, `dt_masks_form_delete`, `dt_masks_creation_mode_enter`, the five `dt_masks_events_*` dispatchers, `dt_masks_events_post_expose`, opacity/interaction/group helpers, …).
- `dt_masks_shape_buttons_config_t` carries `dev` so the shape-manager toolbar callback (no creation module) has a context.
- `dt_masks_form_get_own_hash()` takes its membership list explicitly; the live-forms `dt_masks_group_get_hash()` wrapper is **removed**. Its one external user (`history_merge_gui.c`) was silently buggy under the wrapper: it compared two history snapshots by resolving grouped children from *live* `dev->forms` — two hybrid states. It now hashes each snapshot against its own forms list.

**Invariant established: `grep darktable.develop src/develop/masks/` is empty**, and the CI-able rule for review is simple — the masks engine takes its develop instance from arguments, never from ambient state.

External callers (blend_gui.c, libs/masks.c, darkroom.c, retouch.c, spots.c, develop.c, imageop.c) pass `module->dev`/`dev` where they have one, or `darktable.develop` explicitly where the file has no handle yet — making the remaining coupling *visible at the call site* instead of hidden inside the engine.

## Remaining tranches (720 uses), by density

1. `src/libs/histogram.c` (84) — scopes; needs a dev handle on the lib (or pipe-centric accessors).
2. `src/libs/masks.c` (~75) — mask-manager panel.
3. `src/develop/blend_gui.c` (~50) — has `module` almost everywhere; mostly mechanical `module->dev`.
4. `src/views/darkroom.c` (38) — has `self->data` = dev; mechanical.
5. `src/iop/*` (~200 total, ~25 files) — `self->dev` in GUI callbacks; mechanical per file.
6. `src/libs/*` rest (modulegroups, ioporder, history, snapshots, navigation) — needs a decision on how libs obtain the dev handle (init-time injection vs. view-manager accessor).
7. `src/develop/imageop.c`, `gui/color_picker_proxy.c`, `gui/actions/*` — mixed.

The end state also allows dropping `#include "common/darktable.h"` from the masks TUs once the remaining helpers they use (`dt_print`, allocators) stop living there — that include-graph slimming is a separate axis, per the CLAUDE.md modularity note.

Builds clean (full `ninja`, zero warnings introduced).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
