### PR TITLE
app: move darktable.{c,h} out of common/ to src/

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -292,6 +292,5 @@ xyz1001
 zhaowq32
 
 * Sub-module samples contributors (at least 1 commit):
-Guillaume Stutin
 
 And all those of you that made previous releases possible

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,7 +26,7 @@ Enforcement: `python3 tools/pragma_once_to_guards.py --verify` exits non-zero if
 `#pragma once` reappears. `python3 tools/include_graph.py --summary` must keep reporting
 `cycles 0`.
 
-**`common/darktable.h` has no guard either — it has a TRIPWIRE.** It ends up included by
+**`darktable.h` (at `src/`, not in a module) has no guard either — it has a TRIPWIRE.** It ends up included by
 at most one path per translation unit (an entry point calling `dt_init()`, or a subsystem
 that owns one of the `darktable` members), so a *second* inclusion is never legitimate: it
 means the header arrived through a path nobody intended. A guard would absorb that
@@ -35,9 +35,10 @@ find who included it and give that code the specific lib it needs (`common/loggi
 `common/mem_alloc.h`, …) or the accessor for the global it wants (`dt_dev_get_global()`,
 `dt_control_get_global()`, …). **No header may include it**; as of this writing none does.
 
-**When auditing this, grep for `darktable\.h"`, not `common/darktable.h"`.** Includes can be
-written relative to the including file's own directory, so `src/common/*` spells it
-`#include "darktable.h"`. Three files (and one *header*, `common/colorchecker.h`) hid behind
+**When auditing this, grep for `darktable\.h"` and check the spelling.** Includes can be
+written relative to the including file's own directory, which is how several files hid from
+earlier audits while the header still lived in `src/common/`. It now sits at `src/`, so
+`#include "darktable.h"` IS the canonical root-relative spelling. Three files (and one *header*, `common/colorchecker.h`) hid behind
 that spelling through several audits of this series; the compile-time tripwire is what
 finally caught them. `tools/include_graph.py` resolves both spellings and was right when the
 ad-hoc greps were wrong.
@@ -971,7 +972,7 @@ See `doc/sentry.md` for setup details.
 
 Ansel carries the burden of Darktable legacy, which made it a principle to entangle all
 application layers (GUI, pipeline, history, database) and imported the whole software
-into the whole software through `#include "common/darktable.h"`. This voids the modularity
+into the whole software through `#include "darktable.h"`. This voids the modularity
 principle, creates many bugs, data races, and makes any maintenance tedious and prone to 
 edge effects, since the app is heavily asynchronous and parallel.
 
@@ -979,7 +980,7 @@ The Ansel codebase should move toward more enclosed modularity, making data stru
 to each translation unit and exposing only API to the outside (getters/setters/init/cleanup). 
 Direct value changes on data not owned by the current TU are forbidden. The dependency graph 
 should be simplified and only a minimal set of `#include` should be kept per TU. In particular,
-`src/common/darktable.h` should inherit from lower-level modules, but lower-level modules
+`src/darktable.h` should inherit from lower-level modules, but lower-level modules
 should not inherit it, so it should stop being the glue of all common helpers throughout
 the software.
 

--- a/doc/globals-migration.md
+++ b/doc/globals-migration.md
@@ -51,7 +51,7 @@ Then: `collection` 97/27, `undo` 91/16, `selection` 88/24, `mipmap_cache` 70/19,
 
 - **A — thread through existing args** (`dev`/`pipe`/`self`/`module`): the real injection.
 - **B — orchestrator-implemented accessor** (declared by the owning lib, implemented in
-  `common/darktable.c`; precedent: `dt_pixelpipe_cache_get_global()`,
+  `darktable.c`; precedent: `dt_pixelpipe_cache_get_global()`,
   `dt_get_num_openmp_threads()`): interim step that already frees lib headers from
   darktable.h.
 - **C — pass at init, store in the subsystem's own struct**: for services with a natural

--- a/doc/include-graph.md
+++ b/doc/include-graph.md
@@ -26,7 +26,7 @@ python3 tools/include_graph.py                    # cycles, inversions, god-head
 | `darktable_h_direct_includers` | 343 | **16** | −95% |
 | `max_closure` | 84 | **82** | |
 
-`darktable_h_reach` is the number of files that reach `common/darktable.h` transitively — i.e.
+`darktable_h_reach` is the number of files that reach `darktable.h` transitively — i.e.
 how much of the codebase the application orchestrator is welded to. That is the number this
 whole series exists to move.
 
@@ -50,7 +50,7 @@ precondition for fixing them. The two dominant ones are the next target:
 
 ## Why node-counting is the wrong metric, and what replaced it
 
-Counting *nodes* in a transitive closure rewards monoliths. `master`'s `common/darktable.h` was
+Counting *nodes* in a transitive closure rewards monoliths. `master`'s `darktable.h` was
 a 1277-line header that **defined** its content inline: it counted as **one node dragging in
 nine headers**. The same content split into eleven honest headers (`macros.h`, `mem_alloc.h`,
 `simd.h`, `openmp.h`, `logging.h`, …) counts as up to eleven — so a naive node metric got
@@ -170,7 +170,7 @@ X-macro headers: re-included several times per translation unit with different m
 and expanded *inside struct bodies* to generate members. An `#include` at the top of one of them
 lands inside those structs — a mistake worth making exactly once.
 
-## `common/darktable.h` carries a tripwire, not a guard
+## `darktable.h` carries a tripwire, not a guard
 
 It has no include guard. A second inclusion in one translation unit is never legitimate
 for the orchestrator, so instead of absorbing it silently the header `#error`s. That is
@@ -179,7 +179,7 @@ the same principle as banning `#pragma once`, taken to its end for the one heade
 
 Installing it immediately caught what several greps had missed: `common/colorchecker.h`
 — a *header* — plus `colorchecker.c` and `sqliteicu.c` were including it as
-`#include "darktable.h"` (relative to `src/common/`), not `#include "common/darktable.h"`.
+`#include "darktable.h"` (relative to `src/common/`), not `#include "darktable.h"`.
 All three were vestigial and are gone. Audit this with `grep -r 'darktable\.h"'`; the
 qualified spelling alone under-reports.
 

--- a/doc/include-hygiene-roadmap.md
+++ b/doc/include-hygiene-roadmap.md
@@ -99,7 +99,7 @@ never remove in bulk without the verify pass.
    | MinGW: `near` / `grp2` as identifiers | same lost shim; the `#undef` came from `darktable.h` |
    | MinGW: unrelated parse errors | `<immintrin.h>` accidentally placed inside an `extern "C"` block |
 
-   The structural fix applied: the Windows legacy-macro shim moved from `common/darktable.h`
+   The structural fix applied: the Windows legacy-macro shim moved from `darktable.h`
    to `common/macros.h`, so it sits at the bottom of the stack where every TU reaches it,
    instead of riding on the orchestrator that low-level code is supposed to stop including.
 
@@ -299,7 +299,7 @@ Where the calls actually are:
 | `develop/blend_gui.c` | 172 |
 | `develop/imageop.c` | 66 |
 | `common/lut_viewer.c` | 47 |
-| `common/darktable.c` | 25 |
+| `darktable.c` | 25 |
 | `develop/imageop_gui.c` | 17 |
 | `develop/masks/masks_gui.c` | 13 |
 | `common/history_merge_gui.c` | 12 |
@@ -323,7 +323,7 @@ daunting:
    the module that also owns pipeline logic. This is the real work: separate the module
    API from its widget plumbing.
 
-3. **Legitimate.** `common/darktable.c` is the orchestrator; initialising the GUI is its
+3. **Legitimate.** `darktable.c` is the orchestrator; initialising the GUI is its
    job. Not a defect.
 
 The pattern to apply is the one that worked for the two solvers in `math/`: the backend
@@ -350,6 +350,6 @@ six that disappeared were misclassifications rather than fixes.
 
 It also settles the spelling trap recorded in `CLAUDE.md`: while the header lived in
 `src/common/`, files in that directory could spell it `#include "darktable.h"` relative to
-themselves, which hid them from audits grepping for `common/darktable.h`. That spelling is
+themselves, which hid them from audits grepping for `darktable.h`. That spelling is
 now the canonical root-relative one.
 

--- a/doc/include-hygiene-roadmap.md
+++ b/doc/include-hygiene-roadmap.md
@@ -332,3 +332,24 @@ already returned an error code the caller checked — the reporting belonged to 
 Most of the 94 are likely to be that shape: a toast, a redraw request, or a widget
 update issued from code whose job is to compute and return.
 
+---
+
+## 8. The orchestrator lives at `src/`
+
+`darktable.c` and `darktable.h` moved out of `src/common/` to `src/`, beside `main.c`.
+
+They are the application root, not a common library: `darktable.h` declares the
+`darktable_t` struct that owns every subsystem, and `darktable.c` initialises them. Being
+filed under `common/` — the BOTTOM layer — inverted that relationship on paper, and made
+the tooling count the orchestrator's legitimate reach into `gui/`, `control/` and
+`develop/` as `common/` violating the layer order.
+
+The layer model gains `app` (9), above every module: nothing the orchestrator includes can
+be an inversion, because there is nothing above it. Layering violations 253 -> 247, and the
+six that disappeared were misclassifications rather than fixes.
+
+It also settles the spelling trap recorded in `CLAUDE.md`: while the header lived in
+`src/common/`, files in that directory could spell it `#include "darktable.h"` relative to
+themselves, which hid them from audits grepping for `common/darktable.h`. That spelling is
+now the canonical root-relative one.
+

--- a/doc/pipeline-cache.md
+++ b/doc/pipeline-cache.md
@@ -595,7 +595,7 @@ system-wide available memory.
 
 The defense has four layers, from planning to last resort:
 
-1. **Envelope-aware startup budgets** (`common/darktable.c`). The detected total RAM is clamped
+1. **Envelope-aware startup budgets** (`darktable.c`). The detected total RAM is clamped
    by the physical RAM (so a misconfigured `host_memory_limit` can only shrink, never grow it) and
    by the tightest cgroup-v2 `memory.max` on our own path (containers, Flatpak, systemd slices —
    the kernel OOM-enforces that envelope no matter how much RAM the machine has). A **pressure
@@ -637,7 +637,7 @@ The defense has four layers, from planning to last resort:
    "does this platform answer at all" is a separate `sys_probe_valid` flag: deriving it from an
    `est == 0` sentinel would silently disable the valve at exactly the moment it matters most.
 
-4. **Pressure-aware tiling** (`dt_get_available_mem()`, `common/darktable.c`). The planning value
+4. **Pressure-aware tiling** (`dt_get_available_mem()`, `darktable.c`). The planning value
    tiled modules size their working set from is capped by the live system availability (plus half
    our own cache, which is LRU-evictable on demand — our own hoard must never force tiling), so
    under pressure modules split into smaller tiles instead of planning allocations the valve

--- a/doc/sentry.md
+++ b/doc/sentry.md
@@ -354,7 +354,7 @@ independently of this script.
 | `src/common/sentry.c` / `.h` | init/shutdown, context, sessions, `on_crash` gdb attach |
 | `src/common/privacy_consent.c` / `.h` | the shared first-launch consent dialog (crash + analytics) |
 | `src/common/system_signal_handling.c` | local gdb fallback; defers to Sentry when it captured |
-| `src/common/darktable.c` | calls `dt_sentry_init()` / `dt_sentry_shutdown()` |
+| `src/darktable.c` | calls `dt_sentry_init()` / `dt_sentry_shutdown()` |
 | `data/anselconfig.xml.in` / `.dtd`, `tools/generate_prefs.xsl` | the `sentry/enabled` preference |
 | `tools/sentry-upload-symbols.sh` | debug-file (symbol) upload |
 | `tools/sentry-fetch-issue.sh` | pull an issue's backtrace + attachments locally to fix it |

--- a/doc/telemetry.md
+++ b/doc/telemetry.md
@@ -173,6 +173,6 @@ PostHog project (EU): create insights under **Product analytics**. Useful breakd
 | `src/CMakeLists.txt` | adds the source, defines `HAVE_TELEMETRY` / `POSTHOG_HOST` |
 | `src/common/telemetry.c` / `.h` | init/shutdown, async POST worker, events, per-session aggregates |
 | `src/common/privacy_consent.c` / `.h` | shared first-launch consent dialog (crash + analytics) |
-| `src/common/darktable.c` | calls `dt_telemetry_init()` / `dt_telemetry_shutdown()` |
+| `src/darktable.c` | calls `dt_telemetry_init()` / `dt_telemetry_shutdown()` |
 | `src/views/view.c`, `src/libs/lib.c`, `src/develop/imageop.c`, `src/develop/pixelpipe_hb.c` | the recording call sites |
 | `data/anselconfig.xml.in` / `.dtd`, `tools/generate_prefs.xsl` | the `telemetry/enabled` preference |

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -64,7 +64,7 @@ FILE(GLOB SOURCE_FILES
   "common/curve_tools.c"
   "common/splines.cpp"
   "common/curl_tools.c"
-  "common/darktable.c"
+  "darktable.c"
   "common/database.c"
   "common/datetime.c"
   "common/dbus.c"

--- a/src/bauhaus/bauhaus.h
+++ b/src/bauhaus/bauhaus.h
@@ -301,7 +301,7 @@ void dt_bauhaus_cleanup(dt_bauhaus_t *bauhaus);
  * callers a handle source. It is the end state: the context is process-wide (one
  * theme, one font, one popup) and a third of the constructor call sites pass
  * DT_GUI_MODULE(NULL), so the handle cannot ride on the module either.
- * Implemented by the orchestrator (common/darktable.c). */
+ * Implemented by the orchestrator (darktable.c). */
 dt_bauhaus_t *dt_bauhaus_get_global(void);
 
 // load theme colors, fonts, etc

--- a/src/cli/main.c
+++ b/src/cli/main.c
@@ -49,7 +49,7 @@
  *  - profit
  */
 
-#include "common/darktable.h"
+#include "darktable.h"
 #include "common/exif.h"
 #include "common/film.h"
 #include "common/file_location.h"

--- a/src/cltest/main.c
+++ b/src/cltest/main.c
@@ -24,7 +24,7 @@
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include "common/darktable.h"
+#include "darktable.h"
 #include "common/opencl.h"
 
 #ifdef __APPLE__

--- a/src/common/anonymous_ids.h
+++ b/src/common/anonymous_ids.h
@@ -21,7 +21,7 @@
 
 /* Anonymous correlation ids shared by crash reporting (common/sentry.c) and usage
  * analytics (common/telemetry.c). Generated/persisted by the orchestrator
- * (common/darktable.c) so both subsystems agree on them. */
+ * (darktable.c) so both subsystems agree on them. */
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/common/capabilities.h
+++ b/src/common/capabilities.h
@@ -22,7 +22,7 @@
 /* Optional features detected at runtime, depending on the environment and the
  * compile options: OpenCL, libsecret, kwallet... Registered by whichever subsystem
  * discovers it can run (common/opencl.c, common/pwstorage/pwstorage.c). The backing
- * list and its mutex belong to the orchestrator (common/darktable.c). */
+ * list and its mutex belong to the orchestrator (darktable.c). */
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/common/conf.c
+++ b/src/common/conf.c
@@ -45,7 +45,7 @@
 #endif
 
 #include "common/calculator.h"
-#include "common/darktable.h"
+#include "darktable.h"
 #include "common/file_location.h"
 #include "math/math.h"
 #include "common/conf.h"

--- a/src/common/database.c
+++ b/src/common/database.c
@@ -2687,7 +2687,7 @@ gboolean dt_database_show_error(const dt_database_t *db)
     {
       // Just try to acquire the lock again: useful once the other instance that held it has
       // since closed. dt_database_show_error() returning FALSE makes the caller's init loop
-      // (common/darktable.c) re-run dt_database_init() without touching any lock file.
+      // (darktable.c) re-run dt_database_init() without touching any lock file.
       error = FALSE;
     }
     else if(choice == 2)

--- a/src/common/dbus.c
+++ b/src/common/dbus.c
@@ -24,7 +24,7 @@
 */
 
 #include "common/dbus.h"
-#include "common/darktable.h"
+#include "darktable.h"
 #include "control/control.h"
 #include "common/file_location.h"
 

--- a/src/common/debug.h
+++ b/src/common/debug.h
@@ -33,7 +33,7 @@
  * dt_database_get_sqlite3_global() (common/database.h), dt_print()/DT_DEBUG_SQL
  * (common/logging.h) and fprintf() (<stdio.h>). Include them here rather than
  * making every consumer of the macros do it: this header used to compile only
- * because common/darktable.h happened to be included first. */
+ * because darktable.h happened to be included first. */
 
 #include "common/database.h"
 #include "common/logging.h"

--- a/src/common/dtpthread.h
+++ b/src/common/dtpthread.h
@@ -481,7 +481,7 @@ static inline int dt_pthread_rwlock_unlock(dt_pthread_rwlock_t *rwlock)
 // before declaring dt_debug_thread_t/darktable_t/dt_print) for dt_print() to be callable
 // directly from the inline functions below -- so the actual logging is delegated to these two
 // non-inline helpers, implemented in dtpthread.c (which, being a .c file and not part of the
-// header cycle, can include common/darktable.h and call dt_print(DT_DEBUG_HISTORY, ...) there).
+// header cycle, can include darktable.h and call dt_print(DT_DEBUG_HISTORY, ...) there).
 // This makes the traces respect `-d history` like every other diagnostic instead of always
 // firing via a raw fprintf. Only ever called for locks opted in via dt_pthread_rwlock_set_name();
 // zero-cost (one pointer compare) for every other lock. Temporary, for

--- a/src/common/exif.cc
+++ b/src/common/exif.cc
@@ -107,7 +107,7 @@
 #include "glib.h"
 
 #include "common/colorlabels.h"
-#include "common/darktable.h"
+#include "darktable.h"
 #include "common/deprecations.h"
 #include "common/debug.h"
 #include "common/dng_opcode.h"

--- a/src/common/glib_utils.h
+++ b/src/common/glib_utils.h
@@ -19,7 +19,7 @@
 #define DT_COMMON_GLIB_UTILS_H
 
 /* Small GLib convenience helpers (GList traversal, string splicing). Application-free
- * on purpose: include this instead of common/darktable.h. */
+ * on purpose: include this instead of darktable.h. */
 
 #include "common/macros.h"
 

--- a/src/common/global_mutexes.h
+++ b/src/common/global_mutexes.h
@@ -19,7 +19,7 @@
 #ifndef DT_COMMON_GLOBAL_MUTEXES_H
 #define DT_COMMON_GLOBAL_MUTEXES_H
 
-/* Process-wide locks owned by the orchestrator (common/darktable.c).
+/* Process-wide locks owned by the orchestrator (darktable.c).
  *
  * They are process-wide because the thing they serialize is process-wide -- a
  * non-reentrant third-party library, or a resource the whole application shares.
@@ -29,7 +29,7 @@
  *
  * Declared here so that the modules which need them (iop/lens.cc, iop/watermark.c,
  * imageio/storage/disk.c, imageio/imageio_rawspeed.cc, ...) do not have to include
- * common/darktable.h, and therefore the whole application, to take a lock. */
+ * darktable.h, and therefore the whole application, to take a lock. */
 
 #include "common/dtpthread.h"
 

--- a/src/common/hash.h
+++ b/src/common/hash.h
@@ -20,7 +20,7 @@
 
 /* dt_hash(): the content-addressing primitive of the whole app (history, pipeline,
  * caches). Pure and dependency-free on purpose: low-level compute units include this
- * instead of common/darktable.h. */
+ * instead of darktable.h. */
 
 #include <stddef.h>
 #include <stdint.h>

--- a/src/common/image_extensions.h
+++ b/src/common/image_extensions.h
@@ -21,7 +21,7 @@
 #include <glib.h>
 
 /** TRUE if `filename`'s extension is one this build can decode. Declared here, beside
- * the extension table it consults; implemented in common/darktable.c. */
+ * the extension table it consults; implemented in darktable.c. */
 gboolean dt_supported_image(const gchar *filename);
 
 #include <glib.h>

--- a/src/common/iop_order.h
+++ b/src/common/iop_order.h
@@ -133,7 +133,7 @@
 
 /* Self-containment: the declarations below use GList/gboolean (glib) and int32_t.
  * This header used to compile only because its consumers happened to include
- * common/darktable.h first. */
+ * darktable.h first. */
 #include <glib.h>
 #include <stdint.h>
 

--- a/src/common/logging.h
+++ b/src/common/logging.h
@@ -19,9 +19,9 @@
 #define DT_COMMON_LOGGING_H
 
 /* Debug-channel flags and the dt_print() family. The implementations live in
- * common/darktable.c (they read the runtime `darktable.unmuted` mask), but the
+ * darktable.c (they read the runtime `darktable.unmuted` mask), but the
  * DECLARATIONS need nothing from the application: low-level compute units include
- * this instead of common/darktable.h to be able to log. */
+ * this instead of darktable.h to be able to log. */
 
 #include <stdint.h>
 
@@ -73,7 +73,7 @@ typedef enum dt_debug_thread_t
 #define DT_DEBUG_SUPERVISOR ((int32_t)(1u << 31))
 
 /* Runtime debug-channel mask (the application's `darktable.unmuted`). Accessor
- * declared here, implemented by the orchestrator (common/darktable.c, next to
+ * declared here, implemented by the orchestrator (darktable.c, next to
  * dt_print()) so header inlines can gate on debug channels without importing
  * the application struct. Test with `dt_get_debug_flags() & DT_DEBUG_XXX`. */
 int32_t dt_get_debug_flags(void);

--- a/src/common/macros.h
+++ b/src/common/macros.h
@@ -26,7 +26,7 @@
 
 /* Windows legacy-macro shim. windows.h #defines `near`, `grp2`, `interface` and
  * friends, and win/win.h #undefs them (and orders winsock2 before windows.h). Every
- * TU used to inherit this through common/darktable.h; now that low-level code no
+ * TU used to inherit this through darktable.h; now that low-level code no
  * longer includes the orchestrator, the shim has to live at the bottom of the stack
  * -- this header -- or the collisions come back on MinGW only, far from their cause.
  * Harmless on every other platform: the whole block disappears. */

--- a/src/common/mem_alloc.h
+++ b/src/common/mem_alloc.h
@@ -20,7 +20,7 @@
 
 /* Cacheline-aligned memory: alignment constants/attributes and the dt_alloc/dt_free
  * family. Self-contained on purpose: low-level compute units include this instead of
- * common/darktable.h. The pixelpipe-cache-tracked allocators
+ * darktable.h. The pixelpipe-cache-tracked allocators
  * (dt_pixelpipe_cache_alloc_*) are NOT here — they reference the darktable global and
  * stay with the orchestrator. */
 

--- a/src/common/module_versioning.h
+++ b/src/common/module_versioning.h
@@ -21,7 +21,7 @@
 /* Module-interface versioning: the DT_MODULE()/DT_MODULE_INTROSPECTION() macros every
  * dynamically-loaded module (iop, lib, view, imageio) must instantiate, and the version
  * they are checked against at dlopen time. Application-free on purpose: module-interface
- * headers include this instead of common/darktable.h. */
+ * headers include this instead of darktable.h. */
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/common/opencl.c
+++ b/src/common/opencl.c
@@ -54,7 +54,7 @@
 #include "common/utility.h"   // dt_util_str_replace, used under __APPLE__ only
 #include "common/capabilities.h"
 #include "pixel/bilateralcl.h"
-#include "common/darktable.h"
+#include "darktable.h"
 #include "common/dlopencl.h"
 #include "pixel/dwt.h"
 #include "common/file_location.h"

--- a/src/common/openmp.h
+++ b/src/common/openmp.h
@@ -20,7 +20,7 @@
 
 /* OpenMP wrappers: the pragma shorthands used across the pixel code, with
  * single-threaded fallbacks when OpenMP is disabled. Self-contained on purpose:
- * low-level compute units include this instead of common/darktable.h. */
+ * low-level compute units include this instead of darktable.h. */
 
 #ifdef _OPENMP
 # include <omp.h>
@@ -78,7 +78,7 @@ extern "C" {
 
 /** Number of OpenMP threads the application decided to use. DECLARED here so
  * low-level compute code can size per-thread buffers without importing
- * common/darktable.h; BOUND by the orchestrator (common/darktable.c). */
+ * darktable.h; BOUND by the orchestrator (darktable.c). */
 int dt_get_num_openmp_threads(void);
 
 static inline int dt_get_thread_num()

--- a/src/common/paths.h
+++ b/src/common/paths.h
@@ -19,13 +19,13 @@
 #define DT_COMMON_PATHS_H
 
 /* g_open() takes O_BINARY on Windows and does not define it elsewhere. Kept here rather
- * than in common/darktable.h so that opening a file does not require the application. */
+ * than in darktable.h so that opening a file does not require the application. */
 #if !defined(O_BINARY)
 #define O_BINARY 0
 #endif
 
 /* Path/filename length constants and path splicing. Application-free on purpose:
- * include this instead of common/darktable.h. */
+ * include this instead of darktable.h. */
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/common/pixelpipe_cache_alloc.h
+++ b/src/common/pixelpipe_cache_alloc.h
@@ -22,11 +22,11 @@
  * cache singleton (and, for the perthread variants, to the application's OpenMP
  * thread count).
  *
- * They moved here from common/darktable.h: they are pipeline-cache API glue, not
+ * They moved here from darktable.h: they are pipeline-cache API glue, not
  * orchestrator material. The binding goes through the dt_pixelpipe_cache_get_global()
  * and dt_get_num_openmp_threads() accessors — declared by the libs, implemented by
- * the orchestrator (common/darktable.c) — so including this helper does NOT drag
- * common/darktable.h (and with it the whole application) into the translation unit. */
+ * the orchestrator (darktable.c) — so including this helper does NOT drag
+ * darktable.h (and with it the whole application) into the translation unit. */
 
 #include "common/macros.h"
 #include "common/mem_alloc.h"

--- a/src/common/sys_resources.h
+++ b/src/common/sys_resources.h
@@ -20,7 +20,7 @@
 #define DT_COMMON_SYS_RESOURCES_H
 
 /* Memory and worker budgets. The values are owned by the orchestrator
- * (common/darktable.c, which fills dt_sys_resources_t once at startup), but the
+ * (darktable.c, which fills dt_sys_resources_t once at startup), but the
  * consumers are low-level compute units -- the pixelpipe cache, tiling, the mipmap
  * cache, the memory arena -- which must not have to include the whole application
  * to ask how much RAM they may use. */

--- a/src/common/target_clones.h
+++ b/src/common/target_clones.h
@@ -20,7 +20,7 @@
 
 /* Function multi-versioning (target_clones) for SIMD compute functions.
  *
- * This is THE canonical definition of __DT_CLONE_TARGETS__: common/darktable.h
+ * This is THE canonical definition of __DT_CLONE_TARGETS__: darktable.h
  * inherits it from here (it used to carry a deliberate duplicate until the
  * de-glueing landed). Self-contained on purpose — low-level compute units
  * (common/nn_model.c and friends) include this without pulling anything else.

--- a/src/common/times.h
+++ b/src/common/times.h
@@ -19,9 +19,9 @@
 #define DT_COMMON_TIMES_H
 
 /* Wall-clock / CPU-time measurement helpers. The dt_show_times* implementations
- * live in common/darktable.c (they honor the runtime perf-debug flag), but the
+ * live in darktable.c (they honor the runtime perf-debug flag), but the
  * declarations are application-free: low-level code includes this instead of
- * common/darktable.h. */
+ * darktable.h. */
 
 #ifdef _WIN32
 #include "win/getrusage.h"
@@ -57,7 +57,7 @@ static inline void dt_get_times(dt_times_t *t)
 }
 
 /* Wall-clock time (dt_get_wtime() domain) at which the application started.
- * Written once at startup, never mutated; implemented in common/darktable.c. */
+ * Written once at startup, never mutated; implemented in darktable.c. */
 double dt_get_start_wtime(void);
 
 void dt_show_times(const dt_times_t *start, const char *prefix);

--- a/src/control/control.c
+++ b/src/control/control.c
@@ -55,7 +55,7 @@
 #include "config.h"
 #endif
 #include "bauhaus/bauhaus.h"
-#include "common/darktable.h"
+#include "darktable.h"
 #include "control/control.h"
 #include "develop/develop.h"
 

--- a/src/control/control.h
+++ b/src/control/control.h
@@ -325,7 +325,7 @@ void dt_control_init(dt_control_t *s);
  * log/toast queue, one pointer state) with no per-call context to ride on, so this
  * accessor is the end state for the handle; finer encapsulation of its three
  * sub-services (log/toast, progress, pointer state) is a separate concern.
- * Implemented by the orchestrator (common/darktable.c). */
+ * Implemented by the orchestrator (darktable.c). */
 struct dt_control_t *dt_control_get_global(void);
 
 // join all worker threads.

--- a/src/control/signal.h
+++ b/src/control/signal.h
@@ -346,7 +346,7 @@ typedef enum dt_debug_signal_action_t
 
 /* read-only accessors for the signal-debugging options, parsed once from the
  * command line at startup and never mutated afterwards (implemented in
- * common/darktable.c, next to dt_get_debug_flags()). */
+ * darktable.c, next to dt_get_debug_flags()). */
 int32_t dt_get_signal_debug_acts(void);
 gboolean dt_get_signal_debug(const int signal);
 
@@ -357,7 +357,7 @@ struct dt_control_signal_t *dt_control_signal_init();
  * global by nature (a process-wide broadcast bus with no per-call context to
  * ride on), so this accessor is the intended end state, not an interim step —
  * same shape as the fully-encapsulated dt_conf_* API. Implemented by the
- * orchestrator (common/darktable.c). */
+ * orchestrator (darktable.c). */
 struct dt_control_signal_t *dt_control_signal_get_global(void);
 /* cleanup the signal framework */
 void dt_control_signal_cleanup(struct dt_control_signal_t *ctlsig);

--- a/src/darktable.c
+++ b/src/darktable.c
@@ -89,7 +89,7 @@
 
 /* Platform memory-query APIs used by dt_get_total_memory()/dt_get_system_available_mem()
  * below: sysctl(CTL_HW, ...) on Apple/BSD and the mach host/task statistics on Apple.
- * These used to arrive through common/darktable.h's OS block; this TU is their only
+ * These used to arrive through darktable.h's OS block; this TU is their only
  * non-external consumer in the tree (common/telemetry.c carries its own), so it declares
  * them itself. */
 #ifdef __APPLE__
@@ -108,7 +108,7 @@
 #include "common/collection.h"
 #include "common/colorspaces.h"
 #include "common/colorlabels.h"
-#include "common/darktable.h"
+#include "darktable.h"
 #include "common/anonymous_ids.h"
 #include "common/capabilities.h"
 #include "common/global_mutexes.h"
@@ -190,7 +190,7 @@
 #include <MagickWand/MagickWand.h>
 #endif
 
-#include "dbus.h"
+#include "common/dbus.h"
 #include "common/utility.h"
 
 #if defined(__SUNOS__)
@@ -501,7 +501,7 @@ void *dt_alloc_align(size_t size)
 
 /* Singleton accessors: the orchestrator BINDS the application-wide instances to the
  * lower-level libs that declare these symbols (develop/pixelpipe_cache.h and
- * common/openmp.h). This keeps those libs free of common/darktable.h — they link
+ * common/openmp.h). This keeps those libs free of darktable.h — they link
  * against two functions instead of importing the whole application struct. */
 struct dt_dev_pixelpipe_cache_t *dt_pixelpipe_cache_get_global(void)
 {

--- a/src/darktable.h
+++ b/src/darktable.h
@@ -73,10 +73,10 @@
  * (dt_dev_get_global(), dt_control_get_global(), ...). See doc/include-graph.md.
  *
  * NEVER include this header from another header. As of this commit, zero headers do. */
-#ifdef DT_COMMON_DARKTABLE_H
-#error "common/darktable.h included more than once in this translation unit -- see the comment at the top of that file"
+#ifdef DT_DARKTABLE_H
+#error "darktable.h included more than once in this translation unit -- see the comment at the top of that file"
 #endif
-#define DT_COMMON_DARKTABLE_H
+#define DT_DARKTABLE_H
 
 
 // just to be sure. the build system should set this for us already:

--- a/src/develop/develop.h
+++ b/src/develop/develop.h
@@ -874,9 +874,9 @@ void dt_dev_update_mouse_effect_radius(dt_develop_t *dev);
 
 /** The darkroom's current dt_develop_t, owned by the application orchestrator.
  * Declared here rather than reached through `darktable.develop` so that modules and
- * libraries do not have to include common/darktable.h -- and therefore the whole
+ * libraries do not have to include darktable.h -- and therefore the whole
  * application -- just to find the image being edited. Implemented in
- * common/darktable.c. Returns NULL outside darkroom. */
+ * darktable.c. Returns NULL outside darkroom. */
 struct dt_develop_t *dt_dev_get_global(void);
 
 /** Publish `dev` as the live darkroom develop. Only the views that own that lifetime

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -63,7 +63,7 @@
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include "common/darktable.h"
+#include "darktable.h"
 #include "common/conf.h"
 #include "common/sentry.h"
 #include "common/telemetry.h"

--- a/src/develop/imageop.h
+++ b/src/develop/imageop.h
@@ -707,7 +707,7 @@ void dt_iop_set_cache_bypass_variant(dt_iop_module_t *module, int variant);
 /** The list of loaded iop module shared objects (dt_iop_module_so_t*), built once at
  * startup by dt_iop_load_modules_so() in develop/imageop.c, which owns it. Readers use
  * this accessor instead of reaching into the application struct, so they need neither
- * common/darktable.h nor knowledge of where the list is stored. */
+ * darktable.h nor knowledge of where the list is stored. */
 GList *dt_iop_get_modules_so(void);
 
 

--- a/src/develop/pixelpipe_cache.h
+++ b/src/develop/pixelpipe_cache.h
@@ -97,7 +97,7 @@ typedef enum dt_dev_pixelpipe_cache_writable_status_t
 dt_dev_pixelpipe_cache_t *dt_dev_pixelpipe_cache_init(size_t max_memory);
 
 /** The application-wide pixelpipe cache singleton. DECLARED here because it is this
- * module's object; BOUND by the orchestrator (common/darktable.c), so this header
+ * module's object; BOUND by the orchestrator (darktable.c), so this header
  * never needs to see the application struct. */
 dt_dev_pixelpipe_cache_t *dt_pixelpipe_cache_get_global(void);
 void dt_dev_pixelpipe_cache_cleanup(dt_dev_pixelpipe_cache_t *cache);

--- a/src/generate-cache/main.c
+++ b/src/generate-cache/main.c
@@ -42,7 +42,7 @@
 #include <string.h>  // for strcmp
 #include <unistd.h>  // for access, R_OK
 
-#include "common/darktable.h"    // for darktable, darktable_t, dt_cleanup, etc
+#include "darktable.h"    // for darktable, darktable_t, dt_cleanup, etc
 #include "common/database.h"     // for dt_database_get
 #include "common/debug.h"        // for DT_DEBUG_SQLITE3_PREPARE_V2
 #include "common/mipmap_cache.h" // for dt_mipmap_size_t, etc

--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -71,7 +71,7 @@
     You should have received a copy of the GNU General Public License
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
-#include "common/darktable.h"
+#include "darktable.h"
 #include "common/colorspaces.h"
 #include "common/l10n.h"
 #include "common/file_location.h"

--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -177,7 +177,7 @@ void dt_gui_set_symbolic_icon(GtkWidget *image, const char *icon_name, GtkIconSi
 }
 
 /* ------------------------------------------------------------------------------------------
- * Widget-callback suppression depth (see common/darktable.h for the rationale and API).
+ * Widget-callback suppression depth (see darktable.h for the rationale and API).
  * ------------------------------------------------------------------------------------------ */
 static inline gboolean _dt_on_gui_thread(void)
 {

--- a/src/gui/gtk.h
+++ b/src/gui/gtk.h
@@ -71,7 +71,7 @@
 extern "C" {
 #endif
 
-/* --- Moved from common/darktable.h: GUI-flavored helpers belong to the GUI layer, and
+/* --- Moved from darktable.h: GUI-flavored helpers belong to the GUI layer, and
  * the orchestrator header must not export GTK/Pango API to the whole application. --- */
 
 /* ------------------------------------------------------------------------------------------
@@ -159,9 +159,9 @@ static inline gchar *strip_markup(const char *s)
 }
 
 /* Application-wide GUI singleton accessor: declared here by the owning lib, implemented by
- * the orchestrator (common/darktable.c, next to dt_pixelpipe_cache_get_global()). It binds
+ * the orchestrator (darktable.c, next to dt_pixelpipe_cache_get_global()). It binds
  * this header's macros and inline helpers to the `dt_gui_get_global()` instance without importing
- * common/darktable.h into every GUI translation unit. */
+ * darktable.h into every GUI translation unit. */
 struct dt_gui_gtk_t;
 struct dt_gui_gtk_t *dt_gui_get_global(void);
 

--- a/src/gui/guides.h
+++ b/src/gui/guides.h
@@ -47,7 +47,7 @@ typedef struct dt_guides_t
 
 /** The registered guide overlays. dt_guides_get_list() is read-only; the `_ref` form
  * returns the address of the list head and exists because registration appends to it —
- * only common/darktable.c's owner and gui/guides.c's registration path may use it. */
+ * only darktable.c's owner and gui/guides.c's registration path may use it. */
 GList *dt_guides_get_list(void);
 GList **dt_guides_get_list_ref(void);
 

--- a/src/imageio/imageio_magick_abort_guard.h
+++ b/src/imageio/imageio_magick_abort_guard.h
@@ -45,7 +45,7 @@
  *  - it restores Ansel's own signal handlers afterward
  *    (common/system_signal_handling.c) since GraphicsMagick is known to
  *    silently steal them as a side effect of its calls (see the
- *    InitializeMagick() callers in common/darktable.c).
+ *    InitializeMagick() callers in darktable.c).
  *
  * Usage, mirroring the existing goto-based error handling in these files:
  *

--- a/src/main.c
+++ b/src/main.c
@@ -26,7 +26,7 @@
     You should have received a copy of the GNU General Public License
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
-#include "common/darktable.h"
+#include "darktable.h"
 #include "gui/gtk.h"
 #include <stdlib.h>
 

--- a/src/math/simd.h
+++ b/src/math/simd.h
@@ -20,7 +20,7 @@
 
 /* SIMD pixel primitives: the 4-float aligned pixel type, its vector helpers and the
  * per-channel loop macros. Self-contained on purpose: low-level compute units include
- * this instead of common/darktable.h. */
+ * this instead of darktable.h. */
 
 #include "common/mem_alloc.h"
 #include "common/openmp.h"

--- a/src/views/view.h
+++ b/src/views/view.h
@@ -276,7 +276,7 @@ typedef struct dt_view_manager_t
 } dt_view_manager_t;
 
 /** The application's single view manager, owned by the orchestrator. Declared here so
- * consumers do not need common/darktable.h for it. Implemented in common/darktable.c. */
+ * consumers do not need darktable.h for it. Implemented in darktable.c. */
 struct dt_view_manager_t *dt_view_manager_get_global(void);
 
 void dt_view_manager_init(dt_view_manager_t *vm);

--- a/src/win/win.h
+++ b/src/win/win.h
@@ -25,7 +25,7 @@
 
 /* winsock2.h must precede windows.h, and this shim exists partly to enforce that.
    But it can no longer assume it is the first Windows header in the translation unit:
-   common/darktable.h used to be included very early everywhere, and since the header
+   darktable.h used to be included very early everywhere, and since the header
    de-glueing it often comes after headers that already pulled windows.h. In that case
    including winsock2.h here cannot fix the ordering retroactively -- it only emits
    MinGW's "Please include winsock2.h before windows.h" warning, which -Werror turns

--- a/tools/include_graph.py
+++ b/tools/include_graph.py
@@ -39,6 +39,7 @@ LAYERS = [
     ('iop', 6), ('imageio', 6),
     ('libs', 7), ('views', 7), ('chart', 7),
     ('cli', 8), ('generate-cache', 8), ('cltest', 8),
+    ('app', 9),                       # main.c, darktable.c/h -- directly in src/
 ]
 LAYER = dict(LAYERS)
 
@@ -46,6 +47,10 @@ def layer_of(path):
     parts = path.split(os.sep)
     if len(parts) < 2:
         return None
+    # A file directly in src/ (main.c, darktable.c/h) is the application root: the
+    # orchestrator sits ABOVE every module, so nothing it includes can be an inversion.
+    if len(parts) == 2:
+        return LAYER['app']
     return LAYER.get(parts[1])
 
 def collect():
@@ -277,7 +282,7 @@ def summary(files, graph, headers, closure, comps, viol):
         print(f"tu_max_closure_lines\t{tu_line_costs[-1]}")
 
     # How far the application orchestrator still reaches.
-    dt_h = os.path.join(SRC, 'common', 'darktable.h')
+    dt_h = os.path.join(SRC, 'darktable.h')   # the orchestrator now lives at src/
     if dt_h in files:
         reach = sum(1 for f in files if dt_h in closure(f))
         direct = sum(1 for f in files if dt_h in graph.get(f, ()))

--- a/tools/include_unused.py
+++ b/tools/include_unused.py
@@ -55,7 +55,7 @@ SIDE_EFFECT_HEADERS = {
     'imageio/format/imageio_format_api.h',
     'imageio/storage/imageio_storage_api.h',
     'external/ThreadSafetyAnalysis.h',
-    'common/darktable.h',       # the orchestrator: handled by its own migration
+    'darktable.h',              # the orchestrator: handled by its own migration
 }
 
 # Declaration shapes. Deliberately generous: a missed declaration turns into a false

--- a/tools/misplaced_files.py
+++ b/tools/misplaced_files.py
@@ -29,7 +29,7 @@ SRC = 'src'
 LAYER = {'external': 0, 'win': 0, 'common': 1, 'math': 1, 'pixel': 2, 'control': 3,
          'gui': 4, 'dtgtk': 4, 'bauhaus': 4, 'develop': 5,
          'iop': 6, 'imageio': 6, 'libs': 7, 'views': 7, 'chart': 7,
-         'cli': 8, 'generate-cache': 8, 'cltest': 8}
+         'cli': 8, 'generate-cache': 8, 'cltest': 8, 'app': 9}
 
 # Headers included for side effects, or re-included X-macro headers: never propose these.
 NEVER_MOVE = {'module_api.h', 'view_api.h', 'lib_api.h', 'imageio_format_api.h',

--- a/tools/symbol_coupling.py
+++ b/tools/symbol_coupling.py
@@ -31,7 +31,7 @@ import sys
 LAYER = {'external': 0, 'win': 0, 'common': 1, 'math': 1, 'pixel': 2, 'control': 3,
          'gui': 4, 'dtgtk': 4, 'bauhaus': 4, 'develop': 5,
          'iop': 6, 'imageio': 6, 'libs': 7, 'views': 7, 'chart': 7,
-         'cli': 8, 'generate-cache': 8, 'cltest': 8}
+         'cli': 8, 'generate-cache': 8, 'cltest': 8, 'app': 9}
 
 OBJ_RE = re.compile(r'\.dir/(.*)\.(?:c|cc|cpp)\.o$')
 


### PR DESCRIPTION
## Move the orchestrator to the application root

`darktable.c` and `darktable.h` move out of `src/common/` to `src/`, beside `main.c`.

They are the application root, not a common library. `darktable.h` declares the `darktable_t`
struct that owns every subsystem; `darktable.c` initialises them. Filing that under `common/` —
the *bottom* layer — inverted the relationship on paper, and made the tooling count the
orchestrator's legitimate reach into `gui/`, `control/` and `develop/` as `common/` breaking the
layer order.

The layer model gains **`app` (9)**, above every module: nothing the orchestrator includes can be
an inversion, because there is nothing above it. `include_graph.py`, `misplaced_files.py` and
`symbol_coupling.py` all learn that a file directly in `src/` is the application root.

| metric | before | after |
|---|---|---|
| layering violations | 253 | **247** |
| include cycles | 0 | 0 |
| `darktable.h` direct includers | 13 | 13 |

**Those six are a reclassification, not a fix.** No code changed behaviour; the model got more
truthful about where the orchestrator sits. Saying so plainly because the number would otherwise
read as progress it isn't.

### It closes a spelling trap this series hit four times

While the header lived in `src/common/`, files in that directory could spell it
`#include "darktable.h"` relative to themselves — which hid four of them (including one *header*,
`common/colorchecker.h`) from audits grepping for `common/darktable.h`. The compile-time tripwire
is what eventually caught them. `src/` is now the canonical root-relative spelling, so the two
forms can no longer diverge. `CLAUDE.md` updated accordingly.

The same trap bit once more during the move: `darktable.c` included `"dbus.h"` by bare name,
resolving to `common/dbus.h` while it lived there and to nothing afterwards. Every bare-name
include in both files was re-scanned — that was the only one.

### Verification

- ✅ `build/` (features on) clean
- ✅ `build-nofeatures/` clean — the config that catches feature-gated include paths
- ✅ `ansel --version` runs
- ✅ `include_graph.py --summary`: cycles 0

⚠️ **No Windows coverage.** The MinGW cross-check reports **12/12 files SKIPPED**: these TUs need
json-glib, libcurl and pugixml, none of which Fedora packages for mingw64. CI is the only Windows
signal on this one.

macOS has no local surrogate either, as usual — but this change touches no `__APPLE__` branch, and
the only header-resolution risk (a bare name shadowing a system header, the `imageio.h` →
`ImageIO.h` incident) does not apply: `darktable.h` gained no new bare-name includes and is not a
framework name.
