### PR TITLE
History merge: the backend stops calling the GUI

### DIFF
--- a/doc/include-hygiene-roadmap.md
+++ b/doc/include-hygiene-roadmap.md
@@ -603,6 +603,71 @@ initialises. Registration is the guard now.
 `common/database.c` is down to zero GTK tokens. Its remaining `gui/legacy_presets.h` include
 is a different problem (preset migration, not a dialog) and is left for its own pass.
 
+## 13. Done: `common/history_merge.c` stops calling the GUI
+
+This file's `#include "gui/common/history_merge_gui.h"` was two problems wearing one include.
+
+**Misplaced ownership.** `_hm_make_node_id()`, `_hm_id_to_op_name()` and
+`_hm_build_last_history_by_id()` are *defined in* `history_merge.c` but were *declared in*
+the GUI header — so the backend included a GUI header to see its own functions. The
+declarations moved to `common/history_merge.h`; the GUI half includes that.
+
+**Four real GUI calls**, now handler slots:
+
+| call | sites |
+|---|---|
+| `_hm_show_merge_report_popup()` | 3 |
+| `_hm_ask_user_constraints_choice()` | 1 |
+| `_hm_warn_missing_raster_producers()` | 1 |
+| `_hm_show_toposort_cycle_popup()` | 1 |
+
+Each took the handler-slot pattern already used by `dt_film_confirm_rmdir_handler`,
+`dt_folder_survey_confirm_import_handler_t` and `dt_database_prompt_handler_t`. Note the
+shapes differ: the report popup and the two warnings are one-way notifications (`void`,
+no-op with no handler), while `_hm_ask_user_constraints_choice()` returns a
+`dt_hm_constraint_choice_t` the merge algorithm branches on — so that one needs a defined
+no-handler answer, chosen the same way as the database prompts: the conservative option that
+does not silently discard the user's history.
+
+### Done — but not the way this section first said to do it
+
+Two earlier attempts, and the advice written here after them, were wrong in the same way,
+and it is worth recording because the wrong answer was the plausible one.
+
+`_hm_collect_labels_from_history_map()` is defined in `gui/common/history_merge_gui.c` and
+was *called from* `history_merge.c`, so the include could not go. It contains no GTK, which
+made it look like a backend helper stranded on the GUI side, and this section said to move
+it — with `_hm_clean_module_name()`, `_hm_module_row_label()`, `_hm_label_t` and
+`_hm_label_cmp()` behind it — down into `common/`.
+
+**That would have been a new violation, not a fix.** `_hm_clean_module_name()` calls
+`dt_capitalize_label()`, which lives in `widgets/widget_style.h` — layer 4. The whole chain
+is *presentation*: it builds the display strings the merge report's rows are made of. "No
+GTK in it" is not the same as "belongs below the GUI", and taking the first for the second
+is what cost two broken builds.
+
+The actual defect was one level up. `_hm_backup_dest()` snapshots the destination before a
+merge, and among that snapshot it captured `orig_labels` / `orig_styles` — **ready-made
+display strings, held by the backend purely so a dialog could show them later**. They were
+passed straight through to the report popup and used nowhere else.
+
+So the fix was to delete them from `_hm_dest_backup_t` entirely. The report derives them
+itself now, at report time, from `orig_ids` (the pre-merge module map, which is genuine
+backend data and was already being passed to it). That shortened the report signature by two
+parameters, and left nothing in `history_merge.c` needing anything from the GUI header.
+
+The four handler slots then went in as planned — `dt_hm_set_{constraints_choice,
+missing_raster,toposort_cycle,merge_report}_handler()`, registered from
+`dt_gui_gtk_init()`, with the no-handler defaults described above — and
+`#include "gui/common/history_merge_gui.h"` left `common/history_merge.c`. The
+`dt_hm_constraint_choice_t` enum moved to `common/history_merge.h`, since the merge
+algorithm is what branches on it.
+
+With #1108, #1109 and this one all landed, **`common/*.c` is down to a single `gui/`
+include**: `database.c`'s `gui/legacy_presets.h`. That one is preset migration rather than a
+dialog, so it is a different kind of problem and gets its own pass. Layering violations are
+at 219.
+
 ## 14. Done: the last `gui/` includes leave `common/`
 
 Four things, found by pulling on the one thread §12 left dangling.

--- a/src/common/history_merge.c
+++ b/src/common/history_merge.c
@@ -79,7 +79,6 @@
  */
 
 #include "common/history_merge.h"
-#include "gui/common/history_merge_gui.h"
 
 #include "common/iop_order.h"
 #include "common/topological_sort.h"
@@ -92,6 +91,68 @@
 #include <limits.h>
 #include <stdlib.h>
 #include <string.h>
+
+/* ---- The four user-facing moments of a merge, dispatched to whoever registered for them.
+ * Each has a defined answer for when nobody did; see history_merge.h for why each default is
+ * the one it is. Registration happens once, from the GUI; a headless merge simply never has
+ * a handler and takes the defaults throughout. */
+
+static dt_hm_constraints_choice_handler_t _constraints_choice_handler = NULL;
+static dt_hm_missing_raster_handler_t _missing_raster_handler = NULL;
+static dt_hm_toposort_cycle_handler_t _toposort_cycle_handler = NULL;
+static dt_hm_merge_report_handler_t _merge_report_handler = NULL;
+
+void dt_hm_set_constraints_choice_handler(dt_hm_constraints_choice_handler_t handler)
+{
+  _constraints_choice_handler = handler;
+}
+
+void dt_hm_set_missing_raster_handler(dt_hm_missing_raster_handler_t handler)
+{
+  _missing_raster_handler = handler;
+}
+
+void dt_hm_set_toposort_cycle_handler(dt_hm_toposort_cycle_handler_t handler)
+{
+  _toposort_cycle_handler = handler;
+}
+
+void dt_hm_set_merge_report_handler(dt_hm_merge_report_handler_t handler)
+{
+  _merge_report_handler = handler;
+}
+
+static dt_hm_constraint_choice_t _hm_constraints_choice(GHashTable *id_ht, const char *faulty_id,
+                                                        const char *src_prev, const char *src_next,
+                                                        const char *dst_prev, const char *dst_next)
+{
+  if(IS_NULL_PTR(_constraints_choice_handler)) return DT_HM_CONSTRAINTS_PREFER_DEST;
+  return _constraints_choice_handler(id_ht, faulty_id, src_prev, src_next, dst_prev, dst_next);
+}
+
+static gboolean _hm_confirm_missing_raster(const GList *mod_list)
+{
+  if(IS_NULL_PTR(_missing_raster_handler)) return TRUE;
+  return _missing_raster_handler(mod_list);
+}
+
+static void _hm_report_toposort_cycle(GList *cycle_nodes, GHashTable *id_ht)
+{
+  if(IS_NULL_PTR(_toposort_cycle_handler)) return;
+  _toposort_cycle_handler(cycle_nodes, id_ht);
+}
+
+static gboolean _hm_report_merge(dt_develop_t *dev_dest, dt_develop_t *dev_src, const gboolean merge_iop_order,
+                                 const gboolean used_source_order, const dt_history_merge_strategy_t strategy,
+                                 GHashTable *src_last_by_id, GHashTable *dst_last_before_by_id,
+                                 const GHashTable *orig_ids, const GHashTable *mod_list_ids,
+                                 const char *source_label, dt_hm_batch_state_t *batch)
+{
+  if(IS_NULL_PTR(_merge_report_handler)) return FALSE;
+  return _merge_report_handler(dev_dest, dev_src, merge_iop_order, used_source_order, strategy, src_last_by_id,
+                               dst_last_before_by_id, orig_ids, mod_list_ids, source_label, batch);
+}
+
 
 char *_hm_make_node_id(const char *op, const char *multi_name)
 {
@@ -289,8 +350,9 @@ typedef struct
   GList *history;
   int history_end;
   GList *iop_order_list;
-  GPtrArray *orig_labels;
-  GPtrArray *orig_styles;
+  /* The module-instance map as it was before the merge. The report dialog derives its
+   * "before" labels from this; it used to be handed ready-made label strings captured
+   * here, which had the backend building presentation on the GUI's behalf. */
   GHashTable *orig_ids;
 } _hm_dest_backup_t;
 
@@ -323,19 +385,11 @@ static int _hm_backup_dest(const dt_develop_t *dev_dest, const GHashTable *mod_l
 
   GHashTable *last_by_id = NULL;
   if(_hm_build_last_history_by_id_from_history(backup->history, backup->history_end, &last_by_id)) return 1;
-  backup->orig_labels = _hm_collect_labels_from_history_map(last_by_id, mod_list_ids, &backup->orig_styles);
-  if(IS_NULL_PTR(backup->orig_labels) || IS_NULL_PTR(backup->orig_styles))
-  {
-    if(backup->orig_labels) g_ptr_array_free(backup->orig_labels, TRUE);
-    if(backup->orig_styles) g_ptr_array_free(backup->orig_styles, TRUE);
-    g_hash_table_destroy(last_by_id);
-    return 1;
-  }
   backup->orig_ids = last_by_id;
   dt_print(DT_DEBUG_HISTORY | DT_DEBUG_VERBOSE,
-           "[_hm_backup_dest] imgid=%d history_end=%d history_len=%d iop_order=%d labels=%u selected=%d\n",
+           "[_hm_backup_dest] imgid=%d history_end=%d history_len=%d iop_order=%d modules=%u selected=%d\n",
            dev_dest->image_storage.id, backup->history_end, g_list_length(backup->history),
-           g_list_length(backup->iop_order_list), backup->orig_labels->len,
+           g_list_length(backup->iop_order_list), g_hash_table_size(backup->orig_ids),
            mod_list_ids ? g_hash_table_size((GHashTable *)mod_list_ids) : 0);
   return 0;
 }
@@ -372,13 +426,9 @@ static void _hm_backup_cleanup(_hm_dest_backup_t *backup)
     g_list_free_full(backup->iop_order_list, dt_free_gpointer);
     backup->iop_order_list = NULL;
   }
-  if(backup->orig_labels) g_ptr_array_free(backup->orig_labels, TRUE);
-  if(backup->orig_styles) g_ptr_array_free(backup->orig_styles, TRUE);
   if(backup->orig_ids) g_hash_table_destroy(backup->orig_ids);
   backup->history = NULL;
   backup->iop_order_list = NULL;
-  backup->orig_labels = NULL;
-  backup->orig_styles = NULL;
   backup->orig_ids = NULL;
 }
 
@@ -1253,7 +1303,7 @@ static int _hm_topo_resolve_incompatible_constraints(GList *flat, GHashTable *id
         g_list_length(_hm_cycles));
 
     const dt_hm_constraint_choice_t choice
-        = _hm_ask_user_constraints_choice(id_ht, faulty ? faulty->id : NULL, sp, sn, dp, dn);
+        = _hm_constraints_choice(id_ht, faulty ? faulty->id : NULL, sp, sn, dp, dn);
 
     dt_print(DT_DEBUG_HISTORY,
              "[dt_history_merge_module_list_into_image_topological] incompatible constraints choice: %s\n",
@@ -1348,7 +1398,7 @@ static int _hm_topo_sort_constraints(_hm_topo_merge_ctx_t *ctx)
   {
     dt_print(DT_DEBUG_HISTORY, "[dt_history_merge_module_list_into_image_topological] iop-order merge: "
                                "unsatisfiable constraints (cycle)\n");
-    _hm_show_toposort_cycle_popup(cycle_nodes, ctx->id_ht);
+    _hm_report_toposort_cycle(cycle_nodes, ctx->id_ht);
     if(cycle_nodes)
     {
       g_list_free(cycle_nodes);
@@ -1673,7 +1723,7 @@ static const char *_hm_failure_message(const char *cleanup_reason)
 {
   if(IS_NULL_PTR(cleanup_reason)) return NULL;
 
-  if(!g_strcmp0(cleanup_reason, "_hm_show_merge_report_popup() revert"))
+  if(!g_strcmp0(cleanup_reason, "merge report revert"))
     return NULL; // user-initiated cancel, not a failure
 
   if(!g_strcmp0(cleanup_reason, "_hm_try_merge_iop_order_topologically()"))
@@ -1715,7 +1765,7 @@ int dt_history_merge(dt_develop_t *dev_dest, dt_develop_t *dev_src, const int32_
   if(dest_imgid <= 0) return 1;
   if(IS_NULL_PTR(mod_list)) return 0;
 
-  if(!_hm_warn_missing_raster_producers(mod_list)) return 1;
+  if(!_hm_confirm_missing_raster(mod_list)) return 1;
 
   int rc = 1;
   gboolean used_source_order = merge_iop_order;
@@ -1870,10 +1920,9 @@ int dt_history_merge(dt_develop_t *dev_dest, dt_develop_t *dev_src, const int32_
   if(silent)
     revert = (batch->decision == DT_HM_BATCH_REVERT);
   else
-    revert = _hm_show_merge_report_popup(dev_dest, dev_src, merge_iop_order, used_source_order, strategy,
-                                         src_last_by_id, dst_last_before_by_id, backup.orig_labels,
-                                         backup.orig_styles, backup.orig_ids, mod_list_ids, source_label,
-                                         batch);
+    revert = _hm_report_merge(dev_dest, dev_src, merge_iop_order, used_source_order, strategy,
+                                         src_last_by_id, dst_last_before_by_id, backup.orig_ids,
+                                         mod_list_ids, source_label, batch);
 
   // Capture the resolved order once, from the first image where the user opted into a silent "accept" for
   // the whole batch. Subsequent images replay it via `_hm_apply_cached_order()` above.
@@ -1883,7 +1932,7 @@ int dt_history_merge(dt_develop_t *dev_dest, dt_develop_t *dev_src, const int32_
   if(revert)
   {
     _hm_restore_dest_from_backup(dev_dest, &backup);
-    cleanup_reason = "_hm_show_merge_report_popup() revert";
+    cleanup_reason = "merge report revert";
     cleanup_line = __LINE__;
     goto cleanup;
   }

--- a/src/common/history_merge.h
+++ b/src/common/history_merge.h
@@ -85,6 +85,61 @@ extern "C"
 }
 #endif
 
+
+/* Node identity helpers, defined in history_merge.c. They were declared in
+ * gui/common/history_merge_gui.h, which had the backend including a GUI header to see
+ * its own functions; the GUI half needs them too, and gets them from here. */
+char *_hm_make_node_id(const char *op, const char *multi_name);
+void _hm_id_to_op_name(const char *id, char *op, char *name);
+int _hm_build_last_history_by_id(const struct dt_develop_t *dev, GHashTable **out_map);
+
+
+typedef enum dt_hm_constraint_choice_t
+{
+  // Keep the destination adjacency constraints when breaking incompatible 2-cycles.
+  DT_HM_CONSTRAINTS_PREFER_DEST = 0,
+  // Keep the source/pasted adjacency constraints when breaking incompatible 2-cycles.
+  DT_HM_CONSTRAINTS_PREFER_SRC = 1
+} dt_hm_constraint_choice_t;
+
+/* The four moments a merge needs a user for.
+ *
+ * Merging runs deep in the backend but hits situations only a person can settle. Those
+ * dialogs used to be called from here directly, which is why a layer-1 file included a gui/
+ * header. They are handlers now, registered by gui/common/history_merge_gui.c, and each has
+ * a defined answer for when nobody registered one -- a headless merge must still finish, or
+ * refuse, on its own.
+ */
+
+/** Break an incompatible 2-cycle by keeping either the destination's or the source's
+ *  adjacency constraints. With no handler: PREFER_DEST. The destination image's existing
+ *  pipeline order is the thing a merge nobody is watching must not quietly rearrange. */
+typedef dt_hm_constraint_choice_t (*dt_hm_constraints_choice_handler_t)(GHashTable *id_ht, const char *faulty_id,
+                                                                       const char *src_prev, const char *src_next,
+                                                                       const char *dst_prev, const char *dst_next);
+
+/** Warn that pasted modules reference raster mask providers not coming with them; return
+ *  FALSE to abort. With no handler: proceed. The modules land without their raster source,
+ *  which is what the warning is about -- not grounds to refuse work nobody can confirm. */
+typedef gboolean (*dt_hm_missing_raster_handler_t)(const GList *mod_list);
+
+/** Report that the module graph could not be topologically sorted. Informational. */
+typedef void (*dt_hm_toposort_cycle_handler_t)(GList *cycle_nodes, GHashTable *id_ht);
+
+/** Show what the merge did and offer to revert it; return TRUE to revert. With no handler:
+ *  FALSE. A merge that completed is kept. */
+typedef gboolean (*dt_hm_merge_report_handler_t)(struct dt_develop_t *dev_dest, struct dt_develop_t *dev_src,
+                                                 const gboolean merge_iop_order, const gboolean used_source_order,
+                                                 const dt_history_merge_strategy_t strategy,
+                                                 GHashTable *src_last_by_id, GHashTable *dst_last_before_by_id,
+                                                 const GHashTable *orig_ids, const GHashTable *mod_list_ids,
+                                                 const char *source_label, dt_hm_batch_state_t *batch);
+
+void dt_hm_set_constraints_choice_handler(dt_hm_constraints_choice_handler_t handler);
+void dt_hm_set_missing_raster_handler(dt_hm_missing_raster_handler_t handler);
+void dt_hm_set_toposort_cycle_handler(dt_hm_toposort_cycle_handler_t handler);
+void dt_hm_set_merge_report_handler(dt_hm_merge_report_handler_t handler);
+
 #endif // DT_COMMON_HISTORY_MERGE_H
 
 // clang-format off

--- a/src/gui/common/history_merge_gui.c
+++ b/src/gui/common/history_merge_gui.c
@@ -1277,8 +1277,7 @@ static void _hm_report_align_drag_hint(GtkWidget *widget, GtkAllocation *allocat
 gboolean _hm_show_merge_report_popup(dt_develop_t *dev_dest, dt_develop_t *dev_src,
                                      const gboolean merge_iop_order, const gboolean used_source_order,
                                      const dt_history_merge_strategy_t strategy, GHashTable *src_last_by_id,
-                                     GHashTable *dst_last_before_by_id, const GPtrArray *orig_labels,
-                                     const GPtrArray *orig_styles, const GHashTable *orig_ids,
+                                     GHashTable *dst_last_before_by_id, const GHashTable *orig_ids,
                                      const GHashTable *mod_list_ids, const char *source_label,
                                      dt_hm_batch_state_t *batch)
 {
@@ -1288,6 +1287,19 @@ gboolean _hm_show_merge_report_popup(dt_develop_t *dev_dest, dt_develop_t *dev_s
 
   GtkWidget *window = dt_gui_main_window();
   if(IS_NULL_PTR(window)) return FALSE;
+
+  /* The "before" rows. Derived here, from the pre-merge module map the backend kept, rather
+   * than handed over ready-made: they are display strings, built with dt_capitalize_label()
+   * and friends, and the backend has no business holding those. */
+  GPtrArray *orig_styles = NULL;
+  GPtrArray *orig_labels
+      = _hm_collect_labels_from_history_map((GHashTable *)orig_ids, mod_list_ids, &orig_styles);
+  if(IS_NULL_PTR(orig_labels) || IS_NULL_PTR(orig_styles))
+  {
+    if(orig_labels) g_ptr_array_free(orig_labels, TRUE);
+    if(orig_styles) g_ptr_array_free(orig_styles, TRUE);
+    return FALSE;
+  }
 
   const char *merge_mode = merge_iop_order ? _("merge") : _("destination");
   const char *strategy_name
@@ -1633,6 +1645,10 @@ gboolean _hm_show_merge_report_popup(dt_develop_t *dev_dest, dt_develop_t *dev_s
   dt_free(dst_title);
   dt_free(title_text);
 
+  // Built at the top of this function, so freed here rather than by the caller.
+  g_ptr_array_free(orig_labels, TRUE);
+  g_ptr_array_free(orig_styles, TRUE);
+
   return (res == GTK_RESPONSE_ACCEPT || res == GTK_RESPONSE_DELETE_EVENT);
 }
 
@@ -1746,4 +1762,13 @@ gboolean dt_gui_merge_options_dialog(const char *title, const char *mode_key,
   gtk_widget_destroy(GTK_WIDGET(dialog));
   dt_gui_refocus_parent(dialog_parent);
   return res == GTK_RESPONSE_OK;
+}
+
+
+void dt_history_merge_gui_register_handlers(void)
+{
+  dt_hm_set_constraints_choice_handler(_hm_ask_user_constraints_choice);
+  dt_hm_set_missing_raster_handler(_hm_warn_missing_raster_producers);
+  dt_hm_set_toposort_cycle_handler(_hm_show_toposort_cycle_popup);
+  dt_hm_set_merge_report_handler(_hm_show_merge_report_popup);
 }

--- a/src/gui/common/history_merge_gui.h
+++ b/src/gui/common/history_merge_gui.h
@@ -25,16 +25,7 @@
 
 struct dt_develop_t;
 
-char *_hm_make_node_id(const char *op, const char *multi_name);
-void _hm_id_to_op_name(const char *id, char *op, char *name);
 
-typedef enum dt_hm_constraint_choice_t
-{
-  // Keep the destination adjacency constraints when breaking incompatible 2-cycles.
-  DT_HM_CONSTRAINTS_PREFER_DEST = 0,
-  // Keep the source/pasted adjacency constraints when breaking incompatible 2-cycles.
-  DT_HM_CONSTRAINTS_PREFER_SRC = 1
-} dt_hm_constraint_choice_t;
 
 dt_hm_constraint_choice_t _hm_ask_user_constraints_choice(GHashTable *id_ht, const char *faulty_id,
                                                          const char *src_prev, const char *src_next,
@@ -44,7 +35,6 @@ gboolean _hm_warn_missing_raster_producers(const GList *mod_list);
 
 void _hm_show_toposort_cycle_popup(GList *cycle_nodes, GHashTable *id_ht);
 
-int _hm_build_last_history_by_id(const struct dt_develop_t *dev, GHashTable **out_map);
 
 GPtrArray *_hm_collect_labels_from_history_map(GHashTable *last_by_id, const GHashTable *mod_list_ids,
                                                GPtrArray **out_styles);
@@ -72,8 +62,11 @@ gboolean dt_gui_merge_options_dialog(const char *title,
 gboolean _hm_show_merge_report_popup(struct dt_develop_t *dev_dest, struct dt_develop_t *dev_src,
                                      const gboolean merge_iop_order, const gboolean used_source_order,
                                      const dt_history_merge_strategy_t strategy, GHashTable *src_last_by_id,
-                                     GHashTable *dst_last_before_by_id, const GPtrArray *orig_labels,
-                                     const GPtrArray *orig_styles, const GHashTable *orig_ids,
+                                     GHashTable *dst_last_before_by_id, const GHashTable *orig_ids,
                                      const GHashTable *mod_list_ids, const char *source_label,
                                      dt_hm_batch_state_t *batch);
+/** Register the four handlers common/history_merge.c asks through. Called from
+ *  dt_gui_gtk_init(); without it merging simply takes its no-handler defaults. */
+void dt_history_merge_gui_register_handlers(void);
+
 #endif // DT_GUI_COMMON_HISTORY_MERGE_H

--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -89,6 +89,7 @@
 #include "common/thumbnail_notify.h"
 #include "gui/common/film_gui.h"
 #include "gui/common/folder_survey_gui.h"
+#include "gui/common/history_merge_gui.h"
 #include "gui/common/collection_gui.h"
 #include "common/startup_progress.h"
 #include "gui/dtgtk/thumbtable.h"
@@ -1346,6 +1347,7 @@ int dt_gui_gtk_init(dt_gui_gtk_t *gui)
   dt_film_gui_register_handlers();
   dt_collection_gui_register_handlers();
   dt_folder_survey_gui_register_handlers();
+  dt_history_merge_gui_register_handlers();
 
   return 0;
 }


### PR DESCRIPTION
**Based on master, independent of #1108 and #1109** — no shared files.

`common/history_merge.c` no longer includes `gui/common/history_merge_gui.h`. Layering violations 226 → **225**.

## Two problems wearing one include

**1. Misplaced ownership.** `_hm_make_node_id()`, `_hm_id_to_op_name()` and `_hm_build_last_history_by_id()` are *defined in* `common/history_merge.c` but were *declared in* the GUI header, left there by the #1103 split — so the backend included a GUI header to see declarations of its own functions. Declarations moved to `common/history_merge.h`.

**2. Four real calls into the GUI**, now handler slots.

## The obstacle, and the wrong answer I wrote down first

`_hm_collect_labels_from_history_map()` is defined on the GUI side but was called from the backend, so the include could not go. It contains **no GTK**, which made it look like a backend helper stranded in the wrong file. My first plan — recorded in roadmap §13 — was to move it down along with `_hm_clean_module_name()`, `_hm_module_row_label()`, `_hm_label_t` and `_hm_label_cmp()`.

**That plan was wrong, and two attempts at it broke the build.** `_hm_clean_module_name()` calls `dt_capitalize_label()`, which lives in `widgets/widget_style.h` — **layer 4**. The whole chain is *presentation*: it builds the display strings the report's rows are made of. Moving it into `common/` would have traded a `common→gui` edge for a `common→widgets` one. *"No GTK in it" is not the same as "belongs below the GUI"*, and taking the first for the second is what cost the two broken builds.

## The actual defect, one level up

`_hm_backup_dest()` snapshots the destination before a merge, and was capturing `orig_labels` / `orig_styles` into that snapshot — **ready-made display strings held by the backend purely so a dialog could show them later**, passed straight through to the report popup and used nowhere else.

They are gone from `_hm_dest_backup_t`. The report derives them itself, at report time, from `orig_ids` — the pre-merge module map, genuine backend data, already being passed to it. That also drops two parameters from the report signature.

## The four handler slots

With nothing left holding the include, the prompts follow the film / folder-survey / database pattern: `dt_hm_set_{constraints_choice,missing_raster,toposort_cycle,merge_report}_handler()`, registered from `dt_gui_gtk_init()`.

Defaults for a merge with nobody to ask:

| prompt | no-handler answer | why |
|---|---|---|
| constraints choice | `PREFER_DEST` | a silent merge must not rearrange the destination's existing pipeline order |
| missing raster producers | proceed | the warning is the point, not grounds to refuse work nobody can confirm |
| toposort cycle | no-op | informational |
| merge report | don't revert | a merge that completed is kept |

`dt_hm_constraint_choice_t` moves to `common/history_merge.h`, since the merge algorithm is what branches on it.

## Verification

Build green, zero first-party warnings, `cycles 0`, guards verified. Layering violations 226 → **225** on this branch's master base.

Not interactively tested: the four dialogs need a paste/style-apply that actually hits each condition (an incompatible 2-cycle, a missing raster provider, an unsortable graph).

🤖 Generated with [Claude Code](https://claude.com/claude-code)