### PR TITLE
Screen metrics are hardware, not GUI state: move them to system/

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -53,6 +53,7 @@ FILE(GLOB SOURCE_FILES
   "common/act_on.c"
   "system/atomic.c"
   "system/display_profile.c"
+  "system/screen_metrics.c"
   "pixel/bilateral.c"
   "pixel/bilateralcl.c"
   "pixel/box_filters.c"

--- a/src/common/opencl.c
+++ b/src/common/opencl.c
@@ -67,7 +67,6 @@
 #include "system/nvidia_gpus.h"
 #include "system/opencl_drivers_blacklist.h"
 #include "common/conf.h"
-#include "gui/splash.h"
 #include "develop/blend.h"
 #include "develop/pixelpipe.h"
 #include "develop/pixelpipe_cache.h"

--- a/src/common/selection.c
+++ b/src/common/selection.c
@@ -43,7 +43,6 @@
 #include "system/mem_alloc.h"
 #include "common/image.h"
 #include "control/signal.h"
-#include "gui/gtk.h"
 
 static sqlite3_stmt *_selection_database_to_glist_stmt = NULL;
 

--- a/src/common/sentry.c
+++ b/src/common/sentry.c
@@ -18,6 +18,7 @@
 
 #ifdef HAVE_CONFIG_H
 #include "config.h"
+#include "system/screen_metrics.h"
 #include "common/anonymous_ids.h"
 #include "system/sys_resources.h"
 #endif
@@ -33,7 +34,6 @@
 #include "common/image.h"
 #include "common/opencl.h"
 #include "common/conf.h"
-#include "gui/gtk.h"
 
 #include <sentry.h>
 
@@ -445,12 +445,12 @@ static void _sentry_set_context(void)
   // from the GUI, already computed during dt_gui_gtk_init(). The window size is
   // read from conf, which holds the restored/last geometry and is kept up to date
   // live on every resize - more reliable than the not-yet-mapped window here.
-  if(dt_gui_get_global())
+  if(dt_screen_metrics_probed())
   {
     sentry_value_t scr = sentry_value_new_object();
-    sentry_value_set_by_key(scr, "dpi", sentry_value_new_double(dt_gui_get_global()->dpi));
-    sentry_value_set_by_key(scr, "dpi_factor", sentry_value_new_double(dt_gui_get_global()->dpi_factor));
-    sentry_value_set_by_key(scr, "ppd", sentry_value_new_double(dt_gui_get_global()->ppd));
+    sentry_value_set_by_key(scr, "dpi", sentry_value_new_double(dt_screen_dpi()));
+    sentry_value_set_by_key(scr, "dpi_factor", sentry_value_new_double(dt_screen_dpi_factor()));
+    sentry_value_set_by_key(scr, "ppd", sentry_value_new_double(dt_screen_ppd()));
 
     const int win_w = dt_conf_get_int("ui_last/window_width");
     const int win_h = dt_conf_get_int("ui_last/window_height");

--- a/src/common/telemetry.c
+++ b/src/common/telemetry.c
@@ -18,6 +18,7 @@
 
 #ifdef HAVE_CONFIG_H
 #include "config.h"
+#include "system/screen_metrics.h"
 #include "common/anonymous_ids.h"
 #include "system/sys_resources.h"
 #endif
@@ -29,7 +30,6 @@
 
 #include "common/image.h"
 #include "common/opencl.h"
-#include "gui/gtk.h"
 
 #include <curl/curl.h>
 #include <string.h>
@@ -358,10 +358,10 @@ static JsonObject *_telemetry_system_properties(void)
   if(desktop && *desktop) json_object_set_string_member(p, "desktop_environment", desktop);
 #endif
 
-  if(dt_gui_get_global())
+  if(dt_screen_metrics_probed())
   {
-    json_object_set_double_member(p, "dpi", dt_gui_get_global()->dpi);
-    json_object_set_double_member(p, "ppd", dt_gui_get_global()->ppd);
+    json_object_set_double_member(p, "dpi", dt_screen_dpi());
+    json_object_set_double_member(p, "ppd", dt_screen_ppd());
     GdkDisplay *display = gdk_display_get_default();
     GdkMonitor *mon = display ? gdk_display_get_primary_monitor(display) : NULL;
     if(!mon && display && gdk_display_get_n_monitors(display) > 0) mon = gdk_display_get_monitor(display, 0);

--- a/src/common/utility.c
+++ b/src/common/utility.c
@@ -52,12 +52,12 @@
 
 #include <glib/gstdio.h>
 #include "common/macros.h"
+#include "system/screen_metrics.h"
 #include "system/mem_alloc.h"
 #include "common/paths.h"
 #include "common/file_location.h"
 #include "common/grealpath.h"
 #include "common/utility.h"
-#include "gui/gtk.h"
 
 /* getpwnam_r availability check */
 #if defined __APPLE__ || defined _POSIX_C_SOURCE >= 1 || defined _XOPEN_SOURCE || defined _BSD_SOURCE        \
@@ -480,7 +480,7 @@ static cairo_surface_t *_util_get_svg_img(gchar *logo, const float size)
     RsvgDimensionData dimension;
     dimension = dt_get_svg_dimension(svg);
 
-    const float ppd = dt_gui_get_global() ? dt_gui_get_global()->ppd : 1.0;
+    const float ppd = dt_screen_ppd();
 
     const float svg_size = MAX(dimension.width, dimension.height);
     const float factor = size > 0.0 ? size / svg_size : -1.0 * size;
@@ -489,12 +489,11 @@ static cairo_surface_t *_util_get_svg_img(gchar *logo, const float size)
     const int stride = cairo_format_stride_for_width(CAIRO_FORMAT_ARGB32, final_width);
 
     guint8 *image_buffer = (guint8 *)calloc(stride * final_height, sizeof(guint8));
-    if(dt_gui_get_global())
-      surface = dt_cairo_image_surface_create_for_data(image_buffer, CAIRO_FORMAT_ARGB32, final_width,
-                                                      final_height, stride);
-    else // during startup we don't know ppd yet and dt_gui_get_global() isn't initialized yet.
-      surface = cairo_image_surface_create_for_data(image_buffer, CAIRO_FORMAT_ARGB32, final_width,
-                                                       final_height, stride);
+    // ppd is 1.0 until a display is probed, and a device scale of 1.0 is what the plain
+    // cairo call already does -- so there is nothing left for the old startup branch to
+    // guard against.
+    surface = dt_cairo_image_surface_create_for_data(image_buffer, CAIRO_FORMAT_ARGB32, final_width,
+                                                     final_height, stride);
     if(cairo_surface_status(surface) != CAIRO_STATUS_SUCCESS)
     {
       fprintf(stderr, "warning: can't load darktable logo from SVG file `%s'\n", dtlogo);

--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -72,6 +72,7 @@
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
 #include "darktable.h"
+#include "system/screen_metrics.h"
 #include "widgets/widget_settings.h"
 #include "widgets/resize_handle.h"
 #include "common/colorspaces.h"
@@ -1442,6 +1443,7 @@ void dt_configure_ppd_dpi(dt_gui_gtk_t *gui)
   }
   gui->dpi_factor
       = gui->dpi / 96;
+  dt_screen_set_dpi(gui->dpi); // the raw resolution, for whoever reports it rather than scales by it
   dt_widget_set_dpi_factor(gui->dpi_factor); // according to man xrandr and the docs of gdk_screen_set_resolution 96 is the default
 
   // em depends on the screen DPI (point -> px), so refresh it here too.

--- a/src/system/screen_metrics.c
+++ b/src/system/screen_metrics.c
@@ -1,0 +1,50 @@
+/*
+    This file is part of Ansel,
+    Copyright (C) 2026 Aurélien PIERRE.
+
+    Ansel is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Ansel is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Ansel.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "system/screen_metrics.h"
+
+/* Written once at startup by whoever can interrogate the display, read everywhere after.
+ * The defaults are the neutral ones, so a reader that runs before the push -- or in a
+ * headless process where the push never happens -- gets unscaled geometry rather than
+ * zeroes. Setters reject non-positive values for the same reason: a bad probe must not be
+ * able to collapse every length in the application to 0. */
+static double _dpi = 96.0;
+static double _dpi_factor = 1.0;
+static double _ppd = 1.0;
+static double _em = 16.0;
+static gboolean _probed = FALSE;
+
+double dt_screen_dpi(void) { return _dpi; }
+void dt_screen_set_dpi(double dpi) { if(dpi > 0.0) { _dpi = dpi; _probed = TRUE; } }
+
+double dt_screen_dpi_factor(void) { return _dpi_factor; }
+void dt_screen_set_dpi_factor(double factor) { if(factor > 0.0) { _dpi_factor = factor; _probed = TRUE; } }
+
+double dt_screen_ppd(void) { return _ppd; }
+void dt_screen_set_ppd(double ppd) { if(ppd > 0.0) { _ppd = ppd; _probed = TRUE; } }
+
+gboolean dt_screen_metrics_probed(void) { return _probed; }
+
+double dt_screen_em_size(void) { return _em; }
+void dt_screen_set_em_size(double em) { if(em > 0.0) _em = em; }
+
+// clang-format off
+// modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py
+// vim: shiftwidth=2 expandtab tabstop=2 cindent
+// kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;
+// clang-format on

--- a/src/system/screen_metrics.h
+++ b/src/system/screen_metrics.h
@@ -1,0 +1,92 @@
+/*
+    This file is part of Ansel,
+    Copyright (C) 2026 Aurélien PIERRE.
+
+    Ansel is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Ansel is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Ansel.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef DT_SYSTEM_SCREEN_METRICS_H
+#define DT_SYSTEM_SCREEN_METRICS_H
+
+#include <cairo.h>
+#include <glib.h>
+
+G_BEGIN_DECLS
+
+/* How dense the screen is, and how much cairo has to draw per logical pixel.
+ *
+ * These are hardware facts -- the same category as the monitor's ICC profile in
+ * system/display_profile.h -- and they had ended up owned by the GUI (dt_gui_gtk_t) and
+ * mirrored in widgets/widget_settings.c, because that is who resolves them. Anyone below
+ * layer 4 who needed them (the crash reporter, the telemetry payload, the SVG rasteriser)
+ * therefore had to include gui/gtk.h to read three doubles.
+ *
+ * They live here instead, as the single copy. Whoever can interrogate the display pushes
+ * them in once -- dt_gui_gtk_init() does, from GDK -- and everyone else reads.
+ *
+ * Before that push, the getters return neutral values (1.0 scaling, 96 dpi), which is what
+ * makes a headless run and early startup work without a single "is there a GUI?" test.
+ */
+
+/** Screen resolution in dots per inch. Defaults to 96.0 (the X/GDK default). */
+double dt_screen_dpi(void);
+void dt_screen_set_dpi(double dpi);
+
+/** dpi / 96, i.e. how much to scale UI lengths by. Defaults to 1.0. */
+double dt_screen_dpi_factor(void);
+void dt_screen_set_dpi_factor(double factor);
+
+/** Device pixels per logical pixel (HiDPI/Retina scaling). Defaults to 1.0. */
+double dt_screen_ppd(void);
+void dt_screen_set_ppd(double ppd);
+
+/** TRUE once something has actually interrogated a display and pushed real values.
+ *
+ *  The getters above are always safe to call, but they answer with neutral defaults until
+ *  this returns TRUE. Use it where reporting an invented 96dpi/1.0 would be worse than
+ *  reporting nothing -- a crash report or a telemetry payload -- and NOT as a "is there a
+ *  GUI?" test for scaling, where the neutral defaults are exactly the right answer. */
+gboolean dt_screen_metrics_probed(void);
+
+/** Height of the theme font's "em", in pixels. Defaults to 16.0. */
+double dt_screen_em_size(void);
+void dt_screen_set_em_size(double em);
+
+/* Device-scale-aware cairo surfaces: allocate at ppd resolution and tell cairo about it, so
+ * callers keep drawing in logical coordinates and get a sharp result on a HiDPI screen. */
+
+static inline cairo_surface_t *dt_cairo_image_surface_create(cairo_format_t format, int width, int height)
+{
+  cairo_surface_t *cst = cairo_image_surface_create(format, width * dt_screen_ppd(), height * dt_screen_ppd());
+  cairo_surface_set_device_scale(cst, dt_screen_ppd(), dt_screen_ppd());
+  return cst;
+}
+
+static inline cairo_surface_t *dt_cairo_image_surface_create_for_data(unsigned char *data, cairo_format_t format,
+                                                                     int width, int height, int stride)
+{
+  cairo_surface_t *cst = cairo_image_surface_create_for_data(data, format, width, height, stride);
+  cairo_surface_set_device_scale(cst, dt_screen_ppd(), dt_screen_ppd());
+  return cst;
+}
+
+G_END_DECLS
+
+#endif // DT_SYSTEM_SCREEN_METRICS_H
+
+// clang-format off
+// modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py
+// vim: shiftwidth=2 expandtab tabstop=2 cindent
+// kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;
+// clang-format on

--- a/src/widgets/widget_settings.c
+++ b/src/widgets/widget_settings.c
@@ -20,6 +20,7 @@
  *    along with darktable.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "system/screen_metrics.h"
 #include "widgets/widget_settings.h"
 
 #include "common/macros.h"
@@ -78,7 +79,9 @@ static gboolean _reverse_x = FALSE, _reverse_y = FALSE;
 
 // Toolkit metrics. Defaults are the 96-DPI, 16px-font reference: correct for standalone
 // dialogs that run after gtk_init() but before the application has resolved the real values.
-static double _dpi_factor = 1.0, _ppd = 1.0, _em = 16.0;
+// dpi/ppd/em are screen hardware facts and live in system/screen_metrics.c, which sits
+// below this layer so common/ can read them too. These stay as the toolkit's names for
+// them -- 45-odd files use them -- but hold no copy of their own.
 
 static dt_widget_cursor_handler_t _cursor_handler = NULL;
 static dt_widget_message_handler_t _message_handler = NULL;
@@ -125,14 +128,14 @@ void dt_widget_set_cursor(GdkCursorType cursor)
   if(_cursor_handler) _cursor_handler(cursor);
 }
 
-double dt_widget_dpi_factor(void) { return _dpi_factor; }
-void dt_widget_set_dpi_factor(double factor) { if(factor > 0.0) _dpi_factor = factor; }
+double dt_widget_dpi_factor(void) { return dt_screen_dpi_factor(); }
+void dt_widget_set_dpi_factor(double factor) { dt_screen_set_dpi_factor(factor); }
 
-double dt_widget_ppd(void) { return _ppd; }
-void dt_widget_set_ppd(double ppd) { if(ppd > 0.0) _ppd = ppd; }
+double dt_widget_ppd(void) { return dt_screen_ppd(); }
+void dt_widget_set_ppd(double ppd) { dt_screen_set_ppd(ppd); }
 
-double dt_widget_em_size(void) { return _em; }
-void dt_widget_set_em_size(double em) { if(em > 0.0) _em = em; }
+double dt_widget_em_size(void) { return dt_screen_em_size(); }
+void dt_widget_set_em_size(double em) { dt_screen_set_em_size(em); }
 
 void dt_widget_set_gui_thread(pthread_t thread)
 {

--- a/src/widgets/widget_settings.h
+++ b/src/widgets/widget_settings.h
@@ -22,6 +22,8 @@
 #include <gtk/gtk.h>
 #include <pthread.h>
 
+#include "system/screen_metrics.h"
+
 G_BEGIN_DECLS
 
 /* Toolkit-wide state that widgets need and the application merely configures.
@@ -153,8 +155,7 @@ enum
 const GdkRGBA *dt_widget_colorlabel(int index);
 void dt_widget_set_colorlabels(const GdkRGBA *labels, int count);
 
-/* Device-scale-aware cairo surfaces: allocate at ppd resolution and tell cairo about it, so
- * drawing code works in logical pixels and stays sharp on HiDPI. */
+/* Does `state` carry exactly `desired_modifier_mask`, ignoring lock/scroll bits? */
 static inline gboolean dt_modifier_is(const GdkModifierType state, const GdkModifierType desired_modifier_mask)
 {
   const GdkModifierType modifiers = gtk_accelerator_get_default_mod_mask();
@@ -162,17 +163,9 @@ static inline gboolean dt_modifier_is(const GdkModifierType state, const GdkModi
   return (state & modifiers) == desired_modifier_mask;
 }
 
-static inline cairo_surface_t *dt_cairo_image_surface_create(cairo_format_t format, int width, int height) {
-  cairo_surface_t *cst = cairo_image_surface_create(format, width * dt_widget_ppd(), height * dt_widget_ppd());
-  cairo_surface_set_device_scale(cst, dt_widget_ppd(), dt_widget_ppd());
-  return cst;
-}
-
-static inline cairo_surface_t *dt_cairo_image_surface_create_for_data(unsigned char *data, cairo_format_t format, int width, int height, int stride) {
-  cairo_surface_t *cst = cairo_image_surface_create_for_data(data, format, width, height, stride);
-  cairo_surface_set_device_scale(cst, dt_widget_ppd(), dt_widget_ppd());
-  return cst;
-}
+/* dt_cairo_image_surface_create{,_for_data}() moved to system/screen_metrics.h with the ppd
+ * they scale by, so code below this layer can build a device-scaled surface too. This header
+ * includes it, so the ~45 files using them by these names are unaffected. */
 
 G_END_DECLS
 


### PR DESCRIPTION
**Based on master, independent of #1108** — touches none of the same files, so the two can land in either order.

Five files under `common/` still included `gui/gtk.h` or `gui/splash.h`. Two of those includes were simply **dead** (`selection.c`, `opencl.c`). The other three — `sentry.c`, `telemetry.c`, `utility.c` — pulled in the whole GUI header to read three doubles: `dpi`, `dpi_factor`, `ppd`.

## Why not just swap the include

Those metrics were mirrored in `widgets/widget_settings.c`, so the quick fix is to include that instead. It isn't a fix: `widgets/` is layer 4 and `common/` is layer 1, so it only trades `common→gui` for `common→widgets`.

They are **hardware facts** — the same category as the monitor's ICC profile already sitting in `system/display_profile.h` from #1103. They ended up owned by `dt_gui_gtk_t` because that is who *resolves* them, not because they are GUI state.

## The move

`system/screen_metrics.{c,h}` becomes the single copy. `dt_gui_gtk_init()` pushes the values in from GDK; `widget_settings` keeps its own names for them (45-odd files use those) but holds no copy of its own — it forwards.

`dt_cairo_image_surface_create{,_for_data}()` move with the ppd they scale by, so code below layer 4 can build a device-scaled surface too. `widget_settings.h` includes the new header, so **every existing user is unaffected**.

## Neutral defaults remove three "is there a GUI?" tests

The getters answer 1.0 scaling / 96 dpi until a display is actually probed. That lets all three callers drop their GUI-pointer guards:

* **`utility.c`**'s SVG rasteriser had a two-branch startup guard choosing between the ppd-scaled surface and the plain one. A device scale of 1.0 *is* the plain call, so the branch collapses to a single call.
* **`sentry.c` / `telemetry.c`** must not report an invented 96dpi/1.0 as though measured, so they ask `dt_screen_metrics_probed()` — honest about whether a screen was seen, rather than using a GUI pointer as a proxy for it.

Setters reject non-positive values: a bad probe must not be able to collapse every length in the application to zero.

## One repair carried in

`dt_modifier_is()` sat in `widget_settings.h` under a comment announcing "device-scale-aware cairo surfaces", which it has nothing to do with. It stays in `widgets/` — it is a GTK keyboard-modifier helper — now with a comment that describes it.

## Verification

Build green, **zero** warnings in first-party code, `cycles 0`, guards verified. Layering violations 226 → **221**.

After this and #1108, the only `gui/` includes left in `common/*.c` are `history_merge.c` → `gui/common/history_merge_gui.h` and `database.c` → `gui/legacy_presets.h`. Both are their own pass: the first is a leftover edge from #1103, the second is preset migration rather than a dialog.

Not interactively tested: HiDPI rendering (ppd ≠ 1) and the DPI figures in a crash report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
