### PR TITLE
it: four format strings that stop msgfmt (master is red)

### DIFF
--- a/.github/workflows/po-check.yml
+++ b/.github/workflows/po-check.yml
@@ -1,0 +1,46 @@
+name: Translations
+
+# ci.yml carries `paths-ignore: po/**`, so a translation-only commit builds nothing --
+# which is how a po/it.po that msgfmt refuses reached master and then failed every
+# subsequent pull request instead of its own. This runs on exactly the paths ci.yml
+# skips, and does the one check that matters for a catalogue: does it compile.
+#
+# `msgfmt -c` is what the build itself runs (see po/CMakeLists.txt), so a green run here
+# is the same verdict, ~2 seconds instead of a full build.
+
+on:
+  push:
+    paths:
+      - "po/**"
+      - ".github/workflows/po-check.yml"
+  pull_request:
+    paths:
+      - "po/**"
+      - ".github/workflows/po-check.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  msgfmt:
+    name: msgfmt -c
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          submodules: false
+      - name: Install gettext
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends gettext
+      - name: Compile every catalogue
+        run: |
+          status=0
+          for po in po/*.po; do
+            if ! msgfmt -c "$po" -o /dev/null; then
+              echo "::error file=$po::$po does not compile; the build stops here"
+              status=1
+            fi
+          done
+          exit $status

--- a/po/it.po
+++ b/po/it.po
@@ -18943,10 +18943,10 @@ msgstr ""
 "Ctrl+click per includere solo le sotto località (suffisso `|%')"
 
 #: ../src/libs/collect.c:2233
-#, c-format
+#, no-c-format
 msgid "use `%' as wildcard and append `*' to match sub-folders"
 msgstr ""
-"Utilizzare `%‘ come carattere jolly e aggiungere `*’ per includere le sottocar"
+"Utilizzare `%' come carattere jolly e aggiungere `*' per includere le sottocar"
 "telle"
 
 #: ../src/libs/collect.c:2236
@@ -21231,10 +21231,10 @@ msgid_plural ""
 "do you really want to delete %d tags?\n"
 "%d images are assigned these tags!"
 msgstr[0] ""
-"Vuoi veramente eliminare l'etichetta '%s'?\n"
+"Vuoi veramente eliminare %d etichetta?\n"
 "A %d immagine è assegnata questa etichetta!"
 msgstr[1] ""
-"Vuoi veramente eliminare le etichetta '%s'?\n"
+"Vuoi veramente eliminare %d etichette?\n"
 "A %d immagini sono assegnate queste etichette!"
 
 #: ../src/libs/tagging.c:2117
@@ -21428,7 +21428,7 @@ msgid "suggestion"
 msgstr "Suggerimento"
 
 #: ../src/libs/tagging.c:3373
-#, c-format
+#, no-c-format
 msgid ""
 "level of confidence to include a tag in the suggestions list:\n"
 "0: all associated tags, 99: 99% matching tags,\n"
@@ -22498,7 +22498,7 @@ msgstr ""
 "su ciascun livello"
 
 #: ../src/iop/crystgrain.c:1467
-#, c-format
+#, no-c-format
 msgid ""
 "average crystal footprint at 100% zoom, clamped so zooming in does not "
 "enlarge it further"


### PR DESCRIPTION
`msgfmt -c` fails on `po/it.po` with 5 fatal errors, so `po/it/LC_MESSAGES/ansel.mo` cannot be built and the build stops there. **This is on master**, from 730719f3cb "Updated Italian translation" — `Win64.UCRT64` and `macOS.XCode` both die at `[833/1054] msgfmt … it.po`, and every open pull request inherits it. `it.po` is the only catalogue affected; the other 25 compile clean.

```
po/it.po:18948: 'msgstr' is not a valid C format string, unlike 'msgid'.
po/it.po:21233: format specifications in 'msgid_plural' and 'msgstr[0]' for argument 1 are not the same
po/it.po:21436: 'msgstr' is not a valid C format string, unlike 'msgid'.
po/it.po:22505: format specifications in 'msgid' and 'msgstr' for argument 1 are not the same
```

## Three tooltips that were never format strings

`collect.c:2233`, `tagging.c:3373` and `crystgrain.c:1467` all reach
`gtk_widget_set_tooltip_text()`, not a printf-family function. Each contains a literal `%` followed by a letter, which is enough for xgettext to mark the entry `c-format`. The English then parses **by accident** — `% zo`, `% m` and `%' a` are all legal directives — while the Italian happens not to: `%,` and a typographic `‘` after the `%` are not.

Flagged `no-c-format`, which is what these strings actually are, and what the sibling entry at `collect.c:2236` (`use \`%' as wildcard`) already carries. The two curly quotes in the first msgstr are normalised to ASCII to match the convention used everywhere else in the file for this idiom.

## One that is a real format string, and a real bug

`tagging.c:2092` genuinely is one:

```c
gchar *text = g_strdup_printf(ngettext("do you really want to delete %d tag?\n%d image is assigned these tags!",
                                       "do you really want to delete %d tags?\n%d images are assigned these tags!",
                                       img_count), nb, img_count);
```

The Italian had `'%s'` where the first `%d` belongs. That is not merely a build break — it reads the tag count as a pointer, so confirming a tag deletion under `LANG=it` would have printed garbage or crashed. Both plural forms are corrected, and the ungrammatical *"le etichetta"* in the plural with them.

## Verification

`msgfmt -v -c po/it.po` → `4405 messages traduits`, exit 0. Message count unchanged, so nothing was dropped. All 26 catalogues checked; `it.po` was the only failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)