### PR TITLE
CI: gate the include graph, and unused includes on the diff

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,18 @@
+# Unused-include detection, and nothing else.
+#
+# The full misc-include-cleaner check has two halves. The "is not used directly" half is what
+# this repository wants: an include that no longer carries its weight is dead weight, and --
+# as src/common/metadata.h showed, an unused include in a *header* silently propagates a whole
+# subsystem into every file downstream of it.
+#
+# The other half ("no header providing X is directly included") is unusable here. On a
+# glib/GTK codebase it fires on essentially every symbol, because include-cleaner attributes
+# g_strrstr() to glib/gstrfuncs.h rather than to the <glib.h> umbrella everyone includes.
+# Measured: 46 warnings on one 900-line file, 45 of them that half. tools/check_unused_includes.sh
+# filters it out; it is left enabled here only because the check offers no switch to disable it.
+#
+# IgnoreHeaders keeps umbrella and system headers out of the "unused" verdict for the same
+# reason -- <glib.h> is "unused" whenever the symbols actually came from its sub-headers.
+Checks: '-*,misc-include-cleaner'
+CheckOptions:
+  misc-include-cleaner.IgnoreHeaders: 'glib[.]h;glib/.*;glib-object[.]h;gtk/.*;gdk/.*;gdk-pixbuf/.*;gio/.*;cairo.*;pango/.*;lcms2[.]h;sqlite3[.]h;json-glib/.*;librsvg/.*;lensfun[.]h;.*intrin[.]h;omp[.]h;.*/external/.*;.*/build/.*'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,7 +115,7 @@ jobs:
           sudo gpg --dearmor -o /usr/share/keyrings/llvm.gpg llvm-snapshot.gpg.key
           echo "deb [signed-by=/usr/share/keyrings/llvm.gpg] http://apt.llvm.org/noble/ llvm-toolchain-noble-20 main" | sudo tee /etc/apt/sources.list.d/llvm.list
           sudo apt-get update
-          sudo apt-get install -y clang-20 libomp-20-dev
+          sudo apt-get install -y clang-20 libomp-20-dev clang-tidy-20
       - uses: actions/checkout@v6
         with:
           submodules: true
@@ -155,6 +155,24 @@ jobs:
           done
 
           exit $status
+      - name: Check include hygiene
+        # Cheap, no compilation database needed, so it runs on every Linux variant. The
+        # ratchet is what catches a header pulling in a higher layer -- the case the
+        # unused-include check below is structurally blind to.
+        run: |
+          "${SRC_DIR}/tools/check_layering.sh"
+      - name: Check for unused includes in changed files
+        # Only on the LLVM variant: clang-tidy reads compile_commands.json, and a database
+        # written by GCC carries flags clang-tidy rejects. Only on pull requests, because it
+        # gates the diff rather than the tree -- see the script's header for why.
+        if: ${{ github.event_name == 'pull_request' && matrix.compiler.compiler == 'LLVM20' && matrix.target == 'skiptest' }}
+        env:
+          BUILD_DIR: ${{ github.workspace }}/build
+          CLANG_TIDY: clang-tidy-20
+        run: |
+          cd "${SRC_DIR}"
+          git fetch --no-tags --depth=1 origin "${{ github.base_ref }}"
+          ./tools/check_unused_includes.sh --changed "origin/${{ github.base_ref }}"
       - name: Upload ansel backtrace
         if: always()
         uses: actions/upload-artifact@v4

--- a/doc/include-hygiene-roadmap.md
+++ b/doc/include-hygiene-roadmap.md
@@ -718,3 +718,51 @@ Note this also corrects the claim in #1109 that `selection.c`'s `gui/gtk.h` incl
 
 `common/` has **one** `gui/` include: `history_merge.c`, removed by #1110. Layering
 violations 219 → 218, and 244 at the start of this series.
+## 15. CI gates: what each one can and cannot see
+
+Two checks, because neither covers the other's cases.
+
+### `tools/check_layering.sh` — a ratchet on the include graph
+
+Layering violations may fall, never rise; cycles must stay at zero. Baseline in
+`tools/include_baseline.txt`, updated with `--update` when the number improves.
+
+A ratchet rather than a threshold because the tree carries ~217 inherited violations:
+demanding zero would mean the check gets switched off. "No worse than yesterday" costs
+nothing to comply with and cannot be quietly eroded. Cycles are *not* ratcheted — the
+explicit include guards this repository uses instead of `#pragma once` exist precisely so a
+cycle is a hard error, and a baseline there would hand that back.
+
+Verified by injecting `#include "gui/gtk.h"` into `common/image_extensions.h`: 220 → 221,
+exit 1, restored → exit 0. And again in the other direction, unplanned: rebasing this branch
+onto a master that had gained #1110 and #1111 made the check fail with *fell 220 → 217*,
+which is the ratchet working — an improvement that is not recorded is an improvement the
+next regression gets to spend.
+
+### `tools/check_unused_includes.sh` — clang-tidy on the diff
+
+`misc-include-cleaner`, filtered to the "is not used directly" half and run only on the `.c`
+files a pull request touches.
+
+**Filtered**, because the other half ("no header providing X is directly included") is
+unusable on a glib/GTK codebase: include-cleaner attributes `g_strrstr()` to
+`glib/gstrfuncs.h` rather than to the `<glib.h>` umbrella everyone includes. Measured 46
+warnings on one file, 45 of them that half. `IgnoreHeaders` in `.clang-tidy` covers the
+umbrella and system headers for the same reason.
+
+**On the diff**, because the measured density is ~0.78 unused includes per translation unit —
+several hundred tree-wide. Gating the diff means every file anyone touches comes out clean,
+with no baseline file to drift.
+
+### The gap, stated plainly
+
+**The unused-include check cannot see headers, and that is not a configuration mistake.**
+include-cleaner analyses the symbols referenced by a translation unit's *main file*; a header
+is not one. `--header-filter` does not help — measured, it selects which files' diagnostics
+are printed, not which are analysed, and reports the `.c`'s unused includes while saying
+nothing about the `.h`. Compiling the header as a synthetic translation unit is worse: that
+unit references nothing, so every one of the header's includes comes out "unused".
+
+This matters because **the case that motivated both checks is exactly the case this one
+cannot see** — `common/metadata.h` including `gui/gtk.h` and using no GTK symbol (§14). The
+layering ratchet is what catches that class, which is why both exist.

--- a/tools/check_layering.sh
+++ b/tools/check_layering.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+#
+# Ratchet on the include graph: the number of layering violations may go down, never up, and
+# the graph must stay acyclic.
+#
+# This is the gate that catches the class tools/check_unused_includes.sh cannot see. That one
+# analyses translation units, so it is blind to headers -- and the case that prompted both
+# checks was a header: common/metadata.h included gui/gtk.h, used no GTK symbol, and pushed
+# the GUI into all 16 of its includers. As a layering violation it is visible here.
+#
+# A ratchet rather than a threshold: the tree carries a few hundred inherited violations, so
+# demanding zero would mean turning the check off. Demanding "no worse than yesterday" costs
+# nothing to comply with and cannot be quietly eroded.
+#
+# Usage:
+#   tools/check_layering.sh            # check against tools/include_baseline.txt
+#   tools/check_layering.sh --update   # record the current numbers as the new baseline
+
+set -uo pipefail
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "${REPO_ROOT}" || exit 2
+BASELINE="tools/include_baseline.txt"
+PYTHON="${PYTHON:-python3}"
+
+summary="$(${PYTHON} tools/include_graph.py --summary 2>/dev/null)" || {
+  echo "error: tools/include_graph.py failed" >&2; exit 2; }
+
+get() { printf '%s\n' "$summary" | awk -v k="$1" '$1==k {print $2}'; }
+cycles="$(get cycles)"
+violations="$(get layering_violations)"
+
+if [ -z "${cycles}" ] || [ -z "${violations}" ]; then
+  echo "error: could not read cycles/layering_violations from the summary" >&2
+  exit 2
+fi
+
+if [ "${1:-}" = "--update" ]; then
+  {
+    echo "# Include-graph ratchet baseline. Regenerate with tools/check_layering.sh --update."
+    echo "# Lower these by fixing includes; never raise them to make CI pass."
+    echo "cycles ${cycles}"
+    echo "layering_violations ${violations}"
+  } > "${BASELINE}"
+  echo "Baseline updated: cycles ${cycles}, layering_violations ${violations}"
+  exit 0
+fi
+
+if [ ! -f "${BASELINE}" ]; then
+  echo "error: ${BASELINE} missing -- run tools/check_layering.sh --update" >&2
+  exit 2
+fi
+
+base_violations="$(awk '$1=="layering_violations" {print $2}' "${BASELINE}")"
+
+status=0
+
+# Cycles are absolute, not ratcheted. The include guards documented in CLAUDE.md exist so a
+# cycle is a hard error rather than something #pragma once absorbs silently; a baseline here
+# would give that back.
+if [ "${cycles}" -ne 0 ]; then
+  echo "FAIL: ${cycles} include cycle(s). The graph must stay acyclic -- see CLAUDE.md on why"
+  echo "      this repository uses explicit include guards instead of #pragma once."
+  status=1
+fi
+
+if [ "${violations}" -gt "${base_violations}" ]; then
+  echo "FAIL: layering violations rose ${base_violations} -> ${violations} (+$((violations - base_violations)))."
+  echo
+  echo "Something now includes a header from a higher layer. Run:"
+  echo "    python3 tools/include_graph.py"
+  echo "for the list, and give the file the specific lower-layer header it needs -- or invert"
+  echo "the dependency with a handler the upper layer registers, as common/film.c and"
+  echo "common/database.c do."
+  echo
+  echo "Do NOT raise the baseline to make this pass."
+  status=1
+elif [ "${violations}" -lt "${base_violations}" ]; then
+  echo "Layering violations fell ${base_violations} -> ${violations}. Please run:"
+  echo "    tools/check_layering.sh --update"
+  echo "and commit ${BASELINE} so the improvement is locked in."
+  status=1
+else
+  echo "OK: cycles 0, layering violations ${violations} (baseline ${base_violations})."
+fi
+
+exit ${status}

--- a/tools/check_unused_includes.sh
+++ b/tools/check_unused_includes.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+#
+# Report #includes that the file does not use, via clang-tidy's misc-include-cleaner.
+#
+# Scope is deliberately the files a change touches, not the whole tree. A measured ~0.78
+# unused includes per translation unit means the tree carries several hundred of them; a
+# blocking whole-tree gate would demand that cleanup up front and would simply be turned off.
+# Gating the diff instead means every file anyone touches comes out clean, with no baseline
+# file to drift out of date.
+#
+# Usage:
+#   tools/check_unused_includes.sh --changed <base-ref>   # files changed since <base-ref>
+#   tools/check_unused_includes.sh <file>...              # explicit files
+#
+# Requires a configured build directory with compile_commands.json (BUILD_DIR, default ./build).
+
+set -uo pipefail
+
+BUILD_DIR="${BUILD_DIR:-build}"
+CLANG_TIDY="${CLANG_TIDY:-clang-tidy}"
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "${REPO_ROOT}" || exit 2
+
+if [ ! -f "${BUILD_DIR}/compile_commands.json" ]; then
+  echo "error: no ${BUILD_DIR}/compile_commands.json -- configure the build first" >&2
+  exit 2
+fi
+if ! command -v "${CLANG_TIDY}" >/dev/null 2>&1; then
+  echo "error: ${CLANG_TIDY} not found" >&2
+  exit 2
+fi
+
+files=()
+if [ "${1:-}" = "--changed" ]; then
+  base="${2:?--changed needs a base ref}"
+  while IFS= read -r f; do
+    [ -n "$f" ] && files+=("$f")
+  # Two dots, not three. CI checks out with fetch-depth 1, so there is no common ancestor to
+  # compute a merge base from and "${base}...HEAD" would fail outright. Comparing the two tips
+  # directly can pull in a file that changed on the base branch rather than here, which errs
+  # toward checking one file too many -- the safe direction for a gate.
+  done < <(git diff --name-only --diff-filter=d "${base}" HEAD -- 'src/*.c' 'src/*.cc' \
+           | grep -v '^src/external/')
+else
+  files=("$@")
+fi
+
+if [ ${#files[@]} -eq 0 ]; then
+  echo "No source files changed; nothing to check."
+  exit 0
+fi
+
+findings=0
+checked=0
+
+for f in "${files[@]}"; do
+  [ -f "$f" ] || continue
+
+  # HEADERS ARE NOT COVERED, and there is no way to cover them with this check.
+  # include-cleaner analyses the symbols referenced by the *main file* of a translation unit.
+  # A header is not one. --header-filter does not help: it selects which files' diagnostics
+  # are printed, not which files are analysed -- measured, it reports the .c's unused includes
+  # and says nothing about the .h. Compiling the header as a synthetic TU is worse than
+  # useless: that TU references nothing, so every one of the header's includes comes out
+  # "unused".
+  #
+  # This matters, because the case that motivated adding this check -- common/metadata.h
+  # including gui/gtk.h and using no GTK symbol -- is exactly the case it cannot see.
+  # tools/include_graph.py is what catches that class; see check_layering.sh next to this file.
+  case "$f" in
+    *.h) continue ;;
+  esac
+
+  out="$("${CLANG_TIDY}" -p "${BUILD_DIR}" --quiet "$f" 2>/dev/null \
+         | grep "is not used directly" | grep -F "${f}:")"
+
+  checked=$((checked + 1))
+  if [ -n "$out" ]; then
+    printf '%s\n' "$out"
+    findings=$((findings + $(printf '%s\n' "$out" | wc -l)))
+  fi
+done
+
+echo
+echo "Checked ${checked} file(s); ${findings} unused include(s) found."
+if [ "${findings}" -gt 0 ]; then
+  cat <<'MSG'
+
+Remove them, or -- if the include is there for a symbol clang-tidy cannot attribute to it --
+replace it with the header that actually declares what this file uses. Do not silence it by
+adding a use.
+MSG
+  exit 1
+fi
+exit 0

--- a/tools/include_baseline.txt
+++ b/tools/include_baseline.txt
@@ -1,0 +1,4 @@
+# Include-graph ratchet baseline. Regenerate with tools/check_layering.sh --update.
+# Lower these by fixing includes; never raise them to make CI pass.
+cycles 0
+layering_violations 217


### PR DESCRIPTION
**Based on master.** Touches only `.clang-tidy`, `tools/`, `.github/workflows/ci.yml` and the roadmap — no conflict with #1110 or #1111 except the roadmap appendix.

Two checks, because **neither covers the other's cases**.

## `tools/check_layering.sh` — a ratchet on the include graph

Layering violations may fall, never rise; cycles must stay at zero. Baseline in `tools/include_baseline.txt`, updated with `--update` when the number improves (the script *fails* when the count drops, telling you to commit the improvement, so gains get locked in).

A **ratchet rather than a threshold** because the tree carries ~220 inherited violations — demanding zero would mean the check gets switched off. "No worse than yesterday" costs nothing to comply with and cannot be quietly eroded.

**Cycles are not ratcheted.** The explicit include guards this repo uses instead of `#pragma once` exist precisely so a cycle is a hard error; a baseline there would hand that back.

Verified rather than assumed — injected `#include "gui/gtk.h"` into `common/image_extensions.h`:

```
FAIL: layering violations rose 220 -> 221 (+1).
```

exit 1; restored → exit 0.

## `tools/check_unused_includes.sh` — clang-tidy on the diff

`misc-include-cleaner`, filtered to the "is not used directly" half, run on the `.c` files a PR touches.

**Filtered**, because the other half ("no header providing X is directly included") is unusable on a glib/GTK codebase: include-cleaner attributes `g_strrstr()` to `glib/gstrfuncs.h` rather than the `<glib.h>` umbrella everyone includes. Measured **46 warnings on one file, 45 of them that half**. `IgnoreHeaders` in `.clang-tidy` covers umbrella and system headers for the same reason. After tuning: 0–1 per file, high signal (`film.c` → `settings.h`, `tags.h`, `errno.h`, … all genuinely unused).

**On the diff**, because measured density is **~0.78 unused includes per TU** — several hundred tree-wide. Gating the diff means every file anyone touches comes out clean, with no baseline to drift.

## The gap, stated rather than papered over

**The unused-include check cannot see headers, and that is not a misconfiguration.** include-cleaner analyses the symbols referenced by a TU's *main file*; a header is not one. `--header-filter` does not help — measured, it selects which diagnostics print, not which files are analysed, and reports the `.c`'s unused includes while saying nothing about the `.h`. Compiling the header as a synthetic TU is worse: that unit references nothing, so *every* include comes out "unused".

Which means **the case that motivated both checks — `common/metadata.h` including `gui/gtk.h` and using no GTK symbol (#1111) — is precisely the one it misses.** The layering ratchet catches that class. That is why there are two.

## Wiring

| check | where | why |
|---|---|---|
| layering ratchet | every Linux variant | no compilation database needed, near-free |
| unused includes | `LLVM20` + `skiptest`, PRs only | a `compile_commands.json` written by GCC carries flags clang-tidy rejects |

`clang-tidy-20` added to the LLVM setup step (it installed only `clang-20`).

The diff uses **two dots, not three**: CI checks out with `fetch-depth: 1`, so there is no merge base and a three-dot diff would fail outright. Two-dot can pull in a file changed on the base branch instead — erring toward one file too many, the safe direction for a gate.

## Verification

Both scripts pass `bash -n`; YAML validated with `yaml.safe_load`. Ratchet regression-tested as above. Unused-include check tested end to end by touching `common/film.c` and running `--changed origin/master`: picked up the one file, reported its 7 unused includes, exit 1.

Not verified: the CI steps as GitHub will actually run them — `${SRC_DIR}` and the `clang-tidy-20` install are reasoned from the workflow, not executed. Worth watching on this PR's own run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)