### PR TITLE
Common: the last dialogs leave the backend (history actions, folder survey)

### DIFF
--- a/doc/include-hygiene-roadmap.md
+++ b/doc/include-hygiene-roadmap.md
@@ -557,3 +557,43 @@ only commits if that scan reports a change. Removing it would run that scan on e
 mouse-motion event of a mask drag. Different mechanism, different cost, no request behind
 touching it.
 
+
+## 12. The last GUI calls in `common/`
+
+Two of the three remaining files are done (PR after #1106):
+
+* **`history_actions.c`** — a *relocation*. Three of its functions asked the user something
+  (`dt_history_copy_parts`, `dt_history_paste_parts_prepare`, `delete_history_callback`) and
+  were the only reason it included `gui/hist_dialog.h`, `gui/gtk.h` and `gui/actions/menu.h`.
+  Both callers already live above this layer, so no handler slot was needed.
+* **`folder_survey.c`** — one relocation and one *inversion*. The resume-at-startup prompt is
+  GUI orchestration end to end and moved whole; the pending-import prompt is interleaved with
+  private session state under the survey lock, so it goes through a handler registered from
+  `dt_gui_gtk_init()`, next to the film and collection ones.
+
+### `common/database.c` — analysed, not done
+
+Three dialogs (~120 lines, 88 GTK tokens), all inside `dt_database_init()` and gated by its
+`has_gui` argument: "database is read-only", and two "error opening database" variants that
+offer to delete lock files or restore a snapshot.
+
+They were left out of the `dt_database_take_error()` inversion in #1103 for a concrete
+reason: that pattern has the backend *record* an error for the caller to report afterwards,
+and these three are **interactive mid-init** — the user's answer decides whether init
+continues, retries or aborts, so there is nothing to report afterwards to.
+
+A handler slot does work, and the ordering allows it:
+
+```
+darktable.c:1244   gtk_init()              <- GTK is up
+darktable.c:1259   dt_database_init()      <- the dialogs run here
+darktable.c:1402   dt_gui_gtk_init()       <- too late to register from
+```
+
+So registration cannot go where the film/collection/folder-survey handlers go. It belongs in
+`darktable.c` between those two lines, guarded by `init_gui` — legitimate, since `darktable.c`
+is the app layer and is the thing that knows whether there will be a GUI at all.
+
+Each of the three has a different button set and different return semantics, so the slot
+wants a small enum of outcomes rather than a boolean. That, plus the fact that it sits on the
+startup path where a mistake is not subtle, is why it is its own piece of work.

--- a/doc/include-hygiene-roadmap.md
+++ b/doc/include-hygiene-roadmap.md
@@ -571,29 +571,34 @@ Two of the three remaining files are done (PR after #1106):
   private session state under the survey lock, so it goes through a handler registered from
   `dt_gui_gtk_init()`, next to the film and collection ones.
 
-### `common/database.c` — analysed, not done
+### `common/database.c` — done
 
-Three dialogs (~120 lines, 88 GTK tokens), all inside `dt_database_init()` and gated by its
-`has_gui` argument: "database is read-only", and two "error opening database" variants that
-offer to delete lock files or restore a snapshot.
+Three dialogs (~120 lines, 88 GTK tokens), all inside `dt_database_init()`: "database is
+read-only", and two "error opening database" variants offering to restore a snapshot or
+delete and start over.
 
 They were left out of the `dt_database_take_error()` inversion in #1103 for a concrete
 reason: that pattern has the backend *record* an error for the caller to report afterwards,
-and these three are **interactive mid-init** — the user's answer decides whether init
-continues, retries or aborts, so there is nothing to report afterwards to.
+and these are **interactive mid-init** — the answer decides whether init aborts, restores or
+starts over, so there is no "afterwards" to report to. The backend therefore states the
+question and takes back a value: `dt_database_prompt_t` in, `dt_database_response_t` out.
 
-A handler slot does work, and the ordering allows it:
+Registration cannot go where the film/collection/folder-survey handlers go:
 
 ```
 darktable.c:1244   gtk_init()              <- GTK is up
-darktable.c:1259   dt_database_init()      <- the dialogs run here
+darktable.c:1259   dt_database_init()      <- the prompts happen here
 darktable.c:1402   dt_gui_gtk_init()       <- too late to register from
 ```
 
-So registration cannot go where the film/collection/folder-survey handlers go. It belongs in
-`darktable.c` between those two lines, guarded by `init_gui` — legitimate, since `darktable.c`
-is the app layer and is the thing that knows whether there will be a GUI at all.
+It goes in `darktable.c` between the first two, guarded by `init_gui` — legitimate, since
+that is the only thing which knows this early whether there will be anybody to ask.
 
-Each of the three has a different button set and different return semantics, so the slot
-wants a small enum of outcomes rather than a boolean. That, plus the fact that it sits on the
-startup path where a mistake is not subtle, is why it is its own piece of work.
+With no handler every prompt answers `CLOSE`. That is not a fallback that guesses: a corrupt
+database is not deleted or restored on the strength of a question nobody was asked. It also
+closes a latent headless bug — these dialogs had **no `has_gui` guard at all**, so a run
+without a GUI reached `gtk_dialog_new_with_buttons()` on a GTK that `ansel-cli` never
+initialises. Registration is the guard now.
+
+`common/database.c` is down to zero GTK tokens. Its remaining `gui/legacy_presets.h` include
+is a different problem (preset migration, not a dialog) and is left for its own pass.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -88,6 +88,7 @@ FILE(GLOB SOURCE_FILES
   "gui/common/collection_gui.c"
   "gui/common/database_gui.c"
   "gui/common/film_gui.c"
+  "gui/common/history_actions_gui.c"
   "gui/common/history_merge_gui.c"
   "gui/common/styles_gui.c"
   "common/history_snapshot.c"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -88,6 +88,7 @@ FILE(GLOB SOURCE_FILES
   "gui/common/collection_gui.c"
   "gui/common/database_gui.c"
   "gui/common/film_gui.c"
+  "gui/common/folder_survey_gui.c"
   "gui/common/history_actions_gui.c"
   "gui/common/history_merge_gui.c"
   "gui/common/styles_gui.c"

--- a/src/common/database.c
+++ b/src/common/database.c
@@ -2962,6 +2962,27 @@ gchar* _get_pragma_string_val(sqlite3 *db, const char* pragma)
   return val;
 }
 
+static dt_database_prompt_handler_t _prompt_handler = NULL;
+
+void dt_database_set_prompt_handler(dt_database_prompt_handler_t handler)
+{
+  _prompt_handler = handler;
+}
+
+/* Ask, or answer CLOSE if there is nobody to ask. Deliberately not a fallback that guesses:
+ * deleting or restoring a database is not something to do on nobody's authority. */
+static dt_database_response_t _ask_user(const dt_database_prompt_t prompt, const char *dbfilename,
+                                        const char *quick_check, const gboolean snapshot_available)
+{
+  if(IS_NULL_PTR(_prompt_handler))
+  {
+    fprintf(stderr, "[init] cannot ask the user about `%s': no prompt handler registered\n", dbfilename);
+    return DT_DATABASE_RESPONSE_CLOSE;
+  }
+
+  return _prompt_handler(prompt, dbfilename, quick_check, snapshot_available);
+}
+
 dt_database_t *dt_database_init(const char *alternative, const gboolean load_data, const gboolean has_gui)
 {
   /*  set the threading mode to Serialized */
@@ -3083,31 +3104,10 @@ start:
   {
     fprintf(stderr, "%s database is read only. Abort...\n", db->dbfilename_library);
 
-    GtkWidget *dialog;
-    GtkDialogFlags dflags = GTK_DIALOG_MODAL | GTK_DIALOG_DESTROY_WITH_PARENT;
-
-    dialog = gtk_dialog_new_with_buttons(_("Ansel - Database is read-only"),
-                                           NULL, dflags,
-                                           _("Close Ansel"), GTK_RESPONSE_CLOSE, NULL);
-    gtk_dialog_set_default_response(GTK_DIALOG(dialog), GTK_RESPONSE_CLOSE);
-    char *label_options
-        = g_strdup_printf(_("<span weight='bold'>Ansel library database is read-only</span>\n\n"
-                            "This happens if you don't have permissions to write on the filesystem\n"
-                            "or if you have restored a write-protected backup snapshot.\n\n"
-                            "Please change the filesystem access permissions for:\n\n"
-                            "\t<span style='italic'>%s</span>"),
-                          db->dbfilename_library);
-
-    GtkWidget *content_area = gtk_dialog_get_content_area(GTK_DIALOG (dialog));
-    GtkWidget *label = gtk_label_new(NULL);
-    gtk_label_set_markup(GTK_LABEL(label), label_options);
-    gtk_container_add(GTK_CONTAINER (content_area), label);
-    gtk_widget_show_all(content_area);
-    gtk_dialog_run(GTK_DIALOG(dialog));
-    gtk_widget_destroy(dialog);
+    // Informational: there is nothing the user can decide here, only be told.
+    _ask_user(DT_DATABASE_PROMPT_READONLY, db->dbfilename_library, NULL, FALSE);
     dt_database_destroy(db);
     dt_free(dbname);
-    dt_free(label_options);
     db = NULL;
     return NULL;
   }
@@ -3209,75 +3209,18 @@ start:
 
       gchar *data_snap = dt_database_get_most_recent_snap(dbfilename_data);
 
-      GtkWidget *dialog;
-      GtkDialogFlags dflags = GTK_DIALOG_MODAL | GTK_DIALOG_DESTROY_WITH_PARENT;
-
-      const char* label_options = NULL;
-
-      if(data_snap)
-      {
-        dialog = gtk_dialog_new_with_buttons(_("ansel - error opening database"),
-                                            NULL,
-                                            dflags,
-                                            _("close Ansel"),
-                                            GTK_RESPONSE_CLOSE,
-                                            _("attempt restore"),
-                                            GTK_RESPONSE_ACCEPT,
-                                            _("delete database"),
-                                            GTK_RESPONSE_REJECT,
-                                            NULL);
-        gtk_dialog_set_default_response(GTK_DIALOG(dialog), GTK_RESPONSE_ACCEPT);
-        label_options = _("do you want to close Ansel now to manually restore\n"
-                          "the database from a backup, attempt an automatic restore\n"
-                          "from the most recent snapshot or delete the corrupted database\n"
-                          "and start with a new one?");
-      }
-      else
-      {
-        dialog = gtk_dialog_new_with_buttons(_("ansel - error opening database"),
-                                            NULL,
-                                            dflags,
-                                            _("close Ansel"),
-                                            GTK_RESPONSE_CLOSE,
-                                            _("delete database"),
-                                            GTK_RESPONSE_REJECT,
-                                            NULL);
-        gtk_dialog_set_default_response(GTK_DIALOG(dialog), GTK_RESPONSE_CLOSE);
-        label_options = _("do you want to close Ansel now to manually restore\n"
-                          "the database from a backup or delete the corrupted database\n"
-                          "and start with a new one?");
-      }
-
-
-
-      char *label_text = g_markup_printf_escaped(_("an error has occurred while trying to open the database from\n"
-                                                   "\n"
-                                                   "<span style='italic'>%s</span>\n"
-                                                   "\n"
-                                                   "it seems that the database is corrupted.\n"
-                                                   "%s"
-                                                   "%s"),
-                                                 dbfilename_data, quick_check_text, label_options);
+      // The user's answer decides whether init aborts, restores or starts fresh, so it has to
+      // come back as a value. Everything about how it is obtained -- and whether anybody can be
+      // asked at all -- belongs to whoever registered the handler.
+      const dt_database_response_t resp
+          = _ask_user(DT_DATABASE_PROMPT_CORRUPTED, dbfilename_data, quick_check_text, data_snap != NULL);
 
       dt_free(quick_check_text);
-      dt_free(data_status);
-
-      GtkWidget *content_area = gtk_dialog_get_content_area(GTK_DIALOG (dialog));
-      GtkWidget *label = gtk_label_new(NULL);
-      gtk_label_set_markup(GTK_LABEL(label), label_text);
-      dt_free(label_text);
-      gtk_container_add(GTK_CONTAINER (content_area), label);
-
-      gtk_widget_show_all(content_area);
-
-      const int resp = gtk_dialog_run(GTK_DIALOG(dialog));
-
-      gtk_widget_destroy(dialog);
 
       dt_database_destroy(db);
       db = NULL;
 
-      if(resp != GTK_RESPONSE_ACCEPT && resp != GTK_RESPONSE_REJECT)
+      if(resp != DT_DATABASE_RESPONSE_RESTORE && resp != DT_DATABASE_RESPONSE_DELETE)
       {
         fprintf(stderr, "[init] database `%s' is corrupt and can't be opened! either replace it from a backup or "
         "delete the file so that darktable can create a new one the next time. aborting\n", dbfilename_data);
@@ -3294,7 +3237,7 @@ start:
       else
         fprintf(stderr, " ... failed\n");
 
-      if(resp == GTK_RESPONSE_ACCEPT && data_snap)
+      if(resp == DT_DATABASE_RESPONSE_RESTORE && data_snap)
       {
         fprintf(stderr, "[init] restoring `%s' from `%s'...", dbfilename_data, data_snap);
         GError *gerror = NULL;
@@ -3387,73 +3330,18 @@ start:
 
     gchar *data_snap = dt_database_get_most_recent_snap(dbfilename_library);
 
-    GtkWidget *dialog;
-    GtkDialogFlags dflags = GTK_DIALOG_MODAL | GTK_DIALOG_DESTROY_WITH_PARENT;
-
-    const char* label_options = NULL;
-
-    if(data_snap)
-    {
-      dialog = gtk_dialog_new_with_buttons(_("ansel - error opening database"),
-                                          NULL,
-                                          dflags,
-                                          _("close Ansel"),
-                                          GTK_RESPONSE_CLOSE,
-                                          _("attempt restore"),
-                                          GTK_RESPONSE_ACCEPT,
-                                          _("delete database"),
-                                          GTK_RESPONSE_REJECT,
-                                          NULL);
-      gtk_dialog_set_default_response(GTK_DIALOG(dialog), GTK_RESPONSE_ACCEPT);
-      label_options = _("do you want to close Ansel now to manually restore\n"
-                        "the database from a backup, attempt an automatic restore\n"
-                        "from the most recent snapshot or delete the corrupted database\n"
-                        "and start with a new one?");
-    }
-    else
-    {
-      dialog = gtk_dialog_new_with_buttons(_("ansel - error opening database"),
-                                          NULL,
-                                          dflags,
-                                          _("close Ansel"),
-                                          GTK_RESPONSE_CLOSE,
-                                          _("delete database"),
-                                          GTK_RESPONSE_REJECT,
-                                          NULL);
-      gtk_dialog_set_default_response(GTK_DIALOG(dialog), GTK_RESPONSE_CLOSE);
-      label_options = _("do you want to close Ansel now to manually restore\n"
-                        "the database from a backup or delete the corrupted database\n"
-                        "and start with a new one?");
-    }
-
-    char *label_text = g_markup_printf_escaped(_("an error has occurred while trying to open the database from\n"
-                                                 "\n"
-                                                 "<span style='italic'>%s</span>\n"
-                                                 "\n"
-                                                 "it seems that the database is corrupted.\n"
-                                                 "%s"
-                                                 "%s"),
-                                               dbfilename_data, quick_check_text, label_options);
+    // The user's answer decides whether init aborts, restores or starts fresh, so it has to
+    // come back as a value. Everything about how it is obtained -- and whether anybody can be
+    // asked at all -- belongs to whoever registered the handler.
+    const dt_database_response_t resp
+        = _ask_user(DT_DATABASE_PROMPT_CORRUPTED, dbfilename_library, quick_check_text, data_snap != NULL);
 
     dt_free(quick_check_text);
-    dt_free(libdb_status);
-
-    GtkWidget *content_area = gtk_dialog_get_content_area(GTK_DIALOG (dialog));
-    GtkWidget *label = gtk_label_new(NULL);
-    gtk_label_set_markup(GTK_LABEL(label), label_text);
-    dt_free(label_text);
-    gtk_container_add(GTK_CONTAINER (content_area), label);
-
-    gtk_widget_show_all(content_area);
-
-    const int resp = gtk_dialog_run(GTK_DIALOG(dialog));
-
-    gtk_widget_destroy(dialog);
 
     dt_database_destroy(db);
     db = NULL;
 
-    if(resp != GTK_RESPONSE_ACCEPT && resp != GTK_RESPONSE_REJECT)
+    if(resp != DT_DATABASE_RESPONSE_RESTORE && resp != DT_DATABASE_RESPONSE_DELETE)
     {
       fprintf(stderr, "[init] database `%s' is corrupt and can't be opened! either replace it from a backup or "
         "delete the file so that darktable can create a new one the next time. aborting\n", dbfilename_library);
@@ -3470,7 +3358,7 @@ start:
     else
       fprintf(stderr, " ... failed\n");
 
-    if(resp == GTK_RESPONSE_ACCEPT && data_snap)
+    if(resp == DT_DATABASE_RESPONSE_RESTORE && data_snap)
     {
       fprintf(stderr, "[init] restoring `%s' from `%s'...", dbfilename_library, data_snap);
       GError *gerror = NULL;

--- a/src/common/database.h
+++ b/src/common/database.h
@@ -74,6 +74,55 @@ void dt_database_take_error(struct dt_database_t *db, dt_database_error_t *error
 /** Release the strings owned by `error`. */
 void dt_database_error_free(dt_database_error_t *error);
 
+/* Questions dt_database_init() must ask before it can continue.
+ *
+ * These are NOT the dt_database_error_t path below. That one records what went wrong for
+ * whoever can report it afterwards; these three happen mid-init and the answer decides
+ * whether init aborts, restores from a snapshot, or starts over -- there is no "afterwards"
+ * to report to. So the backend states the question and takes back a value, and every trace
+ * of how it is put to the user lives in gui/common/database_gui.c.
+ */
+typedef enum dt_database_prompt_t
+{
+  /** The library database cannot be written to. Informational: nothing to decide. */
+  DT_DATABASE_PROMPT_READONLY = 0,
+  /** The database is corrupt. Offer to close, restore a snapshot, or delete and start over. */
+  DT_DATABASE_PROMPT_CORRUPTED
+} dt_database_prompt_t;
+
+typedef enum dt_database_response_t
+{
+  /** Give up and abort startup. Also what a caller with no handler gets. */
+  DT_DATABASE_RESPONSE_CLOSE = 0,
+  /** Delete the corrupt file and restore the most recent snapshot over it. */
+  DT_DATABASE_RESPONSE_RESTORE,
+  /** Delete the corrupt file and start with a fresh database. */
+  DT_DATABASE_RESPONSE_DELETE
+} dt_database_response_t;
+
+/** Put @p prompt to the user and return their answer.
+ *
+ *  @param dbfilename          the database file the question is about.
+ *  @param quick_check         sqlite's quick_check output, or NULL. Never NULL-terminated markup:
+ *                             the handler escapes it, since only the handler knows the format.
+ *  @param snapshot_available  TRUE when a snapshot exists, i.e. RESTORE is worth offering. */
+typedef dt_database_response_t (*dt_database_prompt_handler_t)(dt_database_prompt_t prompt,
+                                                               const char *dbfilename,
+                                                               const char *quick_check,
+                                                               gboolean snapshot_available);
+
+/** Install the handler dt_database_init() asks through. NULL removes it.
+ *
+ *  Must be registered BEFORE dt_database_init() runs -- which is before dt_gui_gtk_init(),
+ *  so this one cannot go where the film/collection/folder-survey handlers go. darktable.c
+ *  registers it, being the only thing that knows this early whether there will be a GUI.
+ *
+ *  With no handler, every prompt answers CLOSE: a corrupt database is not deleted or
+ *  restored on the strength of a question nobody was asked. That is also what makes a
+ *  headless run safe -- these dialogs used to be built unconditionally, with no has_gui
+ *  guard, on a GTK that ansel-cli never initialises. */
+void dt_database_set_prompt_handler(dt_database_prompt_handler_t handler);
+
 /** Delete data.db.lock and library.db.lock beside `dbfilename`. Returns 0 when every lock
  *  file that existed was removed. Call only once the user has agreed. */
 int dt_database_delete_lock_files(const char *dbfilename);

--- a/src/common/folder_survey.c
+++ b/src/common/folder_survey.c
@@ -24,8 +24,6 @@
 #include "control/control.h"
 #include "control/jobs.h"
 #include "control/jobs/import_jobs.h"
-#include "gui/gtk.h"
-#include "views/view.h"
 
 #include <gio/gio.h>
 #include "common/utility.h"
@@ -810,55 +808,39 @@ void dt_folder_survey_init()
   dt_free(base_dir);
 }
 
-/**
- * @brief Ask whether images already sitting in the source folder should be
- * imported right away, instead of being silently absorbed into the
- * baseline.
- *
- * Runs every time monitoring starts: a plain Start on a never-before-
- * surveyed folder would otherwise treat its existing content as the
- * baseline without importing it, and a resumed session would otherwise
- * import files that appeared while the application was closed without
- * asking. Declining absorbs every currently observed file into the
- * baseline so a later scan does not import it behind the user's back.
- * Accepting on a folder with no baseline yet seeds an initialized, empty
- * one so the next scan treats those files as new pending imports instead
- * of silently absorbing them.
- */
+static dt_folder_survey_confirm_import_handler_t _confirm_import_handler = NULL;
+
+void dt_folder_survey_set_confirm_import_handler(dt_folder_survey_confirm_import_handler_t handler)
+{
+  _confirm_import_handler = handler;
+}
+
 static void _folder_survey_offer_pending_import()
 {
   const int new_files = dt_folder_survey_count_new_files();
   if(new_files <= 0) return;
 
-  GtkWindow *parent = GTK_WINDOW(dt_gui_main_window());
-  GtkWidget *dialog = gtk_message_dialog_new(
-      parent, GTK_DIALOG_DESTROY_WITH_PARENT | GTK_DIALOG_MODAL, GTK_MESSAGE_QUESTION, GTK_BUTTONS_YES_NO,
-      ngettext("%d image in the surveyed folder is not in the library yet.\nImport it now?",
-               "%d images in the surveyed folder are not in the library yet.\nImport them now?",
-               new_files),
-      new_files);
-
-  GtkWidget *delete_check
-      = gtk_check_button_new_with_label(_("Delete the originals after verifying the complete copies"));
-  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(delete_check),
-                               dt_conf_get_bool("studio_capture/delete_source"));
-  gtk_widget_set_sensitive(delete_check, dt_conf_get_bool("studio_capture/copy"));
-  gtk_box_pack_start(GTK_BOX(gtk_message_dialog_get_message_area(GTK_MESSAGE_DIALOG(dialog))), delete_check,
-                     FALSE, FALSE, DT_GUI_BOX_SPACING);
-  gtk_widget_show_all(dialog);
-
-  const int import_now = gtk_dialog_run(GTK_DIALOG(dialog));
-  if(import_now == GTK_RESPONSE_YES && dt_conf_get_bool("studio_capture/copy"))
-    dt_conf_set_bool("studio_capture/delete_source",
-                     gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(delete_check)));
-  gtk_widget_destroy(dialog);
-
-  if(import_now != GTK_RESPONSE_YES)
+  if(IS_NULL_PTR(_confirm_import_handler))
   {
+    // Nobody registered to ask. Do NOT absorb: absorbing is the answer to a question that
+    // was never put, and it would silently make these files invisible to every later scan.
+    // Leaving the state untouched keeps them pending, to be offered whenever someone can ask.
+    dt_print(DT_DEBUG_CONTROL,
+             "[folder_survey] %d new file(s) pending, but no handler to ask about importing them\n",
+             new_files);
+    return;
+  }
+
+  if(!_confirm_import_handler(new_files))
+  {
+    // Declined: absorb every currently observed file into the baseline so a later scan does
+    // not import it behind the user's back.
     dt_folder_survey_absorb_new_files();
     return;
   }
 
+  // Accepted on a folder with no baseline yet: seed an initialized, empty one so the next
+  // scan treats those files as new pending imports instead of silently absorbing them.
   dt_pthread_mutex_lock(&_folder_survey.lock);
   if(!_folder_survey.baseline_initialized)
   {
@@ -1037,40 +1019,20 @@ void dt_folder_survey_absorb_new_files()
   g_hash_table_destroy(observed);
 }
 
-gboolean dt_folder_survey_propose_resume()
+gboolean dt_folder_survey_take_session_marker()
 {
-  if(!dt_folder_survey_session_was_active()) return G_SOURCE_REMOVE;
+  // Consumed, not merely read: the resume question must be asked at most once per start,
+  // whatever the answer, so clearing here is the point rather than a side effect.
+  if(!dt_folder_survey_session_was_active()) return FALSE;
   _folder_survey.was_active_last_session = FALSE;
+  return TRUE;
+}
 
-  char *folder = dt_conf_get_string("studio_capture/folder");
-  GtkWindow *parent = GTK_WINDOW(dt_gui_main_window());
-
-  GtkWidget *dialog = gtk_message_dialog_new(
-      parent, GTK_DIALOG_DESTROY_WITH_PARENT | GTK_DIALOG_MODAL, GTK_MESSAGE_QUESTION, GTK_BUTTONS_YES_NO,
-      _("A studio capture session was monitoring `%s` when Ansel was last closed.\n"
-        "Resume the session?"),
-      folder ? folder : "");
-  const int resume = gtk_dialog_run(GTK_DIALOG(dialog));
-  gtk_widget_destroy(dialog);
-
-  if(resume != GTK_RESPONSE_YES)
-  {
-    // Clear the persisted marker so the question is not asked again.
-    dt_pthread_mutex_lock(&_folder_survey.lock);
-    _folder_survey_save_locked();
-    dt_pthread_mutex_unlock(&_folder_survey.lock);
-    dt_free(folder);
-    return G_SOURCE_REMOVE;
-  }
-
-  dt_view_manager_switch(dt_view_manager_get_global(), "studio_capture");
-
-  // dt_folder_survey_start() itself offers to import any images already
-  // sitting in the folder, covering files that appeared while Ansel was
-  // closed the same way it covers a plain session start.
-  dt_folder_survey_start();
-  dt_free(folder);
-  return G_SOURCE_REMOVE;
+void dt_folder_survey_forget_session()
+{
+  dt_pthread_mutex_lock(&_folder_survey.lock);
+  _folder_survey_save_locked();
+  dt_pthread_mutex_unlock(&_folder_survey.lock);
 }
 
 void dt_folder_survey_cleanup()

--- a/src/common/folder_survey.h
+++ b/src/common/folder_survey.h
@@ -86,17 +86,39 @@ int dt_folder_survey_count_new_files();
  */
 void dt_folder_survey_absorb_new_files();
 
-/**
- * @brief Propose to resume an interrupted studio session at application start.
+/* Two questions this module needs a user for, and cannot ask itself.
  *
- * When the previous session quit while monitoring, ask the user whether to
- * resume; on acceptance, switch to the Studio Capture view, then ask whether
- * files that appeared meanwhile should be imported now (with an optional
- * delete-source-after-verified-copy). Call after the GUI and views are ready.
- *
- * @return gboolean always G_SOURCE_REMOVE, so it can be scheduled with g_idle_add().
+ * The resume-at-startup prompt is pure GUI orchestration (ask, switch view, start) and
+ * lives whole in gui/common/folder_survey_gui.c; only the session marker below is backend.
+ * The pending-import prompt is interleaved with private session state, so it is inverted
+ * instead: the backend asks through a handler the GUI registers.
  */
-gboolean dt_folder_survey_propose_resume();
+
+/** Ask whether the @p new_files images found in the surveyed folder should be imported now.
+ *  Return TRUE to import them, FALSE to absorb them into the baseline.
+ *
+ *  With no handler registered the question is not asked AND nothing is absorbed: absorbing
+ *  is the answer to a question nobody put, and would silently hide those files from every
+ *  later scan. They stay pending instead. */
+typedef gboolean (*dt_folder_survey_confirm_import_handler_t)(int new_files);
+
+/** Install the handler that asks about pending imports. NULL removes it. */
+void dt_folder_survey_set_confirm_import_handler(dt_folder_survey_confirm_import_handler_t handler);
+
+/**
+ * @brief Consume the "a session was monitoring when we last closed" marker.
+ *
+ * Returns TRUE when the previous run quit while monitoring, and clears the in-memory marker
+ * either way, so the resume question is asked at most once per start. Persist the cleared
+ * marker with dt_folder_survey_forget_session() if the user declines; accepting leads to
+ * dt_folder_survey_start(), which persists it itself.
+ */
+gboolean dt_folder_survey_take_session_marker();
+
+/**
+ * @brief Persist the cleared session marker, so resume is not proposed again.
+ */
+void dt_folder_survey_forget_session();
 
 /**
  * @brief Stop new scans before control workers begin shutting down.

--- a/src/common/history_actions.c
+++ b/src/common/history_actions.c
@@ -32,9 +32,6 @@
 #include "develop/dev_history.h"
 #include "develop/develop.h"
 #include "develop/imageop.h"
-#include "gui/actions/menu.h"
-#include "gui/gtk.h"
-#include "gui/hist_dialog.h"
 #include "views/view.h"
 
 #ifdef GDK_WINDOWING_QUARTZ
@@ -229,20 +226,6 @@ gboolean dt_history_copy(int32_t imgid)
   return TRUE;
 }
 
-gboolean dt_history_copy_parts(int32_t imgid)
-{
-  if(dt_history_copy(imgid))
-  {
-    // run dialog, it will insert into selops the selected moduel
-
-    if(dt_gui_hist_dialog_new(&(dt_view_manager_get_global()->copy_paste), imgid, TRUE) == GTK_RESPONSE_CANCEL)
-      return FALSE;
-    return TRUE;
-  }
-  else
-    return FALSE;
-}
-
 typedef struct _paste_action_ctx_t
 {
   dt_hm_batch_state_t batch;
@@ -277,22 +260,6 @@ gboolean dt_history_paste_on_list(const GList *list)
   const gboolean changed = _history_action_on_list(list, _history_paste_apply, &ctx);
   dt_hm_batch_state_cleanup(&ctx.batch);
   return changed;
-}
-
-gboolean dt_history_paste_parts_prepare(void)
-{
-  dt_history_copy_item_t *copy_paste = &dt_view_manager_get_global()->copy_paste;
-  if(copy_paste->copied_imageid <= 0) return FALSE;
-
-  // we launch the dialog
-  const int res = dt_gui_hist_dialog_new(copy_paste, copy_paste->copied_imageid, FALSE);
-
-  if(res != GTK_RESPONSE_OK)
-  {
-    return FALSE;
-  }
-
-  return TRUE;
 }
 
 static gboolean _history_paste_parts_apply(const int32_t imgid, void *user_data)
@@ -453,70 +420,6 @@ gboolean dt_history_delete_on_list(const GList *list, gboolean undo)
 {
   dt_history_delete_params_t params = { .undo = undo };
   return _history_action_on_list_with_undo(list, _history_delete_apply, &params, undo);
-}
-
-gboolean delete_history_callback(GtkAccelGroup *group, GObject *acceleratable, guint keyval, GdkModifierType mods, gpointer user_data)
-{
-  if(!has_active_images()) return FALSE;
-
-  GList *imgs = dt_act_on_get_images();
-  if(IS_NULL_PTR(imgs)) return FALSE;
-
-  if(dt_conf_get_bool("ask_before_discard"))
-  {
-    const int img_count = g_list_length(imgs);
-    const GtkWidget *win = dt_gui_main_window();
-    GtkWidget *dialog = gtk_message_dialog_new(
-        GTK_WINDOW(win), GTK_DIALOG_DESTROY_WITH_PARENT, GTK_MESSAGE_QUESTION, GTK_BUTTONS_YES_NO,
-        ngettext("Do you really want to clear history of %d image?",
-                 "Do you really want to clear history of %d images?", img_count),
-        img_count);
-#ifdef GDK_WINDOWING_QUARTZ
-    dt_osx_disallow_fullscreen(dialog);
-#endif
-    gtk_window_set_title(GTK_WINDOW(dialog), ngettext("Delete image's history?", "Delete images' history?", img_count));
-
-    GtkWidget *message_area = gtk_message_dialog_get_message_area(GTK_MESSAGE_DIALOG(dialog));
-    GtkWidget *ask_check = gtk_check_button_new_with_label(_("Always ask"));
-    gtk_widget_set_tooltip_text(ask_check,
-        _("when unchecked, history will be deleted silently from now on without this confirmation.\n"
-          "you can turn it back on from preferences."));
-    gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(ask_check), TRUE);
-    gtk_box_pack_start(GTK_BOX(message_area), ask_check, FALSE, FALSE, 6);
-    gtk_widget_show(ask_check);
-
-    const gint res = gtk_dialog_run(GTK_DIALOG(dialog));
-    dt_conf_set_bool("ask_before_discard", gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(ask_check)));
-    gtk_widget_destroy(dialog);
-    dt_gui_refocus_parent(GTK_WINDOW(win));
-    if(res != GTK_RESPONSE_YES)
-    {
-      g_list_free(imgs);
-      return TRUE;
-    }
-  }
-
-  gboolean is_darkroom_image_in_list = dt_dev_history_is_image_in_dev(imgs);
-
-  dt_develop_t *dev = dt_dev_get_global();
-
-  if(is_darkroom_image_in_list)
-  {
-    dt_dev_undo_start_record(dev);
-  }
-
-  dt_history_delete_on_list(imgs, TRUE);
-
-  if(is_darkroom_image_in_list)
-  {
-    dt_dev_undo_end_record(dev);
-    dt_apply_dev_history_update(dev);
-  }
-
-  dt_control_queue_redraw_center();
-  g_list_free(imgs);
-  imgs = NULL;
-  return TRUE;
 }
 
 typedef struct dt_history_style_params_t

--- a/src/common/history_actions.h
+++ b/src/common/history_actions.h
@@ -20,16 +20,13 @@
 #define DT_COMMON_HISTORY_ACTIONS_H
 
 #include <glib.h>
-#include <gtk/gtk.h>
 #include <inttypes.h>
 
 #include "common/history_merge.h"
 
 /** copy history from imgid and pasts on selected images, merge or overwrite... */
 gboolean dt_history_copy(int32_t imgid);
-gboolean dt_history_copy_parts(int32_t imgid);
 gboolean dt_history_paste_on_list(const GList *list);
-gboolean dt_history_paste_parts_prepare(void);
 gboolean dt_history_paste_parts_on_list(const GList *list);
 gboolean dt_history_paste_on_image(const int32_t imgid);
 gboolean dt_history_paste_parts_on_image(const int32_t imgid);
@@ -48,12 +45,6 @@ void dt_history_compress_on_image(const int32_t imgid);
 
 /** delete historystack of selected images */
 gboolean dt_history_delete_on_list(const GList *list, gboolean undo);
-
-/** GUI entry point: confirm (if configured) then delete history of the active images.
-    Shared verbatim between the Edit menu's "Delete history" action and the darkroom
-    history module's reset button -- see common/history_actions.c. */
-gboolean delete_history_callback(GtkAccelGroup *group, GObject *acceleratable, guint keyval, GdkModifierType mods,
-                                 gpointer user_data);
 
 /** load a dt file and applies to selected images */
 int dt_history_load_and_apply_on_list(gchar *filename, const GList *list);

--- a/src/darktable.c
+++ b/src/darktable.c
@@ -1256,6 +1256,12 @@ int dt_init(int argc, char *argv[], const gboolean init_gui, const gboolean load
   gboolean recheck_needed = TRUE;
   while (recheck_needed)
   {
+    // Before, not after: dt_database_init() can hit a read-only or corrupt database and needs
+    // to ask the user what to do about it, and dt_gui_gtk_init() -- where every other backend
+    // handler is registered -- only runs much further down. This is the only place that knows
+    // this early whether there will be anybody to ask.
+    if(init_gui) dt_database_gui_register_handlers();
+
     darktable.db = dt_database_init(dbfilename_from_command, load_data, init_gui);
     if(IS_NULL_PTR(darktable.db))
     {

--- a/src/darktable.c
+++ b/src/darktable.c
@@ -130,6 +130,7 @@
 #include "common/file_location.h"
 #include "common/film.h"
 #include "common/folder_survey.h"
+#include "gui/common/folder_survey_gui.h"
 #include "common/grealpath.h"
 #include "common/image.h"
 #include "common/image_cache.h"

--- a/src/gui/actions/edit.c
+++ b/src/gui/actions/edit.c
@@ -19,6 +19,7 @@
 #include "common/conf.h"
 #include "common/act_on.h"
 #include "common/history_actions.h"
+#include "gui/common/history_actions_gui.h"
 #include "control/jobs/control_jobs.h"
 #include "gui/actions/menu.h"
 #ifdef __APPLE__
@@ -144,8 +145,9 @@ static gboolean compress_history_callback(GtkAccelGroup *group, GObject *acceler
   return TRUE;
 }
 
-// delete_history_callback() now lives in common/history_actions.c: it is shared
-// verbatim with the darkroom history module's reset button (see libs/history.c).
+// delete_history_callback() sits in gui/common/history_actions_gui.c rather than here with
+// its siblings: it is shared verbatim with the darkroom history module's reset button
+// (libs/history.c), so neither menu owns it.
 
 static gboolean copy_callback(GtkAccelGroup *group, GObject *acceleratable, guint keyval, GdkModifierType mods, gpointer user_data)
 {

--- a/src/gui/common/database_gui.c
+++ b/src/gui/common/database_gui.c
@@ -121,6 +121,97 @@ gboolean dt_database_show_error(struct dt_database_t *db)
   return error;
 }
 
+/* The three prompts dt_database_init() puts, now that it only states them.
+ *
+ * They were built inline in common/database.c with no has_gui guard at all, so a headless
+ * run reached gtk_dialog_new_with_buttons() on a GTK that ansel-cli never initialises.
+ * Registration is what gates them now, and darktable.c only registers when there is a GUI.
+ */
+static dt_database_response_t _database_prompt(const dt_database_prompt_t prompt, const char *dbfilename,
+                                               const char *quick_check, const gboolean snapshot_available)
+{
+  const GtkDialogFlags dflags = GTK_DIALOG_MODAL | GTK_DIALOG_DESTROY_WITH_PARENT;
+  GtkWidget *dialog = NULL;
+  char *label_text = NULL;
+
+  if(prompt == DT_DATABASE_PROMPT_READONLY)
+  {
+    dialog = gtk_dialog_new_with_buttons(_("Ansel - Database is read-only"), NULL, dflags,
+                                         _("Close Ansel"), GTK_RESPONSE_CLOSE, NULL);
+    gtk_dialog_set_default_response(GTK_DIALOG(dialog), GTK_RESPONSE_CLOSE);
+    label_text = g_markup_printf_escaped(_("<span weight='bold'>Ansel library database is read-only</span>\n\n"
+                                           "This happens if you don't have permissions to write on the filesystem\n"
+                                           "or if you have restored a write-protected backup snapshot.\n\n"
+                                           "Please change the filesystem access permissions for:\n\n"
+                                           "\t<span style='italic'>%s</span>"),
+                                         dbfilename);
+  }
+  else
+  {
+    const char *label_options;
+    if(snapshot_available)
+    {
+      dialog = gtk_dialog_new_with_buttons(_("ansel - error opening database"), NULL, dflags,
+                                           _("close Ansel"), GTK_RESPONSE_CLOSE,
+                                           _("attempt restore"), GTK_RESPONSE_ACCEPT,
+                                           _("delete database"), GTK_RESPONSE_REJECT, NULL);
+      gtk_dialog_set_default_response(GTK_DIALOG(dialog), GTK_RESPONSE_ACCEPT);
+      label_options = _("do you want to close Ansel now to manually restore\n"
+                        "the database from a backup, attempt an automatic restore\n"
+                        "from the most recent snapshot or delete the corrupted database\n"
+                        "and start with a new one?");
+    }
+    else
+    {
+      dialog = gtk_dialog_new_with_buttons(_("ansel - error opening database"), NULL, dflags,
+                                           _("close Ansel"), GTK_RESPONSE_CLOSE,
+                                           _("delete database"), GTK_RESPONSE_REJECT, NULL);
+      gtk_dialog_set_default_response(GTK_DIALOG(dialog), GTK_RESPONSE_CLOSE);
+      label_options = _("do you want to close Ansel now to manually restore\n"
+                        "the database from a backup or delete the corrupted database\n"
+                        "and start with a new one?");
+    }
+
+    // quick_check is sqlite output, i.e. arbitrary text landing in a markup label. Escaping
+    // is the handler's job because only the handler knows it is markup at all.
+    label_text = g_markup_printf_escaped(_("an error has occurred while trying to open the database from\n"
+                                           "\n"
+                                           "<span style='italic'>%s</span>\n"
+                                           "\n"
+                                           "it seems that the database is corrupted.\n"
+                                           "%s%s"),
+                                         dbfilename, IS_NULL_PTR(quick_check) ? "" : quick_check, label_options);
+  }
+
+  GtkWidget *content_area = gtk_dialog_get_content_area(GTK_DIALOG(dialog));
+  GtkWidget *label = gtk_label_new(NULL);
+  gtk_label_set_markup(GTK_LABEL(label), label_text);
+  dt_free(label_text);
+  gtk_container_add(GTK_CONTAINER(content_area), label);
+  gtk_widget_show_all(content_area);
+
+  const int resp = gtk_dialog_run(GTK_DIALOG(dialog));
+  gtk_widget_destroy(dialog);
+
+  switch(resp)
+  {
+    case GTK_RESPONSE_ACCEPT:
+      return DT_DATABASE_RESPONSE_RESTORE;
+    case GTK_RESPONSE_REJECT:
+      return DT_DATABASE_RESPONSE_DELETE;
+    default:
+      // Covers the window being closed outright, which must not be read as consent to
+      // delete anything.
+      return DT_DATABASE_RESPONSE_CLOSE;
+  }
+}
+
+void dt_database_gui_register_handlers(void)
+{
+  dt_database_set_prompt_handler(_database_prompt);
+}
+
+
 // clang-format off
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py
 // vim: shiftwidth=2 expandtab tabstop=2 cindent

--- a/src/gui/common/database_gui.h
+++ b/src/gui/common/database_gui.h
@@ -35,4 +35,9 @@ struct dt_database_t;
  *  to answer first. */
 gboolean dt_database_show_error(struct dt_database_t *db);
 
+/** Register the handler common/database.c puts its mid-init prompts through.
+ *  Must be called BEFORE dt_database_init(), so darktable.c does it -- dt_gui_gtk_init()
+ *  runs too late. See dt_database_set_prompt_handler(). */
+void dt_database_gui_register_handlers(void);
+
 #endif // DT_GUI_COMMON_DATABASE_GUI_H

--- a/src/gui/common/folder_survey_gui.c
+++ b/src/gui/common/folder_survey_gui.c
@@ -1,0 +1,113 @@
+/*
+    This file is part of Ansel,
+    Copyright (C) 2026 Aurélien PIERRE.
+
+    Ansel is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Ansel is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Ansel.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+
+/* The two studio-capture questions that need a user, split out of common/folder_survey.c.
+ *
+ * They were the only reason a folder-monitoring state machine included gui/gtk.h -- and,
+ * for the resume prompt, views/view.h as well, so a layer-1 module was driving a view
+ * switch. Both dependencies leave with them.
+ */
+
+#include "gui/common/folder_survey_gui.h"
+
+#include "common/conf.h"
+#include "common/folder_survey.h"
+#include "common/macros.h"
+#include "gui/gtk.h"
+#include "views/view.h"
+
+#include <glib/gi18n.h>
+
+/* Asks about images sitting in the surveyed folder that the library does not have yet.
+ * Returns TRUE to import them. The "delete originals" checkbox is only meaningful when
+ * copy-on-import is on, and is persisted here because it is the checkbox's own state --
+ * the backend has no opinion about it. */
+static gboolean _confirm_pending_import(int new_files)
+{
+  GtkWindow *parent = GTK_WINDOW(dt_gui_main_window());
+  GtkWidget *dialog = gtk_message_dialog_new(
+      parent, GTK_DIALOG_DESTROY_WITH_PARENT | GTK_DIALOG_MODAL, GTK_MESSAGE_QUESTION, GTK_BUTTONS_YES_NO,
+      ngettext("%d image in the surveyed folder is not in the library yet.\nImport it now?",
+               "%d images in the surveyed folder are not in the library yet.\nImport them now?",
+               new_files),
+      new_files);
+
+  GtkWidget *delete_check
+      = gtk_check_button_new_with_label(_("Delete the originals after verifying the complete copies"));
+  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(delete_check),
+                               dt_conf_get_bool("studio_capture/delete_source"));
+  gtk_widget_set_sensitive(delete_check, dt_conf_get_bool("studio_capture/copy"));
+  gtk_box_pack_start(GTK_BOX(gtk_message_dialog_get_message_area(GTK_MESSAGE_DIALOG(dialog))), delete_check,
+                     FALSE, FALSE, DT_GUI_BOX_SPACING);
+  gtk_widget_show_all(dialog);
+
+  const int import_now = gtk_dialog_run(GTK_DIALOG(dialog));
+  if(import_now == GTK_RESPONSE_YES && dt_conf_get_bool("studio_capture/copy"))
+    dt_conf_set_bool("studio_capture/delete_source",
+                     gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(delete_check)));
+  gtk_widget_destroy(dialog);
+  dt_gui_refocus_parent(parent);
+
+  return import_now == GTK_RESPONSE_YES;
+}
+
+void dt_folder_survey_gui_register_handlers()
+{
+  dt_folder_survey_set_confirm_import_handler(_confirm_pending_import);
+}
+
+gboolean dt_folder_survey_propose_resume()
+{
+  if(!dt_folder_survey_take_session_marker()) return G_SOURCE_REMOVE;
+
+  char *folder = dt_conf_get_string("studio_capture/folder");
+  GtkWindow *parent = GTK_WINDOW(dt_gui_main_window());
+
+  GtkWidget *dialog = gtk_message_dialog_new(
+      parent, GTK_DIALOG_DESTROY_WITH_PARENT | GTK_DIALOG_MODAL, GTK_MESSAGE_QUESTION, GTK_BUTTONS_YES_NO,
+      _("A studio capture session was monitoring `%s` when Ansel was last closed.\n"
+        "Resume the session?"),
+      folder ? folder : "");
+  const int resume = gtk_dialog_run(GTK_DIALOG(dialog));
+  gtk_widget_destroy(dialog);
+
+  if(resume != GTK_RESPONSE_YES)
+  {
+    // Persist the cleared marker so the question is not asked again.
+    dt_folder_survey_forget_session();
+    dt_free(folder);
+    return G_SOURCE_REMOVE;
+  }
+
+  dt_view_manager_switch(dt_view_manager_get_global(), "studio_capture");
+
+  // dt_folder_survey_start() itself offers to import any images already
+  // sitting in the folder, covering files that appeared while Ansel was
+  // closed the same way it covers a plain session start.
+  dt_folder_survey_start();
+  dt_free(folder);
+  return G_SOURCE_REMOVE;
+}
+
+
+// clang-format off
+// modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py
+// vim: shiftwidth=2 expandtab tabstop=2 cindent
+// kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;
+// clang-format on

--- a/src/gui/common/folder_survey_gui.h
+++ b/src/gui/common/folder_survey_gui.h
@@ -1,0 +1,51 @@
+/*
+    This file is part of Ansel,
+    Copyright (C) 2026 Aurélien PIERRE.
+
+    Ansel is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Ansel is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Ansel.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+
+#ifndef DT_GUI_COMMON_FOLDER_SURVEY_GUI_H
+#define DT_GUI_COMMON_FOLDER_SURVEY_GUI_H
+
+#include <glib.h>
+
+G_BEGIN_DECLS
+
+/** Register the handler common/folder_survey.c calls to ask about pending imports.
+ *  Called from dt_gui_gtk_init(); without it the backend simply never asks. */
+void dt_folder_survey_gui_register_handlers();
+
+/**
+ * @brief Propose to resume an interrupted studio session at application start.
+ *
+ * When the previous session quit while monitoring, ask the user whether to resume; on
+ * acceptance, switch to the Studio Capture view and start monitoring, which in turn asks
+ * whether files that appeared meanwhile should be imported now. Call after the GUI and
+ * views are ready.
+ *
+ * @return gboolean always G_SOURCE_REMOVE, so it can be scheduled with g_idle_add().
+ */
+gboolean dt_folder_survey_propose_resume();
+
+G_END_DECLS
+
+#endif // DT_GUI_COMMON_FOLDER_SURVEY_GUI_H
+
+// clang-format off
+// modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py
+// vim: shiftwidth=2 expandtab tabstop=2 cindent
+// kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;
+// clang-format on

--- a/src/gui/common/history_actions_gui.c
+++ b/src/gui/common/history_actions_gui.c
@@ -1,0 +1,152 @@
+/*
+    This file is part of Ansel,
+    Copyright (C) 2026 Aurélien PIERRE.
+
+    Ansel is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Ansel is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Ansel.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+/* The three history actions that need to ask the user something.
+ *
+ * They were in common/history_actions.c, which is otherwise pure backend -- and were the
+ * only reason it included gui/hist_dialog.h, gui/gtk.h and gui/actions/menu.h. Nothing
+ * about them is shared with the batch machinery there: two open the module-picker dialog
+ * and store its answer in the copy/paste proxy, the third is a GtkAccelGroup accelerator.
+ *
+ * Every caller already lives at or above this layer (gui/actions/edit.c, libs/history.c),
+ * so this is a relocation, not an inversion: no handler slot is needed.
+ */
+
+#include "gui/common/history_actions_gui.h"
+
+#include "common/act_on.h"
+#include "common/conf.h"
+#include "common/history_actions.h"
+#include "common/macros.h"
+#include "common/selection.h"
+#include "control/control.h"
+#include "develop/develop.h"
+#include "develop/dev_history.h"
+#include "gui/actions/menu.h"
+#include "gui/gtk.h"
+#include "gui/hist_dialog.h"
+#include "views/view.h"
+
+#include <glib/gi18n.h>
+
+#ifdef GDK_WINDOWING_QUARTZ
+#include "osx/osx.h"
+#endif
+
+gboolean dt_history_copy_parts(int32_t imgid)
+{
+  if(dt_history_copy(imgid))
+  {
+    // run dialog, it will insert into selops the selected moduel
+
+    if(dt_gui_hist_dialog_new(&(dt_view_manager_get_global()->copy_paste), imgid, TRUE) == GTK_RESPONSE_CANCEL)
+      return FALSE;
+    return TRUE;
+  }
+  else
+    return FALSE;
+}
+
+
+gboolean dt_history_paste_parts_prepare(void)
+{
+  dt_history_copy_item_t *copy_paste = &dt_view_manager_get_global()->copy_paste;
+  if(copy_paste->copied_imageid <= 0) return FALSE;
+
+  // we launch the dialog
+  const int res = dt_gui_hist_dialog_new(copy_paste, copy_paste->copied_imageid, FALSE);
+
+  if(res != GTK_RESPONSE_OK)
+  {
+    return FALSE;
+  }
+
+  return TRUE;
+}
+
+
+gboolean delete_history_callback(GtkAccelGroup *group, GObject *acceleratable, guint keyval, GdkModifierType mods, gpointer user_data)
+{
+  if(!has_active_images()) return FALSE;
+
+  GList *imgs = dt_act_on_get_images();
+  if(IS_NULL_PTR(imgs)) return FALSE;
+
+  if(dt_conf_get_bool("ask_before_discard"))
+  {
+    const int img_count = g_list_length(imgs);
+    const GtkWidget *win = dt_gui_main_window();
+    GtkWidget *dialog = gtk_message_dialog_new(
+        GTK_WINDOW(win), GTK_DIALOG_DESTROY_WITH_PARENT, GTK_MESSAGE_QUESTION, GTK_BUTTONS_YES_NO,
+        ngettext("Do you really want to clear history of %d image?",
+                 "Do you really want to clear history of %d images?", img_count),
+        img_count);
+#ifdef GDK_WINDOWING_QUARTZ
+    dt_osx_disallow_fullscreen(dialog);
+#endif
+    gtk_window_set_title(GTK_WINDOW(dialog), ngettext("Delete image's history?", "Delete images' history?", img_count));
+
+    GtkWidget *message_area = gtk_message_dialog_get_message_area(GTK_MESSAGE_DIALOG(dialog));
+    GtkWidget *ask_check = gtk_check_button_new_with_label(_("Always ask"));
+    gtk_widget_set_tooltip_text(ask_check,
+        _("when unchecked, history will be deleted silently from now on without this confirmation.\n"
+          "you can turn it back on from preferences."));
+    gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(ask_check), TRUE);
+    gtk_box_pack_start(GTK_BOX(message_area), ask_check, FALSE, FALSE, 6);
+    gtk_widget_show(ask_check);
+
+    const gint res = gtk_dialog_run(GTK_DIALOG(dialog));
+    dt_conf_set_bool("ask_before_discard", gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(ask_check)));
+    gtk_widget_destroy(dialog);
+    dt_gui_refocus_parent(GTK_WINDOW(win));
+    if(res != GTK_RESPONSE_YES)
+    {
+      g_list_free(imgs);
+      return TRUE;
+    }
+  }
+
+  gboolean is_darkroom_image_in_list = dt_dev_history_is_image_in_dev(imgs);
+
+  dt_develop_t *dev = dt_dev_get_global();
+
+  if(is_darkroom_image_in_list)
+  {
+    dt_dev_undo_start_record(dev);
+  }
+
+  dt_history_delete_on_list(imgs, TRUE);
+
+  if(is_darkroom_image_in_list)
+  {
+    dt_dev_undo_end_record(dev);
+    dt_apply_dev_history_update(dev);
+  }
+
+  dt_control_queue_redraw_center();
+  g_list_free(imgs);
+  imgs = NULL;
+  return TRUE;
+}
+
+
+// clang-format off
+// modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py
+// vim: shiftwidth=2 expandtab tabstop=2 cindent
+// kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;
+// clang-format on

--- a/src/gui/common/history_actions_gui.h
+++ b/src/gui/common/history_actions_gui.h
@@ -1,0 +1,55 @@
+/*
+    This file is part of Ansel,
+    Copyright (C) 2026 Aurélien PIERRE.
+
+    Ansel is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Ansel is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Ansel.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef DT_GUI_COMMON_HISTORY_ACTIONS_GUI_H
+#define DT_GUI_COMMON_HISTORY_ACTIONS_GUI_H
+
+#include <glib.h>
+#include <gtk/gtk.h>
+#include <inttypes.h>
+
+G_BEGIN_DECLS
+
+/* The history actions that ask the user something, split out of common/history_actions.c.
+ * The pure-backend half stays there and knows nothing about any of this. */
+
+/** Copy history from @p imgid, then run the module-picker dialog to narrow it down.
+ *  Returns FALSE if the user cancelled. The chosen modules land in the copy/paste proxy,
+ *  where dt_history_paste_parts_on_{image,list}() read them. */
+gboolean dt_history_copy_parts(int32_t imgid);
+
+/** Run the module-picker dialog over what was copied, ahead of a partial paste.
+ *  Returns FALSE if the user cancelled or nothing was copied. */
+gboolean dt_history_paste_parts_prepare(void);
+
+/** Confirm (if `ask_before_discard` is set), then delete the history of the active images.
+ *  Shared verbatim by the Edit menu's "Delete history" action and the darkroom history
+ *  module's reset button, which is why it is a GtkAccelGroup callback rather than a plain
+ *  function. */
+gboolean delete_history_callback(GtkAccelGroup *group, GObject *acceleratable, guint keyval, GdkModifierType mods,
+                                 gpointer user_data);
+
+G_END_DECLS
+
+#endif // DT_GUI_COMMON_HISTORY_ACTIONS_GUI_H
+
+// clang-format off
+// modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py
+// vim: shiftwidth=2 expandtab tabstop=2 cindent
+// kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;
+// clang-format on

--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -87,6 +87,7 @@
 #include "gui/gtk.h"
 #include "common/thumbnail_notify.h"
 #include "gui/common/film_gui.h"
+#include "gui/common/folder_survey_gui.h"
 #include "gui/common/collection_gui.h"
 #include "common/startup_progress.h"
 #include "gui/dtgtk/thumbtable.h"
@@ -1344,6 +1345,7 @@ int dt_gui_gtk_init(dt_gui_gtk_t *gui)
   dt_startup_progress_set_handler(_gui_startup_progress);
   dt_film_gui_register_handlers();
   dt_collection_gui_register_handlers();
+  dt_folder_survey_gui_register_handlers();
 
   return 0;
 }

--- a/src/libs/history.c
+++ b/src/libs/history.c
@@ -51,6 +51,7 @@
 */
 
 #include "common/history_actions.h"
+#include "gui/common/history_actions_gui.h"
 #include "common/macros.h"
 #include "common/module_versioning.h"
 #include "common/styles.h"


### PR DESCRIPTION
**Stacked on #1106** (branched from `refactor/throttle-to-history`, not master). Merge that first.

Continues the `common/` → GUI detangling from #1103. Three files were still calling GTK from layer 1; two of them are done here.

## `common/history_actions.c` — a relocation

The file is batch machinery: run an action over a list of images, with undo and a report. Three of its functions were not that.

* `dt_history_copy_parts()` and `dt_history_paste_parts_prepare()` open the module-picker dialog and store the answer in the copy/paste proxy;
* `delete_history_callback()` is a `GtkAccelGroup` accelerator with a confirmation dialog.

They were the only reason the file included `gui/hist_dialog.h`, `gui/gtk.h` and `gui/actions/menu.h`, and nothing in the batch machinery uses them.

**No handler slot needed** — both callers (`gui/actions/edit.c`, `libs/history.c`) already live above this layer, so this is a move, not an inversion. The partial-paste `apply`/`on_image`/`on_list` functions stay in the backend: they read the `selops` the dialog filled and never open it themselves.

The `_gui` suffix is load-bearing, not cosmetic: an unsuffixed `gui/common/history_actions.h` would shadow the backend header for every file that includes it by that name. (Same trap as the `styles.h` one in #1103.)

`common/history_actions.c` now has zero GTK tokens, and its header no longer drags `<gtk/gtk.h>` into everything that includes it.

## `common/folder_survey.c` — one relocation, one inversion

A folder-monitoring state machine that included `gui/gtk.h` — and `views/view.h`, so a layer-1 module was driving a view switch. Two prompts, two different problems:

**`dt_folder_survey_propose_resume()`** is GUI orchestration end to end: ask, switch to the Studio Capture view, start monitoring. It moves whole. What it needed from the backend is the session marker, now behind `dt_folder_survey_take_session_marker()` — *consumed*, not merely read, since clearing it is the point (the question must be asked at most once per start) — and `dt_folder_survey_forget_session()` for the declined case.

**The pending-import prompt cannot move**: it is interleaved with private session state (`baseline_initialized`, under the survey lock). Inverted instead, following the `dt_film_confirm_rmdir_handler` pattern, registered from `dt_gui_gtk_init()` next to the film and collection ones.

One judgement call worth flagging: **with no handler, the question is not asked AND nothing is absorbed.** That is deliberately *not* the same as declining — absorbing is the answer to a question nobody put, and would silently hide those files from every later scan. They stay pending, to be offered whenever someone can ask. (Same reasoning as the film rmdir default: "ask first" cannot be honoured when there is nobody to ask.)

The "delete originals after copy" preference is written by the GUI half now — it is the checkbox's own state and the backend has no opinion about it.

## Not done: `common/database.c`

Analysed and written up in `doc/include-hygiene-roadmap.md` §12 rather than half-attempted.

Three dialogs (~120 lines), all inside `dt_database_init()` and gated by its `has_gui` argument. They were left out of the `dt_database_take_error()` inversion in #1103 for a concrete reason: that pattern has the backend *record* an error for the caller to report afterwards, and these are **interactive mid-init** — the answer decides whether init continues, retries or aborts, so there is nothing to report afterwards to.

A handler slot does work, and the ordering allows it:

```
darktable.c:1244   gtk_init()            <- GTK is up
darktable.c:1259   dt_database_init()    <- the dialogs run here
darktable.c:1402   dt_gui_gtk_init()     <- too late to register from
```

Registration therefore cannot go where the other three handlers go; it belongs in `darktable.c` between those two lines, guarded by `init_gui`. Each dialog has a different button set and different return semantics, so the slot wants a small enum of outcomes rather than a boolean. That, on the startup path, is its own piece of work.

## Verification

Build green, no new first-party warnings, `cycles 0`. Layering violations 226 → **225**.

Not interactively tested: the studio-capture resume prompt and the pending-import prompt both need a live session to exercise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
