### PR TITLE
masks: deduplicate masks_history content across unchanged history steps

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -292,5 +292,6 @@ xyz1001
 zhaowq32
 
 * Sub-module samples contributors (at least 1 commit):
+Guillaume Stutin
 
 And all those of you that made previous releases possible

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -674,8 +674,8 @@ the persistence boundary, so a form shared unchanged across 100 history steps st
 points BLOB serialized 100 times on every commit (`dt_dev_write_history_ext` rewrites the whole
 image's history + masks_history every time). Known, not yet fixed — see
 `doc/masks_history_dedup.md` for the full design (developed on a dedicated branch, merged only
-when Ansel 1.0 is prepared, per explicit instruction not to migrate any user's live DB
-prematurely).
+when the project's version is bumped to 0.1, per explicit instruction not to migrate any user's
+live DB prematurely).
 
 ---
 

--- a/doc/masks_history_dedup.md
+++ b/doc/masks_history_dedup.md
@@ -4,10 +4,20 @@
 
 ## Status
 
-**Design only — no code has been written yet.** This document exists so the design survives
-between sessions and contributors; it is not a description of current behavior. See
-`CLAUDE.md`'s "Masks / forms history" section for what *is* currently implemented (the in-memory
-refcounting/copy-on-write refactor this design builds on).
+**Implemented on the dedicated `masks-history-dedup` branch, not yet merged to `master`** (see
+the hard constraint below — merge waits for the project version to actually reach 0.1). This
+document is kept up to date with what the branch does, not a forward-looking design anymore; see
+`CLAUDE.md`'s "Masks / forms history" section for the in-memory refcounting/copy-on-write refactor
+this design builds on.
+
+2026-08: revised to (a) reuse the existing `masks_history` table instead of splitting it in two,
+which shrinks the migration to a single nullable column with no data transform, and (b) fold in
+write-time savings that are independent of dedup but were previously left as a "measure it"
+verification item — the actual write path had two real, separate inefficiencies found by reading
+the code (see "Write-time cost, independent of dedup" below). Implemented shortly after: see the
+"Trap found during implementation" note under history_snapshot.c for one correctness issue the
+design missed (rowid preservation across undo/redo snapshots) and the write path for the exact
+final hash-table-based dedup shape.
 
 ## Problem
 
@@ -17,24 +27,24 @@ cloning only on write (copy-on-write). This sharing **stops at the persistence b
 places still serialize one row/entry **per (history step, formid)**, with no dedup, even when the
 exact same form is unchanged across dozens of consecutive steps:
 
-- SQL table `masks_history` (`src/common/database.c:1855`):
+- SQL table `masks_history` (`src/common/database.c:1086`, current schema):
   `(imgid, num, formid, form, name, version, points, points_count, source)`, no `UNIQUE`
-  constraint. Written by `dt_masks_write_masks_history_item()`
-  (`src/develop/masks/masks.c:2181`), called once per form per history item by
-  `dt_dev_write_history_item()` (`src/develop/dev_history.c:1355-1359`), itself called for
-  **every** history step by `dt_dev_write_history_ext()` (`src/develop/dev_history.c:1372`).
-  That function deletes and rewrites the **entire** history + masks_history for the image on
-  **every single commit** (`_cleanup_history` → `dt_history_db_delete_dev_history` →
-  `dt_history_db_delete_masks_history`). A form shared unchanged across 100 history steps (the
-  common case, enabled by the refactor above) still gets its full points BLOB serialized 100
-  times, on every commit.
+  constraint. Written by `dt_masks_write_masks_history_item()` (`src/develop/masks/masks.c:2227`),
+  called once per form per history item by `dt_dev_write_history_item()`
+  (`src/develop/dev_history.c:1488-1518`), itself called for **every** history step by
+  `dt_dev_write_history_ext()` (`src/develop/dev_history.c:1527-1554`). That function deletes and
+  rewrites the **entire** history + masks_history for the image on **every single commit**
+  (`_cleanup_history` → `dt_history_db_delete_dev_history` → `dt_history_db_delete_masks_history`,
+  `src/common/history.c:488-536`). A form shared unchanged across 100 history steps (the common
+  case, enabled by the refactor above) still gets its full points BLOB serialized 100 times, on
+  every commit.
 - XMP array `Xmp.darktable.masks_history[N]` (`src/common/exif.cc:3515-3553`): reads directly
   from the SQL table above and writes one XMP array entry per row — same duplication, downstream.
 
-`dt_dev_mask_history_overload()` (`src/develop/dev_history.c:1297`) already warns users about
+`dt_dev_mask_history_overload()` (`src/develop/dev_history.c:1452`) already warns users about
 this via a toast ("consider compressing history...") without fixing it. The maintainer already
 flagged the intended direction as a code comment near `dt_masks_read_masks_history()`
-(`src/develop/masks/masks.c:2159-2163`): attach the forms snapshot to its own object, linked by ID
+(`src/develop/masks/masks.c:2205-2209`): attach the forms snapshot to its own object, linked by ID
 to the history item, instead of duplicating it inline.
 
 **Historical precedent**: before XMP format version 3, `read_masks()` (`src/common/exif.cc`,
@@ -42,111 +52,339 @@ legacy path) stored a single entry per `mask_id` for the whole image — already
 no `num` dimension. The current "one row per step" scheme is a v3 regression. This design
 reverses it.
 
-## Hard constraint: must not touch any user's live database before Ansel 1.0 ships
+## Write-time cost, independent of dedup
 
-This is a persistent-schema change to a table every existing user already has data in. It is
-developed and merged on a **dedicated branch**, kept out of `master` until the Ansel 1.0 release
-is actually being prepared — never landed on the branch users' current builds track. This avoids
-any risk of migrating a live database prematurely, without needing conditional compilation.
+Read while designing this: two costs in the current write path have nothing to do with the
+missing dedup and are worth fixing at the same time, since they're touched by the same code.
+
+1. **No transaction around the per-image rewrite.** `dt_dev_write_history_ext()`
+   (`src/develop/dev_history.c:1527`) issues one `DELETE` (main.history), one `DELETE`
+   (masks_history), then one `INSERT` per history item plus one `INSERT` per form — all as
+   separate statements with no `dt_database_start_transaction()`/`dt_database_release_transaction()`
+   around them, unlike the equivalent batch-write pattern already used elsewhere (e.g.
+   `src/develop/imageop.c:3073-3084`, prepared statement reused in a loop inside one transaction).
+   Under SQLite's default autocommit mode each statement is its own transaction; for a history of
+   any depth with masks this is N+M+2 separate commits where one would do. This is very likely the
+   dominant cost of a commit, well above anything BLOB-size-related — should be fixed regardless
+   of the dedup schema work, by wrapping the delete+rewrite loop in
+   `dt_database_start_transaction(dt_database_get_global())` /
+   `dt_database_release_transaction(dt_database_get_global())` (reentrant via `_trx_batch_level`,
+   safe to nest inside a caller that's already mid-transaction — see `database.c:4625-4781`).
+2. **No statement caching in the masks write path.** `dt_masks_write_masks_history_item()`
+   (`src/develop/masks/masks.c:2227`) calls `DT_DEBUG_SQLITE3_PREPARE_V2` + `sqlite3_finalize`
+   fresh on every single call, unlike `src/common/history.c`'s equivalent functions for
+   `main.history` (`dt_history_db_write_history_item` and friends), which cache a `static
+   sqlite3_stmt*` behind a mutex and just `sqlite3_reset`/`sqlite3_clear_bindings` it
+   (`history.c:488-505` for the pattern). Re-preparing the same INSERT for every form on every
+   commit is pure waste; should follow the same cached-statement pattern.
+
+Neither of these needs the schema change below to fix, and both are cheap/low-risk (no stored
+data changes). They compound with the dedup design: once large point BLOBs stop being
+re-serialized for unchanged forms (next section), the per-statement/transaction overhead becomes
+proportionally even more of what's left, so it's worth fixing in the same pass.
+
+## Hard constraint: must not touch any user's live database before Ansel 0.1 ships
+
+Both persistence formats need a real version bump for this design — there's no way around either
+one (`CURRENT_DATABASE_VERSION_LIBRARY` 36→37, `DT_XMP_EXIF_VERSION` 5→6; see "Why one table
+instead of two" and the XMP section below for why each is unavoidable). It's the bump *landing on
+`master`* that must wait for 0.1, not the bump itself — the whole point of this design is that it
+still requires one.
+
+**SQLite (`main.masks_history`)**: no partial merge is possible. The moment
+`CURRENT_DATABASE_VERSION_LIBRARY` reaches `master`, `_upgrade_library_schema_step()` runs the
+migration on every user's database the next time they start the app — even if none of the new
+write-dedup logic is active yet, this already touches live data (irreversibly, since a build older
+than the bump then refuses to open the migrated database — `database.c:3408`,
+`db_version > CURRENT_DATABASE_VERSION_LIBRARY`). Schema, read path, and write path stay bundled
+on the dedicated branch together; there is nothing here that's safe to land early.
+
+**XMP (`masks_history`/`masks_history_forms` array)**: asymmetric, because `DT_XMP_EXIF_VERSION`
+only affects files *written from this point on* — it doesn't touch anything already on disk the
+way the DB version counter does. `read_masks_v6()` and the two widened dispatch conditions
+(`exif.cc:3284`, `exif.cc:3366`) are inert as long as `DT_XMP_EXIF_VERSION` stays at 5: nothing
+produces a v6 sidecar, so that code never runs on `master`. It would be *possible* to land that
+read-side code ahead of 0.1 as dormant forward-compat. Default here is to keep it bundled with the
+rest anyway — a fragmented merge history buys little for a branch that isn't tracked by any build
+in the meantime — but note the option in case an early partial merge is ever useful.
+
+Both are developed and merged on a **dedicated branch**, kept out of `master` until the project's
+version is actually bumped to 0.1 (current tag: `v0.0.0`). Enforced by merge discipline (process,
+not code): no compile-time/`PROJECT_VERSION` guard is added, since the branch holding this work
+simply never gets merged to `master` before that point.
 
 ## Design
 
+### Why one table instead of two
+
+An earlier version of this design split `masks_history` into a deduplicated content table
+(`masks_history_forms`) plus a thin per-step reference table. That works, but it means: a new
+table, a `FOREIGN KEY`, and — critically — a migration that does `INSERT ... SELECT DISTINCT`
+data transformation across every existing user's `masks_history` rows the moment the version
+bumps.
+
+There is no way to avoid the version bump itself: every schema change to an already-shipped table
+in this codebase goes through the version-gated `_upgrade_library_schema_step()`
+(`src/common/database.c:482`, `else if(version == N) { ...; new_version = N+1; }`), which forces
+`CURRENT_DATABASE_VERSION_LIBRARY` (currently 36, `database.c:84`) to bump. The unconditional
+`ALTER TABLE ... ADD COLUMN` calls seen elsewhere in `database.c` (e.g. around line 163-310) are
+not a general-purpose escape hatch — they only exist inside `_migrate_schema()`, a one-time bridge
+for pre-versioning darktable databases, not a pattern available for ongoing schema evolution.
+
+But the bump doesn't have to carry a data migration. Reusing `masks_history` **in place**, via a
+single self-referencing nullable column, needs no data transform at all: every existing row simply
+gets `content_ref = NULL`, which is already the correct interpretation ("this row carries its own
+content") for historical data. That is strictly safer for the "don't touch live user data"
+constraint than a table split, and it's a smaller surface for everything downstream (undo
+snapshots, XMP) — see below.
+
 ### SQL schema
 
-Split the current table in two (same rename → create → copy-transform → drop migration pattern
-already used elsewhere in this file, e.g. `src/common/database.c:1851-1872`):
-
 ```sql
-CREATE TABLE masks_history_forms (
-  id INTEGER PRIMARY KEY AUTOINCREMENT,
-  imgid INTEGER,
-  formid INTEGER, form INTEGER, name VARCHAR(256), version INTEGER,
-  points BLOB, points_count INTEGER, source BLOB,
-  UNIQUE(imgid, formid, form, name, version, points, points_count, source),
-  FOREIGN KEY(imgid) REFERENCES images(id) ON DELETE CASCADE ON UPDATE CASCADE
-);
-
-CREATE TABLE masks_history (   -- becomes a thin reference table
-  imgid INTEGER, num INTEGER, formid INTEGER, content_id INTEGER,
-  FOREIGN KEY(imgid) REFERENCES images(id) ON DELETE CASCADE ON UPDATE CASCADE,
-  FOREIGN KEY(content_id) REFERENCES masks_history_forms(id) ON DELETE CASCADE
-);
-CREATE INDEX masks_history_imgid_index ON masks_history(imgid, num);
+ALTER TABLE main.masks_history ADD COLUMN content_ref INTEGER;
 ```
 
-The `UNIQUE` constraint on the content columns does the dedup **at the SQL level**, no
-application-side hash needed (no new dependency, no collision risk): `INSERT OR IGNORE` into
-`masks_history_forms`, then `SELECT id` (via the unique index, so fast) to get the `content_id`
-to reference. This works correctly **regardless of caller** — important because
-`dt_masks_write_masks_history_item()` has **two call sites**: the main per-commit loop
-(`src/develop/dev_history.c:1355`) and the legacy "spots" compatibility path
-(`src/iop/spots.c:189`) — both benefit automatically, with no cache to thread between them.
+That's the entire migration. `masks_history` keeps its existing columns and its existing job (one
+row per `(history step, formid)` — this already *is* the "pointer per history line" structure).
+`content_ref` is nullable and, when set, points to the SQLite `rowid` (implicit, no need for an
+explicit `id` column) of an **earlier row in the same table** that carries the real content:
 
-Since `dt_dev_write_history_ext()` deletes and rewrites the whole image's history on every
-commit, dedup happens naturally on every full rewrite: `_cleanup_history` must empty **both**
-tables for that `imgid`, then the rewrite loop repopulates `masks_history_forms` only with
-content actually in use — self-cleaning, no separate GC pass needed.
+- `content_ref IS NULL` → this row's own `form`/`name`/`version`/`points`/`points_count`/`source`
+  are authoritative (either the first time this content appeared, or dedup wasn't attempted for
+  it).
+- `content_ref = <rowid>` → this row is a pointer; `points`/`points_count`/`source` are left NULL
+  (no BLOB duplicated), and the real content lives at the referenced row (which is itself
+  guaranteed to have `content_ref IS NULL` — see write path below, dedup always resolves to the
+  root, never chains through another pointer).
 
 Migration: new `else if(version == 36)` block in `_upgrade_library_schema_step`
-(`src/common/database.c:485`), bumping `CURRENT_DATABASE_VERSION_LIBRARY` 36 → 37. Pure SQL,
-no C-driven transform needed: `INSERT ... SELECT DISTINCT` populates `masks_history_forms`, then
-`INSERT ... SELECT ... JOIN` populates the new thin `masks_history` resolving `content_id`.
+(`src/common/database.c:482`), bumping `CURRENT_DATABASE_VERSION_LIBRARY` 36 → 37. One
+`ALTER TABLE`, no `INSERT ... SELECT`, no new table, no new index required by the schema itself
+(see write path for why no content-lookup index is needed either).
 
-The ephemeral `memory.undo_masks_history` table (`src/common/database.c:2545`, recreated on
-every startup, **not** subject to the version counter — no migration needed, just update its
-`CREATE TABLE`) needs a `memory.undo_masks_history_forms` mirror. `src/common/history_snapshot.c`
-(create/restore/clear around lines 95, 168, 228) must copy **both** tables for lighttable
-undo/redo snapshots.
+`_create_library_schema()` (`database.c:2355`, fresh installs) needs `content_ref` added directly
+to its `CREATE TABLE main.masks_history(...)` literal (currently ~line 2423) — same one-column
+addition, just written directly instead of via `ALTER TABLE`.
+
+The ephemeral `memory.undo_masks_history` table (`database.c:2546`, recreated on every startup,
+**not** subject to the version counter) needs the same column added to its `CREATE TABLE` literal
+— no migration needed, and no second mirror table to maintain (unlike the two-table design):
+`src/common/history_snapshot.c` (create/restore/clear, ~lines 95/168/228) keeps copying exactly
+one table for lighttable undo/redo snapshots, just with one more column along for the ride.
+
+**Trap found during implementation, not anticipated at design time**: `content_ref` is a `rowid`
+into `main.masks_history` itself. A plain `INSERT ... SELECT` does **not** preserve rowids — the
+destination gets fresh, auto-assigned ones — so a naive column-for-column copy of `content_ref`
+into `memory.undo_masks_history` and back would, on restore, point every dedup row at whatever
+unrelated row later happened to claim that old rowid value, not at its actual sibling. Fixed by
+also capturing the row's own `rowid` into a new `memory.undo_masks_history.orig_rowid` column at
+snapshot-create time, then restoring with an **explicit column list that includes `rowid`**
+(`INSERT INTO main.masks_history (rowid, imgid, ...) SELECT orig_rowid, imgid, ... FROM
+memory.undo_masks_history ...` — `main.masks_history` has no declared `INTEGER PRIMARY KEY` alias
+for it, but the bare `rowid` pseudo-column can always be read and written explicitly). This is
+safe to reuse because `dt_history_delete_on_image_ext()` already cleared this image's own rows
+before the restore INSERT runs, and SQLite's default rowid allocator never reissues a value once
+used elsewhere in the table (barring the table going fully empty, which does not have a real
+codepath here since some image's masks_history row almost always still exists). Cross-image paths
+(`dt_history_copy_and_paste_on_image`, `dt_masks_copy_used_forms_for_module`) don't have this
+hazard — checked in `src/common/history_merge.c`, they route through in-memory
+`dt_masks_form_t*`/`dev->forms` objects and call `dt_dev_write_history_ext()` on the destination,
+which computes its own fresh `content_ref` values from scratch rather than copying rows or their
+rowids across images.
+
+### Write path: dedup by pointer identity, not by BLOB comparison
+
+The naive way to detect "is this content already stored?" is a SQL lookup comparing BLOB columns
+(what the two-table design's `UNIQUE` constraint did implicitly). That works but needs an index
+over BLOB columns and a query per form per commit.
+
+There's a cheaper option that falls out of work already done: the in-memory COW refactor
+(`src/develop/masks/masks_history.{h,c}`, see `CLAUDE.md`) guarantees that when a form is
+*unchanged* between two history steps, `hist->forms` for both steps hold the **literal same
+`dt_masks_form_t*` pointer** — copy-on-write only clones on an actual mutation. So "did this
+form's content change since the last time I wrote it?" is answerable by a pointer comparison, in
+memory, for free — no SQL round-trip, no BLOB comparison, no index.
+
+`dt_dev_write_history_ext()` already walks `dev->history` once, in `num` order, to write every
+item. Extend that single pass with a local `GHashTable *last_written` (key: `formid`, value:
+`{dt_masks_form_t *ptr, sqlite3_int64 rowid}`, scoped to the function call, freed at the end):
+
+- For each form being written at this step: look up `last_written[form->formid]`.
+  - If present and `entry->ptr == form` (same object — guaranteed identical content by the COW
+    invariant): insert a pointer row (`content_ref = entry->rowid`, points/points_count/source
+    NULL). No malloc, no memcpy, no BLOB bind for the points buffer.
+  - Otherwise: full write as today (`content_ref = NULL`), then
+    `last_written[form->formid] = {form, sqlite3_last_insert_rowid(...)}`.
+
+This only catches the dominant real case (the same shape persisted unchanged across consecutive
+commits — exactly what `dt_dev_mask_history_overload()`'s toast is warning about) rather than
+every possible content coincidence (e.g. two independently-drawn shapes that happen to end up with
+identical points would not be deduped against each other). That trade is fine here: the toast and
+the actual DB bloat both come from the *same-form-persisted* case, and this catches all of it,
+transitively — if a form is unchanged for 100 steps, steps 2-100 all point at step 1's rowid, they
+never chain through each other. It also means no new index and no schema support beyond the one
+column: the dedup decision is made entirely in application memory before any SQL runs.
 
 ### Read path (in-memory dedup bonus)
 
-`dt_masks_read_masks_history()` (`src/develop/masks/masks.c:2075`): join the two tables on
-`content_id`, ordered by `num`, as today. Keep a local `GHashTable` (`content_id` →
-`dt_masks_form_t*`) while looping: if a `content_id` was already materialized, call
-`dt_masks_form_ref()` on the existing object instead of allocating a new one. This extends the
-in-memory refactor's benefit to **loading** an image, not just editing an already-open session.
+`dt_masks_read_masks_history()` (`src/develop/masks/masks.c:2115`): change the query to resolve
+`content_ref` via a self-join, ordered by `num` as today:
 
-### XMP (new v4 format, selected by file version)
-
-The XMP reader already supports multiple mask-format generations, selected by the file's
-declared version (legacy `read_masks()` vs `read_masks_v3()`, `src/common/exif.cc:~2850-2918`).
-Add `read_masks_v4()` next to the existing readers, dispatched the same way. Writing switches to
-the new format outright (no old-format writer to keep around, since this all lives on the
-dedicated branch until merge):
-
-```
-Xmp.darktable.masks_history_forms[K]/darktable:{mask_id, mask_type, mask_name, mask_version, mask_points, mask_nb, mask_src}
-Xmp.darktable.masks_history_refs[N]/darktable:{mask_num, mask_content_ref}   -- mask_content_ref = index K
+```sql
+SELECT m.imgid, m.formid, m.form, COALESCE(c.form, m.form),
+       COALESCE(c.name, m.name), COALESCE(c.version, m.version),
+       COALESCE(c.points, m.points), COALESCE(c.points_count, m.points_count),
+       COALESCE(c.source, m.source), m.num
+FROM main.masks_history m
+LEFT JOIN main.masks_history c ON c.rowid = m.content_ref
+WHERE m.imgid = ?1
+ORDER BY m.num
 ```
 
-Direct mirror of the SQL split (content array + thin reference array), reusing the same
-in-memory dedup pass (one walk over `dev->history`, same pointer/content_id keyed hash table as
-the SQL side). Touches `src/common/exif.cc:3515-3553` (write) and needs the new `read_masks_v4()`
-next to `read_masks_v3()` (`src/common/exif.cc:~2913`).
+(`form`/`name`/`version` are tiny and could just be duplicated on every row instead of coalesced,
+but coalescing costs nothing extra here and keeps every column dedup-consistent.)
+
+Keep a local `GHashTable` (resolved content rowid → `dt_masks_form_t*`) while looping: if a
+content rowid was already materialized, call `dt_masks_form_ref()` on the existing object instead
+of allocating a new one. This extends the in-memory refactor's benefit to **loading** an image,
+not just editing an already-open session — unchanged from the previous version of this design.
+
+### XMP: real size reduction, gated behind a new `xmp_version`
+
+Two options were considered here.
+
+**Rejected: purely additive `mask_content_ref`, no version bump.** Add the attribute to the
+existing v3 array and always still write full `mask_points` on every entry, using
+`mask_content_ref` only as an optional read-time hint to reuse an already-parsed
+`dt_masks_form_t*`. Fully backward/forward compatible in both directions by construction (an
+unknown attribute is ignored by RDF; a reader that ignores it just reads `mask_points` as always),
+but it does **not** shrink the XMP sidecar — the whole point of dedup for DB writes was avoiding
+re-serializing large point BLOBs on every commit, and that specific pressure doesn't exist for
+XMP (written far less often, on export/sidecar-write, not on every darkroom parameter tweak). If
+XMP file size doesn't actually matter here, this option is simpler and safer; it was dropped only
+because the goal below was chosen instead.
+
+**Chosen: bump `DT_XMP_EXIF_VERSION` (`src/common/exif.cc:133`) 5 → 6.** Referencing entries omit
+`mask_points`/`mask_nb`/`mask_src` entirely and carry `mask_content_ref` (an index into the same
+`Xmp.darktable.masks_history` array) instead — the actual size reduction. This mirrors exactly how
+this file already handles real format changes (the iop-order-list rework was v3→v4/v5 the same
+way), so it's consistent with existing precedent rather than a new mechanism. The cost: `xmp_version`
+is a single counter for the **whole sidecar** (history, iop-order, timestamps — not scoped to
+masks), and the final dispatch `else` (`exif.cc:3370-3373`) rejects the **entire file** — all
+history included, not just masks — when it doesn't recognize the version:
+
+```cpp
+std::cerr << "error: Xmp schema version " << xmp_version << " in " << filename << " not supported" << std::endl;
+g_hash_table_destroy(mask_entries);
+return 1;
+```
+
+So any older Ansel/darktable build (or a downgrade) that encounters a v6 sidecar loses the whole
+file's history, not a gracefully-degraded mask. Accepted trade-off for the real size win, but
+worth being explicit about since it's a bigger blast radius than "just the masks."
+
+Concrete changes, from an exhaustive grep of every `xmp_version` comparison in `exif.cc` (14
+sites — most need no change, listed here for completeness):
+
+- `#define DT_XMP_EXIF_VERSION` (`exif.cc:133`): 5 → 6.
+- **Writer**, `dt_set_xmp_dt_history()` masks block (`exif.cc:3609-3669`): extend the `SELECT` to
+  include `content_ref, rowid`; keep a local `GHashTable` (DB `rowid` → position already written
+  in the XMP array) while looping `ORDER BY num` (this order guarantees a `content_ref` target was
+  already visited, since it always points to a row written earlier in the same
+  delete+rewrite pass — see the write-path section above). Rows with `content_ref IS NULL` write
+  exactly as today and register their array position; rows with `content_ref` set write
+  `mask_content_ref` (the referenced row's array position) and omit `mask_points`/`mask_nb`/
+  `mask_src`.
+- **New `read_masks_v6()`** next to `read_masks_v3()` (~`exif.cc:3018`): resolves
+  `mask_content_ref` against entries already parsed earlier in the same array pass and
+  materializes full `points`/`nb`/`src` into the returned `mask_entry_t` — same output shape as
+  `read_masks_v3()`. This means `add_mask_entry_to_db()` and everything downstream of mask parsing
+  need **no changes**: they always receive fully-populated entries, v3 or v6 alike.
+- **Mask reader dispatch** (`exif.cc:3329-3332`, currently `if(xmp_version < 3) ... else
+  read_masks_v3(...)`): three-way — legacy / `xmp_version >= 6` → `read_masks_v6()` / else →
+  `read_masks_v3()`.
+- **Two exact-match version lists must be widened to include 6**, or the new code rejects its own
+  files:
+  - `exif.cc:3284`, `if(xmp_version == 4 || xmp_version == 5)` (iop-order-list handling) → add
+    `|| xmp_version == 6`.
+  - `exif.cc:3366`, `else if(xmp_version == 2 || xmp_version == 3 || xmp_version == 4 ||
+    xmp_version == 5)` (selects `read_history_v2()`) → add `|| xmp_version == 6`. Missing this
+    sends v6 files straight into the "not supported" `return 1` at `exif.cc:3370-3373`.
+- **No change needed** at the other 8 comparison sites (`exif.cc:3359,3388,3392,3419,3431,3477`:
+  all `xmp_version < N` bounds already correctly exclude 6 into the modern branch;
+  `exif.cc:3803,3810,3817`: `xmp_version > 5` for timestamps already treats 6 as "current" —
+  confirmed by reading each one, not assumed from the pattern.
 
 ## Files to touch
 
-- `src/common/database.c` — new `version==36` migration block, bump
-  `CURRENT_DATABASE_VERSION_LIBRARY`, new `memory.undo_masks_history_forms` ephemeral table.
-- `src/develop/masks/masks.c` — rewrite `dt_masks_write_masks_history_item()` and
-  `dt_masks_read_masks_history()` for the two-table schema.
-- `src/common/history.c` — `dt_history_db_delete_masks_history()` must empty both tables.
-- `src/common/history_snapshot.c` — lighttable undo snapshot create/restore/clear, mirrored to
-  two tables.
-- `src/common/exif.cc` — new XMP v4 writer; new `read_masks_v4()` selected by file version
-  (v3 reader stays, for files written by older Ansel/darktable versions).
-- `src/iop/spots.c` — no signature change needed (benefits automatically via
-  `dt_masks_write_masks_history_item()`), verify in testing only.
+- `src/common/database.c` — new `version==36` migration block (single `ALTER TABLE ADD COLUMN`),
+  bump `CURRENT_DATABASE_VERSION_LIBRARY`, add the column to `_create_library_schema()`'s
+  `masks_history` literal and to `memory.undo_masks_history`'s literal.
+- `src/develop/dev_history.c` — `dt_dev_write_history_ext()`: wrap the delete+rewrite loop in
+  `dt_database_start_transaction()`/`dt_database_release_transaction()`; add the per-call
+  `last_written` hash table and thread it through to the masks write calls (needs `formid` →
+  `{ptr, rowid}` visibility at the point `dt_masks_write_masks_history_item()` is called from
+  `dt_dev_write_history_item()`).
+- `src/develop/masks/masks.c` — `dt_masks_write_masks_history_item()`: accept the dedup decision
+  (or the `last_written` table) from the caller, cache its prepared statement like
+  `src/common/history.c` does, write pointer rows when applicable. `dt_masks_read_masks_history()`:
+  self-join query + read-side `GHashTable` dedup.
+- `src/common/history.c` — no schema-shape change needed here (`dt_history_db_delete_masks_history`
+  still just deletes by `imgid`, one table, unchanged).
+- `src/common/history_snapshot.c` — lighttable undo snapshot create/restore/clear: still one table
+  to mirror, one more column.
+- `src/common/exif.cc` — bump `DT_XMP_EXIF_VERSION` 5→6; extend `dt_set_xmp_dt_history()`'s masks
+  block to resolve/write `content_ref`/`mask_content_ref` and omit content on referencing entries;
+  new `read_masks_v6()`; widen the two exact-match version lists at `exif.cc:3284` and
+  `exif.cc:3366` to include 6; three-way mask-reader dispatch at `exif.cc:3329-3332`.
+- `src/iop/spots.c` — no signature change if the dedup hash table is threaded through
+  `dt_dev_write_history_ext()`'s caller rather than made a parameter of
+  `dt_masks_write_masks_history_item()` itself; verify in testing only either way.
 
 ## Verification plan
 
+**All items below confirmed 2026-08-07**, manual testing on the dedicated branch.
+
 1. On the dedicated branch, against a **copy** of a test database (never a real user DB): run the
-   migration, verify `SELECT COUNT(*) FROM masks_history_forms` is far below the old row count for
-   an image with deep history, and that the image reloads identically (compare rendering
-   before/after migration). Test: lighttable undo/redo, copying history to another image,
-   `iop/spots.c` (image with legacy "spots"), XMP export then reimport, history compression.
-2. Confirm XMP files written by older Ansel/darktable versions (v3 format) still import correctly
-   through the existing `read_masks_v3()` path.
-3. Measure `dt_dev_write_history_ext()` time before/after on a heavily-masked image (e.g. the
-   140-shape retouch test image used for pipeline performance work), to quantify the win.
-4. Merge to `master` only when Ansel 1.0 is actually being prepared.
+   migration, verify existing images still load identically (every pre-existing row has
+   `content_ref = NULL`, so this should be a pure no-op read-wise).
+2. Write a new commit on a heavily-masked image, confirm `points IS NULL AND content_ref IS NOT
+   NULL` rows appear for forms that didn't change, and that reload reconstructs identical
+   `dev->forms`. **Confirmed**: shape loading, shape editing, lighttable undo/redo, copying/
+   duplicating history to another image, XMP export then reimport, history compression (see the
+   deadlock note below). `iop/spots.c` (legacy "spots" compatibility path) intentionally **not**
+   tested — the module is deprecated (`deprecated_msg()` points users at retouch), not worth the
+   manual-test time for this branch.
+   - **Unrelated deadlock found and fixed while testing compression**: compressing history on the
+     image open in darkroom hung. Root-caused via gdb to a pre-existing bug in
+     `common/dtpthread.h`'s temporary `find_history_mutex_blocker` diagnostic instrumentation —
+     `dt_pthread_rwlock_wrlock()`'s named-lock branch never set `writer_depth = 1` on success,
+     breaking the same-thread reentrant-writer fast path for `dev->history_mutex` (the only
+     currently-named lock) and self-deadlocking `dt_apply_dev_history_update()`'s write-lock-then-
+     nested-read-lock sequence. Not caused by this design; fixed on `master` directly (commit
+     `16fe4f739f`), independent of the 0.1 gate, since it's a general concurrency bug unrelated to
+     masks/history schema.
+3. Measure `dt_dev_write_history_ext()` wall time before/after on a heavily-masked image (e.g. the
+   140-shape retouch test image used for pipeline performance work) — expect most of the win from
+   the transaction-wrapping fix, with the pointer-identity skip mattering most on deep histories
+   with large point counts per shape. **Measured 2026-08-07** (`-d history` log,
+   `_dt_dev_write_history_job_run`, image 2298, live editing across several threads/commits):
+   - Before (pre-dedup code, N+M separate autocommits per commit): 22 samples, 6.93-10.44 ms,
+     mean ≈ 8.79 ms.
+   - After (transaction-wrapped + pointer-identity dedup): 14 samples, 1.96-4.01 ms, mean ≈
+     2.47 ms.
+   - ≈ 3.6× faster, matching the diagnosis that the missing transaction was the dominant cost.
+4. Confirm XMP files written by older Ansel/darktable versions (`xmp_version` 2-5) still import
+   correctly through the unchanged `read_masks_v3()`/legacy paths — regression only, no new code
+   involved for those.
+5. Round-trip a v6 sidecar: export, reimport, verify `dev->forms` matches what was exported
+   (referencing entries correctly resolve through `mask_content_ref`). **Confirmed**: "load
+   history from XMP" round-trip with masks works.
+6. Confirm the version-rejection path still fires cleanly for a genuinely unknown version (not a
+   silent partial read) — write a sidecar with an out-of-range `xmp_version` and check the
+   `exif.cc:3370-3373` `return 1` triggers, no crash, no partial DB write. **Confirmed**: sidecar
+   edited to `xmp_version=99`, reimport hits the exact expected message ("error: Xmp schema
+   version 99 in ... not supported") and surfaces as a clean GTK error dialog
+   (`gui/actions/edit.c:338`) instead of a crash or partial write.
+7. Merge to `master` only when the project's version is actually bumped to 0.1 — see the hard
+   constraint above.

--- a/src/common/database.c
+++ b/src/common/database.c
@@ -81,7 +81,7 @@
 
 // whenever _create_*_schema() gets changed you HAVE to bump this version and add an update path to
 // _upgrade_*_schema_step()!
-#define CURRENT_DATABASE_VERSION_LIBRARY 36
+#define CURRENT_DATABASE_VERSION_LIBRARY 37
 #define CURRENT_DATABASE_VERSION_DATA     9
 
 // #define USE_NESTED_TRANSACTIONS
@@ -2090,6 +2090,20 @@ static int _upgrade_library_schema_step(dt_database_t *db, int version)
     TRY_EXEC("DROP TABLE `images_new`", "[init] can't drop temp images table\n");
     new_version = 36;
   }
+  else if(version == 36)
+  {
+    // 36 -> 37 added masks_history.content_ref, for the in-DB masks-history dedup: a row can now
+    // point at an earlier row (by rowid) that carries its actual points/points_count/source
+    // instead of duplicating them. Every pre-existing row gets content_ref = NULL, which is
+    // already the correct meaning ("this row carries its own content") -- no data transform.
+    sqlite3_exec(db->handle, "BEGIN TRANSACTION", NULL, NULL, NULL);
+    // clang-format off
+    TRY_EXEC("ALTER TABLE main.masks_history ADD COLUMN content_ref INTEGER",
+             "[init] can't add `content_ref' column to `masks_history' table\n");
+    // clang-format on
+    sqlite3_exec(db->handle, "COMMIT", NULL, NULL, NULL);
+    new_version = 37;
+  }
   else
     new_version = version; // should be the fallback so that calling code sees that we are in an infinite loop
 
@@ -2417,7 +2431,7 @@ static void _create_library_schema(dt_database_t *db)
   ////////////////////////////// masks history
   sqlite3_exec(db->handle,
                "CREATE TABLE main.masks_history (imgid INTEGER, num INTEGER, formid INTEGER, form INTEGER, name VARCHAR(256), "
-               "version INTEGER, points BLOB, points_count INTEGER, source BLOB, "
+               "version INTEGER, points BLOB, points_count INTEGER, source BLOB, content_ref INTEGER, "
                 "FOREIGN KEY(imgid) REFERENCES images(id) ON UPDATE CASCADE ON DELETE CASCADE)",
                  NULL, NULL, NULL);
 
@@ -2540,7 +2554,8 @@ static void _create_memory_schema(dt_database_t *db)
   sqlite3_exec(
       db->handle,
       "CREATE TABLE memory.undo_masks_history (id INTEGER, imgid INTEGER, num INTEGER, formid INTEGER,"
-      " form INTEGER, name VARCHAR(256), version INTEGER, points BLOB, points_count INTEGER, source BLOB)",
+      " form INTEGER, name VARCHAR(256), version INTEGER, points BLOB, points_count INTEGER, source BLOB,"
+      " content_ref INTEGER, orig_rowid INTEGER)",
       NULL, NULL, NULL);
   sqlite3_exec(
       db->handle,

--- a/src/common/dtpthread.h
+++ b/src/common/dtpthread.h
@@ -557,6 +557,7 @@ static inline int dt_pthread_rwlock_wrlock(dt_pthread_rwlock_t *rwlock)
     if(!res)
     {
       __sync_lock_test_and_set(&(rwlock->writer), pthread_self());
+      rwlock->writer_depth = 1;
       rwlock->last_holder_tid = (long)pthread_self();
       rwlock->last_holder_was_writer = TRUE;
     }

--- a/src/common/exif.cc
+++ b/src/common/exif.cc
@@ -130,7 +130,7 @@
 
 using namespace std;
 
-#define DT_XMP_EXIF_VERSION 5
+#define DT_XMP_EXIF_VERSION 6
 
 #if EXIV2_TEST_VERSION(0,28,0)
 #define AnyError Error
@@ -2626,6 +2626,10 @@ typedef struct mask_entry_t
   gboolean already_added;
   int mask_num;
   int version;
+  // v6+ dedup: index (1-based, matching the XMP array position) of another entry in the same
+  // Xmp.darktable.masks_history array that carries this entry's actual mask_points/mask_nb/
+  // mask_src. 0 means unset (this entry is self-contained). See read_masks_v6().
+  int mask_content_ref;
 } mask_entry_t;
 
 static void print_history_entry(history_entry_t *entry) __attribute__((unused));
@@ -3120,6 +3124,140 @@ skip:
   return history_entries;
 }
 
+// v6+: same array/parse loop as read_masks_v3(), plus darktable:mask_content_ref. A referencing
+// entry omits mask_points/mask_nb/mask_src on disk (the actual size reduction, see
+// doc/masks_history_dedup.md) and instead carries the 1-based array position of the entry that
+// has them. Resolved here, after the parse loop, into a deep copy (both entries go through
+// free_mask_entry() independently) so every returned mask_entry_t is fully self-contained, same
+// as read_masks_v3()'s output -- nothing downstream of this function needs to know v6 exists.
+static GList *read_masks_v6(Exiv2::XmpData &xmpData, const char *filename, const int version)
+{
+  GList *history_entries = NULL;
+  mask_entry_t *current_entry = NULL;
+
+  for(auto history = xmpData.findKey(Exiv2::XmpKey("Xmp.darktable.masks_history")); history != xmpData.end(); history++)
+  {
+    std::string key_item = history->key();
+    char *key = g_strdup(key_item.c_str());
+    char *key_iter = key;
+    if(g_str_has_prefix(key, "Xmp.darktable.masks_history["))
+    {
+      key_iter += strlen("Xmp.darktable.masks_history[");
+      errno = 0;
+      unsigned int n = strtol(key_iter, &key_iter, 10);
+      if(errno)
+      {
+        std::cerr << "error reading masks history from '" << key << "' (" << filename << ")" << std::endl;
+        g_list_free_full(history_entries, free_mask_entry);
+        history_entries = NULL;
+        dt_free(key);
+        return NULL;
+      }
+
+      // skip everything that isn't part of the actual array
+      if(*(key_iter++) != ']')
+      {
+        std::cerr << "error reading masks history from '" << key << "' (" << filename << ")" << std::endl;
+        g_list_free_full(history_entries, free_mask_entry);
+        history_entries = NULL;
+        dt_free(key);
+        return NULL;
+      }
+      if(*(key_iter++) != '/') goto skip;
+      if(*key_iter == '?') key_iter++;
+
+      // make sure we are filling in the details of the correct entry
+      unsigned int length = g_list_length(history_entries);
+      if(n > length)
+      {
+        current_entry = (mask_entry_t *)calloc(1, sizeof(mask_entry_t));
+        current_entry->version = version;
+        history_entries = g_list_append(history_entries, current_entry);
+      }
+      else if(n < length)
+      {
+        current_entry = (mask_entry_t *)g_list_nth_data(history_entries, n - 1); // XMP starts counting at 1!
+      }
+
+      // go on reading things into current_entry
+      if(g_str_has_prefix(key_iter, "darktable:mask_num"))
+      {
+        current_entry->mask_num = history->toLong();
+      }
+      else if(g_str_has_prefix(key_iter, "darktable:mask_id"))
+      {
+        current_entry->mask_id = history->toLong();
+      }
+      else if(g_str_has_prefix(key_iter, "darktable:mask_type"))
+      {
+        current_entry->mask_type = history->toLong();
+      }
+      else if(g_str_has_prefix(key_iter, "darktable:mask_name"))
+      {
+        std::string value_item = history->toString();
+        current_entry->mask_name = g_strdup(value_item.c_str());
+      }
+      else if(g_str_has_prefix(key_iter, "darktable:mask_version"))
+      {
+        current_entry->mask_version = history->toLong();
+      }
+      else if(g_str_has_prefix(key_iter, "darktable:mask_points"))
+      {
+        std::string value_item = history->toString();
+        current_entry->mask_points = dt_exif_xmp_decode(value_item.c_str(),
+                                                        history->size(),
+                                                        &current_entry->mask_points_len);
+      }
+      else if(g_str_has_prefix(key_iter, "darktable:mask_nb"))
+      {
+        current_entry->mask_nb = history->toLong();
+      }
+      else if(g_str_has_prefix(key_iter, "darktable:mask_src"))
+      {
+        std::string value_item = history->toString();
+        current_entry->mask_src = dt_exif_xmp_decode(value_item.c_str(),
+                                                     history->size(),
+                                                     &current_entry->mask_src_len);
+      }
+      else if(g_str_has_prefix(key_iter, "darktable:mask_content_ref"))
+      {
+        current_entry->mask_content_ref = history->toLong();
+      }
+
+    }
+skip:
+    dt_free(key);
+  }
+
+  // Resolve mask_content_ref into a deep copy of the referenced entry's content. The referenced
+  // entry was necessarily written earlier in the array (see the writer in dt_set_xmp_dt_history()),
+  // so by the time we get here every reference target has already been fully parsed above.
+  for(GList *iter = history_entries; iter; iter = g_list_next(iter))
+  {
+    mask_entry_t *entry = (mask_entry_t *)iter->data;
+    if(entry->mask_content_ref <= 0) continue;
+
+    mask_entry_t *source = (mask_entry_t *)g_list_nth_data(history_entries, entry->mask_content_ref - 1);
+    if(!source)
+    {
+      std::cerr << "error resolving mask_content_ref " << entry->mask_content_ref << " (" << filename << ")" << std::endl;
+      continue;
+    }
+
+    entry->mask_points_len = source->mask_points_len;
+    entry->mask_points = (unsigned char *)malloc(entry->mask_points_len);
+    memcpy(entry->mask_points, source->mask_points, entry->mask_points_len);
+
+    entry->mask_nb = source->mask_nb;
+
+    entry->mask_src_len = source->mask_src_len;
+    entry->mask_src = (unsigned char *)malloc(entry->mask_src_len);
+    memcpy(entry->mask_src, source->mask_src, entry->mask_src_len);
+  }
+
+  return history_entries;
+}
+
 static void add_mask_entry_to_db(int32_t imgid, mask_entry_t *entry)
 {
   // add the mask entry only once
@@ -3281,7 +3419,7 @@ int dt_exif_xmp_read(dt_image_t *img, const char *filename, const int history_on
     // when we are reading the xmp data it doesn't make sense to flag the image as removed
     img->flags &= ~DT_IMAGE_REMOVE;
 
-    if(xmp_version == 4 || xmp_version == 5)
+    if(xmp_version == 4 || xmp_version == 5 || xmp_version == 6)
     {
       if((pos = xmpData.findKey(Exiv2::XmpKey("Xmp.darktable.iop_order_version"))) != xmpData.end())
       {
@@ -3328,6 +3466,10 @@ int dt_exif_xmp_read(dt_image_t *img, const char *filename, const int history_on
     // read the masks from the file first so we can add them to the db while reading history entries
     if(xmp_version < 3)
       mask_entries = read_masks(xmpData, filename, xmp_version);
+    else if(xmp_version >= 6)
+      // Same mask_entry_t GList shape as read_masks_v3() -- resolves mask_content_ref
+      // internally, nothing downstream needs to know v6 exists.
+      mask_entries_v3 = read_masks_v6(xmpData, filename, xmp_version);
     else
       mask_entries_v3 = read_masks_v3(xmpData, filename, xmp_version);
 
@@ -3363,7 +3505,7 @@ int dt_exif_xmp_read(dt_image_t *img, const char *filename, const int history_on
       if(!history_entries) // didn't work? try super old version with rdf:Bag
         history_entries = read_history_v1(xmpPacket, filename, 1);
     }
-    else if(xmp_version == 2 || xmp_version == 3 || xmp_version == 4 || xmp_version == 5 )
+    else if(xmp_version == 2 || xmp_version == 3 || xmp_version == 4 || xmp_version == 5 || xmp_version == 6)
       history_entries = read_history_v2(xmpData, filename);
     else
     {
@@ -3624,13 +3766,22 @@ static void dt_set_xmp_dt_history(Exiv2::XmpData &xmpData, const int32_t imgid, 
   // clang-format off
   DT_DEBUG_SQLITE3_PREPARE_V2(
       dt_database_get_sqlite3_global(),
-      "SELECT imgid, formid, form, name, version, points, points_count, source, num"
+      "SELECT imgid, formid, form, name, version, points, points_count, source, num, content_ref, rowid"
       " FROM main.masks_history"
       " WHERE imgid = ?1"
       " ORDER BY num",
       -1, &stmt, NULL);
   // clang-format on
   DT_DEBUG_SQLITE3_BIND_INT(stmt, 1, imgid);
+
+  // Maps a masks_history rowid to the XMP array position (the `num` loop counter below) its
+  // full content was written at, so a later dedup row can reference that position via
+  // mask_content_ref instead of re-encoding its points/nb/src -- the actual size reduction over
+  // the v3 format. ORDER BY num above guarantees a row's content_ref target (always written
+  // earlier in the same delete+rewrite pass, see dt_dev_write_history_ext() in dev_history.c)
+  // has already been visited and registered here. See doc/masks_history_dedup.md.
+  GHashTable *rowid_to_xmp_num = g_hash_table_new_full(g_int64_hash, g_int64_equal, g_free, NULL);
+
   while(sqlite3_step(stmt) == SQLITE_ROW)
   {
     const int32_t mask_num = sqlite3_column_int(stmt, 8);
@@ -3638,11 +3789,8 @@ static void dt_set_xmp_dt_history(Exiv2::XmpData &xmpData, const int32_t imgid, 
     const int32_t mask_type = sqlite3_column_int(stmt, 2);
     const char *mask_name = (const char *)sqlite3_column_text(stmt, 3);
     const int32_t mask_version = sqlite3_column_int(stmt, 4);
-    int32_t len = sqlite3_column_bytes(stmt, 5);
-    char *mask_d = dt_exif_xmp_encode((const unsigned char *)sqlite3_column_blob(stmt, 5), len, NULL);
-    const int32_t mask_nb = sqlite3_column_int(stmt, 6);
-    len = sqlite3_column_bytes(stmt, 7);
-    char *mask_src = dt_exif_xmp_encode((const unsigned char *)sqlite3_column_blob(stmt, 7), len, NULL);
+    const gint64 content_ref = sqlite3_column_int64(stmt, 9);
+    const gint64 rowid = sqlite3_column_int64(stmt, 10);
 
     snprintf(key, sizeof(key), "Xmp.darktable.masks_history[%d]/darktable:mask_num", num);
     xmpData[key] = mask_num;
@@ -3654,19 +3802,42 @@ static void dt_set_xmp_dt_history(Exiv2::XmpData &xmpData, const int32_t imgid, 
     xmpData[key] = mask_name;
     snprintf(key, sizeof(key), "Xmp.darktable.masks_history[%d]/darktable:mask_version", num);
     xmpData[key] = mask_version;
-    snprintf(key, sizeof(key), "Xmp.darktable.masks_history[%d]/darktable:mask_points", num);
-    xmpData[key] = mask_d;
-    snprintf(key, sizeof(key), "Xmp.darktable.masks_history[%d]/darktable:mask_nb", num);
-    xmpData[key] = mask_nb;
-    snprintf(key, sizeof(key), "Xmp.darktable.masks_history[%d]/darktable:mask_src", num);
-    xmpData[key] = mask_src;
 
-    dt_free(mask_d);
-    dt_free(mask_src);
+    gpointer xmp_pos = content_ref > 0 ? g_hash_table_lookup(rowid_to_xmp_num, &content_ref) : NULL;
+    if(xmp_pos)
+    {
+      // Dedup: identical content to an earlier entry already written in this same array --
+      // reference it instead of re-encoding the (possibly large) points/nb/src again.
+      snprintf(key, sizeof(key), "Xmp.darktable.masks_history[%d]/darktable:mask_content_ref", num);
+      xmpData[key] = GPOINTER_TO_INT(xmp_pos);
+    }
+    else
+    {
+      int32_t len = sqlite3_column_bytes(stmt, 5);
+      char *mask_d = dt_exif_xmp_encode((const unsigned char *)sqlite3_column_blob(stmt, 5), len, NULL);
+      const int32_t mask_nb = sqlite3_column_int(stmt, 6);
+      len = sqlite3_column_bytes(stmt, 7);
+      char *mask_src = dt_exif_xmp_encode((const unsigned char *)sqlite3_column_blob(stmt, 7), len, NULL);
+
+      snprintf(key, sizeof(key), "Xmp.darktable.masks_history[%d]/darktable:mask_points", num);
+      xmpData[key] = mask_d;
+      snprintf(key, sizeof(key), "Xmp.darktable.masks_history[%d]/darktable:mask_nb", num);
+      xmpData[key] = mask_nb;
+      snprintf(key, sizeof(key), "Xmp.darktable.masks_history[%d]/darktable:mask_src", num);
+      xmpData[key] = mask_src;
+
+      dt_free(mask_d);
+      dt_free(mask_src);
+
+      gint64 *rowid_key = g_new(gint64, 1);
+      *rowid_key = rowid;
+      g_hash_table_insert(rowid_to_xmp_num, rowid_key, GINT_TO_POINTER(num));
+    }
 
     num++;
   }
   sqlite3_finalize(stmt);
+  g_hash_table_destroy(rowid_to_xmp_num);
 
   // history stack:
   num = 1;

--- a/src/common/history_snapshot.c
+++ b/src/common/history_snapshot.c
@@ -89,13 +89,17 @@ void dt_history_snapshot_undo_create(const int32_t imgid, int *snap_id, int *his
   all_ok = all_ok && (sqlite3_step(stmt) == SQLITE_DONE);
   sqlite3_finalize(stmt);
 
-  // copy current state into undo_masks_history
+  // copy current state into undo_masks_history. rowid is captured as orig_rowid so it can be
+  // restored verbatim below -- content_ref values are rowids into main.masks_history itself, and
+  // a plain INSERT...SELECT does not preserve rowids, so without this a restored row's
+  // content_ref would point at whatever unrelated row later claimed that rowid, not at the
+  // sibling row it originally meant. See doc/masks_history_dedup.md.
 
   // clang-format off
   DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get_sqlite3_global(),
                               "INSERT INTO memory.undo_masks_history"
                               "  SELECT ?1, imgid, num, formid, form, name, version,"
-                              "         points, points_count, source"
+                              "         points, points_count, source, content_ref, rowid"
                               "  FROM main.masks_history"
                               "  WHERE imgid=?2", -1, &stmt, NULL);
   // clang-format on
@@ -162,13 +166,20 @@ static void _history_snapshot_undo_restore(const int32_t imgid, const int snap_i
   all_ok &= (sqlite3_step(stmt) == SQLITE_DONE);
   sqlite3_finalize(stmt);
 
-  // copy undo_masks_history snapshot back as current masks_history state
+  // copy undo_masks_history snapshot back as current masks_history state. Restoring at the
+  // original rowid (explicit column list required: main.masks_history has no declared
+  // INTEGER PRIMARY KEY alias for it) is what keeps content_ref -- captured at snapshot time as
+  // a rowid into this same table -- pointing at the right sibling row after restore. Safe to
+  // reuse: dt_history_delete_on_image_ext() above already cleared this image's own rows, and
+  // SQLite never reissues a rowid once used elsewhere in the table.
 
   // clang-format off
   DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get_sqlite3_global(),
                               "INSERT INTO main.masks_history"
-                              "  SELECT imgid, num, formid, form, name, version, "
-                              "         points, points_count, source"
+                              "  (rowid, imgid, num, formid, form, name, version, points, "
+                              "   points_count, source, content_ref)"
+                              "  SELECT orig_rowid, imgid, num, formid, form, name, version, "
+                              "         points, points_count, source, content_ref"
                               "  FROM memory.undo_masks_history"
                               "  WHERE imgid=?2 AND id=?1",
                               -1, &stmt, NULL);

--- a/src/darktable.c
+++ b/src/darktable.c
@@ -1682,6 +1682,7 @@ void dt_cleanup()
   dt_colorlabels_cleanup();
   dt_history_cleanup();
   dt_dev_history_cleanup();
+  dt_masks_history_cleanup();
   dt_metadata_cleanup();
   dt_image_cleanup();
   dt_tags_cleanup();

--- a/src/develop/dev_history.c
+++ b/src/develop/dev_history.c
@@ -60,6 +60,7 @@
 */
 #include "common/conf.h"
 #include "common/history.h"
+#include "common/database.h"
 
 #include "common/undo.h"
 #include "common/image_cache.h"
@@ -1484,12 +1485,26 @@ void dt_dev_history_notify_change(dt_develop_t *dev, const int32_t imgid)
 }
 
 
-// helper used to synch a single history item with db
-int dt_dev_write_history_item(const int32_t imgid, dt_dev_history_item_t *h, int32_t num)
+// Tracks, per formid, the last dt_masks_form_t* written to masks_history during one
+// dt_dev_write_history_ext() call and the DB rowid that holds its content. The copy-on-write
+// invariant (develop/masks/masks_history.h) guarantees an unchanged form keeps the exact same
+// pointer across consecutive history steps, so a pointer match here proves the content is
+// identical -- no BLOB comparison needed. See doc/masks_history_dedup.md.
+typedef struct _dt_masks_written_form_t
+{
+  dt_masks_form_t *form;
+  int64_t rowid;
+} _dt_masks_written_form_t;
+
+// helper used to synch a single history item with db. last_written_forms is the per-formid
+// dedup table described above, owned and freed by the dt_dev_write_history_ext() call this
+// belongs to.
+int dt_dev_write_history_item(const int32_t imgid, dt_dev_history_item_t *h, int32_t num,
+                              GHashTable *last_written_forms)
 {
   if(IS_NULL_PTR(h)) return 1;
 
-  dt_print(DT_DEBUG_HISTORY, "[dt_dev_write_history_item] writing history for module %s (%s) (enabled %i) at pipe position %i for image %i\n", 
+  dt_print(DT_DEBUG_HISTORY, "[dt_dev_write_history_item] writing history for module %s (%s) (enabled %i) at pipe position %i for image %i\n",
                                                     h->op_name, h->multi_name, h->enabled, h->iop_order, imgid);
 
   const char *operation = h->module ? h->module->op : h->op_name;
@@ -1510,8 +1525,25 @@ int dt_dev_write_history_item(const int32_t imgid, dt_dev_history_item_t *h, int
   for(GList *forms = g_list_first(h->forms); forms; forms = g_list_next(forms))
   {
     dt_masks_form_t *form = (dt_masks_form_t *)forms->data;
-    if (form)
-      dt_masks_write_masks_history_item(imgid, num, form);
+    if(!form) continue;
+
+    _dt_masks_written_form_t *prev
+        = (_dt_masks_written_form_t *)g_hash_table_lookup(last_written_forms, GINT_TO_POINTER(form->formid));
+    const int64_t content_ref = (prev && prev->form == form) ? prev->rowid : 0;
+
+    const int64_t rowid = dt_masks_write_masks_history_item(imgid, num, form, content_ref);
+
+    if(content_ref == 0)
+    {
+      // full write just happened: (re)seat this formid's canonical content pointer
+      if(!prev)
+      {
+        prev = malloc(sizeof(_dt_masks_written_form_t));
+        g_hash_table_insert(last_written_forms, GINT_TO_POINTER(form->formid), prev);
+      }
+      prev->form = form;
+      prev->rowid = rowid;
+    }
   }
 
   return 0;
@@ -1519,7 +1551,9 @@ int dt_dev_write_history_item(const int32_t imgid, dt_dev_history_item_t *h, int
 
 void dt_dev_history_cleanup(void)
 {
-  // No-op: SQL statement caching/cleanup for history lives in common/history.c (dt_history_cleanup()).
+  // No-op: SQL statement caching/cleanup for history lives in common/history.c
+  // (dt_history_cleanup()) and, for masks_history, in develop/masks/masks.c
+  // (dt_masks_history_cleanup()).
 }
 
 
@@ -1533,6 +1567,14 @@ void dt_dev_write_history_ext(dt_develop_t *dev, const int32_t imgid)
 
   dt_dev_set_history_hash(dev, dt_dev_history_compute_hash(dev));
 
+  // Per-formid pointer-identity dedup table for this rewrite pass, see
+  // dt_dev_write_history_item() and doc/masks_history_dedup.md.
+  GHashTable *last_written_forms = g_hash_table_new_full(g_direct_hash, g_direct_equal, NULL, dt_free_gpointer);
+
+  // Everything below used to run as N+M+2 separate autocommits (one per DELETE/INSERT); wrapping
+  // it in a single transaction is the single biggest win for a commit's DB write time.
+  dt_database_start_transaction(dt_database_get_global());
+
   _cleanup_history(imgid);
 
   // write history entries
@@ -1540,7 +1582,7 @@ void dt_dev_write_history_ext(dt_develop_t *dev, const int32_t imgid)
   for(GList *history = g_list_first(dev->history); history; history = g_list_next(history))
   {
     dt_dev_history_item_t *hist = (dt_dev_history_item_t *)(history->data);
-    dt_dev_write_history_item(imgid, hist, i);
+    dt_dev_write_history_item(imgid, hist, i, last_written_forms);
     i++;
   }
 
@@ -1548,6 +1590,10 @@ void dt_dev_write_history_ext(dt_develop_t *dev, const int32_t imgid)
 
   // write the current iop-order-list for this image
   dt_ioppr_write_iop_order_list(dev->iop_order_list, imgid);
+
+  dt_database_release_transaction(dt_database_get_global());
+
+  g_hash_table_destroy(last_written_forms);
 
   cache_img->history_hash = dt_dev_get_history_hash(dev);
 

--- a/src/develop/masks.h
+++ b/src/develop/masks.h
@@ -929,8 +929,15 @@ struct dt_iop_module_t *dt_masks_get_mask_manager(struct dt_develop_t *dev);
 
 /** read the forms from the db */
 void dt_masks_read_masks_history(dt_develop_t *dev, const int32_t imgid);
-/** write the forms into the db */
-void dt_masks_write_masks_history_item(const int32_t imgid, const int num, dt_masks_form_t *form);
+/** write the forms into the db. content_ref > 0 writes a dedup pointer row referencing an
+ * earlier row's rowid instead of duplicating points/points_count/source; pass 0 for a full
+ * write. Returns the rowid of the row just written (used by the caller to dedup subsequent,
+ * unchanged writes of the same form). */
+int64_t dt_masks_write_masks_history_item(const int32_t imgid, const int num, dt_masks_form_t *form,
+                                          const int64_t content_ref);
+/** finalize the cached statement used by dt_masks_write_masks_history_item(), mirroring
+ * dt_history_cleanup() in common/history.c. */
+void dt_masks_history_cleanup(void);
 void dt_masks_free_form(dt_masks_form_t *form);
 void dt_masks_cleanup_unused(dt_develop_t *dev);
 

--- a/src/develop/masks/masks.c
+++ b/src/develop/masks/masks.c
@@ -2118,12 +2118,22 @@ void dt_masks_read_masks_history(dt_develop_t *develop, const int32_t image_id)
   dt_dev_history_item_t *last_history_item = NULL;
   int previous_num = -1;
 
+  // Keyed by "content_key" (see query below): the rowid of whichever masks_history row actually
+  // carries a given form's content. A form shared unchanged across many history steps resolves
+  // to the same content_key on every row, so it only gets parsed/allocated once per image load --
+  // later rows just dt_masks_form_ref() the object already materialized here.
+  GHashTable *materialized = g_hash_table_new_full(g_int64_hash, g_int64_equal, g_free, NULL);
+
   sqlite3_stmt *statement = NULL;
   // clang-format off
   DT_DEBUG_SQLITE3_PREPARE_V2(
       dt_database_get_sqlite3_global(),
-      "SELECT imgid, formid, form, name, version, points, points_count, source, num "
-      "FROM main.masks_history WHERE imgid = ?1 ORDER BY num",
+      "SELECT m.imgid, m.formid, COALESCE(c.form, m.form), COALESCE(c.name, m.name), "
+      "COALESCE(c.version, m.version), COALESCE(c.points, m.points), "
+      "COALESCE(c.points_count, m.points_count), COALESCE(c.source, m.source), m.num, "
+      "COALESCE(m.content_ref, m.rowid) "
+      "FROM main.masks_history m LEFT JOIN main.masks_history c ON c.rowid = m.content_ref "
+      "WHERE m.imgid = ?1 ORDER BY m.num",
       -1, &statement, NULL);
   // clang-format on
   DT_DEBUG_SQLITE3_BIND_INT(statement, 1, image_id);
@@ -2131,60 +2141,75 @@ void dt_masks_read_masks_history(dt_develop_t *develop, const int32_t image_id)
   while(sqlite3_step(statement) == SQLITE_ROW)
   {
     // db record:
-    // 0-img, 1-formid, 2-form_type, 3-name, 4-version, 5-points, 6-points_count, 7-source, 8-num
+    // 0-img, 1-formid, 2-form_type, 3-name, 4-version, 5-points, 6-points_count, 7-source, 8-num,
+    // 9-content_key (the rowid of the row that actually carries this content)
 
     // we get the values
 
     const int form_id = sqlite3_column_int(statement, 1);
     const int history_num = sqlite3_column_int(statement, 8);
-    const dt_masks_type_t mask_type = sqlite3_column_int(statement, 2);
-    dt_masks_form_t *mask_form = dt_masks_create(mask_type);
-    mask_form->formid = form_id;
-    const char *form_name = (const char *)sqlite3_column_text(statement, 3);
-    g_strlcpy(mask_form->name, form_name, sizeof(mask_form->name));
-    mask_form->version = sqlite3_column_int(statement, 4);
-    mask_form->points = NULL;
-    const int point_count = sqlite3_column_int(statement, 6);
-    memcpy(mask_form->source, sqlite3_column_blob(statement, 7), sizeof(float) * 2);
+    const gint64 content_key = sqlite3_column_int64(statement, 9);
 
-    // and now we "read" the blob
-    if(mask_form->functions)
+    dt_masks_form_t *mask_form = (dt_masks_form_t *)g_hash_table_lookup(materialized, &content_key);
+    if(mask_form)
     {
-      const char *const point_buffer = (char *)sqlite3_column_blob(statement, 5);
-      const size_t point_struct_size = mask_form->functions->point_struct_size;
-      for(int point_index = 0; point_index < point_count; point_index++)
-      {
-        char *point_data = (char *)malloc(point_struct_size);
-        memcpy(point_data, point_buffer + point_index * point_struct_size, point_struct_size);
-        mask_form->points = g_list_append(mask_form->points, point_data);
-      }
+      mask_form = dt_masks_form_ref(mask_form);
     }
-
-    if(mask_form->version != dt_masks_version())
+    else
     {
-      if(dt_masks_legacy_params(develop, mask_form, mask_form->version, dt_masks_version()))
+      const dt_masks_type_t mask_type = sqlite3_column_int(statement, 2);
+      mask_form = dt_masks_create(mask_type);
+      mask_form->formid = form_id;
+      const char *form_name = (const char *)sqlite3_column_text(statement, 3);
+      g_strlcpy(mask_form->name, form_name, sizeof(mask_form->name));
+      mask_form->version = sqlite3_column_int(statement, 4);
+      mask_form->points = NULL;
+      const int point_count = sqlite3_column_int(statement, 6);
+      memcpy(mask_form->source, sqlite3_column_blob(statement, 7), sizeof(float) * 2);
+
+      // and now we "read" the blob
+      if(mask_form->functions)
       {
-        const char *fname = develop->image_storage.filename + strlen(develop->image_storage.filename);
-        while(fname > develop->image_storage.filename && *fname != '/') fname--;
-        if(fname > develop->image_storage.filename) fname++;
-
-        fprintf(stderr,
-                "[_dev_read_masks_history] %s (imgid `%i'): mask version mismatch: history is %d, dt %d.\n",
-                fname, image_id, mask_form->version, dt_masks_version());
-        dt_control_log(_("%s: mask version mismatch: %d != %d"),
-                       fname, dt_masks_version(), mask_form->version);
-
-        continue;
+        const char *const point_buffer = (char *)sqlite3_column_blob(statement, 5);
+        const size_t point_struct_size = mask_form->functions->point_struct_size;
+        for(int point_index = 0; point_index < point_count; point_index++)
+        {
+          char *point_data = (char *)malloc(point_struct_size);
+          memcpy(point_data, point_buffer + point_index * point_struct_size, point_struct_size);
+          mask_form->points = g_list_append(mask_form->points, point_data);
+        }
       }
+
+      if(mask_form->version != dt_masks_version())
+      {
+        if(dt_masks_legacy_params(develop, mask_form, mask_form->version, dt_masks_version()))
+        {
+          const char *fname = develop->image_storage.filename + strlen(develop->image_storage.filename);
+          while(fname > develop->image_storage.filename && *fname != '/') fname--;
+          if(fname > develop->image_storage.filename) fname++;
+
+          fprintf(stderr,
+                  "[_dev_read_masks_history] %s (imgid `%i'): mask version mismatch: history is %d, dt %d.\n",
+                  fname, image_id, mask_form->version, dt_masks_version());
+          dt_control_log(_("%s: mask version mismatch: %d != %d"),
+                         fname, dt_masks_version(), mask_form->version);
+
+          continue;
+        }
+      }
+
+      gint64 *key = g_new(gint64, 1);
+      *key = content_key;
+      g_hash_table_insert(materialized, key, mask_form);
     }
 
     // Not computed here: dt_masks_replace_current_forms() below (via
     // dt_masks_form_update_gravity_center() in masks_history.c) already computes it for
     // every form that actually ends up live in dev->forms. Computing it here too would
     // redundantly do it for every history step's row read from masks_history -- including
-    // every duplicate of a form shared unchanged across many steps (see the un-deduped
-    // masks_history table, doc/masks_history_dedup.md) -- for forms that are either
-    // superseded (never read again) or about to be recomputed anyway.
+    // every duplicate of a form shared unchanged across many steps (see
+    // doc/masks_history_dedup.md) -- for forms that are either superseded (never read again) or
+    // about to be recomputed anyway.
 
     // if this is a new history entry let's find it
     if(previous_num != history_num)
@@ -2201,12 +2226,10 @@ void dt_masks_read_masks_history(dt_develop_t *develop, const int32_t image_id)
       }
       previous_num = history_num;
     }
-    // add the form to the history entry
-    // FIXME: there is no reason to hack history_item to add a forms snapshot that doesn't
-    // belong to it because dt_dev_write_history_item() doesn't save history_item->forms to the DB.
-    // So this forms snapshot should be attached to its own object, and that object should be
-    // linked by ID to the history_item object. That would allow to share one forms snapshot
-    // between several history items without duplication.
+    // add the form to the history entry. On-disk sharing across history items without
+    // duplication is handled above via content_ref (see doc/masks_history_dedup.md); in memory
+    // each history_item->forms entry still holds its own reference to the (possibly shared)
+    // dt_masks_form_t*, per the copy-on-write refcounting scheme in masks_history.h.
     if(history_item)
     {
       history_item->forms = g_list_append(history_item->forms, mask_form);
@@ -2219,52 +2242,108 @@ void dt_masks_read_masks_history(dt_develop_t *develop, const int32_t image_id)
     if(history_num < dt_dev_get_history_end_ext(develop)) last_history_item = history_item;
   }
   sqlite3_finalize(statement);
+  g_hash_table_destroy(materialized);
 
   // and we update the current forms snapshot
   dt_masks_replace_current_forms(develop, (last_history_item) ? last_history_item->forms : NULL);
 }
 
-void dt_masks_write_masks_history_item(const int32_t image_id, const int history_num,
-                                       dt_masks_form_t *mask_form)
+// Cached prepared statement for dt_masks_write_masks_history_item(), mirroring the pattern in
+// src/common/history.c (avoids a PREPARE_V2/finalize pair on every single form write -- this
+// runs once per form per history commit, i.e. very often).
+static sqlite3_stmt *_masks_history_write_stmt = NULL;
+static dt_pthread_mutex_t _masks_history_write_stmt_mutex;
+static gsize _masks_history_write_stmt_mutex_inited = 0;
+
+static inline void _masks_history_write_stmt_mutex_ensure(void)
 {
-  sqlite3_stmt *statement = NULL;
+  if(g_once_init_enter(&_masks_history_write_stmt_mutex_inited))
+  {
+    dt_pthread_mutex_init(&_masks_history_write_stmt_mutex, NULL);
+    g_once_init_leave(&_masks_history_write_stmt_mutex_inited, 1);
+  }
+}
 
-  dt_print(DT_DEBUG_HISTORY, "[dt_masks_write_masks_history_item] writing mask %s of type %i for image %i\n",
-           mask_form->name, mask_form->type, image_id);
+void dt_masks_history_cleanup(void)
+{
+  _masks_history_write_stmt_mutex_ensure();
+  dt_pthread_mutex_lock(&_masks_history_write_stmt_mutex);
+  if(_masks_history_write_stmt)
+  {
+    sqlite3_finalize(_masks_history_write_stmt);
+    _masks_history_write_stmt = NULL;
+  }
+  dt_pthread_mutex_unlock(&_masks_history_write_stmt_mutex);
+}
 
-  // write the form into the database
-  // clang-format off
-  DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get_sqlite3_global(),
-                              "INSERT INTO main.masks_history (imgid, num, formid, form, name, "
-                              "version, points, points_count,source) VALUES "
-                              "(?1, ?9, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
-                              -1, &statement, NULL);
-  // clang-format on
+int64_t dt_masks_write_masks_history_item(const int32_t image_id, const int history_num,
+                                          dt_masks_form_t *mask_form, const int64_t content_ref)
+{
+  dt_print(DT_DEBUG_HISTORY, "[dt_masks_write_masks_history_item] writing mask %s of type %i for image %i%s\n",
+           mask_form->name, mask_form->type, image_id, content_ref > 0 ? " (deduplicated)" : "");
+
+  _masks_history_write_stmt_mutex_ensure();
+  dt_pthread_mutex_lock(&_masks_history_write_stmt_mutex);
+
+  if(!_masks_history_write_stmt)
+    // clang-format off
+    DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get_sqlite3_global(),
+                                "INSERT INTO main.masks_history (imgid, num, formid, form, name, "
+                                "version, points, points_count, source, content_ref) VALUES "
+                                "(?1, ?9, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?10)",
+                                -1, &_masks_history_write_stmt, NULL);
+    // clang-format on
+  sqlite3_stmt *statement = _masks_history_write_stmt;
+  sqlite3_reset(statement);
+  sqlite3_clear_bindings(statement);
+
   DT_DEBUG_SQLITE3_BIND_INT(statement, 1, image_id);
   DT_DEBUG_SQLITE3_BIND_INT(statement, 9, history_num);
   DT_DEBUG_SQLITE3_BIND_INT(statement, 2, mask_form->formid);
   DT_DEBUG_SQLITE3_BIND_INT(statement, 3, mask_form->type);
   DT_DEBUG_SQLITE3_BIND_TEXT(statement, 4, mask_form->name, -1, SQLITE_TRANSIENT);
-  DT_DEBUG_SQLITE3_BIND_BLOB(statement, 8, mask_form->source, 2 * sizeof(float), SQLITE_TRANSIENT);
   DT_DEBUG_SQLITE3_BIND_INT(statement, 5, mask_form->version);
-  if(mask_form->functions)
+
+  char *point_buffer = NULL;
+  if(content_ref > 0)
   {
-    const size_t point_struct_size = mask_form->functions->point_struct_size;
-    const guint point_count = g_list_length(mask_form->points);
-    char *const restrict point_buffer = (char *)malloc(point_count * point_struct_size);
-    int buffer_offset = 0;
-    for(GList *point_node = mask_form->points; point_node; point_node = g_list_next(point_node))
-    {
-      memcpy(point_buffer + buffer_offset, point_node->data, point_struct_size);
-      buffer_offset += point_struct_size;
-    }
-    DT_DEBUG_SQLITE3_BIND_BLOB(statement, 6, point_buffer,
-                               point_count * point_struct_size, SQLITE_TRANSIENT);
-    DT_DEBUG_SQLITE3_BIND_INT(statement, 7, point_count);
-    sqlite3_step(statement);
-    sqlite3_finalize(statement);
-    dt_free(point_buffer);
+    // Dedup: an earlier row already carries this exact content -- the copy-on-write invariant
+    // (develop/masks/masks_history.h) guarantees identical content whenever the caller hands us
+    // back the same dt_masks_form_t* it saw last time. Leave points/points_count/source NULL and
+    // just point at the earlier row instead of re-serializing them.
+    DT_DEBUG_SQLITE3_BIND_INT64(statement, 10, content_ref);
   }
+  else
+  {
+    DT_DEBUG_SQLITE3_BIND_BLOB(statement, 8, mask_form->source, 2 * sizeof(float), SQLITE_TRANSIENT);
+    if(mask_form->functions)
+    {
+      const size_t point_struct_size = mask_form->functions->point_struct_size;
+      const guint point_count = g_list_length(mask_form->points);
+      point_buffer = (char *)malloc(point_count * point_struct_size);
+      int buffer_offset = 0;
+      for(GList *point_node = mask_form->points; point_node; point_node = g_list_next(point_node))
+      {
+        memcpy(point_buffer + buffer_offset, point_node->data, point_struct_size);
+        buffer_offset += point_struct_size;
+      }
+      DT_DEBUG_SQLITE3_BIND_BLOB(statement, 6, point_buffer,
+                                 point_count * point_struct_size, SQLITE_TRANSIENT);
+      DT_DEBUG_SQLITE3_BIND_INT(statement, 7, point_count);
+    }
+  }
+
+  sqlite3_step(statement);
+  // Reliable only because every caller of this function runs inside a
+  // dt_database_start_transaction() block: that holds dt_database_threadsafe_lock() as writer
+  // for its whole duration, so no other thread's INSERT on this shared connection can land
+  // between our sqlite3_step() and this read and get misattributed to us.
+  const int64_t rowid = sqlite3_last_insert_rowid(dt_database_get_sqlite3_global());
+  dt_free(point_buffer);
+
+  dt_pthread_mutex_unlock(&_masks_history_write_stmt_mutex);
+
+  return rowid;
 }
 
 void dt_masks_free_form(dt_masks_form_t *mask_form)

--- a/src/iop/spots.c
+++ b/src/iop/spots.c
@@ -190,7 +190,7 @@ int legacy_params(dt_iop_module_t *self, const void *const old_params, const int
       {
         bp->mask_id = form->formid;
       }
-      dt_masks_write_masks_history_item(self->dev->image_storage.id, last_spot_num, form);
+      dt_masks_write_masks_history_item(self->dev->image_storage.id, last_spot_num, form, 0);
     }
 
     return 0;


### PR DESCRIPTION
## Summary
- Adds a single self-referencing `content_ref` column to `main.masks_history` (no table split, no data migration) and detects unchanged forms by pointer identity, avoiding a full points BLOB re-serialization on every commit for forms that haven't changed.
- Bundles two independent write-time fixes found in the same code path: `dt_dev_write_history_ext()` now wraps its delete+rewrite in a single transaction (was N+M separate autocommits), and `dt_masks_write_masks_history_item()` caches its prepared statement. Measured ~3.6x faster (8.79ms → 2.47ms mean) on a heavily-masked image.
- XMP gets the matching size reduction: `DT_XMP_EXIF_VERSION` bumps 5→6, referencing entries carry `mask_content_ref` instead of full points/nb/src, resolved by the new `read_masks_v6()`. Older files (`xmp_version` 2-5) are unaffected.
- Along the way, found and fixed an unrelated, pre-existing `history_mutex` self-deadlock in `common/dtpthread.h` (already merged directly to `master` in a separate commit, `16fe4f739f`, since it's a general concurrency bug unrelated to this schema work).

Full design rationale and the manual verification log are in `doc/masks_history_dedup.md`.

## Not for merge yet
Per the hard constraint documented in `doc/masks_history_dedup.md`: this bumps `CURRENT_DATABASE_VERSION_LIBRARY` (36→37) and `DT_XMP_EXIF_VERSION` (5→6). The DB version bump alone touches every user's database on next startup regardless of whether the write-dedup logic ever runs, and blocks downgrading to an older build. **Stays open as draft, not merged to `master` until the project version is actually bumped to the next vrsion.**

## Test plan
- [x] Shape loading / editing
- [x] Lighttable undo/redo
- [x] Copying/duplicating history to another image
- [x] XMP export then reimport (v6 round-trip)
- [x] History compression
- [x] Unknown `xmp_version` rejected cleanly (no crash, no partial DB write)
- [ ] `iop/spots.c` legacy path (intentionally skipped — deprecated module)
