### PR TITLE
Common: the last gui/ includes leave the backend

### DIFF
--- a/doc/include-hygiene-roadmap.md
+++ b/doc/include-hygiene-roadmap.md
@@ -602,3 +602,54 @@ initialises. Registration is the guard now.
 
 `common/database.c` is down to zero GTK tokens. Its remaining `gui/legacy_presets.h` include
 is a different problem (preset migration, not a dialog) and is left for its own pass.
+
+## 14. Done: the last `gui/` includes leave `common/`
+
+Four things, found by pulling on the one thread §12 left dangling.
+
+### `gui/legacy_presets.h` was a database migration in the wrong directory
+
+A **1144-line header** holding ~1100 lines of SQL string literals, plus the function that
+runs them, so every translation unit including it got a private copy of the array. Presets
+are a GUI concept, which is presumably how it landed in `gui/`; creating a table of them
+from hard-coded SQL is a database migration and nothing else. No GUI code ever included it —
+`common/database.c` did, and was its only consumer.
+
+Now `common/legacy_presets.{c,h}`, with the data in the `.c` and one declaration in the `.h`.
+
+### …and it never committed its transaction
+
+The loop was bounded by a hand-maintained `static const int num_sql_lines = 99;` against an
+array of **100** elements. The last one is `"COMMIT"`. So every statement ran inside the
+transaction opened by the leading `"BEGIN TRANSACTION"`, which was then left dangling on the
+connection for whatever came next to commit or roll back.
+
+Bounded by `G_N_ELEMENTS(sql_lines)` now, which fixes it and makes the class of bug
+unrepresentable. Worth noting the shape: a hand-maintained count next to the array it counts
+is a bug waiting for someone to append an element.
+
+### `common/metadata.h` included `gui/gtk.h` and used no GTK at all
+
+A dead include **in a header**, so it propagated `gui/gtk.h` into all 16 of its includers.
+It was, however, where several of them were getting `<glib.h>` and `<stdint.h>` from —
+including `metadata.h` itself, for its own declarations. Those are declared directly now.
+
+This is the argument for the clang-tidy `misc-include-cleaner` gate in §10: nothing about
+this include was visible at the point of use, and it survived every previous audit in this
+series because the audits grepped `.c` files.
+
+### `dt_gui_gtk_t.selection_stacked` was selection state parked on the GUI struct
+
+Removing the above exposed `common/selection.c` reaching for `dt_gui_get_global()` — not for
+anything GUI, but to read and write a flag of its own that happened to live on
+`dt_gui_gtk_t`. Three touch points, no GUI code among them. It is `dt_selection_t.stacked`
+now, and the field is gone from `dt_gui_gtk_t` (same treatment as `has_scroll_focus`).
+
+Note this also corrects the claim in #1109 that `selection.c`'s `gui/gtk.h` include was
+"dead": it was *redundant* — `dt_gui_get_global()` was arriving through
+`metadata.h` → `gui/gtk.h` — not unused.
+
+### Where that leaves it
+
+`common/` has **one** `gui/` include: `history_merge.c`, removed by #1110. Layering
+violations 219 → 218, and 244 at the start of this series.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -115,6 +115,7 @@ FILE(GLOB SOURCE_FILES
   "pixel/locallaplacian.c"
   "pixel/locallaplaciancl.c"
   "common/l10n.c"
+  "common/legacy_presets.c"
   "common/lut3d.c"
   "gui/lut_viewer.c"
   "common/metadata.c"

--- a/src/common/database.c
+++ b/src/common/database.c
@@ -66,7 +66,7 @@
 #include "common/history.h"
 #ifdef HAVE_ICU
 #endif
-#include "gui/legacy_presets.h"
+#include "common/legacy_presets.h"
 
 #include <gio/gio.h>
 #include <glib.h>

--- a/src/common/legacy_presets.c
+++ b/src/common/legacy_presets.c
@@ -1,32 +1,37 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2012 Aldric Renaudin.
-    Copyright (C) 2012 johannes hanika.
-    Copyright (C) 2012 Mikko Rasa.
-    Copyright (C) 2013-2014, 2016 Tobias Ellinghaus.
-    Copyright (C) 2020-2021 Pascal Obry.
-    Copyright (C) 2021 HansBull.
-    Copyright (C) 2022 Martin Bařinka.
-    Copyright (C) 2025 Aurélien PIERRE.
-    
+    Copyright (C) 2011-2020 darktable developers.
+    Copyright (C) 2026 Aurélien PIERRE.
+
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation, either version 3 of the License, or
     (at your option) any later version.
-    
+
     darktable is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
-    
+
     You should have received a copy of the GNU General Public License
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#ifndef DT_GUI_LEGACY_PRESETS_H
-#define DT_GUI_LEGACY_PRESETS_H
+/* The pre-auto-apply-cleanup preset table, as a database migration.
+ *
+ * This lived in gui/legacy_presets.h -- a 1144-line *header* holding ~1100 lines of SQL
+ * string literals plus the function that runs them, so every translation unit including it
+ * got its own copy of the array. It was also the last gui/ include in common/, which is how
+ * it was found: presets are a GUI concept, but creating a table of them from hard-coded SQL
+ * is a database migration and nothing else. No GUI code ever included it; database.c did.
+ */
+
+#include "common/legacy_presets.h"
 
 #include "common/database.h"
+
+#include <glib.h>
+#include <sqlite3.h>
 
 static const char *sql_lines[] = {
   "BEGIN TRANSACTION;",
@@ -1126,16 +1131,19 @@ static const char *sql_lines[] = {
   "','%','%','%',0.0,51200.0,0.0,10000000.0,0.0,100000000.0,0.0,1000.0,1,1,0,0,2);",
   "COMMIT"
 };
-static const int num_sql_lines = 99;
 
-static void dt_legacy_presets_create(const struct dt_database_t *db)
+void dt_legacy_presets_create(const struct dt_database_t *db)
 {
   // a bit stupid, deletes and re-inserts every time :(
-  for(int i = 0; i < num_sql_lines; i++)
+  //
+  // The bound is G_N_ELEMENTS, not a hand-maintained count. It used to be
+  // `static const int num_sql_lines = 99;` against an array of 100, so the loop stopped one
+  // short and the final "COMMIT" never ran: every statement here executed inside the
+  // transaction opened by the leading "BEGIN TRANSACTION", which was then left dangling on
+  // the connection for whatever came next to commit or roll back.
+  for(size_t i = 0; i < G_N_ELEMENTS(sql_lines); i++)
     sqlite3_exec(dt_database_get(db), sql_lines[i], NULL, NULL, NULL);
 }
-
-#endif // DT_GUI_LEGACY_PRESETS_H
 
 // clang-format off
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py

--- a/src/common/legacy_presets.h
+++ b/src/common/legacy_presets.h
@@ -1,0 +1,35 @@
+/*
+    This file is part of darktable,
+    Copyright (C) 2011-2020 darktable developers.
+    Copyright (C) 2026 Aurélien PIERRE.
+
+    darktable is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    darktable is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with darktable.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef DT_COMMON_LEGACY_PRESETS_H
+#define DT_COMMON_LEGACY_PRESETS_H
+
+struct dt_database_t;
+
+/** (Re)create main.legacy_presets and fill it with the presets darktable shipped before the
+ *  auto-apply cleanup. Drops and re-inserts every time it is called. */
+void dt_legacy_presets_create(const struct dt_database_t *db);
+
+#endif // DT_COMMON_LEGACY_PRESETS_H
+
+// clang-format off
+// modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py
+// vim: shiftwidth=2 expandtab tabstop=2 cindent
+// kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;
+// clang-format on

--- a/src/common/metadata.h
+++ b/src/common/metadata.h
@@ -30,7 +30,12 @@
 #ifndef DT_COMMON_METADATA_H
 #define DT_COMMON_METADATA_H
 
-#include "gui/gtk.h"
+// Types this header's own declarations use. They used to arrive through gui/gtk.h, which
+// this file included without using a single GTK symbol -- and which it then propagated to
+// all 16 of its includers.
+#include <glib.h>
+#include <stdint.h>
+
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/common/selection.c
+++ b/src/common/selection.c
@@ -57,6 +57,12 @@ typedef struct dt_selection_t
 
   /* GList of ids of all images in selection */
   GList *ids;
+
+  /* TRUE while a selection is parked in memory.selected_backup by dt_selection_push(),
+     waiting for the matching dt_selection_pop(). This lived on dt_gui_gtk_t, which is why a
+     layer-1 module reached for dt_gui_get_global() to read its own state -- it is not GUI
+     state, and no GUI code ever touched it. */
+  gboolean stacked;
 } dt_selection_t;
 
 
@@ -206,12 +212,12 @@ static void _selection_deselect(dt_selection_t *selection, int32_t imgid)
 void dt_selection_push(dt_selection_t *selection)
 {
   // Backup current selection
-  if(!dt_gui_get_global()->selection_stacked)
+  if(!selection->stacked)
   {
     DT_DEBUG_SQLITE3_EXEC(dt_database_get_sqlite3_global(), "DELETE FROM memory.selected_backup", NULL, NULL, NULL);
     DT_DEBUG_SQLITE3_EXEC(dt_database_get_sqlite3_global(), "INSERT INTO memory.selected_backup"
                                                          " SELECT * FROM main.selected_images", NULL, NULL, NULL);
-    dt_gui_get_global()->selection_stacked = TRUE;
+    selection->stacked = TRUE;
 
     // Commit from DB to GList of imgids
     dt_selection_reload_from_database(selection);
@@ -223,12 +229,12 @@ void dt_selection_push(dt_selection_t *selection)
 void dt_selection_pop(dt_selection_t *selection)
 {
   // Restore current selection
-  if(dt_gui_get_global()->selection_stacked)
+  if(selection->stacked)
   {
     DT_DEBUG_SQLITE3_EXEC(dt_database_get_sqlite3_global(), "DELETE FROM main.selected_images", NULL, NULL, NULL);
     DT_DEBUG_SQLITE3_EXEC(dt_database_get_sqlite3_global(), "INSERT INTO main.selected_images"
                                                          " SELECT * FROM memory.selected_backup", NULL, NULL, NULL);
-    dt_gui_get_global()->selection_stacked = FALSE;
+    selection->stacked = FALSE;
 
     // Commit from DB to GList of imgids
     dt_selection_reload_from_database(selection);

--- a/src/gui/common/collection_gui.c
+++ b/src/gui/common/collection_gui.c
@@ -25,6 +25,7 @@
 
 #include "common/collection.h"
 #include "common/macros.h"
+#include "system/mem_alloc.h"   // dt_free(), previously arriving through common/metadata.h -> gui/gtk.h
 #include "common/conf.h"
 
 #include <stdio.h>

--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -1188,7 +1188,6 @@ int dt_gui_gtk_init(dt_gui_gtk_t *gui)
   gui->surface = NULL;
   gui->center_tooltip = 0;
   gui->culling_mode = FALSE;
-  gui->selection_stacked = FALSE;
   gui->presets_popup_menu = NULL;
   gui->last_preset = NULL;
   gui->export_popup.window = NULL;

--- a/src/gui/gtk.h
+++ b/src/gui/gtk.h
@@ -296,7 +296,6 @@ typedef struct dt_gui_gtk_t
 
   // Track if the current selection has pushed on the backup copy
   // see common/selection.h:dt_selection_push()
-  gboolean selection_stacked;
 
   // Global accelerators for main menu, needed for GtkMenu mnemonics.
   dt_accels_t *accels;


### PR DESCRIPTION
**Based on master.** Slight overlap with #1110 in `src/gui/gtk.c` and the roadmap doc; whichever lands second needs a trivial rebase.

Four findings, from pulling on the one thread §12 left dangling.

## `gui/legacy_presets.h` was a database migration in the wrong directory

A **1144-line header** holding ~1100 lines of SQL string literals plus the function that runs them — so every translation unit including it got a private copy of the array. Presets are a GUI concept, which is presumably how it landed in `gui/`; creating a table of them from hard-coded SQL is a database migration and nothing else. **No GUI code ever included it.** `common/database.c` was its only consumer.

Now `common/legacy_presets.{c,h}`, data in the `.c`, one declaration in the `.h`.

## …and it never committed its transaction

The loop was bounded by a hand-maintained `static const int num_sql_lines = 99;` against an array of **100** elements. The last one is `"COMMIT"`.

So every statement ran inside the transaction opened by the leading `"BEGIN TRANSACTION"`, which was then left dangling on the connection for whatever came next to commit or roll back.

Bounded by `G_N_ELEMENTS(sql_lines)` now — fixes it, and makes the class unrepresentable. A hand-maintained count sitting next to the array it counts is a bug waiting for someone to append an element.

## `common/metadata.h` included `gui/gtk.h` and used no GTK at all

A dead include **in a header**, propagating `gui/gtk.h` into all 16 of its includers. It was, however, where several of them were getting `<glib.h>` and `<stdint.h>` — `metadata.h` itself included, for its own declarations. Those are declared directly now.

This one survived every earlier audit in this series because they all grepped `.c` files. It's the argument for the clang-tidy `misc-include-cleaner` gate in §10.

## `dt_gui_gtk_t.selection_stacked` was selection state parked on the GUI struct

Removing the above exposed `common/selection.c` reaching for `dt_gui_get_global()` — not for anything GUI, but to read and write a flag of its own that happened to live on `dt_gui_gtk_t`. Three touch points, no GUI code among them. It's `dt_selection_t.stacked` now, and the field is gone from `dt_gui_gtk_t` (same treatment as `has_scroll_focus`).

**Correction to #1109:** I described `selection.c`'s `gui/gtk.h` include there as "dead". It was *redundant*, not unused — `dt_gui_get_global()` was arriving through `metadata.h` → `gui/gtk.h`. The removal was still correct, but the reason I gave was wrong.

## Where that leaves `common/`

**One** `gui/` include left in the whole directory: `history_merge.c`, removed by #1110. Layering violations 219 → **218** (244 at the start of this series).

## Verification

Build green, zero first-party warnings, `cycles 0`, guards verified.

The legacy-presets migration itself is not exercised by a normal run — it only fires on a pre-auto-apply-cleanup database — so the `COMMIT` fix is reasoned from the code, not observed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)