### PR TITLE
opencl: close the module — private state, device queries, no globals

### DIFF
--- a/src/colorprofiles/iop_profile.c
+++ b/src/colorprofiles/iop_profile.c
@@ -690,7 +690,14 @@ void dt_ioppr_transform_image_colorspace_rgb(const float *const restrict image_i
 }
 
 #ifdef HAVE_OPENCL
-dt_colorspaces_cl_global_t *dt_colorspaces_init_cl_global()
+/* The kernels this subsystem compiles, owned HERE. They used to be handed to
+ * common/opencl.c, parked on the application-wide dt_opencl_t, and read back from it --
+ * a round trip through a god-struct that added nothing but an ordering. opencl.c still
+ * calls init/free, because the kernels must be built after the devices exist, but the
+ * pointer never leaves this file. */
+static dt_colorspaces_cl_global_t *_colorspaces_cl_global = NULL;
+
+void dt_colorspaces_init_cl_global(void)
 {
   dt_colorspaces_cl_global_t *g = (dt_colorspaces_cl_global_t *)malloc(sizeof(dt_colorspaces_cl_global_t));
 
@@ -699,11 +706,13 @@ dt_colorspaces_cl_global_t *dt_colorspaces_init_cl_global()
   g->kernel_colorspaces_transform_rgb_matrix_to_lab = dt_opencl_create_kernel(program, "colorspaces_transform_rgb_matrix_to_lab");
   g->kernel_colorspaces_transform_rgb_matrix_to_rgb
       = dt_opencl_create_kernel(program, "colorspaces_transform_rgb_matrix_to_rgb");
-  return g;
+  _colorspaces_cl_global = g;
 }
 
-void dt_colorspaces_free_cl_global(dt_colorspaces_cl_global_t *g)
+void dt_colorspaces_free_cl_global(void)
 {
+  dt_colorspaces_cl_global_t *g = _colorspaces_cl_global;
+  _colorspaces_cl_global = NULL;
   if(IS_NULL_PTR(g)) return;
 
   // destroy kernels
@@ -890,7 +899,7 @@ int dt_ioppr_transform_image_colorspace_rgb_cl(const int devid, cl_mem dev_img_i
     size_t origin[] = { 0, 0, 0 };
     size_t region[] = { width, height, 1 };
 
-    kernel_transform = dt_opencl_get_global()->colorspaces->kernel_colorspaces_transform_rgb_matrix_to_rgb;
+    kernel_transform = _colorspaces_cl_global->kernel_colorspaces_transform_rgb_matrix_to_rgb;
 
     dt_ioppr_get_profile_info_cl(profile_info_from, &profile_info_from_cl);
     lut_from_cl = dt_ioppr_get_trc_cl(profile_info_from);
@@ -1401,11 +1410,11 @@ int dt_colorspaces_apply_profile_cl(const char *const op_name, const char *const
 
     if(dt_iop_colorspace_is_rgb(cst_from) && cst_to == IOP_CS_LAB)
     {
-      kernel_transform = dt_opencl_get_global()->colorspaces->kernel_colorspaces_transform_rgb_matrix_to_lab;
+      kernel_transform = _colorspaces_cl_global->kernel_colorspaces_transform_rgb_matrix_to_lab;
     }
     else if(cst_from == IOP_CS_LAB && dt_iop_colorspace_is_rgb(cst_to))
     {
-      kernel_transform = dt_opencl_get_global()->colorspaces->kernel_colorspaces_transform_lab_to_rgb_matrix;
+      kernel_transform = _colorspaces_cl_global->kernel_colorspaces_transform_lab_to_rgb_matrix;
     }
     else
     {

--- a/src/colorprofiles/iop_profile.h
+++ b/src/colorprofiles/iop_profile.h
@@ -378,7 +378,7 @@ void dt_ioppr_transform_image_colorspace_rgb(const float *const image_in, float 
  *
  * @details Built from `colorspaces.cl` (program 23 in `data/kernels/programs.conf`) by
  * dt_colorspaces_init_cl_global(), reached from the pixel loops as
- * `dt_opencl_get_global()->colorspaces`. Members are kernel handles, not pointers.
+ * a file-static in colorprofiles/iop_profile.c. Members are kernel handles, not pointers.
  */
 typedef struct dt_colorspaces_cl_global_t
 {
@@ -415,9 +415,9 @@ typedef struct dt_colorspaces_iccprofile_info_cl_t
  * @brief Compile the colorspace kernels. Called once by common/opencl.c at device init.
  * @return A `malloc`ed struct the caller owns; release with dt_colorspaces_free_cl_global().
  */
-dt_colorspaces_cl_global_t *dt_colorspaces_init_cl_global(void);
+void dt_colorspaces_init_cl_global(void);
 /** @brief Release the kernels and the struct from dt_colorspaces_init_cl_global(). NULL-safe. */
-void dt_colorspaces_free_cl_global(dt_colorspaces_cl_global_t *g);
+void dt_colorspaces_free_cl_global(void);
 
 /**
  * @brief sets profile_info_cl using profile_info, to be used as a parameter when calling

--- a/src/common/opencl.c
+++ b/src/common/opencl.c
@@ -83,6 +83,52 @@
 #include <sys/stat.h>
 #include <zlib.h>
 
+typedef struct dt_opencl_t
+{
+  dt_pthread_mutex_t lock;
+  int inited;
+  int print_statistics;
+  int enabled;
+  int stopped;
+  int num_devs;
+  int num_detected_devs;
+  int error_count;
+  int opencl_synchronization_timeout;
+  uint32_t crc;
+  int mandatory[5];
+  int *dev_priority_image;
+  int *dev_priority_preview;
+  int *dev_priority_export;
+  int *dev_priority_thumbnail;
+  dt_opencl_device_t *dev;
+  dt_opencl_detected_device_t *detected_devs;
+  dt_dlopencl_t *dlocl;
+
+  /* NOTE: the per-subsystem OpenCL kernel bundles (blend, bilateral, gaussian, interpolation,
+   * local laplacian, dwt, heal, colorspaces, guided filter) used to live here. Each was built
+   * by its own subsystem, parked on this struct, and read back from it by that same
+   * subsystem -- a round trip that made nine modules' state look like the OpenCL module's.
+   * They are file-statics in their owners now; this module only orders their init and free
+   * against device setup. */
+
+  // Maps every live cl_mem we allocated to the (devid, byte size) we requested,
+  // so memory accounting never has to query the driver (clGetMemObjectInfo) about
+  // a freshly-created object -- some drivers fault on that under vRAM pressure.
+  GHashTable *mem_sizes;
+  dt_pthread_mutex_t mem_sizes_lock;
+} dt_opencl_t;
+
+/* The OpenCL module's state, owned HERE. It used to hang off the application god-struct as
+ * `darktable.opencl`, which put every device handle, every kernel bundle and this module's
+ * lock one dereference away from any translation unit that included darktable.h. Nothing
+ * outside src/common/opencl.* names it now; callers ask questions instead
+ * (dt_opencl_get_num_devices(), dt_opencl_get_device_name(), ...) and reserve devices through
+ * dt_opencl_reserve_device_*(). */
+static dt_opencl_t *_opencl = NULL;
+
+/* Internal: neither is called from outside this file. */
+static void dt_opencl_cleanup_device(dt_opencl_t *cl, int i);
+
 static inline void _opencl_splash_update_compile(const char *programname)
 {
   if(IS_NULL_PTR(programname)) return;
@@ -104,7 +150,7 @@ static void dt_opencl_apply_scheduling_profile();
 static void dt_opencl_set_synchronization_timeout(int value);
 
 
-int dt_opencl_get_device_info(dt_opencl_t *cl, cl_device_id device, cl_device_info param_name, void **param_value,
+static int dt_opencl_get_device_info(dt_opencl_t *cl, cl_device_id device, cl_device_info param_name, void **param_value,
                               size_t *param_value_size)
 {
   *param_value_size = SIZE_MAX;
@@ -163,19 +209,19 @@ error:
 
 int dt_opencl_avoid_atomics(const int devid)
 {
-  dt_opencl_t *cl = darktable.opencl;
+  dt_opencl_t *cl = _opencl;
   return (!cl->inited || devid < 0) ? 0 : cl->dev[devid].avoid_atomics;
 }
 
 int dt_opencl_micro_nap(const int devid)
 {
-  dt_opencl_t *cl = darktable.opencl;
+  dt_opencl_t *cl = _opencl;
   return (!cl->inited || devid < 0) ? 0 : cl->dev[devid].micro_nap;
 }
 
 gboolean dt_opencl_use_pinned_memory(const int devid)
 {
-  dt_opencl_t *cl = darktable.opencl;
+  dt_opencl_t *cl = _opencl;
   if(!cl->inited || devid < 0) return FALSE;
   return cl->dev[devid].pinned_memory & DT_OPENCL_PINNING_ON;
 }
@@ -189,7 +235,7 @@ gboolean dt_opencl_is_pinned_memory(cl_mem mem)
 void dt_opencl_write_device_config(const int devid)
 {
   if(devid < 0) return;
-  dt_opencl_t *cl = darktable.opencl;
+  dt_opencl_t *cl = _opencl;
   gchar buf[256] = { 0 };
   gchar key_device[256] = { 0 };
   g_snprintf(key_device, 254, "%s/%i/%s", DT_CLDEVICE_HEAD, devid, cl->dev[devid].cname);
@@ -239,7 +285,7 @@ static int _dt_opencl_get_conf_int(const gchar *key_device, const gchar *conf_na
 gboolean dt_opencl_read_device_config(const int devid)
 {
   if(devid < 0) return FALSE;
-  dt_opencl_t *cl = darktable.opencl;
+  dt_opencl_t *cl = _opencl;
   gchar key_device[256] = { 0 };
   g_snprintf(key_device, 254, "%s/%i/%s", DT_CLDEVICE_HEAD, devid, cl->dev[devid].cname);
   gboolean safety_ok = TRUE;
@@ -302,7 +348,7 @@ gboolean dt_opencl_read_device_config(const int devid)
 
 int dt_opencl_get_detected_device_count(void)
 {
-  dt_opencl_t *cl = darktable.opencl;
+  dt_opencl_t *cl = _opencl;
   if(IS_NULL_PTR(cl)) return 0;
 
   return cl->num_detected_devs;
@@ -310,7 +356,7 @@ int dt_opencl_get_detected_device_count(void)
 
 const dt_opencl_detected_device_t *dt_opencl_get_detected_device(const int detected)
 {
-  dt_opencl_t *cl = darktable.opencl;
+  dt_opencl_t *cl = _opencl;
   if(IS_NULL_PTR(cl) || detected < 0 || detected >= cl->num_detected_devs) return NULL;
 
   return cl->detected_devs + detected;
@@ -339,7 +385,7 @@ int dt_opencl_set_detected_device_enabled(const int detected, const gboolean ena
              !IS_NULL_PTR(device->cname) ? device->cname : "");
   dt_conf_set_int(key, enabled ? 0 : 1);
 
-  dt_opencl_t *cl = darktable.opencl;
+  dt_opencl_t *cl = _opencl;
   cl->detected_devs[detected].disabled = enabled ? 0 : 1;
 
   gboolean opencl_enabled = enabled;
@@ -385,7 +431,7 @@ int dt_opencl_set_detected_device_pinned_memory(const int detected, const gboole
              !IS_NULL_PTR(device->cname) ? device->cname : "");
   dt_conf_set_int(key, pinned_memory);
 
-  dt_opencl_t *cl = darktable.opencl;
+  dt_opencl_t *cl = _opencl;
   cl->detected_devs[detected].pinned_memory = pinned_memory;
   // device->config_id is this device's live index into cl->dev[] (assigned at detection time,
   // see dt_opencl_device_init()) -- apply immediately instead of only on the next restart, since
@@ -418,7 +464,7 @@ int dt_opencl_set_detected_device_headroom(const int detected, const size_t head
   const int clamped_headroom = (int)MIN(headroom, (size_t)G_MAXINT);
   dt_conf_set_int(key, clamped_headroom);
 
-  dt_opencl_t *cl = darktable.opencl;
+  dt_opencl_t *cl = _opencl;
   cl->detected_devs[detected].forced_headroom = clamped_headroom;
   // Same live-apply as pinned memory above: device->config_id is this device's index into
   // cl->dev[], which dt_opencl_get_device_available() actually reads through used_available.
@@ -1009,8 +1055,12 @@ end:
   return res;
 }
 
-void dt_opencl_init(dt_opencl_t *cl, const gboolean exclude_opencl, const gboolean print_statistics)
+void dt_opencl_init(const gboolean exclude_opencl, const gboolean print_statistics)
 {
+  if(_opencl) return;
+  _opencl = (dt_opencl_t *)calloc(1, sizeof(dt_opencl_t));
+  if(IS_NULL_PTR(_opencl)) return;
+  dt_opencl_t *cl = _opencl;
   dt_pthread_mutex_init(&cl->lock, NULL);
   dt_pthread_mutex_init(&cl->mem_sizes_lock, NULL);
   cl->mem_sizes = g_hash_table_new_full(g_direct_hash, g_direct_equal, NULL, g_free);
@@ -1249,7 +1299,7 @@ finally:
   return;
 }
 
-void dt_opencl_cleanup_device(dt_opencl_t *cl, int i)
+static void dt_opencl_cleanup_device(dt_opencl_t *cl, int i)
 {
   dt_pthread_mutex_destroy(&cl->dev[i].lock);
   for(int k = 0; k < DT_OPENCL_MAX_KERNELS; k++)
@@ -1298,8 +1348,10 @@ void dt_opencl_cleanup_device(dt_opencl_t *cl, int i)
   dt_free(cl->dev[i].options_md5);
 }
 
-void dt_opencl_cleanup(dt_opencl_t *cl)
+void dt_opencl_cleanup(void)
 {
+  dt_opencl_t *cl = _opencl;
+  if(IS_NULL_PTR(cl)) return;
   if(cl->inited)
   {
     dt_develop_blend_free_cl_global();
@@ -1339,6 +1391,9 @@ void dt_opencl_cleanup(dt_opencl_t *cl)
   if(cl->mem_sizes) g_hash_table_destroy(cl->mem_sizes);
   dt_pthread_mutex_destroy(&cl->mem_sizes_lock);
   dt_pthread_mutex_destroy(&cl->lock);
+
+  dt_free(_opencl);
+  _opencl = NULL;
 }
 
 static const char *dt_opencl_get_vendor_by_id(unsigned int id)
@@ -1365,7 +1420,7 @@ static const char *dt_opencl_get_vendor_by_id(unsigned int id)
 
 gboolean dt_opencl_finish(const int devid)
 {
-  dt_opencl_t *cl = darktable.opencl;
+  dt_opencl_t *cl = _opencl;
   if(!cl->inited || devid < 0) return FALSE;
 
   cl_int err = (cl->dlocl->symbols->dt_clFinish)(cl->dev[devid].cmd_queue);
@@ -1379,7 +1434,7 @@ gboolean dt_opencl_finish(const int devid)
 
 int dt_opencl_enqueue_barrier(const int devid)
 {
-  dt_opencl_t *cl = darktable.opencl;
+  dt_opencl_t *cl = _opencl;
   if(!cl->inited || devid < 0) return -1;
   return (cl->dlocl->symbols->dt_clEnqueueBarrier)(cl->dev[devid].cmd_queue);
 }
@@ -1403,7 +1458,7 @@ static int _take_from_list(int *list, int value)
 
 static int _device_by_cname(const char *name)
 {
-  dt_opencl_t *cl = darktable.opencl;
+  dt_opencl_t *cl = _opencl;
   int devs = cl->num_devs;
   char tmp[2048] = { 0 };
   int result = -1;
@@ -1546,7 +1601,7 @@ static void dt_opencl_priority_parse(dt_opencl_t *cl, char *configstr, int *prio
 // set device priorities according to config string
 static void dt_opencl_update_priorities()
 {
-  dt_opencl_t *cl = darktable.opencl;
+  dt_opencl_t *cl = _opencl;
   if(!cl->inited) return;
 
   // Priority parsing iterates over the list of available devices.
@@ -1579,9 +1634,9 @@ static void dt_opencl_update_priorities()
              cl->mandatory[1] ? "yes" : "no", cl->mandatory[2] ? "yes" : "no", cl->mandatory[3] ? "yes" : "no");
 }
 
-int dt_opencl_lock_device(const int pipetype)
+int dt_opencl_reserve_device_for_pipe(const int pipetype)
 {
-  dt_opencl_t *cl = darktable.opencl;
+  dt_opencl_t *cl = _opencl;
   if(!cl->inited) return -1;
 
 
@@ -1664,12 +1719,78 @@ int dt_opencl_lock_device(const int pipetype)
   return -1;
 }
 
-void dt_opencl_unlock_device(const int dev)
+void dt_opencl_release_device(const int devid)
 {
-  dt_opencl_t *cl = darktable.opencl;
+  dt_opencl_t *cl = _opencl;
   if(!cl->inited) return;
-  if(dev < 0 || dev >= cl->num_devs) return;
-  dt_pthread_mutex_BAD_unlock(&cl->dev[dev].lock);
+  if(devid < 0 || devid >= cl->num_devs) return;
+  dt_pthread_mutex_BAD_unlock(&cl->dev[devid].lock);
+}
+
+/* The same per-device lock dt_opencl_reserve_device_for_pipe() takes, for callers that
+ * already know which device they need -- typically to touch that device's cl_mem or its
+ * eventlist, which races the pipe using it otherwise. */
+void dt_opencl_reserve_device_by_id(const int devid)
+{
+  dt_opencl_t *cl = _opencl;
+  if(!cl->inited) return;
+  if(devid < 0 || devid >= cl->num_devs) return;
+  dt_pthread_mutex_lock(&cl->dev[devid].lock);
+}
+
+int dt_opencl_try_reserve_device_by_id(const int devid)
+{
+  dt_opencl_t *cl = _opencl;
+  if(!cl->inited) return 1;
+  if(devid < 0 || devid >= cl->num_devs) return 1;
+  return dt_pthread_mutex_BAD_trylock(&cl->dev[devid].lock);
+}
+
+int dt_opencl_get_num_devices(void)
+{
+  dt_opencl_t *cl = _opencl;
+  if(!cl || !cl->inited) return 0;
+  return cl->num_devs;
+}
+
+const char *dt_opencl_get_device_name(const int devid)
+{
+  dt_opencl_t *cl = _opencl;
+  if(!cl || !cl->inited || IS_NULL_PTR(cl->dev)) return NULL;
+  if(devid < 0 || devid >= cl->num_devs) return NULL;
+  return cl->dev[devid].name;
+}
+
+gboolean dt_opencl_get_device_max_image_size(const int devid, int *width, int *height)
+{
+  dt_opencl_t *cl = _opencl;
+  if(!cl || !cl->inited || IS_NULL_PTR(cl->dev)) return FALSE;
+  if(devid < 0 || devid >= cl->num_devs) return FALSE;
+  if(width) *width = cl->dev[devid].max_image_width;
+  if(height) *height = cl->dev[devid].max_image_height;
+  return TRUE;
+}
+
+size_t dt_opencl_get_device_max_global_mem(const int devid)
+{
+  dt_opencl_t *cl = _opencl;
+  if(!cl || !cl->inited || IS_NULL_PTR(cl->dev)) return 0;
+  if(devid < 0 || devid >= cl->num_devs) return 0;
+  return (size_t)cl->dev[devid].max_global_mem;
+}
+
+int dt_opencl_report_pipe_error(void)
+{
+  dt_opencl_t *cl = _opencl;
+  if(!cl) return 2;
+
+  cl->error_count++;
+  if(cl->error_count < DT_OPENCL_MAX_ERRORS) return 1;
+
+  /* Too many failures: OpenCL is finished for this session. */
+  cl->stopped = 1;
+  dt_capabilities_remove("opencl");
+  return 2;
 }
 
 static FILE *fopen_stat(const char *filename, struct stat *st)
@@ -1748,7 +1869,7 @@ int dt_opencl_load_program(const int dev, const int prog, const char *filename, 
                            const char *cachedir, char *md5sum, char **includemd5, int *loaded_cached)
 {
   cl_int err;
-  dt_opencl_t *cl = darktable.opencl;
+  dt_opencl_t *cl = _opencl;
 
   struct stat filestat, cachedstat;
   *loaded_cached = 0;
@@ -1922,7 +2043,7 @@ int dt_opencl_build_program(const int dev, const int prog, const char *binname, 
                             char *md5sum, int loaded_cached)
 {
   if(prog < 0 || prog >= DT_OPENCL_MAX_PROGRAMS) return -1;
-  dt_opencl_t *cl = darktable.opencl;
+  dt_opencl_t *cl = _opencl;
   cl_program program = cl->dev[dev].program[prog];
   cl_int err = (cl->dlocl->symbols->dt_clBuildProgram)(program, 1, &(cl->dev[dev].devid), cl->dev[dev].options, 0, 0);
 
@@ -2048,7 +2169,7 @@ int dt_opencl_build_program(const int dev, const int prog, const char *binname, 
 
 int dt_opencl_create_kernel(const int prog, const char *name)
 {
-  dt_opencl_t *cl = darktable.opencl;
+  dt_opencl_t *cl = _opencl;
   if(!cl->inited) return -1;
   if(prog < 0 || prog >= DT_OPENCL_MAX_PROGRAMS) return -1;
   dt_pthread_mutex_lock(&cl->lock);
@@ -2091,7 +2212,7 @@ error:
 
 void dt_opencl_free_kernel(const int kernel)
 {
-  dt_opencl_t *cl = darktable.opencl;
+  dt_opencl_t *cl = _opencl;
   if(!cl->inited) return;
   if(kernel < 0 || kernel >= DT_OPENCL_MAX_KERNELS) return;
   dt_pthread_mutex_lock(&cl->lock);
@@ -2105,7 +2226,7 @@ void dt_opencl_free_kernel(const int kernel)
 
 int dt_opencl_get_max_work_item_sizes(const int dev, size_t *sizes)
 {
-  dt_opencl_t *cl = darktable.opencl;
+  dt_opencl_t *cl = _opencl;
   if(!cl->inited || dev < 0) return -1;
   return (cl->dlocl->symbols->dt_clGetDeviceInfo)(cl->dev[dev].devid, CL_DEVICE_MAX_WORK_ITEM_SIZES,
                                                   sizeof(size_t) * 3, sizes, NULL);
@@ -2114,7 +2235,7 @@ int dt_opencl_get_max_work_item_sizes(const int dev, size_t *sizes)
 int dt_opencl_get_work_group_limits(const int dev, size_t *sizes, size_t *workgroupsize,
                                     unsigned long *localmemsize)
 {
-  dt_opencl_t *cl = darktable.opencl;
+  dt_opencl_t *cl = _opencl;
   if(!cl->inited || dev < 0) return -1;
   cl_ulong lmemsize;
   cl_int err = (cl->dlocl->symbols->dt_clGetDeviceInfo)(cl->dev[dev].devid, CL_DEVICE_LOCAL_MEM_SIZE,
@@ -2133,7 +2254,7 @@ int dt_opencl_get_work_group_limits(const int dev, size_t *sizes, size_t *workgr
 
 int dt_opencl_get_kernel_work_group_size(const int dev, const int kernel, size_t *kernelworkgroupsize)
 {
-  dt_opencl_t *cl = darktable.opencl;
+  dt_opencl_t *cl = _opencl;
   if(!cl->inited || dev < 0) return -1;
   if(kernel < 0 || kernel >= DT_OPENCL_MAX_KERNELS) return -1;
 
@@ -2146,7 +2267,7 @@ int dt_opencl_get_kernel_work_group_size(const int dev, const int kernel, size_t
 int dt_opencl_set_kernel_arg(const int dev, const int kernel, const int num, const size_t size,
                              const void *arg)
 {
-  dt_opencl_t *cl = darktable.opencl;
+  dt_opencl_t *cl = _opencl;
   if(!cl->inited || dev < 0) return -1;
   if(kernel < 0 || kernel >= DT_OPENCL_MAX_KERNELS) return -1;
   return (cl->dlocl->symbols->dt_clSetKernelArg)(cl->dev[dev].kernel[kernel], num, size, arg);
@@ -2161,7 +2282,7 @@ int dt_opencl_enqueue_kernel_2d(const int dev, const int kernel, const size_t *s
 int dt_opencl_enqueue_kernel_2d_with_local(const int dev, const int kernel, const size_t *sizes,
                                            const size_t *local)
 {
-  dt_opencl_t *cl = darktable.opencl;
+  dt_opencl_t *cl = _opencl;
   if(!cl->inited || dev < 0) return -1;
   if(kernel < 0 || kernel >= DT_OPENCL_MAX_KERNELS) return -1;
 
@@ -2194,7 +2315,7 @@ int dt_opencl_read_host_from_device(const int devid, void *host, void *device, c
 int dt_opencl_read_host_from_device_rowpitch(const int devid, void *host, void *device, const int width,
                                              const int height, const int rowpitch)
 {
-  if(!darktable.opencl->inited || devid < 0) return -1;
+  if(!(_opencl && _opencl->inited) || devid < 0) return -1;
   const size_t origin[] = { 0, 0, 0 };
   const size_t region[] = { width, height, 1 };
   // blocking.
@@ -2212,7 +2333,7 @@ int dt_opencl_read_host_from_device_rowpitch_non_blocking(const int devid, void 
                                                           const int width, const int height,
                                                           const int rowpitch)
 {
-  if(!darktable.opencl->inited || devid < 0) return -1;
+  if(!(_opencl && _opencl->inited) || devid < 0) return -1;
   const size_t origin[] = { 0, 0, 0 };
   const size_t region[] = { width, height, 1 };
   // non-blocking.
@@ -2223,11 +2344,11 @@ int dt_opencl_read_host_from_device_rowpitch_non_blocking(const int devid, void 
 int dt_opencl_read_host_from_device_raw(const int devid, void *host, void *device, const size_t *origin,
                                         const size_t *region, const int rowpitch, const int blocking)
 {
-  if(!darktable.opencl->inited) return -1;
+  if(!(_opencl && _opencl->inited)) return -1;
 
   cl_event *eventp = dt_opencl_events_get_slot(devid, "[Read Image (from device to host)]");
 
-  return (darktable.opencl->dlocl->symbols->dt_clEnqueueReadImage)(darktable.opencl->dev[devid].cmd_queue,
+  return (_opencl->dlocl->symbols->dt_clEnqueueReadImage)(_opencl->dev[devid].cmd_queue,
                                                                    device, blocking ? CL_TRUE : CL_FALSE, origin, region, rowpitch,
                                                                    0, host, 0, NULL, eventp);
 }
@@ -2241,7 +2362,7 @@ int dt_opencl_write_host_to_device(const int devid, void *host, void *device, co
 int dt_opencl_write_host_to_device_rowpitch(const int devid, void *host, void *device, const int width,
                                             const int height, const int rowpitch)
 {
-  if(!darktable.opencl->inited || devid < 0) return -1;
+  if(!(_opencl && _opencl->inited) || devid < 0) return -1;
   const size_t origin[] = { 0, 0, 0 };
   const size_t region[] = { width, height, 1 };
   // blocking.
@@ -2258,7 +2379,7 @@ int dt_opencl_write_host_to_device_rowpitch_non_blocking(const int devid, void *
                                                          const int width, const int height,
                                                          const int rowpitch)
 {
-  if(!darktable.opencl->inited || devid < 0) return -1;
+  if(!(_opencl && _opencl->inited) || devid < 0) return -1;
   const size_t origin[] = { 0, 0, 0 };
   const size_t region[] = { width, height, 1 };
   // non-blocking.
@@ -2268,11 +2389,11 @@ int dt_opencl_write_host_to_device_rowpitch_non_blocking(const int devid, void *
 int dt_opencl_write_host_to_device_raw(const int devid, const void *host, void *device, const size_t *origin,
                                        const size_t *region, const int rowpitch, const int blocking)
 {
-  if(!darktable.opencl->inited) return -1;
+  if(!(_opencl && _opencl->inited)) return -1;
 
   cl_event *eventp = dt_opencl_events_get_slot(devid, "[Write Image (from host to device)]");
 
-  return (darktable.opencl->dlocl->symbols->dt_clEnqueueWriteImage)(darktable.opencl->dev[devid].cmd_queue,
+  return (_opencl->dlocl->symbols->dt_clEnqueueWriteImage)(_opencl->dev[devid].cmd_queue,
                                                                     device, blocking ? CL_TRUE : CL_FALSE, origin, region,
                                                                     rowpitch, 0, host, 0, NULL, eventp);
 }
@@ -2280,10 +2401,10 @@ int dt_opencl_write_host_to_device_raw(const int devid, const void *host, void *
 int dt_opencl_enqueue_copy_image(const int devid, cl_mem src, cl_mem dst, size_t *orig_src, size_t *orig_dst,
                                  size_t *region)
 {
-  if(!darktable.opencl->inited || devid < 0) return -1;
+  if(!(_opencl && _opencl->inited) || devid < 0) return -1;
   cl_event *eventp = dt_opencl_events_get_slot(devid, "[Copy Image (on device)]");
-  cl_int err = (darktable.opencl->dlocl->symbols->dt_clEnqueueCopyImage)(
-      darktable.opencl->dev[devid].cmd_queue, src, dst, orig_src, orig_dst, region, 0, NULL, eventp);
+  cl_int err = (_opencl->dlocl->symbols->dt_clEnqueueCopyImage)(
+      _opencl->dev[devid].cmd_queue, src, dst, orig_src, orig_dst, region, 0, NULL, eventp);
   if(err != CL_SUCCESS) dt_print(DT_DEBUG_OPENCL, "[opencl copy_image] could not copy image on device %d: %i\n", devid, err);
   return err;
 }
@@ -2291,10 +2412,10 @@ int dt_opencl_enqueue_copy_image(const int devid, cl_mem src, cl_mem dst, size_t
 int dt_opencl_enqueue_copy_image_to_buffer(const int devid, cl_mem src_image, cl_mem dst_buffer,
                                            size_t *origin, size_t *region, size_t offset)
 {
-  if(!darktable.opencl->inited) return -1;
+  if(!(_opencl && _opencl->inited)) return -1;
   cl_event *eventp = dt_opencl_events_get_slot(devid, "[Copy Image to Buffer (on device)]");
-  cl_int err = (darktable.opencl->dlocl->symbols->dt_clEnqueueCopyImageToBuffer)(
-      darktable.opencl->dev[devid].cmd_queue, src_image, dst_buffer, origin, region, offset, 0, NULL, eventp);
+  cl_int err = (_opencl->dlocl->symbols->dt_clEnqueueCopyImageToBuffer)(
+      _opencl->dev[devid].cmd_queue, src_image, dst_buffer, origin, region, offset, 0, NULL, eventp);
   if(err != CL_SUCCESS)
     dt_print(DT_DEBUG_OPENCL, "[opencl copy_image_to_buffer] could not copy image on device %d: %i\n", devid, err);
   return err;
@@ -2303,10 +2424,10 @@ int dt_opencl_enqueue_copy_image_to_buffer(const int devid, cl_mem src_image, cl
 int dt_opencl_enqueue_copy_buffer_to_image(const int devid, cl_mem src_buffer, cl_mem dst_image,
                                            size_t offset, size_t *origin, size_t *region)
 {
-  if(!darktable.opencl->inited) return -1;
+  if(!(_opencl && _opencl->inited)) return -1;
   cl_event *eventp = dt_opencl_events_get_slot(devid, "[Copy Buffer to Image (on device)]");
-  cl_int err = (darktable.opencl->dlocl->symbols->dt_clEnqueueCopyBufferToImage)(
-      darktable.opencl->dev[devid].cmd_queue, src_buffer, dst_image, offset, origin, region, 0, NULL, eventp);
+  cl_int err = (_opencl->dlocl->symbols->dt_clEnqueueCopyBufferToImage)(
+      _opencl->dev[devid].cmd_queue, src_buffer, dst_image, offset, origin, region, 0, NULL, eventp);
   if(err != CL_SUCCESS)
     dt_print(DT_DEBUG_OPENCL, "[opencl copy_buffer_to_image] could not copy buffer on device %d: %i\n", devid, err);
   return err;
@@ -2315,9 +2436,9 @@ int dt_opencl_enqueue_copy_buffer_to_image(const int devid, cl_mem src_buffer, c
 int dt_opencl_enqueue_copy_buffer_to_buffer(const int devid, cl_mem src_buffer, cl_mem dst_buffer,
                                             size_t srcoffset, size_t dstoffset, size_t size)
 {
-  if(!darktable.opencl->inited) return -1;
+  if(!(_opencl && _opencl->inited)) return -1;
   cl_event *eventp = dt_opencl_events_get_slot(devid, "[Copy Buffer to Buffer (on device)]");
-  cl_int err = (darktable.opencl->dlocl->symbols->dt_clEnqueueCopyBuffer)(darktable.opencl->dev[devid].cmd_queue,
+  cl_int err = (_opencl->dlocl->symbols->dt_clEnqueueCopyBuffer)(_opencl->dev[devid].cmd_queue,
                                                                    src_buffer, dst_buffer, srcoffset,
                                                                    dstoffset, size, 0, NULL, eventp);
   if(err != CL_SUCCESS)
@@ -2328,32 +2449,32 @@ int dt_opencl_enqueue_copy_buffer_to_buffer(const int devid, cl_mem src_buffer, 
 int dt_opencl_read_buffer_from_device(const int devid, void *host, void *device, const size_t offset,
                                       const size_t size, const int blocking)
 {
-  if(!darktable.opencl->inited) return -1;
+  if(!(_opencl && _opencl->inited)) return -1;
 
   cl_event *eventp = dt_opencl_events_get_slot(devid, "[Read Buffer (from device to host)]");
 
-  return (darktable.opencl->dlocl->symbols->dt_clEnqueueReadBuffer)(
-      darktable.opencl->dev[devid].cmd_queue, device, blocking ? CL_TRUE : CL_FALSE, offset, size, host, 0, NULL, eventp);
+  return (_opencl->dlocl->symbols->dt_clEnqueueReadBuffer)(
+      _opencl->dev[devid].cmd_queue, device, blocking ? CL_TRUE : CL_FALSE, offset, size, host, 0, NULL, eventp);
 }
 
 int dt_opencl_write_buffer_to_device(const int devid, void *host, void *device, const size_t offset,
                                      const size_t size, const int blocking)
 {
-  if(!darktable.opencl->inited) return -1;
+  if(!(_opencl && _opencl->inited)) return -1;
 
   cl_event *eventp = dt_opencl_events_get_slot(devid, "[Write Buffer (from host to device)]");
 
-  return (darktable.opencl->dlocl->symbols->dt_clEnqueueWriteBuffer)(
-      darktable.opencl->dev[devid].cmd_queue, device, blocking ? CL_TRUE : CL_FALSE, offset, size, host, 0, NULL, eventp);
+  return (_opencl->dlocl->symbols->dt_clEnqueueWriteBuffer)(
+      _opencl->dev[devid].cmd_queue, device, blocking ? CL_TRUE : CL_FALSE, offset, size, host, 0, NULL, eventp);
 }
 
 
 void *dt_opencl_copy_host_to_device_constant(const int devid, const size_t size, void *host)
 {
-  if(!darktable.opencl->inited || devid < 0) return NULL;
+  if(!(_opencl && _opencl->inited) || devid < 0) return NULL;
   cl_int err;
-  cl_mem dev = (darktable.opencl->dlocl->symbols->dt_clCreateBuffer)(
-      darktable.opencl->dev[devid].context, CL_MEM_READ_ONLY | CL_MEM_COPY_HOST_PTR, size, host, &err);
+  cl_mem dev = (_opencl->dlocl->symbols->dt_clCreateBuffer)(
+      _opencl->dev[devid].context, CL_MEM_READ_ONLY | CL_MEM_COPY_HOST_PTR, size, host, &err);
   if(err != CL_SUCCESS)
     dt_print(DT_DEBUG_OPENCL,
              "[opencl copy_host_to_device_constant] could not alloc buffer on device %d: %i\n", devid, err);
@@ -2372,7 +2493,7 @@ void *dt_opencl_copy_host_to_device(const int devid, void *host, const int width
 void *dt_opencl_copy_host_to_device_rowpitch(const int devid, void *host, const int width, const int height,
                                              const int bpp, const int rowpitch)
 {
-  if(!darktable.opencl->inited || devid < 0) return NULL;
+  if(!(_opencl && _opencl->inited) || devid < 0) return NULL;
   cl_int err;
   cl_image_format fmt;
   // guess pixel format from bytes per pixel
@@ -2386,8 +2507,8 @@ void *dt_opencl_copy_host_to_device_rowpitch(const int devid, void *host, const 
     return NULL;
 
   // TODO: if fmt = uint16_t, blow up to 4xuint16_t and copy manually!
-  cl_mem dev = (darktable.opencl->dlocl->symbols->dt_clCreateImage2D)(
-      darktable.opencl->dev[devid].context, CL_MEM_READ_WRITE | CL_MEM_COPY_HOST_PTR, &fmt, width, height,
+  cl_mem dev = (_opencl->dlocl->symbols->dt_clCreateImage2D)(
+      _opencl->dev[devid].context, CL_MEM_READ_WRITE | CL_MEM_COPY_HOST_PTR, &fmt, width, height,
       rowpitch, host, &err);
   if(err != CL_SUCCESS)
     dt_print(DT_DEBUG_OPENCL,
@@ -2405,7 +2526,7 @@ void *dt_opencl_copy_host_to_device_rowpitch(const int devid, void *host, const 
 
 void dt_opencl_release_mem_object(cl_mem mem)
 {
-  if(!darktable.opencl->inited) return;
+  if(!(_opencl && _opencl->inited)) return;
 
   // the OpenCL specs are not absolutely clear if clReleaseMemObject(NULL) is a no-op. we take care of the
   // case in a centralized way at this place
@@ -2413,18 +2534,18 @@ void dt_opencl_release_mem_object(cl_mem mem)
 
   dt_opencl_memory_statistics(-1, mem, 0, OPENCL_MEMORY_SUB);
 
-  (darktable.opencl->dlocl->symbols->dt_clReleaseMemObject)(mem);
+  (_opencl->dlocl->symbols->dt_clReleaseMemObject)(mem);
 }
 
 void *dt_opencl_map_buffer(const int devid, cl_mem buffer, const int blocking, const int flags, size_t offset,
                            size_t size)
 {
-  if(!darktable.opencl->inited) return NULL;
+  if(!(_opencl && _opencl->inited)) return NULL;
   cl_int err;
   void *ptr;
   cl_event *eventp = dt_opencl_events_get_slot(devid, "[Map Buffer]");
-  ptr = (darktable.opencl->dlocl->symbols->dt_clEnqueueMapBuffer)(
-      darktable.opencl->dev[devid].cmd_queue, buffer, blocking ? CL_TRUE : CL_FALSE, flags, offset, size, 0, NULL, eventp, &err);
+  ptr = (_opencl->dlocl->symbols->dt_clEnqueueMapBuffer)(
+      _opencl->dev[devid].cmd_queue, buffer, blocking ? CL_TRUE : CL_FALSE, flags, offset, size, 0, NULL, eventp, &err);
   if(err != CL_SUCCESS) dt_print(DT_DEBUG_OPENCL, "[opencl map buffer] could not map buffer on device %d: %i\n", devid, err);
   return ptr;
 }
@@ -2432,7 +2553,7 @@ void *dt_opencl_map_buffer(const int devid, cl_mem buffer, const int blocking, c
 
 void *dt_opencl_map_image(const int devid, cl_mem buffer, const int blocking, const int flags, size_t width, size_t height, int bpp)
 {
-  if(!darktable.opencl->inited) return NULL;
+  if(!(_opencl && _opencl->inited)) return NULL;
   cl_int err;
   void *ptr;
   cl_event *eventp = dt_opencl_events_get_slot(devid, "[Map Image 2D]");
@@ -2440,8 +2561,8 @@ void *dt_opencl_map_image(const int devid, cl_mem buffer, const int blocking, co
   size_t region[3] = {width, height, 1};
   size_t mapped_row_pitch;
 
-  ptr = (darktable.opencl->dlocl->symbols->dt_clEnqueueMapImage)(
-      darktable.opencl->dev[devid].cmd_queue, buffer, blocking ? CL_TRUE : CL_FALSE, flags, origin, region,
+  ptr = (_opencl->dlocl->symbols->dt_clEnqueueMapImage)(
+      _opencl->dev[devid].cmd_queue, buffer, blocking ? CL_TRUE : CL_FALSE, flags, origin, region,
       &mapped_row_pitch, NULL, 0, NULL, eventp, &err);
 
   if(err != CL_SUCCESS)
@@ -2452,10 +2573,10 @@ void *dt_opencl_map_image(const int devid, cl_mem buffer, const int blocking, co
 
 int dt_opencl_unmap_mem_object(const int devid, cl_mem mem_object, void *mapped_ptr)
 {
-  if(!darktable.opencl->inited) return -1;
+  if(!(_opencl && _opencl->inited)) return -1;
   cl_event *eventp = dt_opencl_events_get_slot(devid, "[Unmap Mem Object]");
-  cl_int err = (darktable.opencl->dlocl->symbols->dt_clEnqueueUnmapMemObject)(
-      darktable.opencl->dev[devid].cmd_queue, mem_object, mapped_ptr, 0, NULL, eventp);
+  cl_int err = (_opencl->dlocl->symbols->dt_clEnqueueUnmapMemObject)(
+      _opencl->dev[devid].cmd_queue, mem_object, mapped_ptr, 0, NULL, eventp);
   if(err != CL_SUCCESS)
     dt_print(DT_DEBUG_OPENCL, "[opencl unmap mem object] could not unmap mem object on device %d: %i\n", devid, err);
   return err;
@@ -2466,12 +2587,12 @@ static inline void *_dt_opencl_alloc_image2d(const int devid, const int width, c
                                              const cl_image_format fmt, void *host,
                                              const char *const context)
 {
-  if(!darktable.opencl->inited || devid < 0) return NULL;
+  if(!(_opencl && _opencl->inited) || devid < 0) return NULL;
   cl_int err;
   cl_mem dev = NULL;
   for(int attempt = 0; attempt < 2; attempt++)
   {
-    dev = (darktable.opencl->dlocl->symbols->dt_clCreateImage2D)(darktable.opencl->dev[devid].context, flags,
+    dev = (_opencl->dlocl->symbols->dt_clCreateImage2D)(_opencl->dev[devid].context, flags,
                                                                   &fmt, width, height, 0, host, &err);
     if(err == CL_SUCCESS) break;
     if(attempt == 0 && (err == CL_MEM_OBJECT_ALLOCATION_FAILURE || err == CL_OUT_OF_RESOURCES))
@@ -2540,12 +2661,12 @@ void *dt_opencl_alloc_device_use_host_pointer(const int devid, const int width, 
 
 void *dt_opencl_alloc_device_buffer_with_flags(const int devid, const size_t size, const int flags, void *host_ptr)
 {
-  if(!darktable.opencl->inited) return NULL;
+  if(!(_opencl && _opencl->inited)) return NULL;
   cl_int err;
   cl_mem buf = NULL;
   for(int attempt = 0; attempt < 2; attempt++)
   {
-    buf = (darktable.opencl->dlocl->symbols->dt_clCreateBuffer)(darktable.opencl->dev[devid].context,
+    buf = (_opencl->dlocl->symbols->dt_clCreateBuffer)(_opencl->dev[devid].context,
                                                                flags, size, host_ptr, &err);
     if(err == CL_SUCCESS) break;
     if(attempt == 0 && (err == CL_MEM_OBJECT_ALLOCATION_FAILURE || err == CL_OUT_OF_RESOURCES))
@@ -2579,7 +2700,7 @@ size_t dt_opencl_get_mem_object_size(cl_mem mem)
   size_t size;
   if(IS_NULL_PTR(mem)) return 0;
 
-  cl_int err = (darktable.opencl->dlocl->symbols->dt_clGetMemObjectInfo)(mem, CL_MEM_SIZE, sizeof(size), &size, NULL);
+  cl_int err = (_opencl->dlocl->symbols->dt_clGetMemObjectInfo)(mem, CL_MEM_SIZE, sizeof(size), &size, NULL);
 
   return (err == CL_SUCCESS) ? size : 0;
 }
@@ -2589,13 +2710,13 @@ int dt_opencl_get_mem_context_id(cl_mem mem)
   cl_context context;
   if(IS_NULL_PTR(mem)) return -1;
 
-  cl_int err = (darktable.opencl->dlocl->symbols->dt_clGetMemObjectInfo)(mem, CL_MEM_CONTEXT, sizeof(context), &context, NULL);
+  cl_int err = (_opencl->dlocl->symbols->dt_clGetMemObjectInfo)(mem, CL_MEM_CONTEXT, sizeof(context), &context, NULL);
   if(err != CL_SUCCESS)
     return -1;
 
-  for(int devid = 0; devid < darktable.opencl->num_devs; devid++)
+  for(int devid = 0; devid < _opencl->num_devs; devid++)
   {
-    if(darktable.opencl->dev[devid].context == context)
+    if(_opencl->dev[devid].context == context)
       return devid;
   }
 
@@ -2604,9 +2725,9 @@ int dt_opencl_get_mem_context_id(cl_mem mem)
 
 cl_mem_flags dt_opencl_get_mem_flags(cl_mem mem)
 {
-  if(!darktable.opencl->inited || IS_NULL_PTR(mem)) return 0;
+  if(!(_opencl && _opencl->inited) || IS_NULL_PTR(mem)) return 0;
   cl_mem_flags flags = 0;
-  cl_int err = (darktable.opencl->dlocl->symbols->dt_clGetMemObjectInfo)(mem, CL_MEM_FLAGS, sizeof(flags), &flags, NULL);
+  cl_int err = (_opencl->dlocl->symbols->dt_clGetMemObjectInfo)(mem, CL_MEM_FLAGS, sizeof(flags), &flags, NULL);
   if(err != CL_SUCCESS) return 0;
   return flags;
 }
@@ -2616,7 +2737,7 @@ int dt_opencl_get_image_width(cl_mem mem)
   size_t size;
   if(IS_NULL_PTR(mem)) return 0;
 
-  cl_int err = (darktable.opencl->dlocl->symbols->dt_clGetImageInfo)(mem, CL_IMAGE_WIDTH, sizeof(size), &size, NULL);
+  cl_int err = (_opencl->dlocl->symbols->dt_clGetImageInfo)(mem, CL_IMAGE_WIDTH, sizeof(size), &size, NULL);
   if(size > INT_MAX) size = 0;
 
   return (err == CL_SUCCESS) ? (int)size : 0;
@@ -2627,7 +2748,7 @@ int dt_opencl_get_image_height(cl_mem mem)
   size_t size;
   if(IS_NULL_PTR(mem)) return 0;
 
-  cl_int err = (darktable.opencl->dlocl->symbols->dt_clGetImageInfo)(mem, CL_IMAGE_HEIGHT, sizeof(size), &size, NULL);
+  cl_int err = (_opencl->dlocl->symbols->dt_clGetImageInfo)(mem, CL_IMAGE_HEIGHT, sizeof(size), &size, NULL);
   if(size > INT_MAX) size = 0;
 
   return (err == CL_SUCCESS) ? (int)size : 0;
@@ -2638,7 +2759,7 @@ int dt_opencl_get_image_element_size(cl_mem mem)
   size_t size;
   if(IS_NULL_PTR(mem)) return 0;
 
-  cl_int err = (darktable.opencl->dlocl->symbols->dt_clGetImageInfo)(mem, CL_IMAGE_ELEMENT_SIZE, sizeof(size), &size,
+  cl_int err = (_opencl->dlocl->symbols->dt_clGetImageInfo)(mem, CL_IMAGE_ELEMENT_SIZE, sizeof(size), &size,
                                                               NULL);
   if(size > INT_MAX) size = 0;
 
@@ -2663,24 +2784,24 @@ void dt_opencl_memory_statistics(int devid, cl_mem mem, size_t size, dt_opencl_m
     dt_opencl_mem_record_t *rec = (dt_opencl_mem_record_t *)malloc(sizeof(dt_opencl_mem_record_t));
     rec->devid = devid;
     rec->size = size;
-    dt_pthread_mutex_lock(&darktable.opencl->mem_sizes_lock);
+    dt_pthread_mutex_lock(&_opencl->mem_sizes_lock);
     // g_hash_table_insert frees the previous value (g_free) if the key already
     // exists, so re-inserting the same cl_mem pointer never leaks.
-    g_hash_table_insert(darktable.opencl->mem_sizes, mem, rec);
-    dt_pthread_mutex_unlock(&darktable.opencl->mem_sizes_lock);
+    g_hash_table_insert(_opencl->mem_sizes, mem, rec);
+    dt_pthread_mutex_unlock(&_opencl->mem_sizes_lock);
   }
   else
   {
     // Look up what we recorded on ADD. Never ask the driver about the object here
     // either: on some Windows drivers clGetMemObjectInfo faults under vRAM
     // pressure (issues #130221119 / #130557353), aborting the process.
-    dt_pthread_mutex_lock(&darktable.opencl->mem_sizes_lock);
-    dt_opencl_mem_record_t *rec = (dt_opencl_mem_record_t *)g_hash_table_lookup(darktable.opencl->mem_sizes, mem);
+    dt_pthread_mutex_lock(&_opencl->mem_sizes_lock);
+    dt_opencl_mem_record_t *rec = (dt_opencl_mem_record_t *)g_hash_table_lookup(_opencl->mem_sizes, mem);
     if(rec)
     {
       devid = rec->devid;
       size = rec->size;
-      g_hash_table_remove(darktable.opencl->mem_sizes, mem);
+      g_hash_table_remove(_opencl->mem_sizes, mem);
     }
     else
     {
@@ -2688,32 +2809,32 @@ void dt_opencl_memory_statistics(int devid, cl_mem mem, size_t size, dt_opencl_m
       // did not register). Nothing reliable to subtract; leave the counter be.
       devid = -1;
     }
-    dt_pthread_mutex_unlock(&darktable.opencl->mem_sizes_lock);
+    dt_pthread_mutex_unlock(&_opencl->mem_sizes_lock);
   }
 
   if(devid < 0)
     return;
 
   if(action == OPENCL_MEMORY_ADD)
-    darktable.opencl->dev[devid].memory_in_use += size;
+    _opencl->dev[devid].memory_in_use += size;
   else
-    darktable.opencl->dev[devid].memory_in_use =
-      (darktable.opencl->dev[devid].memory_in_use > size)
-        ? (darktable.opencl->dev[devid].memory_in_use - size)
+    _opencl->dev[devid].memory_in_use =
+      (_opencl->dev[devid].memory_in_use > size)
+        ? (_opencl->dev[devid].memory_in_use - size)
         : 0;
 
-  darktable.opencl->dev[devid].peak_memory = MAX(darktable.opencl->dev[devid].peak_memory,
-                                                 darktable.opencl->dev[devid].memory_in_use);
+  _opencl->dev[devid].peak_memory = MAX(_opencl->dev[devid].peak_memory,
+                                                 _opencl->dev[devid].memory_in_use);
 
   if((dt_get_debug_flags() & DT_DEBUG_MEMORY) && (dt_get_debug_flags() & DT_DEBUG_OPENCL))
     dt_print(DT_DEBUG_OPENCL,
-              "[opencl memory] device %d: %" G_GSIZE_FORMAT " bytes (%.1f MB) in use\n", devid, darktable.opencl->dev[devid].memory_in_use,
-                                      (float)darktable.opencl->dev[devid].memory_in_use/(1024*1024));
+              "[opencl memory] device %d: %" G_GSIZE_FORMAT " bytes (%.1f MB) in use\n", devid, _opencl->dev[devid].memory_in_use,
+                                      (float)_opencl->dev[devid].memory_in_use/(1024*1024));
 }
 
 void dt_opencl_check_tuning(const int devid)
 {
-  dt_opencl_t *cl = darktable.opencl;
+  dt_opencl_t *cl = _opencl;
   if(!cl->inited || devid < 0) return;
 
   // Apply the headroom read from this device configuration. Older configs without
@@ -2730,20 +2851,20 @@ void dt_opencl_check_tuning(const int devid)
 
 cl_ulong dt_opencl_get_device_available(const int devid)
 {
-  if(!darktable.opencl->inited || devid < 0) return 0;
-  const cl_ulong limit = darktable.opencl->dev[devid].used_available;
-  const size_t in_use = darktable.opencl->dev[devid].memory_in_use;
+  if(!(_opencl && _opencl->inited) || devid < 0) return 0;
+  const cl_ulong limit = _opencl->dev[devid].used_available;
+  const size_t in_use = _opencl->dev[devid].memory_in_use;
   return (limit > in_use) ? (limit - in_use) : 0;
 }
 
 static cl_ulong _opencl_get_device_memalloc(const int devid)
 {
-  return darktable.opencl->dev[devid].max_mem_alloc;
+  return _opencl->dev[devid].max_mem_alloc;
 }
 
 cl_ulong dt_opencl_get_device_memalloc(const int devid)
 {
-  if(!darktable.opencl->inited || devid < 0) return 0;
+  if(!(_opencl && _opencl->inited) || devid < 0) return 0;
   return _opencl_get_device_memalloc(devid);
 }
 
@@ -2754,7 +2875,7 @@ dt_opencl_fit_reason_t dt_opencl_image_fits_device_reason(const int devid, const
   size_t n = 0, l = 0;
   dt_opencl_fit_reason_t reason = DT_OPENCL_FIT_OK;
 
-  dt_opencl_t *cl = darktable.opencl;
+  dt_opencl_t *cl = _opencl;
   if(!cl->inited || devid < 0)
   {
     reason = DT_OPENCL_FIT_UNINITED;
@@ -2806,35 +2927,35 @@ gboolean dt_opencl_image_fits_device(const int devid, const size_t width, const 
 /** round size to a multiple of the value given in the device specifig config parameter clroundup_wd/ht */
 int dt_opencl_dev_roundup_width(int size, const int devid)
 {
-  const int roundup = darktable.opencl->dev[devid].clroundup_wd;
+  const int roundup = _opencl->dev[devid].clroundup_wd;
   return (size % roundup == 0 ? size : (size / roundup + 1) * roundup);
 }
 int dt_opencl_dev_roundup_height(int size, const int devid)
 {
-  const int roundup = darktable.opencl->dev[devid].clroundup_ht;
+  const int roundup = _opencl->dev[devid].clroundup_ht;
   return (size % roundup == 0 ? size : (size / roundup + 1) * roundup);
 }
 
 /** check if opencl is inited */
 int dt_opencl_is_inited(void)
 {
-  return darktable.opencl->inited;
+  return (_opencl && _opencl->inited);
 }
 
 
 /** check if opencl is enabled */
 int dt_opencl_is_enabled(void)
 {
-  if(!darktable.opencl->inited) return FALSE;
-  return darktable.opencl->enabled;
+  if(!(_opencl && _opencl->inited)) return FALSE;
+  return _opencl->enabled;
 }
 
 
 /** disable opencl */
 void dt_opencl_disable(void)
 {
-  if(!darktable.opencl->inited) return;
-  darktable.opencl->enabled = FALSE;
+  if(!(_opencl && _opencl->inited)) return;
+  _opencl->enabled = FALSE;
   dt_conf_set_bool("opencl", FALSE);
 }
 
@@ -2842,7 +2963,7 @@ void dt_opencl_disable(void)
 /** update enabled flag and profile with value from preferences, returns enabled flag */
 int dt_opencl_update_settings(void)
 {
-  dt_opencl_t *cl = darktable.opencl;
+  dt_opencl_t *cl = _opencl;
   // FIXME: This pulls in prefs every time the pixelpipe runs. Instead have a callback for DT_SIGNAL_PREFERENCES_CHANGE?
   if(!cl->inited) return FALSE;
   const int prefs = dt_conf_get_bool("opencl");
@@ -2862,17 +2983,17 @@ int dt_opencl_update_settings(void)
 /** set opencl specific synchronization timeout */
 static void dt_opencl_set_synchronization_timeout(int value)
 {
-  darktable.opencl->opencl_synchronization_timeout = value;
+  _opencl->opencl_synchronization_timeout = value;
   dt_print_nts(DT_DEBUG_OPENCL, "[opencl_synchronization_timeout] synchronization timeout set to %d\n", value);
 }
 
 /** adjust opencl subsystem according to scheduling profile */
 static void dt_opencl_apply_scheduling_profile()
 {
-  dt_pthread_mutex_lock(&darktable.opencl->lock);
+  dt_pthread_mutex_lock(&_opencl->lock);
   dt_opencl_update_priorities();
   dt_opencl_set_synchronization_timeout(dt_conf_get_int("pixelpipe_synchronization_timeout"));
-  dt_pthread_mutex_unlock(&darktable.opencl->lock);
+  dt_pthread_mutex_unlock(&_opencl->lock);
 }
 
 
@@ -2881,7 +3002,7 @@ static void dt_opencl_apply_scheduling_profile()
 /** get next free slot in eventlist (and manage size of eventlist) */
 cl_event *dt_opencl_events_get_slot(const int devid, const char *tag)
 {
-  dt_opencl_t *cl = darktable.opencl;
+  dt_opencl_t *cl = _opencl;
   if(!cl->inited || devid < 0) return NULL;
   if(!cl->dev[devid].use_events) return NULL;
 
@@ -2979,7 +3100,7 @@ cl_event *dt_opencl_events_get_slot(const int devid, const char *tag)
 /** reset eventlist to empty state */
 void dt_opencl_events_reset(const int devid)
 {
-  dt_opencl_t *cl = darktable.opencl;
+  dt_opencl_t *cl = _opencl;
   if(!cl->inited || devid < 0) return;
   if(!cl->dev[devid].use_events) return;
 
@@ -3017,7 +3138,7 @@ void dt_opencl_events_reset(const int devid)
     Does not flush eventlist. Side effect: might adjust numevents. */
 void dt_opencl_events_wait_for(const int devid)
 {
-  dt_opencl_t *cl = darktable.opencl;
+  dt_opencl_t *cl = _opencl;
   if(!cl->inited || devid < 0) return;
   if(!cl->dev[devid].use_events) return;
 
@@ -3074,7 +3195,7 @@ If "reset" is FALSE just store info (success value, profiling) from terminated e
 and release events for re-use by OpenCL driver. */
 cl_int dt_opencl_events_flush(const int devid, const int reset)
 {
-  dt_opencl_t *cl = darktable.opencl;
+  dt_opencl_t *cl = _opencl;
   if(!cl->inited || devid < 0) return FALSE;
   if(!cl->dev[devid].use_events) return FALSE;
 
@@ -3177,7 +3298,7 @@ cl_int dt_opencl_events_flush(const int devid, const int reset)
  * kernel */
 void dt_opencl_events_profiling(const int devid, const int aggregated)
 {
-  dt_opencl_t *cl = darktable.opencl;
+  dt_opencl_t *cl = _opencl;
   if(!cl->inited || devid < 0) return;
   if(!cl->dev[devid].use_events) return;
 
@@ -3276,7 +3397,7 @@ static int nextpow2(int n)
 // taking device specific restrictions and local memory limitations into account
 int dt_opencl_local_buffer_opt(const int devid, const int kernel, dt_opencl_local_buffer_t *factors)
 {
-  dt_opencl_t *cl = darktable.opencl;
+  dt_opencl_t *cl = _opencl;
   if(!cl->inited || devid < 0) return FALSE;
 
   size_t maxsizes[3] = { 0 };     // the maximum dimensions for a work group

--- a/src/common/opencl.c
+++ b/src/common/opencl.c
@@ -1217,15 +1217,15 @@ finally:
   if(cl->inited)
   {
     dt_capabilities_add("opencl");
-    cl->blendop = dt_develop_blend_init_cl_global();
-    cl->bilateral = dt_bilateral_init_cl_global();
-    cl->gaussian = dt_gaussian_init_cl_global();
-    cl->interpolation = dt_interpolation_init_cl_global();
-    cl->local_laplacian = dt_local_laplacian_init_cl_global();
-    cl->dwt = dt_dwt_init_cl_global();
-    cl->heal = dt_heal_init_cl_global();
-    cl->colorspaces = dt_colorspaces_init_cl_global();
-    cl->guided_filter = dt_guided_filter_init_cl_global();
+    dt_develop_blend_init_cl_global();
+    dt_bilateral_init_cl_global();
+    dt_gaussian_init_cl_global();
+    dt_interpolation_init_cl_global();
+    dt_local_laplacian_init_cl_global();
+    dt_dwt_init_cl_global();
+    dt_heal_init_cl_global();
+    dt_colorspaces_init_cl_global();
+    dt_guided_filter_init_cl_global();
   }
 
   dt_opencl_apply_scheduling_profile();
@@ -1302,15 +1302,15 @@ void dt_opencl_cleanup(dt_opencl_t *cl)
 {
   if(cl->inited)
   {
-    dt_develop_blend_free_cl_global(cl->blendop);
-    dt_bilateral_free_cl_global(cl->bilateral);
-    dt_gaussian_free_cl_global(cl->gaussian);
-    dt_interpolation_free_cl_global(cl->interpolation);
-    dt_local_laplacian_free_cl_global(cl->local_laplacian);
-    dt_dwt_free_cl_global(cl->dwt);
-    dt_heal_free_cl_global(cl->heal);
-    dt_colorspaces_free_cl_global(cl->colorspaces);
-    dt_guided_filter_free_cl_global(cl->guided_filter);
+    dt_develop_blend_free_cl_global();
+    dt_bilateral_free_cl_global();
+    dt_gaussian_free_cl_global();
+    dt_interpolation_free_cl_global();
+    dt_local_laplacian_free_cl_global();
+    dt_dwt_free_cl_global();
+    dt_heal_free_cl_global();
+    dt_colorspaces_free_cl_global();
+    dt_guided_filter_free_cl_global();
 
     for(int i = 0; i < cl->num_devs; i++)
       dt_opencl_cleanup_device(cl, i);

--- a/src/common/opencl.h
+++ b/src/common/opencl.h
@@ -275,32 +275,12 @@ typedef struct dt_opencl_t
   dt_opencl_detected_device_t *detected_devs;
   dt_dlopencl_t *dlocl;
 
-  // global kernels for blending operations.
-  struct dt_blendop_cl_global_t *blendop;
-
-  // global kernels for bilateral filtering, to be reused by a few plugins.
-  struct dt_bilateral_cl_global_t *bilateral;
-
-  // global kernels for gaussian filtering, to be reused by a few plugins.
-  struct dt_gaussian_cl_global_t *gaussian;
-
-  // global kernels for interpolation resampling.
-  struct dt_interpolation_cl_global_t *interpolation;
-
-  // global kernels for local laplacian filter.
-  struct dt_local_laplacian_cl_global_t *local_laplacian;
-
-  // global kernels for dwt filter.
-  struct dt_dwt_cl_global_t *dwt;
-
-  // global kernels for heal filter.
-  struct dt_heal_cl_global_t *heal;
-
-  // global kernels for colorspaces filter.
-  struct dt_colorspaces_cl_global_t *colorspaces;
-
-  // global kernels for guided filter.
-  struct dt_guided_filter_cl_global_t *guided_filter;
+  /* NOTE: the per-subsystem OpenCL kernel bundles (blend, bilateral, gaussian, interpolation,
+   * local laplacian, dwt, heal, colorspaces, guided filter) used to live here. Each was built
+   * by its own subsystem, parked on this struct, and read back from it by that same
+   * subsystem -- a round trip that made nine modules' state look like the OpenCL module's.
+   * They are file-statics in their owners now; this module only orders their init and free
+   * against device setup. */
 
   // Maps every live cl_mem we allocated to the (devid, byte size) we requested,
   // so memory accounting never has to query the driver (clGetMemObjectInfo) about

--- a/src/common/opencl.h
+++ b/src/common/opencl.h
@@ -251,43 +251,18 @@ struct dt_colorspaces_cl_global_t; // colorspaces transform
 struct dt_guided_filter_cl_global_t;
 
 /**
- * main struct, stored in dt_opencl_get_global().
+ * main struct, private to common/opencl.c.
  * holds pointers to all
  */
-typedef struct dt_opencl_t
-{
-  dt_pthread_mutex_t lock;
-  int inited;
-  int print_statistics;
-  int enabled;
-  int stopped;
-  int num_devs;
-  int num_detected_devs;
-  int error_count;
-  int opencl_synchronization_timeout;
-  uint32_t crc;
-  int mandatory[5];
-  int *dev_priority_image;
-  int *dev_priority_preview;
-  int *dev_priority_export;
-  int *dev_priority_thumbnail;
-  dt_opencl_device_t *dev;
-  dt_opencl_detected_device_t *detected_devs;
-  dt_dlopencl_t *dlocl;
-
-  /* NOTE: the per-subsystem OpenCL kernel bundles (blend, bilateral, gaussian, interpolation,
-   * local laplacian, dwt, heal, colorspaces, guided filter) used to live here. Each was built
-   * by its own subsystem, parked on this struct, and read back from it by that same
-   * subsystem -- a round trip that made nine modules' state look like the OpenCL module's.
-   * They are file-statics in their owners now; this module only orders their init and free
-   * against device setup. */
-
-  // Maps every live cl_mem we allocated to the (devid, byte size) we requested,
-  // so memory accounting never has to query the driver (clGetMemObjectInfo) about
-  // a freshly-created object -- some drivers fault on that under vRAM pressure.
-  GHashTable *mem_sizes;
-  dt_pthread_mutex_t mem_sizes_lock;
-} dt_opencl_t;
+/* dt_opencl_t is PRIVATE to common/opencl.c.
+ *
+ * It used to be defined here and instantiated on the application god-struct, so its device
+ * array, its lock and nine other subsystems' kernel bundles were reachable from any file that
+ * included darktable.h. Callers ask questions now -- dt_opencl_get_num_devices(),
+ * dt_opencl_get_device_name(), dt_opencl_get_device_max_image_size() -- and reserve devices
+ * through dt_opencl_reserve_device_for_pipe() / _by_id(). Nothing outside the module needs
+ * the layout, so nothing outside the module has it. */
+typedef struct dt_opencl_t dt_opencl_t;
 
 /** description of memory requirements of local buffer
   * local buffer size will be calculated as:
@@ -307,17 +282,16 @@ typedef struct dt_opencl_local_buffer_t
 /** internally calls dt_clGetDeviceInfo, and takes care of memory allocation
  * afterwards, *param_value will point to memory block of size at least *param_value
  * which needs to be g_free()'d manually */
-int dt_opencl_get_device_info(dt_opencl_t *cl, cl_device_id device, cl_device_info param_name, void **param_value,
-                              size_t *param_value_size);
+
 
 /** inits the opencl subsystem. */
-void dt_opencl_init(dt_opencl_t *cl, const gboolean exclude_opencl, const gboolean print_statistics);
+void dt_opencl_init(const gboolean exclude_opencl, const gboolean print_statistics);
 
 /** cleans up the opencl subsystem. */
-void dt_opencl_cleanup(dt_opencl_t *cl);
+void dt_opencl_cleanup(void);
 
 /** cleans up the i-th device in the cl->dev list */
-void dt_opencl_cleanup_device(dt_opencl_t *cl, int i);
+
 
 /** both finish functions return TRUE in case of success */
 /** cleans up command queue. */
@@ -327,10 +301,77 @@ int dt_opencl_finish(const int devid);
 int dt_opencl_enqueue_barrier(const int devid);
 
 /** locks a device for your thread's exclusive use */
-int dt_opencl_lock_device(const int pipetype);
+/**
+ * @brief Reserve a device for a pipe run: choose a free one by the pipe's priority list and
+ * take its lock. Blocks or gives up per the `opencl_mandatory_timeout` conf key.
+ *
+ * @param pipetype a ::dt_dev_pixelpipe_type_t; selects which priority list applies.
+ * @return the reserved device id, or -1 if none could be had. Release with
+ *         dt_opencl_release_device().
+ *
+ * @note There is ONE lock per device and this is it -- reserving a device and locking it are
+ * the same act. dt_opencl_reserve_device_by_id() takes the same lock when the caller already
+ * knows which device it needs. This used to be called `dt_opencl_lock_device()`, which took a
+ * PIPE TYPE while its `dt_opencl_unlock_device()` counterpart took a DEVICE ID -- two
+ * different ints, one of them silently wrong if the pair were ever read as symmetric. The old
+ * names are gone rather than redefined, so a stale caller fails to compile.
+ */
+int dt_opencl_reserve_device_for_pipe(const int pipetype);
+
+/**
+ * @brief Reserve a device the caller has already identified, blocking until it is free.
+ * @param devid device id; out-of-range ids are ignored.
+ */
+void dt_opencl_reserve_device_by_id(const int devid);
+
+/**
+ * @brief Reserve a device only if it is free right now.
+ * @param devid device id.
+ * @return 0 when the device was reserved (pthread convention), non-zero when it was busy or
+ *         the id was out of range. Never waits -- callers use this on paths that must not
+ *         block behind a pipe that is mid-run.
+ */
+int dt_opencl_try_reserve_device_by_id(const int devid);
+
+/** @brief Number of usable OpenCL devices; 0 when OpenCL is unavailable. */
+int dt_opencl_get_num_devices(void);
+
+/**
+ * @brief Human-readable device name, owned by the OpenCL module.
+ * @param devid device id.
+ * @return the name, or NULL for an out-of-range id or a device with no name. Valid until
+ *         cleanup; do not free.
+ */
+const char *dt_opencl_get_device_name(const int devid);
+
+/**
+ * @brief Largest 2D image the device will accept, which is what bounds tile size.
+ * @param devid device id.
+ * @param width receives the maximum width. Not written for an out-of-range id.
+ * @param height receives the maximum height. Same.
+ * @return TRUE when both were written.
+ */
+gboolean dt_opencl_get_device_max_image_size(const int devid, int *width, int *height);
+
+/** @brief Total device memory in bytes, or 0 for an out-of-range id. */
+size_t dt_opencl_get_device_max_global_mem(const int devid);
+
+/**
+ * @brief Record that a pipe run failed on OpenCL, and decide whether to give up on it.
+ *
+ * @details The count and the give-up threshold belong to the OpenCL module, not to the
+ * pipeline: the pipeline's job is to report the failure and be told what to do next. Crossing
+ * the threshold also drops the "opencl" capability, so this is the one place that decides
+ * OpenCL is finished for the session.
+ *
+ * @return 1 for "this run failed, retry on CPU", 2 for "too many failures, OpenCL is off for
+ *         the rest of the session".
+ */
+int dt_opencl_report_pipe_error(void);
 
 /** done with your command queue. */
-void dt_opencl_unlock_device(const int dev);
+/** @brief Release a device reserved by either reserve function. */
+void dt_opencl_release_device(const int devid);
 
 /** calculates md5sums for a list of CL include files. */
 void dt_opencl_md5sum(const char **files, char **md5sums);
@@ -597,16 +638,13 @@ typedef struct dt_opencl_detected_device_t
   // headroom setting accurately for integrated GPUs without reaching into the live device array.
   gboolean host_unified_memory;
 } dt_opencl_detected_device_t;
-static inline void dt_opencl_init(dt_opencl_t *cl, const gboolean exclude_opencl, const gboolean print_statistics)
+static inline void dt_opencl_init(const gboolean exclude_opencl, const gboolean print_statistics)
 {
-  cl->inited = 0;
-  cl->enabled = 0;
-  cl->stopped = 0;
-  cl->error_count = 0;
+  /* There is no state to initialise in this build: the queries below are constants. */
   dt_conf_set_bool("opencl", FALSE);
   dt_print(DT_DEBUG_OPENCL, "[opencl_init] this version of darktable was built without opencl support\n");
 }
-static inline void dt_opencl_cleanup(dt_opencl_t *cl)
+static inline void dt_opencl_cleanup(void)
 {
 }
 static inline gboolean dt_opencl_finish(const int devid)
@@ -617,12 +655,39 @@ static inline int dt_opencl_enqueue_barrier(const int devid)
 {
   return -1;
 }
-static inline int dt_opencl_lock_device(const int dev)
+static inline int dt_opencl_reserve_device_for_pipe(const int pipetype)
 {
   return -1;
 }
-static inline void dt_opencl_unlock_device(const int dev)
+static inline void dt_opencl_reserve_device_by_id(const int devid)
 {
+}
+static inline int dt_opencl_try_reserve_device_by_id(const int devid)
+{
+  return 1; // never free: there are no devices
+}
+static inline void dt_opencl_release_device(const int devid)
+{
+}
+static inline int dt_opencl_get_num_devices(void)
+{
+  return 0;
+}
+static inline const char *dt_opencl_get_device_name(const int devid)
+{
+  return NULL;
+}
+static inline gboolean dt_opencl_get_device_max_image_size(const int devid, int *width, int *height)
+{
+  return FALSE;
+}
+static inline size_t dt_opencl_get_device_max_global_mem(const int devid)
+{
+  return 0;
+}
+static inline int dt_opencl_report_pipe_error(void)
+{
+  return 2;
 }
 static inline int dt_opencl_load_program(const int dev, const char *filename)
 {
@@ -772,7 +837,6 @@ extern "C" {
  * compiling in no-OpenCL builds exactly as they did when they read the global directly.
  * NOTE: common/opencl.c keeps direct access for now; relocating ownership into the subsystem
  * itself (a file-static set at init) is the follow-up, not an accessor. */
-struct dt_opencl_t *dt_opencl_get_global(void);
 
 #ifdef __cplusplus
 }

--- a/src/common/opencl.h
+++ b/src/common/opencl.h
@@ -618,13 +618,10 @@ gboolean dt_opencl_is_pinned_memory(cl_mem mem);
 extern "C" {
 #endif
 
-typedef struct dt_opencl_t
-{
-  int inited;
-  int enabled;
-  int stopped;
-  int error_count;
-} dt_opencl_t;
+/* Opaque here too, so the type name means the same thing in both configurations: private to
+ * common/opencl.c, and impossible to instantiate anywhere else. In this build there is no
+ * state at all -- every query below is a constant. */
+typedef struct dt_opencl_t dt_opencl_t;
 typedef struct dt_opencl_detected_device_t
 {
   int config_id;
@@ -829,14 +826,6 @@ static inline void dt_opencl_events_profiling(const int devid, const int aggrega
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-/* Process-wide singleton with no per-call context to ride on: this accessor is the intended
- * end state (same category as dt_conf_*), implemented by the orchestrator. Declared OUTSIDE the
- * HAVE_OPENCL split on purpose: dt_opencl_t exists in both configurations and darktable.c
- * defines the accessor unconditionally, so callers that merely pass the handle around keep
- * compiling in no-OpenCL builds exactly as they did when they read the global directly.
- * NOTE: common/opencl.c keeps direct access for now; relocating ownership into the subsystem
- * itself (a file-static set at init) is the follow-up, not an accessor. */
 
 #ifdef __cplusplus
 }

--- a/src/common/sentry.c
+++ b/src/common/sentry.c
@@ -399,18 +399,18 @@ static void _sentry_set_context(void)
 
 #ifdef HAVE_OPENCL
   // Device enumeration fields (num_devs/dev) only exist in HAVE_OPENCL builds.
-  if(dt_opencl_get_global() && dt_opencl_is_inited() && dt_opencl_get_global()->num_devs > 0 && dt_opencl_get_global()->dev)
+  if(dt_opencl_get_num_devices() > 0)
   {
     sentry_value_t gpus = sentry_value_new_list();
-    for(int i = 0; i < dt_opencl_get_global()->num_devs; i++)
+    for(int i = 0; i < dt_opencl_get_num_devices(); i++)
     {
-      const char *name = dt_opencl_get_global()->dev[i].name;
+      const char *name = dt_opencl_get_device_name(i);
       if(name) sentry_value_append(gpus, sentry_value_new_string(name));
     }
     sentry_value_set_by_key(device, "opencl_devices", gpus);
 
     // Tag with the first device so events are filterable by GPU.
-    if(dt_opencl_get_global()->dev[0].name) sentry_set_tag("opencl_device", dt_opencl_get_global()->dev[0].name);
+    if(dt_opencl_get_device_name(0)) sentry_set_tag("opencl_device", dt_opencl_get_device_name(0));
   }
 #endif
   sentry_set_context("device", device);

--- a/src/common/telemetry.c
+++ b/src/common/telemetry.c
@@ -346,9 +346,8 @@ static JsonObject *_telemetry_system_properties(void)
   json_object_set_boolean_member(p, "opencl", cl);
 #ifdef HAVE_OPENCL
   // Device enumeration fields (num_devs/dev) only exist in HAVE_OPENCL builds.
-  if(dt_opencl_get_global() && dt_opencl_is_inited() && dt_opencl_get_global()->num_devs > 0 && dt_opencl_get_global()->dev
-     && dt_opencl_get_global()->dev[0].name)
-    json_object_set_string_member(p, "gpu", dt_opencl_get_global()->dev[0].name);
+  if(dt_opencl_get_num_devices() > 0 && dt_opencl_get_device_name(0))
+    json_object_set_string_member(p, "gpu", dt_opencl_get_device_name(0));
 #endif
 
 #if !defined(_WIN32) && !defined(__APPLE__)

--- a/src/darktable.c
+++ b/src/darktable.c
@@ -677,11 +677,6 @@ JsonParser *dt_noiseprofile_get_parser_global(void)
   return darktable.noiseprofile_parser;
 }
 
-struct dt_opencl_t *dt_opencl_get_global(void)
-{
-  return darktable.opencl;
-}
-
 struct dt_bauhaus_t *dt_bauhaus_get_global(void)
 {
   return darktable.bauhaus;
@@ -1464,9 +1459,8 @@ int dt_init(int argc, char *argv[], const gboolean init_gui, const gboolean load
   darktable.mipmap_cache = (dt_mipmap_cache_t *)calloc(1, sizeof(dt_mipmap_cache_t));
   dt_mipmap_cache_init(darktable.mipmap_cache);
 
-  darktable.opencl = (dt_opencl_t *)calloc(1, sizeof(dt_opencl_t));
 #ifdef HAVE_OPENCL
-  dt_opencl_init(darktable.opencl, exclude_opencl, print_statistics);
+  dt_opencl_init(exclude_opencl, print_statistics);
   // Show the splash only while compiling OpenCL kernels (triggered from opencl.c),
   // then close it immediately so the rest of the startup stays splash-free.
   dt_gui_splash_close();
@@ -1719,9 +1713,9 @@ void dt_cleanup()
   darktable.iop_order_rules = NULL;
 
 #ifdef HAVE_OPENCL
-  if(darktable.opencl && darktable.opencl->inited && darktable.pixelpipe_cache)
+  if(dt_opencl_is_inited() && darktable.pixelpipe_cache)
   {
-    for(int i = 0; i < darktable.opencl->num_devs; i++)
+    for(int i = 0; i < dt_opencl_get_num_devices(); i++)
       dt_opencl_finish(i);
   }
 #endif
@@ -1729,8 +1723,7 @@ void dt_cleanup()
   dt_dev_pixelpipe_cache_cleanup(darktable.pixelpipe_cache);
   dt_supervisor_cleanup();
 
-  dt_opencl_cleanup(darktable.opencl);
-  dt_free(darktable.opencl);
+  dt_opencl_cleanup();
   dt_pwstorage_destroy(darktable.pwstorage);
 
 #ifdef HAVE_GRAPHICSMAGICK

--- a/src/darktable.h
+++ b/src/darktable.h
@@ -195,7 +195,6 @@ typedef struct darktable_t
   struct dt_selection_t *selection;
   struct dt_points_t *points;
   struct dt_imageio_t *imageio;
-  struct dt_opencl_t *opencl;
   struct dt_dbus_t *dbus;
   struct dt_undo_t *undo;
   struct dt_l10n_t *l10n;

--- a/src/develop/blend.c
+++ b/src/develop/blend.c
@@ -60,6 +60,18 @@
 #include <math.h>
 #include <string.h>
 
+/* The blend kernels, owned HERE. They used to be handed to common/opencl.c, parked on the
+ * application-wide dt_opencl_t, and read back from it by this file and by two IOPs -- a round
+ * trip through a god-struct that added nothing but an ordering. opencl.c still calls init and
+ * free, because the kernels must be built after the devices exist; the pointer itself no
+ * longer leaves the blend subsystem except through dt_develop_blend_get_cl_global(). */
+static dt_blendop_cl_global_t *_blendop_cl_global = NULL;
+
+dt_blendop_cl_global_t *dt_develop_blend_get_cl_global(void)
+{
+  return _blendop_cl_global;
+}
+
 typedef enum _develop_mask_post_processing
 {
   DEVELOP_MASK_POST_NONE = 0,
@@ -994,7 +1006,7 @@ static void _refine_with_detail_mask_cl(struct dt_iop_module_t *self, const stru
 
   {
     size_t sizes[3] = { ROUNDUPDWD(iwidth, devid), ROUNDUPDHT(iheight, devid), 1 };
-    const int kernel = dt_opencl_get_global()->blendop->kernel_read_mask;
+    const int kernel = _blendop_cl_global->kernel_read_mask;
     dt_opencl_set_kernel_arg(devid, kernel, 0, sizeof(cl_mem), &out);
     dt_opencl_set_kernel_arg(devid, kernel, 1, sizeof(cl_mem), &tmp);
     dt_opencl_set_kernel_arg(devid, kernel, 2, sizeof(int), &iwidth);
@@ -1005,7 +1017,7 @@ static void _refine_with_detail_mask_cl(struct dt_iop_module_t *self, const stru
 
   {
     size_t sizes[3] = { ROUNDUPDWD(iwidth, devid), ROUNDUPDHT(iheight, devid), 1 };
-    const int kernel = dt_opencl_get_global()->blendop->kernel_calc_blend;
+    const int kernel = _blendop_cl_global->kernel_calc_blend;
     dt_opencl_set_kernel_arg(devid, kernel, 0, sizeof(cl_mem), &out);
     dt_opencl_set_kernel_arg(devid, kernel, 1, sizeof(cl_mem), &blur);
     dt_opencl_set_kernel_arg(devid, kernel, 2, sizeof(int), &iwidth);
@@ -1024,7 +1036,7 @@ static void _refine_with_detail_mask_cl(struct dt_iop_module_t *self, const stru
     if(!IS_NULL_PTR(dev_blurmat))
     {
       size_t sizes[3] = { ROUNDUPDWD(iwidth, devid), ROUNDUPDHT(iheight, devid), 1 };
-      const int clkernel = dt_opencl_get_global()->blendop->kernel_mask_blur;
+      const int clkernel = _blendop_cl_global->kernel_mask_blur;
       dt_opencl_set_kernel_arg(devid, clkernel, 0, sizeof(cl_mem), &blur);
       dt_opencl_set_kernel_arg(devid, clkernel, 1, sizeof(cl_mem), &out);
       dt_opencl_set_kernel_arg(devid, clkernel, 2, sizeof(int), &iwidth);
@@ -1043,7 +1055,7 @@ static void _refine_with_detail_mask_cl(struct dt_iop_module_t *self, const stru
 
   {
     size_t sizes[3] = { ROUNDUPDWD(iwidth, devid), ROUNDUPDHT(iheight, devid), 1 };
-    const int kernel = dt_opencl_get_global()->blendop->kernel_write_mask;
+    const int kernel = _blendop_cl_global->kernel_write_mask;
     dt_opencl_set_kernel_arg(devid, kernel, 0, sizeof(cl_mem), &out);
     dt_opencl_set_kernel_arg(devid, kernel, 1, sizeof(cl_mem), &tmp);
     dt_opencl_set_kernel_arg(devid, kernel, 2, sizeof(int), &iwidth);
@@ -1184,29 +1196,29 @@ int dt_develop_blend_process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_t
   switch(blend_csp)
   {
     case DEVELOP_BLEND_CS_RAW:
-      kernel = dt_opencl_get_global()->blendop->kernel_blendop_RAW;
-      kernel_mask = dt_opencl_get_global()->blendop->kernel_blendop_mask_RAW;
+      kernel = _blendop_cl_global->kernel_blendop_RAW;
+      kernel_mask = _blendop_cl_global->kernel_blendop_mask_RAW;
       break;
 
     case DEVELOP_BLEND_CS_RGB_DISPLAY:
-      kernel = dt_opencl_get_global()->blendop->kernel_blendop_rgb_hsl;
-      kernel_mask = dt_opencl_get_global()->blendop->kernel_blendop_mask_rgb_hsl;
+      kernel = _blendop_cl_global->kernel_blendop_rgb_hsl;
+      kernel_mask = _blendop_cl_global->kernel_blendop_mask_rgb_hsl;
       break;
 
     case DEVELOP_BLEND_CS_RGB_SCENE:
-      kernel = dt_opencl_get_global()->blendop->kernel_blendop_rgb_jzczhz;
-      kernel_mask = dt_opencl_get_global()->blendop->kernel_blendop_mask_rgb_jzczhz;
+      kernel = _blendop_cl_global->kernel_blendop_rgb_jzczhz;
+      kernel_mask = _blendop_cl_global->kernel_blendop_mask_rgb_jzczhz;
       break;
 
     case DEVELOP_BLEND_CS_LAB:
     default:
-      kernel = dt_opencl_get_global()->blendop->kernel_blendop_Lab;
-      kernel_mask = dt_opencl_get_global()->blendop->kernel_blendop_mask_Lab;
+      kernel = _blendop_cl_global->kernel_blendop_Lab;
+      kernel_mask = _blendop_cl_global->kernel_blendop_mask_Lab;
       break;
   }
-  int kernel_mask_tone_curve = dt_opencl_get_global()->blendop->kernel_blendop_mask_tone_curve;
-  int kernel_set_mask = dt_opencl_get_global()->blendop->kernel_blendop_set_mask;
-  int kernel_display_channel = dt_opencl_get_global()->blendop->kernel_blendop_display_channel;
+  int kernel_mask_tone_curve = _blendop_cl_global->kernel_blendop_mask_tone_curve;
+  int kernel_set_mask = _blendop_cl_global->kernel_blendop_set_mask;
+  int kernel_display_channel = _blendop_cl_global->kernel_blendop_display_channel;
 
   const int devid = pipe->devid;
   const int offs[2] = { xoffs, yoffs };
@@ -1591,7 +1603,7 @@ error:
 #endif
 
 /** global init of blendops */
-dt_blendop_cl_global_t *dt_develop_blend_init_cl_global(void)
+void dt_develop_blend_init_cl_global(void)
 {
 #ifdef HAVE_OPENCL
   dt_blendop_cl_global_t *b = (dt_blendop_cl_global_t *)calloc(1, sizeof(dt_blendop_cl_global_t));
@@ -1617,16 +1629,16 @@ dt_blendop_cl_global_t *dt_develop_blend_init_cl_global(void)
   b->kernel_calc_blend = dt_opencl_create_kernel(program_rcd, "calc_detail_blend");
   b->kernel_mask_blur  = dt_opencl_create_kernel(program_rcd, "fastblur_mask_9x9");
 
-  return b;
-#else
-  return NULL;
+  _blendop_cl_global = b;
 #endif
 }
 
 /** global cleanup of blendops */
-void dt_develop_blend_free_cl_global(dt_blendop_cl_global_t *b)
+void dt_develop_blend_free_cl_global(void)
 {
 #ifdef HAVE_OPENCL
+  dt_blendop_cl_global_t *b = _blendop_cl_global;
+  _blendop_cl_global = NULL;
   if(IS_NULL_PTR(b)) return;
 
   dt_opencl_free_kernel(b->kernel_blendop_mask_Lab);

--- a/src/develop/blend.h
+++ b/src/develop/blend.h
@@ -409,9 +409,12 @@ typedef struct dt_iop_gui_blend_data_t
 
 
 /** global init of blendops */
-dt_blendop_cl_global_t *dt_develop_blend_init_cl_global(void);
+void dt_develop_blend_init_cl_global(void);
 /** global cleanup of blendops */
-void dt_develop_blend_free_cl_global(dt_blendop_cl_global_t *b);
+void dt_develop_blend_free_cl_global(void);
+/** The blend OpenCL kernels, for the two IOPs that reuse them (iop/detailmask.c,
+ * iop/demosaic/dual.c). NULL when OpenCL is unavailable or not yet initialised. */
+dt_blendop_cl_global_t *dt_develop_blend_get_cl_global(void);
 
 /** apply blend. Return 0 if ok, 1 if error */
 int dt_develop_blend_process(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_t *pipe,

--- a/src/develop/pixelpipe_cache.c
+++ b/src/develop/pixelpipe_cache.c
@@ -495,9 +495,9 @@ void dt_dev_pixelpipe_cache_flush_clmem(dt_dev_pixelpipe_cache_t *cache, const i
   // cl_mem objects at application exit, when nothing else is running.
   if(devid < 0) return;
 
-  // NOTE: the caller must hold dt_opencl_get_global()->dev[devid].lock -- either
+  // NOTE: the caller must hold the device lock (dt_opencl_reserve_device_by_id()) -- either
   // because it IS the pixelpipe currently running on that device (the lock
-  // dt_opencl_lock_device() handed it for the duration of its run), or because
+  // dt_opencl_reserve_device_for_pipe() handed it for the duration of its run), or because
   // it explicitly took that lock to safely flush this device's cache entries
   // after its own run finished (see dt_dev_pixelpipe_cache_flush_clmem_for_pipe()).
   dt_opencl_events_wait_for(devid);
@@ -551,15 +551,15 @@ void dt_dev_pixelpipe_cache_flush_clmem(dt_dev_pixelpipe_cache_t *cache, const i
 void dt_dev_pixelpipe_cache_flush_clmem_for_pipe(dt_dev_pixelpipe_cache_t *cache, const int devid)
 {
   // Like dt_dev_pixelpipe_cache_flush_clmem(), but for callers that do NOT
-  // currently hold dt_opencl_get_global()->dev[devid].lock -- typically a pipe's own
+  // currently hold the device lock (dt_opencl_reserve_device_by_id()) -- typically a pipe's own
   // cleanup, running after dt_dev_pixelpipe_process() already released that
   // lock. Taking it here ensures we can't race the eventlist/cl_mem bookkeeping
   // of whichever OTHER pixelpipe is now running on that device.
-  if(devid < 0 || IS_NULL_PTR(dt_opencl_get_global()) || !dt_opencl_is_inited()) return;
+  if(devid < 0 || !dt_opencl_is_inited()) return;
 
-  dt_pthread_mutex_lock(&dt_opencl_get_global()->dev[devid].lock);
+  dt_opencl_reserve_device_by_id(devid);
   dt_dev_pixelpipe_cache_flush_clmem(cache, devid);
-  dt_pthread_mutex_unlock(&dt_opencl_get_global()->dev[devid].lock);
+  dt_opencl_release_device(devid);
 }
 #else
 void dt_dev_pixelpipe_cache_flush_clmem_for_pipe(dt_dev_pixelpipe_cache_t *cache, const int devid)
@@ -1994,7 +1994,7 @@ static void _free_cache_entry(dt_pixel_cache_entry_t *cache_entry)
         * is still reading the previous pixels.
         *
         * dt_opencl_finish() flushes that device's event list, which is only thread-safe while we hold
-        * dt_opencl_get_global()->dev[devid].lock. Touching it without that lock races the eventlist/cl_mem
+        * the device lock (dt_opencl_reserve_device_by_id()). Touching it without that lock races the eventlist/cl_mem
         * bookkeeping of whichever pixelpipe is currently running on that device and crashes inside
         * clWaitForEvents (issues #859, #864, #131742439 -- the 3-min GUI garbage collection timeout
         * dt_dev_pixelpipe_cache_flush_old() owns no device lock). _free_cache_entry() also runs from LRU
@@ -2003,11 +2003,11 @@ static void _free_cache_entry(dt_pixel_cache_entry_t *cache_entry)
         * the owner is draining it itself at the end of its run and this refcount==0 entry is not one of its
         * live borrows, so skipping the finish is safe. */
       const int mem_devid = dt_opencl_get_mem_context_id((cl_mem)c->mem);
-      if(mem_devid >= 0 && !IS_NULL_PTR(dt_opencl_get_global()) && dt_opencl_is_inited()
-         && !dt_pthread_mutex_BAD_trylock(&dt_opencl_get_global()->dev[mem_devid].lock))
+      if(mem_devid >= 0 && dt_opencl_is_inited()
+         && !dt_opencl_try_reserve_device_by_id(mem_devid))
       {
         dt_opencl_finish(mem_devid);
-        dt_pthread_mutex_BAD_unlock(&dt_opencl_get_global()->dev[mem_devid].lock);
+        dt_opencl_release_device(mem_devid);
       }
     }
     dt_pthread_mutex_unlock(&cache_entry->cl_mem_lock);
@@ -2929,10 +2929,10 @@ GArray *dt_dev_pixelpipe_cache_get_entries_stats(dt_dev_pixelpipe_cache_t *cache
 size_t dt_dev_pixelpipe_cache_get_vram_total(void)
 {
 #ifdef HAVE_OPENCL
-  if(!dt_opencl_is_enabled() || IS_NULL_PTR(dt_opencl_get_global())) return 0;
+  if(!dt_opencl_is_enabled()) return 0;
   size_t total = 0;
-  for(int i = 0; i < dt_opencl_get_global()->num_devs; i++)
-    total += (size_t)dt_opencl_get_global()->dev[i].max_global_mem;
+  for(int i = 0; i < dt_opencl_get_num_devices(); i++)
+    total += dt_opencl_get_device_max_global_mem(i);
   return total;
 #else
   return 0;

--- a/src/develop/pixelpipe_cache.h
+++ b/src/develop/pixelpipe_cache.h
@@ -655,7 +655,7 @@ int dt_dev_pixelpipe_cache_invalidate_hashes(dt_dev_pixelpipe_cache_t *cache,
  *
  * @param devid Device to flush, or a negative value for a no-op (e.g. a pipe that
  *              never used OpenCL). The caller must already hold
- *              `dt_opencl_get_global()->dev[devid].lock` -- this is the case for the
+ *              the device lock (`dt_opencl_reserve_device_by_id()`) -- this is the case for the
  *              pixelpipe currently running on that device. Callers that don't hold
  *              it (e.g. cleaning up a pipe after it finished) must use
  *              dt_dev_pixelpipe_cache_flush_clmem_for_pipe() instead.
@@ -664,7 +664,7 @@ void dt_dev_pixelpipe_cache_flush_clmem(dt_dev_pixelpipe_cache_t *cache, const i
 
 /**
  * @brief Like dt_dev_pixelpipe_cache_flush_clmem(), for callers that do not hold
- * `dt_opencl_get_global()->dev[devid].lock` (e.g. a pipe's own cleanup after
+ * the device lock (`dt_opencl_reserve_device_by_id()`) (e.g. a pipe's own cleanup after
  * dt_dev_pixelpipe_process() already released it). Takes the lock itself, then
  * delegates. No-op if devid < 0 or OpenCL isn't available.
  */

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -1281,7 +1281,7 @@ void dt_dev_pixelpipe_disable_before(dt_dev_pixelpipe_t *pipe, const char *op)
   {                                                                                                               \
     if(pipe->devid >= 0)                                                                                          \
     {                                                                                                             \
-      dt_opencl_unlock_device(pipe->devid);                                                                       \
+      dt_opencl_release_device(pipe->devid);                                                                       \
       pipe->devid = -1;                                                                                           \
     }                                                                                                             \
     if(pipe->forms)                                                                                               \
@@ -1580,7 +1580,7 @@ int dt_dev_pixelpipe_process(dt_dev_pixelpipe_t *pipe, dt_iop_roi_t roi)
   }
 
   pipe->opencl_enabled = dt_opencl_update_settings(); // update enabled flag and profile from preferences
-  pipe->devid = (pipe->opencl_enabled) ? dt_opencl_lock_device(pipe->type)
+  pipe->devid = (pipe->opencl_enabled) ? dt_opencl_reserve_device_for_pipe(pipe->type)
                                        : -1; // try to get/lock opencl resource
 
   if(pipe->devid > -1)
@@ -1634,23 +1634,15 @@ int dt_dev_pixelpipe_process(dt_dev_pixelpipe_t *pipe, dt_iop_roi_t roi)
     keep_running = (oclerr || (err && pipe->opencl_error));
     if(keep_running)
     {
-      // Log the error
-      dt_opencl_get_global()->error_count++; // increase error count
-      opencl_error = 1; // = any OpenCL error, next run goes to CPU
+      // Report it and be told what it means: 1 = retry this run on CPU, 2 = OpenCL is off
+      // for the rest of the session. The count and the threshold are the OpenCL module's.
+      opencl_error = dt_opencl_report_pipe_error();
 
       // Disable OpenCL for this pipe
-      dt_opencl_unlock_device(pipe->devid);
+      dt_opencl_release_device(pipe->devid);
       pipe->opencl_enabled = 0;
       pipe->opencl_error = 0;
       pipe->devid = -1;
-
-      if(dt_opencl_get_global()->error_count >= DT_OPENCL_MAX_ERRORS)
-      {
-        // Too many errors : dispable OpenCL for this session
-        dt_opencl_get_global()->stopped = 1;
-        dt_capabilities_remove("opencl");
-        opencl_error = 2; // = too many OpenCL errors, all runs go to CPU
-      }
 
       _print_opencl_errors(opencl_error, pipe);
     }
@@ -1695,7 +1687,7 @@ int dt_dev_pixelpipe_process(dt_dev_pixelpipe_t *pipe, dt_iop_roi_t roi)
   }
   if(pipe->devid >= 0)
   {
-    dt_opencl_unlock_device(pipe->devid);
+    dt_opencl_release_device(pipe->devid);
     pipe->devid = -1;
   }
 

--- a/src/develop/tiling.c
+++ b/src/develop/tiling.c
@@ -870,8 +870,10 @@ static int _default_process_tiling_cl_ptp(struct dt_iop_module_t *self, const st
   const float singlebuffer = fminf(fmaxf((available - tiling.overhead) / factor, 0.0f),
                                    (float)(dt_opencl_get_device_memalloc(devid)));
   const float maxbuf = fmaxf(tiling.maxbuf_cl, 1.0f);
-  int width = _min(roi_in->width, dt_opencl_get_global()->dev[devid].max_image_width);
-  int height = _min(roi_in->height, dt_opencl_get_global()->dev[devid].max_image_height);
+  int max_width = 0, max_height = 0;
+  dt_opencl_get_device_max_image_size(devid, &max_width, &max_height);
+  int width = _min(roi_in->width, max_width);
+  int height = _min(roi_in->height, max_height);
 
   /* shrink tile size in case it would exceed singlebuffer size */
   if((float)width * height * max_bpp * maxbuf > singlebuffer)
@@ -1104,8 +1106,10 @@ static int _default_process_tiling_cl_roi(struct dt_iop_module_t *self, const st
                                    (float)(dt_opencl_get_device_memalloc(devid)));
   const float maxbuf = fmaxf(tiling.maxbuf_cl, 1.0f);
 
-  int width = _min(_max(roi_in->width, roi_out->width), dt_opencl_get_global()->dev[devid].max_image_width);
-  int height = _min(_max(roi_in->height, roi_out->height), dt_opencl_get_global()->dev[devid].max_image_height);
+  int max_width = 0, max_height = 0;
+  dt_opencl_get_device_max_image_size(devid, &max_width, &max_height);
+  int width = _min(_max(roi_in->width, roi_out->width), max_width);
+  int height = _min(_max(roi_in->height, roi_out->height), max_height);
 
   /* Alignment rules: we need to make sure that alignment requirements of module are fulfilled.
      Modules will report alignment requirements via xalign and yalign within tiling_callback().

--- a/src/iop/demosaic/dual.c
+++ b/src/iop/demosaic/dual.c
@@ -129,7 +129,7 @@ gboolean dual_demosaic_cl(struct dt_iop_module_t *self, const dt_dev_pixelpipe_t
     size_t sizes[3] = { ROUNDUPDWD(width, devid), ROUNDUPDHT(height, devid), 1 };
     const dt_aligned_pixel_t wb = { piece->dsc_in.temperature.coeffs[0], piece->dsc_in.temperature.coeffs[1],
                                     piece->dsc_in.temperature.coeffs[2] };
-    const int kernel = dt_opencl_get_global()->blendop->kernel_calc_Y0_mask;
+    const int kernel = dt_develop_blend_get_cl_global()->kernel_calc_Y0_mask;
     dt_opencl_set_kernel_arg(devid, kernel, 0, sizeof(cl_mem), &detail);
     dt_opencl_set_kernel_arg(devid, kernel, 1, sizeof(cl_mem), &high_image);
     dt_opencl_set_kernel_arg(devid, kernel, 2, sizeof(int), &width);
@@ -143,7 +143,7 @@ gboolean dual_demosaic_cl(struct dt_iop_module_t *self, const dt_dev_pixelpipe_t
 
   {
     size_t sizes[3] = { ROUNDUPDWD(width, devid), ROUNDUPDHT(height, devid), 1 };
-    const int kernel = dt_opencl_get_global()->blendop->kernel_calc_scharr_mask;
+    const int kernel = dt_develop_blend_get_cl_global()->kernel_calc_scharr_mask;
     dt_opencl_set_kernel_arg(devid, kernel, 0, sizeof(cl_mem), &detail);
     dt_opencl_set_kernel_arg(devid, kernel, 1, sizeof(cl_mem), &blend);
     dt_opencl_set_kernel_arg(devid, kernel, 2, sizeof(int), &width);
@@ -155,7 +155,7 @@ gboolean dual_demosaic_cl(struct dt_iop_module_t *self, const dt_dev_pixelpipe_t
   {
     const int flag = 1;
     size_t sizes[3] = { ROUNDUPDWD(width, devid), ROUNDUPDHT(height, devid), 1 };
-    const int kernel = dt_opencl_get_global()->blendop->kernel_calc_blend;
+    const int kernel = dt_develop_blend_get_cl_global()->kernel_calc_blend;
     dt_opencl_set_kernel_arg(devid, kernel, 0, sizeof(cl_mem), &blend);
     dt_opencl_set_kernel_arg(devid, kernel, 1, sizeof(cl_mem), &detail);
     dt_opencl_set_kernel_arg(devid, kernel, 2, sizeof(int), &width);
@@ -174,7 +174,7 @@ gboolean dual_demosaic_cl(struct dt_iop_module_t *self, const dt_dev_pixelpipe_t
     if(!IS_NULL_PTR(dev_blurmat))
     {
       size_t sizes[3] = { ROUNDUPDWD(width, devid), ROUNDUPDHT(height, devid), 1 };
-      const int clkernel = dt_opencl_get_global()->blendop->kernel_mask_blur;
+      const int clkernel = dt_develop_blend_get_cl_global()->kernel_mask_blur;
       dt_opencl_set_kernel_arg(devid, clkernel, 0, sizeof(cl_mem), &detail);
       dt_opencl_set_kernel_arg(devid, clkernel, 1, sizeof(cl_mem), &blend);
       dt_opencl_set_kernel_arg(devid, clkernel, 2, sizeof(int), &width);

--- a/src/iop/detailmask.c
+++ b/src/iop/detailmask.c
@@ -201,7 +201,7 @@ int process_cl(struct dt_iop_module_t *self, const dt_dev_pixelpipe_t *pipe, con
   if(IS_NULL_PTR(mask_dev)) goto error;
 
   {
-    const int kernel = dt_opencl_get_global()->blendop->kernel_calc_Y0_mask;
+    const int kernel = dt_develop_blend_get_cl_global()->kernel_calc_Y0_mask;
     dt_aligned_pixel_t wb = { 1.0f, 1.0f, 1.0f };
     if(piece->dsc_in.temperature.enabled)
     {
@@ -223,7 +223,7 @@ int process_cl(struct dt_iop_module_t *self, const dt_dev_pixelpipe_t *pipe, con
   }
 
   {
-    const int kernel = dt_opencl_get_global()->blendop->kernel_calc_scharr_mask;
+    const int kernel = dt_develop_blend_get_cl_global()->kernel_calc_scharr_mask;
     size_t sizes[3] = { ROUNDUPDWD(width, devid), ROUNDUPDHT(height, devid), 1 };
     dt_opencl_set_kernel_arg(devid, kernel, 0, sizeof(cl_mem), &detail);
     dt_opencl_set_kernel_arg(devid, kernel, 1, sizeof(cl_mem), &mask_dev);

--- a/src/pixel/bilateralcl.c
+++ b/src/pixel/bilateralcl.c
@@ -36,7 +36,14 @@
 #include <glib.h>             // for MAX
 #include <stdlib.h>           // for free, malloc
 
-dt_bilateral_cl_global_t *dt_bilateral_init_cl_global()
+/* The kernels this subsystem compiles, owned HERE. They used to be handed to
+ * common/opencl.c, parked on the application-wide dt_opencl_t, and read back from it --
+ * a round trip through a god-struct that added nothing but an ordering. opencl.c still
+ * calls init/free, because the kernels must be built after the devices exist, but the
+ * pointer never leaves this file. */
+static dt_bilateral_cl_global_t *_bilateral_cl_global = NULL;
+
+void dt_bilateral_init_cl_global(void)
 {
   dt_bilateral_cl_global_t *b = (dt_bilateral_cl_global_t *)malloc(sizeof(dt_bilateral_cl_global_t));
 
@@ -47,7 +54,7 @@ dt_bilateral_cl_global_t *dt_bilateral_init_cl_global()
   b->kernel_blur_line_z = dt_opencl_create_kernel(program, "blur_line_z");
   b->kernel_slice = dt_opencl_create_kernel(program, "slice");
   b->kernel_slice2 = dt_opencl_create_kernel(program, "slice_to_output");
-  return b;
+  _bilateral_cl_global = b;
 }
 
 void dt_bilateral_free_cl(dt_bilateral_cl_t *b)
@@ -92,7 +99,7 @@ dt_bilateral_cl_t *dt_bilateral_init_cl(const int devid,
                                   .cellsize = 8 * sizeof(float) + sizeof(int), .overhead = 0,
                                   .sizex = 1 << 6, .sizey = 1 << 6 };
 
-  if(!dt_opencl_local_buffer_opt(devid, dt_opencl_get_global()->bilateral->kernel_splat, &locopt))
+  if(!dt_opencl_local_buffer_opt(devid, _bilateral_cl_global->kernel_splat, &locopt))
   {
     dt_print(DT_DEBUG_OPENCL,
              "[opencl_bilateral] can not identify resource limits for device %d in bilateral grid\n", devid);
@@ -110,7 +117,7 @@ dt_bilateral_cl_t *dt_bilateral_init_cl(const int devid,
   dt_bilateral_cl_t *b = (dt_bilateral_cl_t *)malloc(sizeof(dt_bilateral_cl_t));
   if(IS_NULL_PTR(b)) return NULL;
 
-  b->global = dt_opencl_get_global()->bilateral;
+  b->global = _bilateral_cl_global;
   b->width = width;
   b->height = height;
   b->blocksizex = locopt.sizex;
@@ -303,8 +310,10 @@ cl_int dt_bilateral_slice_cl(dt_bilateral_cl_t *b, cl_mem in, cl_mem out, const 
   return err;
 }
 
-void dt_bilateral_free_cl_global(dt_bilateral_cl_global_t *b)
+void dt_bilateral_free_cl_global(void)
 {
+  dt_bilateral_cl_global_t *b = _bilateral_cl_global;
+  _bilateral_cl_global = NULL;
   if(IS_NULL_PTR(b)) return;
   // destroy kernels
   dt_opencl_free_kernel(b->kernel_zero);

--- a/src/pixel/bilateralcl.h
+++ b/src/pixel/bilateralcl.h
@@ -50,7 +50,7 @@ typedef struct dt_bilateral_cl_t
   cl_mem dev_grid_tmp;
 } dt_bilateral_cl_t;
 
-dt_bilateral_cl_global_t *dt_bilateral_init_cl_global();
+void dt_bilateral_init_cl_global(void);
 
 void dt_bilateral_free_cl(dt_bilateral_cl_t *b);
 
@@ -68,7 +68,7 @@ cl_int dt_bilateral_slice_to_output_cl(dt_bilateral_cl_t *b, cl_mem in, cl_mem o
 
 cl_int dt_bilateral_slice_cl(dt_bilateral_cl_t *b, cl_mem in, cl_mem out, const float detail);
 
-void dt_bilateral_free_cl_global(dt_bilateral_cl_global_t *b);
+void dt_bilateral_free_cl_global(void);
 
 #endif // HAVE_OPENCL
 

--- a/src/pixel/dwt.c
+++ b/src/pixel/dwt.c
@@ -538,7 +538,14 @@ int dwt_denoise(float *const img, const int width, const int height, const int b
 }
 
 #ifdef HAVE_OPENCL
-dt_dwt_cl_global_t *dt_dwt_init_cl_global()
+/* The kernels this subsystem compiles, owned HERE. They used to be handed to
+ * common/opencl.c, parked on the application-wide dt_opencl_t, and read back from it --
+ * a round trip through a god-struct that added nothing but an ordering. opencl.c still
+ * calls init/free, because the kernels must be built after the devices exist, but the
+ * pointer never leaves this file. */
+static dt_dwt_cl_global_t *_dwt_cl_global = NULL;
+
+void dt_dwt_init_cl_global(void)
 {
   dt_dwt_cl_global_t *g = (dt_dwt_cl_global_t *)malloc(sizeof(dt_dwt_cl_global_t));
 
@@ -548,11 +555,13 @@ dt_dwt_cl_global_t *dt_dwt_init_cl_global()
   g->kernel_dwt_hat_transform_col = dt_opencl_create_kernel(program, "dwt_hat_transform_col");
   g->kernel_dwt_hat_transform_row = dt_opencl_create_kernel(program, "dwt_hat_transform_row");
   g->kernel_dwt_init_buffer = dt_opencl_create_kernel(program, "dwt_init_buffer");
-  return g;
+  _dwt_cl_global = g;
 }
 
-void dt_dwt_free_cl_global(dt_dwt_cl_global_t *g)
+void dt_dwt_free_cl_global(void)
 {
+  dt_dwt_cl_global_t *g = _dwt_cl_global;
+  _dwt_cl_global = NULL;
   if(IS_NULL_PTR(g)) return;
 
   // destroy kernels
@@ -572,7 +581,7 @@ dwt_params_cl_t *dt_dwt_init_cl(const int devid, cl_mem image, const int width, 
   dwt_params_cl_t *p = (dwt_params_cl_t *)malloc(sizeof(dwt_params_cl_t));
   if(IS_NULL_PTR(p)) return NULL;
 
-  p->global = dt_opencl_get_global()->dwt;
+  p->global = _dwt_cl_global;
   p->devid = devid;
   p->image = image;
   p->ch = 4;

--- a/src/pixel/dwt.h
+++ b/src/pixel/dwt.h
@@ -133,8 +133,8 @@ typedef struct dwt_params_cl_t
 
 typedef cl_int(_dwt_layer_func_cl)(cl_mem layer, dwt_params_cl_t *const p, const int scale);
 
-dt_dwt_cl_global_t *dt_dwt_init_cl_global(void);
-void dt_dwt_free_cl_global(dt_dwt_cl_global_t *g);
+void dt_dwt_init_cl_global(void);
+void dt_dwt_free_cl_global(void);
 
 dwt_params_cl_t *dt_dwt_init_cl(const int devid, cl_mem image, const int width, const int height, const int scales,
                                 const int return_layer, const int merge_from_scale, void *user_data,

--- a/src/pixel/gaussian.c
+++ b/src/pixel/gaussian.c
@@ -343,7 +343,14 @@ void dt_gaussian_free(dt_gaussian_t *g)
 
 
 #ifdef HAVE_OPENCL
-dt_gaussian_cl_global_t *dt_gaussian_init_cl_global()
+/* The kernels this subsystem compiles, owned HERE. They used to be handed to
+ * common/opencl.c, parked on the application-wide dt_opencl_t, and read back from it --
+ * a round trip through a god-struct that added nothing but an ordering. opencl.c still
+ * calls init/free, because the kernels must be built after the devices exist, but the
+ * pointer never leaves this file. */
+static dt_gaussian_cl_global_t *_gaussian_cl_global = NULL;
+
+void dt_gaussian_init_cl_global(void)
 {
   dt_gaussian_cl_global_t *g = (dt_gaussian_cl_global_t *)malloc(sizeof(dt_gaussian_cl_global_t));
 
@@ -352,7 +359,7 @@ dt_gaussian_cl_global_t *dt_gaussian_init_cl_global()
   g->kernel_gaussian_transpose_1c = dt_opencl_create_kernel(program, "gaussian_transpose_1c");
   g->kernel_gaussian_column_4c = dt_opencl_create_kernel(program, "gaussian_column_4c");
   g->kernel_gaussian_transpose_4c = dt_opencl_create_kernel(program, "gaussian_transpose_4c");
-  return g;
+  _gaussian_cl_global = g;
 }
 
 void dt_gaussian_free_cl(dt_gaussian_cl_t *g)
@@ -382,7 +389,7 @@ dt_gaussian_cl_t *dt_gaussian_init_cl(const int devid,
   dt_gaussian_cl_t *g = (dt_gaussian_cl_t *)malloc(sizeof(dt_gaussian_cl_t));
   if(IS_NULL_PTR(g)) return NULL;
 
-  g->global = dt_opencl_get_global()->gaussian;
+  g->global = _gaussian_cl_global;
   g->devid = devid;
   g->width = width;
   g->height = height;
@@ -576,8 +583,10 @@ cl_int dt_gaussian_blur_cl(dt_gaussian_cl_t *g, cl_mem dev_in, cl_mem dev_out)
 }
 
 
-void dt_gaussian_free_cl_global(dt_gaussian_cl_global_t *g)
+void dt_gaussian_free_cl_global(void)
 {
+  dt_gaussian_cl_global_t *g = _gaussian_cl_global;
+  _gaussian_cl_global = NULL;
   if(IS_NULL_PTR(g)) return;
   // destroy kernels
   dt_opencl_free_kernel(g->kernel_gaussian_column_1c);

--- a/src/pixel/gaussian.h
+++ b/src/pixel/gaussian.h
@@ -87,9 +87,9 @@ typedef struct dt_gaussian_cl_t
   cl_mem dev_temp2;
 } dt_gaussian_cl_t;
 
-dt_gaussian_cl_global_t *dt_gaussian_init_cl_global(void);
+void dt_gaussian_init_cl_global(void);
 
-void dt_gaussian_free_cl_global(dt_gaussian_cl_global_t *g);
+void dt_gaussian_free_cl_global(void);
 
 dt_gaussian_cl_t *dt_gaussian_init_cl(const int devid, const int width, const int height, const int channels,
                                       const float *max, const float *min, const float sigma, const int order);

--- a/src/pixel/guided_filter.c
+++ b/src/pixel/guided_filter.c
@@ -384,7 +384,14 @@ int guided_filter(const float *const guide, const float *const in, float *const 
 
 #ifdef HAVE_OPENCL
 
-dt_guided_filter_cl_global_t *dt_guided_filter_init_cl_global()
+/* The kernels this subsystem compiles, owned HERE. They used to be handed to
+ * common/opencl.c, parked on the application-wide dt_opencl_t, and read back from it --
+ * a round trip through a god-struct that added nothing but an ordering. opencl.c still
+ * calls init/free, because the kernels must be built after the devices exist, but the
+ * pointer never leaves this file. */
+static dt_guided_filter_cl_global_t *_guided_filter_cl_global = NULL;
+
+void dt_guided_filter_init_cl_global(void)
 {
   dt_guided_filter_cl_global_t *g = malloc(sizeof(*g));
   const int program = 26; // guided_filter.cl, from programs.conf
@@ -397,12 +404,14 @@ dt_guided_filter_cl_global_t *dt_guided_filter_init_cl_global()
   g->kernel_guided_filter_update_covariance = dt_opencl_create_kernel(program, "guided_filter_update_covariance");
   g->kernel_guided_filter_solve = dt_opencl_create_kernel(program, "guided_filter_solve");
   g->kernel_guided_filter_generate_result = dt_opencl_create_kernel(program, "guided_filter_generate_result");
-  return g;
+  _guided_filter_cl_global = g;
 }
 
 
-void dt_guided_filter_free_cl_global(dt_guided_filter_cl_global_t *g)
+void dt_guided_filter_free_cl_global(void)
 {
+  dt_guided_filter_cl_global_t *g = _guided_filter_cl_global;
+  _guided_filter_cl_global = NULL;
   if(IS_NULL_PTR(g)) return;
   // destroy kernels
   dt_opencl_free_kernel(g->kernel_guided_filter_split_rgb);
@@ -420,7 +429,7 @@ void dt_guided_filter_free_cl_global(dt_guided_filter_cl_global_t *g)
 static int cl_split_rgb(const int devid, const int width, const int height, cl_mem guide, cl_mem imgg_r,
                         cl_mem imgg_g, cl_mem imgg_b, const float guide_weight)
 {
-  const int kernel = dt_opencl_get_global()->guided_filter->kernel_guided_filter_split_rgb;
+  const int kernel = _guided_filter_cl_global->kernel_guided_filter_split_rgb;
   dt_opencl_set_kernel_arg(devid, kernel, 0, sizeof(int), &width);
   dt_opencl_set_kernel_arg(devid, kernel, 1, sizeof(int), &height);
   dt_opencl_set_kernel_arg(devid, kernel, 2, sizeof(cl_mem), &guide);
@@ -436,7 +445,7 @@ static int cl_split_rgb(const int devid, const int width, const int height, cl_m
 static int cl_box_mean(const int devid, const int width, const int height, const int w, cl_mem in, cl_mem out,
                        cl_mem temp)
 {
-  const int kernel_x = dt_opencl_get_global()->guided_filter->kernel_guided_filter_box_mean_x;
+  const int kernel_x = _guided_filter_cl_global->kernel_guided_filter_box_mean_x;
   dt_opencl_set_kernel_arg(devid, kernel_x, 0, sizeof(int), &width);
   dt_opencl_set_kernel_arg(devid, kernel_x, 1, sizeof(int), &height);
   dt_opencl_set_kernel_arg(devid, kernel_x, 2, sizeof(cl_mem), &in);
@@ -446,7 +455,7 @@ static int cl_box_mean(const int devid, const int width, const int height, const
   const int err = dt_opencl_enqueue_kernel_2d(devid, kernel_x, sizes_x);
   if(err != CL_SUCCESS) return err;
 
-  const int kernel_y = dt_opencl_get_global()->guided_filter->kernel_guided_filter_box_mean_y;
+  const int kernel_y = _guided_filter_cl_global->kernel_guided_filter_box_mean_y;
   dt_opencl_set_kernel_arg(devid, kernel_y, 0, sizeof(int), &width);
   dt_opencl_set_kernel_arg(devid, kernel_y, 1, sizeof(int), &height);
   dt_opencl_set_kernel_arg(devid, kernel_y, 2, sizeof(cl_mem), &temp);
@@ -461,7 +470,7 @@ static int cl_covariances(const int devid, const int width, const int height, cl
                           cl_mem cov_imgg_img_r, cl_mem cov_imgg_img_g, cl_mem cov_imgg_img_b,
                           const float guide_weight)
 {
-  const int kernel = dt_opencl_get_global()->guided_filter->kernel_guided_filter_guided_filter_covariances;
+  const int kernel = _guided_filter_cl_global->kernel_guided_filter_guided_filter_covariances;
   dt_opencl_set_kernel_arg(devid, kernel, 0, sizeof(int), &width);
   dt_opencl_set_kernel_arg(devid, kernel, 1, sizeof(int), &height);
   dt_opencl_set_kernel_arg(devid, kernel, 2, sizeof(cl_mem), &guide);
@@ -479,7 +488,7 @@ static int cl_variances(const int devid, const int width, const int height, cl_m
                         cl_mem var_imgg_rg, cl_mem var_imgg_rb, cl_mem var_imgg_gg, cl_mem var_imgg_gb,
                         cl_mem var_imgg_bb, const float guide_weight)
 {
-  const int kernel = dt_opencl_get_global()->guided_filter->kernel_guided_filter_guided_filter_variances;
+  const int kernel = _guided_filter_cl_global->kernel_guided_filter_guided_filter_variances;
   dt_opencl_set_kernel_arg(devid, kernel, 0, sizeof(int), &width);
   dt_opencl_set_kernel_arg(devid, kernel, 1, sizeof(int), &height);
   dt_opencl_set_kernel_arg(devid, kernel, 2, sizeof(cl_mem), &guide);
@@ -498,7 +507,7 @@ static int cl_variances(const int devid, const int width, const int height, cl_m
 static int cl_update_covariance(const int devid, const int width, const int height, cl_mem in, cl_mem out,
                                 cl_mem a, cl_mem b, float eps)
 {
-  const int kernel = dt_opencl_get_global()->guided_filter->kernel_guided_filter_update_covariance;
+  const int kernel = _guided_filter_cl_global->kernel_guided_filter_update_covariance;
   dt_opencl_set_kernel_arg(devid, kernel, 0, sizeof(int), &width);
   dt_opencl_set_kernel_arg(devid, kernel, 1, sizeof(int), &height);
   dt_opencl_set_kernel_arg(devid, kernel, 2, sizeof(cl_mem), &in);
@@ -517,7 +526,7 @@ static int cl_solve(const int devid, const int width, const int height, cl_mem i
                     cl_mem var_imgg_gg, cl_mem var_imgg_gb, cl_mem var_imgg_bb, cl_mem a_r, cl_mem a_g, cl_mem a_b,
                     cl_mem b)
 {
-  const int kernel = dt_opencl_get_global()->guided_filter->kernel_guided_filter_solve;
+  const int kernel = _guided_filter_cl_global->kernel_guided_filter_solve;
   dt_opencl_set_kernel_arg(devid, kernel, 0, sizeof(int), &width);
   dt_opencl_set_kernel_arg(devid, kernel, 1, sizeof(int), &height);
   dt_opencl_set_kernel_arg(devid, kernel, 2, sizeof(cl_mem), &img_mean);
@@ -546,7 +555,7 @@ static int cl_generate_result(const int devid, const int width, const int height
                               cl_mem a_g, cl_mem a_b, cl_mem b, cl_mem out, const float guide_weight,
                               const float min, const float max)
 {
-  const int kernel = dt_opencl_get_global()->guided_filter->kernel_guided_filter_generate_result;
+  const int kernel = _guided_filter_cl_global->kernel_guided_filter_generate_result;
   dt_opencl_set_kernel_arg(devid, kernel, 0, sizeof(int), &width);
   dt_opencl_set_kernel_arg(devid, kernel, 1, sizeof(int), &height);
   dt_opencl_set_kernel_arg(devid, kernel, 2, sizeof(cl_mem), &guide);

--- a/src/pixel/guided_filter.h
+++ b/src/pixel/guided_filter.h
@@ -105,9 +105,9 @@ typedef struct dt_guided_filter_cl_global_t
 } dt_guided_filter_cl_global_t;
 
 
-dt_guided_filter_cl_global_t *dt_guided_filter_init_cl_global();
+void dt_guided_filter_init_cl_global(void);
 
-void dt_guided_filter_free_cl_global(dt_guided_filter_cl_global_t *g);
+void dt_guided_filter_free_cl_global(void);
 
 int guided_filter_cl(int devid, cl_mem guide, cl_mem in, cl_mem out, int width, int height, int ch, int w,
                      float sqrt_eps, float guide_weight, float min, float max);

--- a/src/pixel/heal.c
+++ b/src/pixel/heal.c
@@ -415,15 +415,24 @@ cleanup:
 
 #ifdef HAVE_OPENCL
 
-dt_heal_cl_global_t *dt_heal_init_cl_global()
+/* The kernels this subsystem compiles, owned HERE. They used to be handed to
+ * common/opencl.c, parked on the application-wide dt_opencl_t, and read back from it --
+ * a round trip through a god-struct that added nothing but an ordering. opencl.c still
+ * calls init/free, because the kernels must be built after the devices exist, but the
+ * pointer never leaves this file. */
+static dt_heal_cl_global_t *_heal_cl_global = NULL;
+
+void dt_heal_init_cl_global(void)
 {
   dt_heal_cl_global_t *g = (dt_heal_cl_global_t *)malloc(sizeof(dt_heal_cl_global_t));
 
-  return g;
+  _heal_cl_global = g;
 }
 
-void dt_heal_free_cl_global(dt_heal_cl_global_t *g)
+void dt_heal_free_cl_global(void)
 {
+  dt_heal_cl_global_t *g = _heal_cl_global;
+  _heal_cl_global = NULL;
   if(IS_NULL_PTR(g)) return;
 
   dt_free(g);
@@ -435,7 +444,7 @@ heal_params_cl_t *dt_heal_init_cl(const int devid)
   heal_params_cl_t *p = (heal_params_cl_t *)malloc(sizeof(heal_params_cl_t));
   if(IS_NULL_PTR(p)) return NULL;
 
-  p->global = dt_opencl_get_global()->heal;
+  p->global = _heal_cl_global;
   p->devid = devid;
 
   return p;

--- a/src/pixel/heal.h
+++ b/src/pixel/heal.h
@@ -41,8 +41,8 @@ typedef struct heal_params_cl_t
   int devid;
 } heal_params_cl_t;
 
-dt_heal_cl_global_t *dt_heal_init_cl_global(void);
-void dt_heal_free_cl_global(dt_heal_cl_global_t *g);
+void dt_heal_init_cl_global(void);
+void dt_heal_free_cl_global(void);
 
 heal_params_cl_t *dt_heal_init_cl(const int devid);
 void dt_heal_free_cl(heal_params_cl_t *p);

--- a/src/pixel/interpolation.c
+++ b/src/pixel/interpolation.c
@@ -1059,7 +1059,14 @@ void dt_interpolation_resample_roi(const struct dt_interpolation *itor,
 }
 
 #ifdef HAVE_OPENCL
-dt_interpolation_cl_global_t *dt_interpolation_init_cl_global()
+/* The kernels this subsystem compiles, owned HERE. They used to be handed to
+ * common/opencl.c, parked on the application-wide dt_opencl_t, and read back from it --
+ * a round trip through a god-struct that added nothing but an ordering. opencl.c still
+ * calls init/free, because the kernels must be built after the devices exist, but the
+ * pointer never leaves this file. */
+static dt_interpolation_cl_global_t *_interpolation_cl_global = NULL;
+
+void dt_interpolation_init_cl_global(void)
 {
   dt_interpolation_cl_global_t *g
       = (dt_interpolation_cl_global_t *)malloc(sizeof(dt_interpolation_cl_global_t));
@@ -1067,11 +1074,13 @@ dt_interpolation_cl_global_t *dt_interpolation_init_cl_global()
   const int program = 2; // basic.cl, from programs.conf
   g->kernel_interpolation_resample =
     dt_opencl_create_kernel(program, "interpolation_resample");
-  return g;
+  _interpolation_cl_global = g;
 }
 
-void dt_interpolation_free_cl_global(dt_interpolation_cl_global_t *g)
+void dt_interpolation_free_cl_global(void)
 {
+  dt_interpolation_cl_global_t *g = _interpolation_cl_global;
+  _interpolation_cl_global = NULL;
   if(IS_NULL_PTR(g)) return;
   // destroy kernels
   dt_opencl_free_kernel(g->kernel_interpolation_resample);
@@ -1159,7 +1168,7 @@ int dt_interpolation_resample_cl(const struct dt_interpolation *itor,
   // a number of parallel work items each taking care of one horizontal convolution,
   // then sum over work items to do the vertical convolution
 
-  const int kernel = dt_opencl_get_global()->interpolation->kernel_interpolation_resample;
+  const int kernel = _interpolation_cl_global->kernel_interpolation_resample;
   const int width = roi_out->width;
   const int height = roi_out->height;
 

--- a/src/pixel/interpolation.h
+++ b/src/pixel/interpolation.h
@@ -152,9 +152,9 @@ typedef struct dt_interpolation_cl_global_t
   int kernel_interpolation_resample;
 } dt_interpolation_cl_global_t;
 
-dt_interpolation_cl_global_t *dt_interpolation_init_cl_global(void);
+void dt_interpolation_init_cl_global(void);
 
-void dt_interpolation_free_cl_global(dt_interpolation_cl_global_t *g);
+void dt_interpolation_free_cl_global(void);
 
 
 /** Image resampler OpenCL version.

--- a/src/pixel/locallaplaciancl.c
+++ b/src/pixel/locallaplaciancl.c
@@ -39,7 +39,14 @@ static inline uint64_t dl(uint64_t size, const int level)
   return size;
 }
 
-dt_local_laplacian_cl_global_t *dt_local_laplacian_init_cl_global()
+/* The kernels this subsystem compiles, owned HERE. They used to be handed to
+ * common/opencl.c, parked on the application-wide dt_opencl_t, and read back from it --
+ * a round trip through a god-struct that added nothing but an ordering. opencl.c still
+ * calls init/free, because the kernels must be built after the devices exist, but the
+ * pointer never leaves this file. */
+static dt_local_laplacian_cl_global_t *_local_laplacian_cl_global = NULL;
+
+void dt_local_laplacian_init_cl_global(void)
 {
   dt_local_laplacian_cl_global_t *g = malloc(sizeof(dt_local_laplacian_cl_global_t));
 
@@ -50,11 +57,13 @@ dt_local_laplacian_cl_global_t *dt_local_laplacian_init_cl_global()
   g->kernel_laplacian_assemble = dt_opencl_create_kernel(program, "laplacian_assemble");
   g->kernel_process_curve      = dt_opencl_create_kernel(program, "process_curve");
   g->kernel_write_back         = dt_opencl_create_kernel(program, "write_back");
-  return g;
+  _local_laplacian_cl_global = g;
 }
 
-void dt_local_laplacian_free_cl_global(dt_local_laplacian_cl_global_t *g)
+void dt_local_laplacian_free_cl_global(void)
 {
+  dt_local_laplacian_cl_global_t *g = _local_laplacian_cl_global;
+  _local_laplacian_cl_global = NULL;
   if(IS_NULL_PTR(g)) return;
 
   dt_opencl_free_kernel(g->kernel_pad_input);
@@ -100,7 +109,7 @@ dt_local_laplacian_cl_t *dt_local_laplacian_init_cl(
   dt_local_laplacian_cl_t *g = malloc(sizeof(dt_local_laplacian_cl_t));
   if(IS_NULL_PTR(g)) return NULL;
 
-  g->global = dt_opencl_get_global()->local_laplacian;
+  g->global = _local_laplacian_cl_global;
   g->devid = devid;
   g->width = width;
   g->height = height;

--- a/src/pixel/locallaplaciancl.h
+++ b/src/pixel/locallaplaciancl.h
@@ -55,8 +55,8 @@ typedef struct dt_local_laplacian_cl_t
 }
 dt_local_laplacian_cl_t;
 
-dt_local_laplacian_cl_global_t *dt_local_laplacian_init_cl_global();
-void dt_local_laplacian_free_cl_global(dt_local_laplacian_cl_global_t *g);
+void dt_local_laplacian_init_cl_global(void);
+void dt_local_laplacian_free_cl_global(void);
 dt_local_laplacian_cl_t *dt_local_laplacian_init_cl(
     const int devid,
     const int width,            // width of input image

--- a/tools/check_module_boundaries.sh
+++ b/tools/check_module_boundaries.sh
@@ -117,6 +117,7 @@ elif [ "${accessor_now}" -lt "${accessor_baseline}" ] || [ "${lock_now}" -lt "${
 fi
 
 echo
+system_widgets_failed=0
 if [ "${findings}" -gt 0 ]; then
   cat <<'MSG'
 A module boundary was crossed.
@@ -135,8 +136,48 @@ through widgets/widget_settings.h -- that is what those handler slots are for.
 Adding an exception to this script should be the last resort, and needs the reason written
 next to it.
 MSG
+  system_widgets_failed=1
+fi
+
+
+# 4. src/common/opencl is closed: nothing outside it names the module's state.
+#
+# `darktable.opencl` used to be a member of the application struct, so dt_opencl_t's device
+# array, its per-device locks and nine other subsystems' kernel bundles were one dereference
+# away from any file that included darktable.h. The struct is a file-static in
+# common/opencl.c now and is not even declared in the header, so both counts are structurally
+# zero -- this check is what keeps someone from re-exporting it "just for one caller".
+#
+# The kernel-bundle count is separate because it is the shape that comes back: a subsystem
+# that hands its own state to opencl.c to hold is re-creating the round trip that was removed.
+opencl_state_baseline=0
+opencl_parked_baseline=0
+
+opencl_state_now=$(grep -rn 'darktable\.opencl\|dt_opencl_get_global' src/ --include='*.c' --include='*.h' --include='*.cc' \
+                   2>/dev/null | grep -v '^src/common/opencl' | grep -cv '^\s*[0-9]*:\s*[/ ]\*')
+# A member of dt_opencl_t that is really another module's: `struct dt_<x>_cl_global_t *` on it.
+# The struct lives in the .c now -- that is the point of the check -- so look for it there,
+# and in the header too, so that re-exporting it does not make the count silently zero.
+opencl_parked_now=$(cat src/common/opencl.c src/common/opencl.h 2>/dev/null \
+                    | sed -n '/^typedef struct dt_opencl_t$/,/^} dt_opencl_t;/p' \
+                    | grep -c '_cl_global_t \*')
+
+echo "opencl:        ${opencl_state_now} external references to the module's state (baseline ${opencl_state_baseline}),"
+echo "               ${opencl_parked_now} foreign kernel bundles parked on dt_opencl_t (baseline ${opencl_parked_baseline})."
+
+if [ "${opencl_state_now}" -gt "${opencl_state_baseline}" ] || [ "${opencl_parked_now}" -gt "${opencl_parked_baseline}" ]; then
+  echo "opencl: a count ROSE. Ask the module a question (dt_opencl_get_num_devices(),"
+  echo "        dt_opencl_get_device_name(), dt_opencl_reserve_device_*()) instead of reaching"
+  echo "        into its state, and keep your own kernels in your own file."
+  findings=$((findings + 1))
+elif [ "${opencl_state_now}" -lt "${opencl_state_baseline}" ] || [ "${opencl_parked_now}" -lt "${opencl_parked_baseline}" ]; then
+  echo "opencl: a count fell -- lower the baseline in this script, in the same commit."
+  findings=$((findings + 1))
+fi
+
+if [ "${findings}" -gt 0 ]; then
   exit 1
 fi
 
-echo "OK: src/system is closed, src/widgets does not reach into gui/, colorprofiles held."
+echo "OK: src/system is closed, src/widgets does not reach into gui/, colorprofiles and opencl held."
 exit 0


### PR DESCRIPTION
Closes `src/common/opencl` the same way #1119 closed `src/colorprofiles`: the module owns its
state, answers questions instead of handing out its internals, and `darktable_t` no longer
knows OpenCL exists.

## Where this started

`darktable.opencl` was a member of the application god-struct, so `dt_opencl_t`'s device
array, its per-device locks, its error counters and **nine other subsystems' kernel bundles**
were one dereference away from any file that included `darktable.h`. Measured at branch point:

| | |
|---|---|
| references to `dt_opencl_t`'s members from outside the module | **62** |
| of those, other modules' own kernel bundles being read back | **37** |
| members on `dt_opencl_t` that belong to another module | **9 of 33** |

## Where it ends

| | before | after |
|---|---|---|
| external references to the module's state | 62 | **0** |
| foreign kernel bundles parked on `dt_opencl_t` | 9 | **0** |
| `opencl` member on `darktable_t` | yes | **gone** |
| `dt_opencl_get_global()` | yes | **gone** |
| `dt_opencl_t` defined in the header | yes | **no — opaque in both build configurations** |
| exported pixels vs master, GPU **and** CPU | — | **identical** |

Gated by `tools/check_module_boundaries.sh`, which grows a third boundary at baseline 0.

## The god-struct as a parking lot

Nine subsystems — blend, bilateral, gaussian, interpolation, local laplacian, dwt, heal,
colorspaces, guided filter — each compiled their own OpenCL kernels, handed the struct to
`common/opencl.c` to store, and then read it straight back out via
`dt_opencl_get_global()->{member}`. A round trip that added nothing but an ordering, and that
made nine modules' private state look like the OpenCL module's.

Each owns a file-static now, set by the same `dt_*_init_cl_global()` that already built the
kernels. `opencl.c` still calls init and free — the kernels genuinely must be built after the
devices exist — but the pointer never leaves its owner. The init/free pair returns `void`
instead of a pointer the caller was expected to park, which is what stops the next subsystem
re-introducing the round trip by following the old signature.

`blend` is the one that needed more than a file-static: `iop/detailmask.c` and
`iop/demosaic/dual.c` legitimately reuse its kernels, so it exposes
`dt_develop_blend_get_cl_global()` rather than pretending nobody else wants them.

## The lock pair was asymmetric and the names hid it

`dt_opencl_lock_device()` took a **pipe type** and returned a device id.
`dt_opencl_unlock_device()` took a **device id**. Both `int`, so nothing would have caught
reading them as a pair — and `develop/pixelpipe_cache.c` was reaching past both of them to
take `dev[devid].lock` by hand, which is *the same mutex*.

One vocabulary now:

```
dt_opencl_reserve_device_for_pipe(pipetype) -> devid
dt_opencl_reserve_device_by_id(devid)
dt_opencl_try_reserve_device_by_id(devid)
dt_opencl_release_device(devid)
```

The old names are **deleted rather than redefined**. Reusing `lock_device` for the by-id
variant would have compiled for every stale caller and locked the wrong thing; now they fail
to build.

## Policy that was living in the pipeline

`develop/pixelpipe_hb.c` incremented the OpenCL module's error counter, compared it against
the module's threshold, set the module's `stopped` flag and dropped the "opencl" capability
itself. It reports the failure now and is told what it means: `1` = retry this run on CPU,
`2` = OpenCL is off for the rest of the session.

## Two defects in the gate itself

Found by probing it rather than trusting it — reintroducing each violation in turn and
checking for a non-zero exit.

- **The colorprofiles boundary check has never failed the build.** The `if [ findings -gt 0 ]`
  that decides the exit code sits after checks 1 and 2 and `exit 1`s there, so checks 3 and 4
  incremented a counter nobody read again and the script fell through to `exit 0`. It has been
  reporting, not gating, since #1119 added it. One exit decision at the end now, after every
  check.
- **The new parked-bundle counter looked in the wrong file** — it scanned `dt_opencl_t` in
  `opencl.h`, but this series moves the struct into `opencl.c`, so the range matched nothing
  and the count was zero by accident rather than by fact. It reads both files now, so
  re-exporting the struct cannot make the check silently pass either.

All four boundary violations are now confirmed to produce a non-zero exit.

## Verification

Four build configurations — Release, Debug, clang Debug and `build-nofeatures` — plus
`tools/check_it_runs.sh`. Include cycles 0, layering violations unchanged at 206, no unused
includes introduced.

Pixels were checked **with OpenCL actually enabled**, which matters here more than usual: the
standing check passes `--disable-opencl`, and device reservation, tiling limits and the
device-lock path are exactly the code this PR touches. On a Quadro M2200, exporting a NEF with
`opencl=TRUE` (log confirms `[pixelpipe_process] [exporter] using device 0`) is bit-identical
to master, at 2048px and at full 20.5 MP resolution, and the CPU path is bit-identical too.

ASAN + LSAN over an export: 937 bytes in 24 allocations, **none of them in OpenCL** — down
from 1113/31 before this branch. The remainder are the startup one-offs and the
`dt_control_signal_raise()` payloads already documented.

## Deliberately not done here

- `common/opencl.c` still includes six `pixel/*.h` headers and `develop/blend.h`, now only to
  call the nine init/free pairs. Moving those calls up to `darktable.c`, which already
  orchestrates startup order, would remove the last `common/ -> pixel/` and `common/ ->
  develop/` edges this file contributes. It is a change to init ordering, so it wants its own
  commit and its own argument.
- `dt_opencl_get_device_max_image_size()` leaves its out-params untouched and returns FALSE
  for an uninitialised module or a bad device id, where the old code read the array directly.
  Both `develop/tiling.c` call sites sit among pre-existing `dt_opencl_get_device_*(devid)`
  accessors with the same guard, and are only reached with a reserved device, so the failure
  path is unreachable — but it degrades to a zero tile size rather than a crash, which is a
  different unreachable-case behaviour than master had.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
