### PR TITLE
Develop T0+T1: dead code out, and the three header supply lines cut

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -112,6 +112,7 @@ FILE(GLOB SOURCE_FILES
   "database/preset_repository.c"
   "database/image_repository.c"
   "common/image_extensions.c"
+  "common/image_notify.c"
   "common/imagebuf.c"
   "imageio/imageio_core.c"
   "imageio/imageio_jpeg.c"

--- a/src/common/image.c
+++ b/src/common/image.c
@@ -72,6 +72,7 @@
 */
 
 #include "common/image.h"
+#include "common/image_notify.h"
 #include "common/thumbnail_notify.h"
 #include "common/act_on.h"
 #include "common/history_actions.h"
@@ -92,6 +93,7 @@
 #include "common/image_extensions.h"
 #include "imageio/imageio_core.h"
 #include "caches/mipmap_cache.h"
+#include "metadata/notify.h"
 #include "metadata/ratings.h"
 #include "metadata/tags.h"
 #include "common/undo.h"
@@ -872,7 +874,9 @@ static void _pop_undo(gpointer user_data, const dt_undo_type_t type, dt_undo_dat
     if(i > 1) dt_control_log((action == DT_ACTION_UNDO)
                               ? _("geo-location undone for %d images")
                               : _("geo-location re-applied to %d images"), i);
-    DT_DEBUG_CONTROL_SIGNAL_RAISE(dt_control_signal_get_global(), DT_SIGNAL_GEOTAG_CHANGED, g_list_copy(*imgs), 0);
+    // the handler copies the list; ours stays ours (the raise it replaces took ownership,
+    // which is why this site used to g_list_copy)
+    dt_metadata_geotags_changed(*imgs);
   }
   else if(type == DT_UNDO_DATETIME)
   {
@@ -1302,7 +1306,7 @@ static int32_t _image_duplicate_with_version(const int32_t imgid, const int32_t 
     // make sure that the duplicate doesn't have some magic darktable| tags
     if(dt_tag_detach_by_string("darktable|changed", newid, FALSE, FALSE)
        || dt_tag_detach_by_string("darktable|exported", newid, FALSE, FALSE))
-      DT_DEBUG_CONTROL_SIGNAL_RAISE(dt_control_signal_get_global(), DT_SIGNAL_TAG_CHANGED);
+      dt_metadata_tags_changed();
 
     const dt_image_t *img = dt_image_cache_get(imgid, 'r');
     const int grpid = img->group_id;
@@ -1681,9 +1685,12 @@ static int32_t _image_import_internal(const int32_t film_id, const char *filenam
 
   if(raise_signals)
   {
-    DT_DEBUG_CONTROL_SIGNAL_RAISE(dt_control_signal_get_global(), DT_SIGNAL_IMAGE_IMPORT, id);
+    dt_image_notify_imported(id);
+    // the old raise handed the freshly built list to the signal; the handler copies now,
+    // so this site frees its own
     GList *imgs = g_list_prepend(NULL, GINT_TO_POINTER(id));
-    DT_DEBUG_CONTROL_SIGNAL_RAISE(dt_control_signal_get_global(), DT_SIGNAL_GEOTAG_CHANGED, imgs, 0);
+    dt_metadata_geotags_changed(imgs);
+    g_list_free(imgs);
   }
 
   // the following line would look logical with new_tags_set being the return value

--- a/src/common/image_notify.c
+++ b/src/common/image_notify.c
@@ -1,0 +1,40 @@
+/*
+    This file is part of Ansel,
+    Copyright (C) 2026 Aurélien PIERRE.
+
+    Ansel is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Ansel is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Ansel.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "common/image_notify.h"
+
+/* Written once, at startup, before any import job exists; read from whichever thread
+ * imports. A lock would be guarding against a race nobody can create. */
+static dt_image_imported_handler_t _imported_handler = NULL;
+
+void dt_image_notify_set_imported_handler(dt_image_imported_handler_t handler)
+{
+  _imported_handler = handler;
+}
+
+void dt_image_notify_imported(const int32_t imgid)
+{
+  dt_image_imported_handler_t handler = _imported_handler;
+  if(handler) handler(imgid);
+}
+
+// clang-format off
+// modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py
+// vim: shiftwidth=2 expandtab tabstop=2 cindent
+// kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;
+// clang-format on

--- a/src/common/image_notify.h
+++ b/src/common/image_notify.h
@@ -1,0 +1,60 @@
+/*
+    This file is part of Ansel,
+    Copyright (C) 2026 Aurélien PIERRE.
+
+    Ansel is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Ansel is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Ansel.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+/** @file common/image_notify.h
+ *
+ * @brief `common/image.c` states that an image entered the library; whoever is showing
+ * the collection decides what that looks like.
+ *
+ * @details The import path used to raise `DT_SIGNAL_IMAGE_IMPORT` itself — a call into
+ * `control/` (layer 3) from a layer-1 file that had no other reason to know the control
+ * loop exists, and whose include line was missing anyway: the symbols arrived through
+ * `develop/imageop.h → control/settings.h → control/signal.h`, a supply line three
+ * headers long. Same inversion as `metadata/notify.h` and `history/notify.h`; same
+ * shape as `common/thumbnail_notify.h` next door. With no handler installed — ansel-cli,
+ * a unit test — the fact is dropped, which is correct for both.
+ */
+
+#ifndef DT_COMMON_IMAGE_NOTIFY_H
+#define DT_COMMON_IMAGE_NOTIFY_H
+
+#include <glib.h>
+#include <inttypes.h>
+
+G_BEGIN_DECLS
+
+/** @brief Receives the id of one freshly imported image. Raised on the thread that did
+ *  the import; a handler that touches widgets gets itself onto the GUI thread, exactly
+ *  as the signal emission it replaces did. */
+typedef void (*dt_image_imported_handler_t)(const int32_t imgid);
+
+/** @brief Install the handler, or NULL to remove it. */
+void dt_image_notify_set_imported_handler(dt_image_imported_handler_t handler);
+
+/** @brief Raise it. Internal to common/image.c. */
+void dt_image_notify_imported(const int32_t imgid);
+
+G_END_DECLS
+
+#endif // DT_COMMON_IMAGE_NOTIFY_H
+
+// clang-format off
+// modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py
+// vim: shiftwidth=2 expandtab tabstop=2 cindent
+// kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;
+// clang-format on

--- a/src/control/control.c
+++ b/src/control/control.c
@@ -69,6 +69,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include "gui/screen_metrics.h"
+#include "control/signal.h"
 
 static dt_control_pointer_input_t _pointer_input = { 0 };
 

--- a/src/control/jobs/control_jobs.c
+++ b/src/control/jobs/control_jobs.c
@@ -78,6 +78,7 @@
 */
 
 #include "control/jobs/control_jobs.h"
+#include "control/signal.h"
 #include "database/film_repository.h"
 #include "database/image_repository.h"
 #include "common/act_on.h"

--- a/src/control/settings.h
+++ b/src/control/settings.h
@@ -34,7 +34,8 @@
 
 #include <inttypes.h>
 
-typedef char dt_dev_operation_t[20];
+// dt_dev_operation_t lived here historically; it is the history-stack operation identity
+// and nothing in control/ ever used it, so it moved to history/history.h.
 
 #define DEV_NUM_OP_PARAMS 10
 

--- a/src/darktable.c
+++ b/src/darktable.c
@@ -141,6 +141,7 @@
 #include "develop/iop_order.h"
 #include "common/l10n.h"
 #include "metadata/metadata.h"
+#include "common/image_notify.h"
 #include "history/notify.h"
 #include "history/presets.h"
 #include "metadata/notify.h"
@@ -738,6 +739,19 @@ static void _metadata_notify(const dt_metadata_notice_t kind, const char *messag
     dt_toast_log("%s", message);
   else
     dt_control_log("%s", message);
+}
+
+/* The geotag list is copied here, at the raise site, exactly where the old call sites
+ * copied it: the signal takes ownership of what it is given. */
+static void _metadata_geotags_changed(const GList *imgs)
+{
+  DT_DEBUG_CONTROL_SIGNAL_RAISE(dt_control_signal_get_global(), DT_SIGNAL_GEOTAG_CHANGED,
+                                g_list_copy((GList *)imgs), 0);
+}
+
+static void _image_imported(const int32_t imgid)
+{
+  DT_DEBUG_CONTROL_SIGNAL_RAISE(dt_control_signal_get_global(), DT_SIGNAL_IMAGE_IMPORT, imgid);
 }
 
 /* History, styles and presets state what happened; turning that into a signal is ours. */
@@ -1472,6 +1486,8 @@ int dt_init(int argc, char *argv[], const gboolean init_gui, const gboolean load
    * further up: the signal system does not exist until the line above, and nothing can
    * edit a tag before it does. */
   dt_metadata_set_tags_changed_handler(_metadata_tags_changed);
+  dt_metadata_set_geotags_changed_handler(_metadata_geotags_changed);
+  dt_image_notify_set_imported_handler(_image_imported);
   // Same reason for these two: they raise signals, so they wait for the signal system.
   dt_history_set_changed_handler(_history_changed);
   dt_history_set_images_changed_handler(_history_images_changed);

--- a/src/develop/blend.c
+++ b/src/develop/blend.c
@@ -2243,6 +2243,92 @@ int dt_develop_blend_legacy_params_from_so(dt_iop_module_so_t *module_so, const 
 
 // tools/update_modelines.sh
 // remove-trailing-space on;
+/* Name tables for the persisted blend enums. Defined here rather than in blend_gui.c:
+ * they map params values to translatable names, and backend consumers
+ * (develop/supervisor.c) read them with no GUI loaded. */
+const dt_develop_name_value_t dt_develop_blend_mode_names[]
+    = { { NC_("blendmode", "normal"), DEVELOP_BLEND_NORMAL2 },
+        { NC_("blendmode", "normal bounded"), DEVELOP_BLEND_BOUNDED },
+        { NC_("blendmode", "lighten"), DEVELOP_BLEND_LIGHTEN },
+        { NC_("blendmode", "darken"), DEVELOP_BLEND_DARKEN },
+        { NC_("blendmode", "multiply"), DEVELOP_BLEND_MULTIPLY },
+        { NC_("blendmode", "average"), DEVELOP_BLEND_AVERAGE },
+        { NC_("blendmode", "addition"), DEVELOP_BLEND_ADD },
+        { NC_("blendmode", "subtract"), DEVELOP_BLEND_SUBTRACT },
+        { NC_("blendmode", "difference"), DEVELOP_BLEND_DIFFERENCE2 },
+        { NC_("blendmode", "screen"), DEVELOP_BLEND_SCREEN },
+        { NC_("blendmode", "overlay"), DEVELOP_BLEND_OVERLAY },
+        { NC_("blendmode", "softlight"), DEVELOP_BLEND_SOFTLIGHT },
+        { NC_("blendmode", "hardlight"), DEVELOP_BLEND_HARDLIGHT },
+        { NC_("blendmode", "vividlight"), DEVELOP_BLEND_VIVIDLIGHT },
+        { NC_("blendmode", "linearlight"), DEVELOP_BLEND_LINEARLIGHT },
+        { NC_("blendmode", "pinlight"), DEVELOP_BLEND_PINLIGHT },
+        { NC_("blendmode", "lightness"), DEVELOP_BLEND_LIGHTNESS },
+        { NC_("blendmode", "chromaticity"), DEVELOP_BLEND_CHROMATICITY },
+        { NC_("blendmode", "hue"), DEVELOP_BLEND_HUE },
+        { NC_("blendmode", "color"), DEVELOP_BLEND_COLOR },
+        { NC_("blendmode", "coloradjustment"), DEVELOP_BLEND_COLORADJUST },
+        { NC_("blendmode", "Lab lightness"), DEVELOP_BLEND_LAB_LIGHTNESS },
+        { NC_("blendmode", "Lab color"), DEVELOP_BLEND_LAB_COLOR },
+        { NC_("blendmode", "Lab L-channel"), DEVELOP_BLEND_LAB_L },
+        { NC_("blendmode", "Lab a-channel"), DEVELOP_BLEND_LAB_A },
+        { NC_("blendmode", "Lab b-channel"), DEVELOP_BLEND_LAB_B },
+        { NC_("blendmode", "HSV value"), DEVELOP_BLEND_HSV_VALUE },
+        { NC_("blendmode", "HSV color"), DEVELOP_BLEND_HSV_COLOR },
+        { NC_("blendmode", "RGB red channel"), DEVELOP_BLEND_RGB_R },
+        { NC_("blendmode", "RGB green channel"), DEVELOP_BLEND_RGB_G },
+        { NC_("blendmode", "RGB blue channel"), DEVELOP_BLEND_RGB_B },
+        { NC_("blendmode", "divide"), DEVELOP_BLEND_DIVIDE },
+        { NC_("blendmode", "geometric mean"), DEVELOP_BLEND_GEOMETRIC_MEAN },
+        { NC_("blendmode", "harmonic mean"), DEVELOP_BLEND_HARMONIC_MEAN },
+
+        /** deprecated blend modes: make them available as legacy history stacks might want them */
+        { NC_("blendmode", "difference (deprecated)"), DEVELOP_BLEND_DIFFERENCE },
+        { NC_("blendmode", "subtract inverse (deprecated)"), DEVELOP_BLEND_SUBTRACT_INVERSE },
+        { NC_("blendmode", "divide inverse (deprecated)"), DEVELOP_BLEND_DIVIDE_INVERSE },
+        { "", 0 } };
+
+const dt_develop_name_value_t dt_develop_blend_mode_flag_names[]
+    = { { NC_("blendoperation", "normal"), 0 },
+        { NC_("blendoperation", "reverse"), DEVELOP_BLEND_REVERSE },
+        { "", 0 } };
+
+const dt_develop_name_value_t dt_develop_blend_colorspace_names[]
+    = { { N_("default"), DEVELOP_BLEND_CS_NONE },
+        { N_("RAW"), DEVELOP_BLEND_CS_RAW },
+        { N_("Lab"), DEVELOP_BLEND_CS_LAB },
+        { N_("RGB (display)"), DEVELOP_BLEND_CS_RGB_DISPLAY },
+        { N_("RGB (scene)"), DEVELOP_BLEND_CS_RGB_SCENE },
+        { "", 0 } };
+
+const dt_develop_name_value_t dt_develop_mask_mode_names[]
+    = { { N_("None"), 0 },
+        { N_("Uniform"), 1 },
+        { N_("Parametric mask"), 2 },
+        { N_("Drawn mask"), 3 },
+        { N_("Drawn & parametric mask"), 4 },
+        { N_("Reuse an existing mask"), 5 },
+        { "", 0 } };
+
+const dt_develop_name_value_t dt_develop_combine_masks_names[]
+    = { { N_("exclusive"), DEVELOP_COMBINE_NORM_EXCL },
+        { N_("inclusive"), DEVELOP_COMBINE_NORM_INCL },
+        { N_("exclusive & inverted"), DEVELOP_COMBINE_INV_EXCL },
+        { N_("inclusive & inverted"), DEVELOP_COMBINE_INV_INCL },
+        { "", 0 } };
+
+const dt_develop_name_value_t dt_develop_feathering_guide_names[]
+    = { { N_("output before blur"), DEVELOP_MASK_GUIDE_OUT_BEFORE_BLUR },
+        { N_("input before blur"), DEVELOP_MASK_GUIDE_IN_BEFORE_BLUR },
+        { N_("output after blur"), DEVELOP_MASK_GUIDE_OUT_AFTER_BLUR },
+        { N_("input after blur"), DEVELOP_MASK_GUIDE_IN_AFTER_BLUR },
+        { "", 0 } };
+
+const dt_develop_name_value_t dt_develop_invert_mask_names[]
+    = { { N_("off"), DEVELOP_COMBINE_NORM },
+        { N_("on"), DEVELOP_COMBINE_INV },
+        { "", 0 } };
+
 // clang-format off
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py
 // vim: shiftwidth=2 expandtab tabstop=2 cindent

--- a/src/develop/blend.h
+++ b/src/develop/blend.h
@@ -37,14 +37,11 @@
 #ifndef DT_DEVELOP_BLEND_H
 #define DT_DEVELOP_BLEND_H
 
-#include "widgets/collapsible_section.h"
 #include "develop/iop_profile.h"
 #include "history/history.h"   // dt_dev_operation_t (raster_mask_source)
 #include "common/opencl.h"
 #include "develop/masks.h"
 #include "develop/pixelpipe.h"
-#include "widgets/gradientslider.h"
-#include "gui/color_picker_proxy.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -262,40 +259,9 @@ typedef struct dt_blendop_cl_global_t
 } dt_blendop_cl_global_t;
 
 
-typedef struct dt_iop_gui_blendif_colorstop_t
-{
-  float stoppoint;
-  GdkRGBA color;
-} dt_iop_gui_blendif_colorstop_t;
-
-typedef struct dt_iop_gui_blendif_channel_t
-{
-  char *label;
-  char *tooltip;
-  float increment;
-  int numberstops;
-  const dt_iop_gui_blendif_colorstop_t *colorstops;
-  gboolean boost_factor_enabled;
-  float boost_factor_offset;
-  dt_develop_blendif_channels_t param_channels[2];
-  dt_dev_pixelpipe_display_mask_t display_channel;
-  void (*scale_print)(float value, float boost_factor, char *string, int n);
-  int (*altdisplay)(GtkWidget *, dt_iop_module_t *, int);
-  char *name;
-} dt_iop_gui_blendif_channel_t;
-
-typedef struct dt_iop_gui_blendif_filter_t
-{
-  GtkDarktableGradientSlider *slider;
-  GtkLabel *head;
-  GtkLabel *label[4];
-  GtkLabel *picker_label;
-  GtkWidget *polarity;
-  GtkWidget *channel_display;
-  GtkWidget *log_scale;
-  GtkBox *box;
-} dt_iop_gui_blendif_filter_t;
-
+/* Maps each persisted blend enum value to a translatable display name. Backend
+ * vocabulary, not GUI: develop/supervisor.c reads these tables with no GUI loaded,
+ * and their definitions live in blend.c. */
 typedef struct dt_iop_blend_name_value_t
 {
   char name[32];
@@ -310,103 +276,10 @@ extern const dt_develop_name_value_t dt_develop_combine_masks_names[];
 extern const dt_develop_name_value_t dt_develop_feathering_guide_names[];
 extern const dt_develop_name_value_t dt_develop_invert_mask_names[];
 
-/** blend gui data */
-typedef struct dt_iop_gui_blend_data_t
-{
-  int blendif_support;
-  int blendif_inited;
-  int masks_support;
-  int masks_inited;
-  int raster_inited;
-
-  dt_develop_blend_colorspace_t csp;
-  dt_iop_module_t *module;
-
-  GtkWidget *blending_box;
-  GtkWidget *blending_notebook;
-  GtkWidget *top_enable;
-  GtkWidget *masks_enable;
-  GtkWidget *raster_enable;
-  GtkWidget *blendif_enable;
-  GtkWidget *masks_content;
-  GtkWidget *raster_content;
-  GtkWidget *blendif_content;
-  GtkWidget *contours_content;
-  GtkBox *blendif_box;
-  GtkBox *masks_box;
-  GtkBox *raster_box;
-
-  GtkWidget *colorpicker;
-  GtkWidget *colorpicker_set_values;
-  dt_iop_gui_blendif_filter_t filter[2];
-  GtkWidget *showmask;
-  GtkWidget *masks_combine_combo;
-  GtkWidget *blend_modes_combo;
-  GtkWidget *blend_modes_blend_order;
-  GtkWidget *blend_mode_parameter_slider;
-  GtkWidget *masks_invert_combo;
-  GtkWidget *opacity_slider;
-  GtkWidget *masks_feathering_guide_combo;
-  GtkWidget *feathering_radius_slider;
-  GtkWidget *blur_radius_slider;
-  GtkWidget *contrast_slider;
-  GtkWidget *brightness_slider;
-
-  dt_develop_blend_colorspace_t blend_modes_csp;
-  dt_develop_blend_colorspace_t channel_tabs_csp;
-
-  const dt_iop_gui_blendif_channel_t *channel;
-  int tab;
-  int altmode[8][2];
-  dt_dev_pixelpipe_display_mask_t save_for_leave;
-  int timeout_handle;
-  GtkNotebook *channel_tabs;
-  gboolean output_channels_shown;
-
-  GtkWidget *channel_boost_factor_slider;
-  GtkWidget *details_slider;
-
-  GtkWidget *masks_combo;
-  GtkWidget *masks_shapes[DEVELOP_MASKS_NB_SHAPES];
-  int masks_type[DEVELOP_MASKS_NB_SHAPES];
-  GtkWidget *masks_edit;
-  GtkWidget *group_shapes_label;
-  GtkWidget *masks_polarity;
-  GtkWidget *wire_shape_toggle;
-  int *masks_combo_ids;
-  int masks_shown;
-  GtkWidget *masks_treeview;
-  GtkWidget *masks_group_treeview;
-  GtkTreeStore *group_shapes_store;
-  GtkTreeViewColumn *group_shapes_col;
-  GtkTreeViewColumn *group_unlink_col;
-  GtkTreeViewColumn *group_delete_col;
-  GtkListStore *all_shapes_store;
-  GtkWidget *group_shapes_sw;
-  GtkTreeViewColumn *all_shapes_col;
-  GtkTreeViewColumn *all_shapes_delete_col;
-  GtkWidget *all_shapes_sw;
-  GtkWidget *lists_stack;
-  GdkPixbuf *masks_ic_inverse;
-  GdkPixbuf *masks_ic_union;
-  GdkPixbuf *masks_ic_intersection;
-  GdkPixbuf *masks_ic_difference;
-  GdkPixbuf *masks_ic_exclusion;
-  GtkWidget *all_shapes_buttons;
-  GtkWidget *lists_box;
-  dt_gui_collapsible_section_t masks_cs;
-
-
-  GtkWidget *raster_combo;
-  GtkWidget *raster_polarity;
-
-  gboolean picker_set_values_box_valid;
-  dt_boundingbox_t picker_set_values_box;
-  gboolean picker_set_values_manual_boost_lock;
-
-  int control_button_pressed;
-  dt_pthread_mutex_t lock;
-} dt_iop_gui_blend_data_t;
+/* The blending GUI state (dt_iop_gui_blend_data_t and its channel/colorstop/filter
+ * companions) and the dt_iop_gui_*_blending() API live in develop/blend_gui.h: they
+ * are what forced this header to feed three widgets/gui headers to every consumer
+ * that only wanted the params vocabulary or the pixel entry points. */
 
 
 /** global init of blendops */
@@ -535,19 +408,6 @@ void dt_develop_blendif_rgb_jzczhz_blend(const struct dt_dev_pixelpipe_t *pipe,
                                          const dt_dev_pixelpipe_display_mask_t request_mask_display);
 
 
-/** gui related stuff */
-void dt_iop_gui_init_blendif(GtkBox *blendw, dt_iop_module_t *module, GtkWidget *header);
-void dt_iop_gui_init_blending(dt_iop_module_t *module);
-void dt_iop_gui_init_blending_body(GtkWidget *container, dt_iop_module_t *module);
-void dt_iop_gui_update_blending(dt_iop_module_t *module);
-void dt_iop_gui_update_blendif(dt_iop_module_t *module);
-void dt_iop_gui_cleanup_blending_body(dt_iop_module_t *module);
-void dt_iop_gui_cleanup_blending(dt_iop_module_t *module);
-void dt_iop_gui_blending_lose_focus(dt_iop_module_t *module);
-void dt_iop_gui_blending_reload_defaults(dt_iop_module_t *module);
-
-gboolean blend_color_picker_apply(dt_iop_module_t *module, GtkWidget *picker, dt_dev_pixelpipe_t *pipe,
-                                  dt_dev_pixelpipe_iop_t *piece);
 
 
 #ifdef HAVE_OPENCL

--- a/src/develop/blend.h
+++ b/src/develop/blend.h
@@ -39,6 +39,7 @@
 
 #include "widgets/collapsible_section.h"
 #include "develop/iop_profile.h"
+#include "history/history.h"   // dt_dev_operation_t (raster_mask_source)
 #include "common/opencl.h"
 #include "develop/masks.h"
 #include "develop/pixelpipe.h"

--- a/src/develop/blend_gui.c
+++ b/src/develop/blend_gui.c
@@ -80,6 +80,7 @@
 #include "widgets/popup.h"
 #include "widgets/scroll_wrap.h"
 #include "widgets/widget_style.h"
+#include "widgets/togglebutton.h"
 
 #define NEUTRAL_GRAY 0.5
 #define BLEND_MASKMODE_CONF_KEY "plugins/darkroom/blending/mask_mode_tab"

--- a/src/develop/blend_gui.c
+++ b/src/develop/blend_gui.c
@@ -52,6 +52,7 @@
 #include "control/signal.h"
 #include "common/usermanual_url.h"
 #include "develop/blend.h"
+#include "develop/blend_gui.h"
 #include "widgets/bauhaus.h"
 #include "gui/bauhaus_conf.h"
 #include "system/dtpthread.h"
@@ -85,89 +86,8 @@
 #define NEUTRAL_GRAY 0.5
 #define BLEND_MASKMODE_CONF_KEY "plugins/darkroom/blending/mask_mode_tab"
 
-const dt_develop_name_value_t dt_develop_blend_mode_names[]
-    = { { NC_("blendmode", "normal"), DEVELOP_BLEND_NORMAL2 },
-        { NC_("blendmode", "normal bounded"), DEVELOP_BLEND_BOUNDED },
-        { NC_("blendmode", "lighten"), DEVELOP_BLEND_LIGHTEN },
-        { NC_("blendmode", "darken"), DEVELOP_BLEND_DARKEN },
-        { NC_("blendmode", "multiply"), DEVELOP_BLEND_MULTIPLY },
-        { NC_("blendmode", "average"), DEVELOP_BLEND_AVERAGE },
-        { NC_("blendmode", "addition"), DEVELOP_BLEND_ADD },
-        { NC_("blendmode", "subtract"), DEVELOP_BLEND_SUBTRACT },
-        { NC_("blendmode", "difference"), DEVELOP_BLEND_DIFFERENCE2 },
-        { NC_("blendmode", "screen"), DEVELOP_BLEND_SCREEN },
-        { NC_("blendmode", "overlay"), DEVELOP_BLEND_OVERLAY },
-        { NC_("blendmode", "softlight"), DEVELOP_BLEND_SOFTLIGHT },
-        { NC_("blendmode", "hardlight"), DEVELOP_BLEND_HARDLIGHT },
-        { NC_("blendmode", "vividlight"), DEVELOP_BLEND_VIVIDLIGHT },
-        { NC_("blendmode", "linearlight"), DEVELOP_BLEND_LINEARLIGHT },
-        { NC_("blendmode", "pinlight"), DEVELOP_BLEND_PINLIGHT },
-        { NC_("blendmode", "lightness"), DEVELOP_BLEND_LIGHTNESS },
-        { NC_("blendmode", "chromaticity"), DEVELOP_BLEND_CHROMATICITY },
-        { NC_("blendmode", "hue"), DEVELOP_BLEND_HUE },
-        { NC_("blendmode", "color"), DEVELOP_BLEND_COLOR },
-        { NC_("blendmode", "coloradjustment"), DEVELOP_BLEND_COLORADJUST },
-        { NC_("blendmode", "Lab lightness"), DEVELOP_BLEND_LAB_LIGHTNESS },
-        { NC_("blendmode", "Lab color"), DEVELOP_BLEND_LAB_COLOR },
-        { NC_("blendmode", "Lab L-channel"), DEVELOP_BLEND_LAB_L },
-        { NC_("blendmode", "Lab a-channel"), DEVELOP_BLEND_LAB_A },
-        { NC_("blendmode", "Lab b-channel"), DEVELOP_BLEND_LAB_B },
-        { NC_("blendmode", "HSV value"), DEVELOP_BLEND_HSV_VALUE },
-        { NC_("blendmode", "HSV color"), DEVELOP_BLEND_HSV_COLOR },
-        { NC_("blendmode", "RGB red channel"), DEVELOP_BLEND_RGB_R },
-        { NC_("blendmode", "RGB green channel"), DEVELOP_BLEND_RGB_G },
-        { NC_("blendmode", "RGB blue channel"), DEVELOP_BLEND_RGB_B },
-        { NC_("blendmode", "divide"), DEVELOP_BLEND_DIVIDE },
-        { NC_("blendmode", "geometric mean"), DEVELOP_BLEND_GEOMETRIC_MEAN },
-        { NC_("blendmode", "harmonic mean"), DEVELOP_BLEND_HARMONIC_MEAN },
-
-        /** deprecated blend modes: make them available as legacy history stacks might want them */
-        { NC_("blendmode", "difference (deprecated)"), DEVELOP_BLEND_DIFFERENCE },
-        { NC_("blendmode", "subtract inverse (deprecated)"), DEVELOP_BLEND_SUBTRACT_INVERSE },
-        { NC_("blendmode", "divide inverse (deprecated)"), DEVELOP_BLEND_DIVIDE_INVERSE },
-        { "", 0 } };
-
-const dt_develop_name_value_t dt_develop_blend_mode_flag_names[]
-    = { { NC_("blendoperation", "normal"), 0 },
-        { NC_("blendoperation", "reverse"), DEVELOP_BLEND_REVERSE },
-        { "", 0 } };
-
-const dt_develop_name_value_t dt_develop_blend_colorspace_names[]
-    = { { N_("default"), DEVELOP_BLEND_CS_NONE },
-        { N_("RAW"), DEVELOP_BLEND_CS_RAW },
-        { N_("Lab"), DEVELOP_BLEND_CS_LAB },
-        { N_("RGB (display)"), DEVELOP_BLEND_CS_RGB_DISPLAY },
-        { N_("RGB (scene)"), DEVELOP_BLEND_CS_RGB_SCENE },
-        { "", 0 } };
-
-const dt_develop_name_value_t dt_develop_mask_mode_names[]
-    = { { N_("None"), 0 },
-        { N_("Uniform"), 1 },
-        { N_("Parametric mask"), 2 },
-        { N_("Drawn mask"), 3 },
-        { N_("Drawn & parametric mask"), 4 },
-        { N_("Reuse an existing mask"), 5 },
-        { "", 0 } };
-
-const dt_develop_name_value_t dt_develop_combine_masks_names[]
-    = { { N_("exclusive"), DEVELOP_COMBINE_NORM_EXCL },
-        { N_("inclusive"), DEVELOP_COMBINE_NORM_INCL },
-        { N_("exclusive & inverted"), DEVELOP_COMBINE_INV_EXCL },
-        { N_("inclusive & inverted"), DEVELOP_COMBINE_INV_INCL },
-        { "", 0 } };
-
-const dt_develop_name_value_t dt_develop_feathering_guide_names[]
-    = { { N_("output before blur"), DEVELOP_MASK_GUIDE_OUT_BEFORE_BLUR },
-        { N_("input before blur"), DEVELOP_MASK_GUIDE_IN_BEFORE_BLUR },
-        { N_("output after blur"), DEVELOP_MASK_GUIDE_OUT_AFTER_BLUR },
-        { N_("input after blur"), DEVELOP_MASK_GUIDE_IN_AFTER_BLUR },
-        { "", 0 } };
-
-const dt_develop_name_value_t dt_develop_invert_mask_names[]
-    = { { N_("off"), DEVELOP_COMBINE_NORM },
-        { N_("on"), DEVELOP_COMBINE_INV },
-        { "", 0 } };
-
+/* The seven blend name tables are DEFINED in blend.c now: backend consumers
+ * (develop/supervisor.c) read them, so they cannot live in a GUI-only file. */
 const dt_iop_gui_blendif_colorstop_t _gradient_L[]
     = { { 0.0f,   { 0, 0, 0, 1.0 } },
         { 0.125f, { NEUTRAL_GRAY / 8, NEUTRAL_GRAY / 8, NEUTRAL_GRAY / 8, 1.0 } },

--- a/src/develop/blend_gui.h
+++ b/src/develop/blend_gui.h
@@ -1,0 +1,203 @@
+/*
+    This file is part of darktable,
+    Copyright (C) 2011-2021 the darktable developers.
+    Copyright (C) 2026 Aurélien PIERRE.
+
+    darktable is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    darktable is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with darktable.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+/** @file develop/blend_gui.h
+ *
+ * @brief The blending panel's GUI state and API, cut out of develop/blend.h.
+ *
+ * @details dt_iop_gui_blend_data_t (~60 widget fields) and the dt_iop_gui_*_blending()
+ * functions were the only reason blend.h fed widgets/gradientslider.h,
+ * widgets/collapsible_section.h and gui/color_picker_proxy.h to all of its consumers --
+ * most of which only wanted the persisted params vocabulary or the pixel entry points.
+ * Implementations live in develop/blend_gui.c.
+ */
+
+#ifndef DT_DEVELOP_BLEND_GUI_H
+#define DT_DEVELOP_BLEND_GUI_H
+
+#include "develop/blend.h"
+#include "develop/imageop.h"
+#include "gui/color_picker_proxy.h"
+#include "widgets/collapsible_section.h"
+#include "widgets/gradientslider.h"
+
+#include <gtk/gtk.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct dt_iop_gui_blendif_colorstop_t
+{
+  float stoppoint;
+  GdkRGBA color;
+} dt_iop_gui_blendif_colorstop_t;
+
+typedef struct dt_iop_gui_blendif_channel_t
+{
+  char *label;
+  char *tooltip;
+  float increment;
+  int numberstops;
+  const dt_iop_gui_blendif_colorstop_t *colorstops;
+  gboolean boost_factor_enabled;
+  float boost_factor_offset;
+  dt_develop_blendif_channels_t param_channels[2];
+  dt_dev_pixelpipe_display_mask_t display_channel;
+  void (*scale_print)(float value, float boost_factor, char *string, int n);
+  int (*altdisplay)(GtkWidget *, dt_iop_module_t *, int);
+  char *name;
+} dt_iop_gui_blendif_channel_t;
+
+typedef struct dt_iop_gui_blendif_filter_t
+{
+  GtkDarktableGradientSlider *slider;
+  GtkLabel *head;
+  GtkLabel *label[4];
+  GtkLabel *picker_label;
+  GtkWidget *polarity;
+  GtkWidget *channel_display;
+  GtkWidget *log_scale;
+  GtkBox *box;
+} dt_iop_gui_blendif_filter_t;
+
+
+/** blend gui data */
+typedef struct dt_iop_gui_blend_data_t
+{
+  int blendif_support;
+  int blendif_inited;
+  int masks_support;
+  int masks_inited;
+  int raster_inited;
+
+  dt_develop_blend_colorspace_t csp;
+  dt_iop_module_t *module;
+
+  GtkWidget *blending_box;
+  GtkWidget *blending_notebook;
+  GtkWidget *top_enable;
+  GtkWidget *masks_enable;
+  GtkWidget *raster_enable;
+  GtkWidget *blendif_enable;
+  GtkWidget *masks_content;
+  GtkWidget *raster_content;
+  GtkWidget *blendif_content;
+  GtkWidget *contours_content;
+  GtkBox *blendif_box;
+  GtkBox *masks_box;
+  GtkBox *raster_box;
+
+  GtkWidget *colorpicker;
+  GtkWidget *colorpicker_set_values;
+  dt_iop_gui_blendif_filter_t filter[2];
+  GtkWidget *showmask;
+  GtkWidget *masks_combine_combo;
+  GtkWidget *blend_modes_combo;
+  GtkWidget *blend_modes_blend_order;
+  GtkWidget *blend_mode_parameter_slider;
+  GtkWidget *masks_invert_combo;
+  GtkWidget *opacity_slider;
+  GtkWidget *masks_feathering_guide_combo;
+  GtkWidget *feathering_radius_slider;
+  GtkWidget *blur_radius_slider;
+  GtkWidget *contrast_slider;
+  GtkWidget *brightness_slider;
+
+  dt_develop_blend_colorspace_t blend_modes_csp;
+  dt_develop_blend_colorspace_t channel_tabs_csp;
+
+  const dt_iop_gui_blendif_channel_t *channel;
+  int tab;
+  int altmode[8][2];
+  dt_dev_pixelpipe_display_mask_t save_for_leave;
+  int timeout_handle;
+  GtkNotebook *channel_tabs;
+  gboolean output_channels_shown;
+
+  GtkWidget *channel_boost_factor_slider;
+  GtkWidget *details_slider;
+
+  GtkWidget *masks_combo;
+  GtkWidget *masks_shapes[DEVELOP_MASKS_NB_SHAPES];
+  int masks_type[DEVELOP_MASKS_NB_SHAPES];
+  GtkWidget *masks_edit;
+  GtkWidget *group_shapes_label;
+  GtkWidget *masks_polarity;
+  GtkWidget *wire_shape_toggle;
+  int *masks_combo_ids;
+  int masks_shown;
+  GtkWidget *masks_treeview;
+  GtkWidget *masks_group_treeview;
+  GtkTreeStore *group_shapes_store;
+  GtkTreeViewColumn *group_shapes_col;
+  GtkTreeViewColumn *group_unlink_col;
+  GtkTreeViewColumn *group_delete_col;
+  GtkListStore *all_shapes_store;
+  GtkWidget *group_shapes_sw;
+  GtkTreeViewColumn *all_shapes_col;
+  GtkTreeViewColumn *all_shapes_delete_col;
+  GtkWidget *all_shapes_sw;
+  GtkWidget *lists_stack;
+  GdkPixbuf *masks_ic_inverse;
+  GdkPixbuf *masks_ic_union;
+  GdkPixbuf *masks_ic_intersection;
+  GdkPixbuf *masks_ic_difference;
+  GdkPixbuf *masks_ic_exclusion;
+  GtkWidget *all_shapes_buttons;
+  GtkWidget *lists_box;
+  dt_gui_collapsible_section_t masks_cs;
+
+
+  GtkWidget *raster_combo;
+  GtkWidget *raster_polarity;
+
+  gboolean picker_set_values_box_valid;
+  dt_boundingbox_t picker_set_values_box;
+  gboolean picker_set_values_manual_boost_lock;
+
+  int control_button_pressed;
+  dt_pthread_mutex_t lock;
+} dt_iop_gui_blend_data_t;
+
+/** gui related stuff */
+void dt_iop_gui_init_blendif(GtkBox *blendw, dt_iop_module_t *module, GtkWidget *header);
+void dt_iop_gui_init_blending(dt_iop_module_t *module);
+void dt_iop_gui_init_blending_body(GtkWidget *container, dt_iop_module_t *module);
+void dt_iop_gui_update_blending(dt_iop_module_t *module);
+void dt_iop_gui_update_blendif(dt_iop_module_t *module);
+void dt_iop_gui_cleanup_blending_body(dt_iop_module_t *module);
+void dt_iop_gui_cleanup_blending(dt_iop_module_t *module);
+void dt_iop_gui_blending_lose_focus(dt_iop_module_t *module);
+void dt_iop_gui_blending_reload_defaults(dt_iop_module_t *module);
+
+gboolean blend_color_picker_apply(dt_iop_module_t *module, GtkWidget *picker, dt_dev_pixelpipe_t *pipe,
+                                  dt_dev_pixelpipe_iop_t *piece);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // DT_DEVELOP_BLEND_GUI_H
+
+// clang-format off
+// modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py
+// vim: shiftwidth=2 expandtab tabstop=2 cindent
+// kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;
+// clang-format on

--- a/src/develop/dev_history.c
+++ b/src/develop/dev_history.c
@@ -69,6 +69,7 @@
 #include "develop/iop_order.h"
 #include "develop/dev_history.h"
 #include "develop/blend.h"
+#include "develop/blend_gui.h"
 #include "develop/develop.h"
 #include "develop/imageop.h"
 #include "develop/masks.h"

--- a/src/develop/dev_history.c
+++ b/src/develop/dev_history.c
@@ -60,6 +60,7 @@
 */
 #include "common/conf.h"
 #include "history/history.h"
+#include "history/presets.h"   // FOR_RAW/FOR_LDR/... matched against the image at auto-apply
 #include "database/history_repository.h"
 
 #include "common/undo.h"
@@ -74,7 +75,6 @@
 #include "develop/supervisor.h"
 #include "develop/gui_throttle.h"
 
-#include "gui/presets.h"
 
 #include <inttypes.h>
 

--- a/src/develop/dev_history.c
+++ b/src/develop/dev_history.c
@@ -81,6 +81,7 @@
 #include <glib.h>
 #include "common/hash.h"
 #include "gui/application.h"
+#include "control/signal.h"
 
 static void _process_history_db_entry(dt_develop_t *dev, const int32_t imgid, const int id, const int num,
                                       const int modversion, const char *operation, const void *module_params,

--- a/src/develop/dev_history.c
+++ b/src/develop/dev_history.c
@@ -58,6 +58,7 @@
     You should have received a copy of the GNU General Public License
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
+#include "control/control.h"
 #include "common/conf.h"
 #include "history/history.h"
 #include "history/presets.h"   // FOR_RAW/FOR_LDR/... matched against the image at auto-apply

--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -146,12 +146,6 @@ void dt_dev_init(dt_develop_t *dev, int32_t gui_attached)
     dt_dev_pixelpipe_init(dev->pipe, dev);
     dt_dev_pixelpipe_init_preview(dev->preview_pipe, dev);
     dt_dev_pixelpipe_init_preview(dev->virtual_pipe, dev);
-    dev->histogram_pre_tonecurve = (uint32_t *)calloc(4 * 256, sizeof(uint32_t));
-    dev->histogram_pre_levels = (uint32_t *)calloc(4 * 256, sizeof(uint32_t));
-
-    // FIXME: these are uint32_t, setting to -1 is confusing
-    dev->histogram_pre_tonecurve_max = -1;
-    dev->histogram_pre_levels_max = -1;
   }
 
   dt_dev_set_backbuf(&dev->raw_histogram, 0, 0, 0, -1, -1);
@@ -287,10 +281,6 @@ void dt_dev_cleanup(dt_develop_t *dev)
   }
   g_list_free_full(dev->iop_order_list, dt_free_gpointer);
   dev->iop_order_list = NULL;
-
-
-  dt_free(dev->histogram_pre_tonecurve);
-  dt_free(dev->histogram_pre_levels);
 
   if(dev->color_picker.primary_sample)
   {

--- a/src/develop/develop.h
+++ b/src/develop/develop.h
@@ -318,11 +318,6 @@ typedef struct dt_develop_t
   } transient_params;
   dt_pthread_mutex_t transient_params_mutex;
 
-
-  // histogram for display.
-  uint32_t *histogram_pre_tonecurve, *histogram_pre_levels;
-  uint32_t histogram_pre_tonecurve_max, histogram_pre_levels_max;
-
   // list of forms iop can use for masks or whatever
   GList *forms;
 
@@ -503,8 +498,6 @@ typedef struct dt_develop_t
   gboolean mask_lock;
 
   cairo_surface_t *image_surface;
-
-  gboolean loading_cache;
 } dt_develop_t;
 
 static inline uint64_t dt_dev_get_history_hash(const dt_develop_t *dev)

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -118,6 +118,7 @@
 #include <string.h>
 #include <strings.h>
 #include <time.h>
+#include "widgets/togglebutton.h"
 
 #define DT_IOP_HEADER_MENU_OPEN "dt-module-header-menu-open"
 #define DT_IOP_HEADER_MENU_DISMISS_CLICK "dt-module-header-menu-dismiss-click"
@@ -2869,7 +2870,7 @@ void dt_iop_gui_set_expander(dt_iop_module_t *module)
                    G_CALLBACK(_iop_plugin_header_child_button_press), module);
   g_signal_connect(G_OBJECT(switch_button), "toggled", G_CALLBACK(_gui_off_callback), module);
 
-  module->off = DTGTK_TOGGLEBUTTON(switch_button);
+  module->off = switch_button;
   gtk_widget_set_sensitive(GTK_WIDGET(switch_button), !module->hide_enable_button);
 
   /* Wrap the switch in a plain box so the CSS spacing trick that visually tucks it

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -86,6 +86,7 @@
 #include "control/control.h"
 #include "control/signal.h"
 #include "develop/blend.h"
+#include "develop/blend_gui.h"
 #include "develop/develop.h"
 #include "pixel/format.h"
 #include "develop/masks.h"

--- a/src/develop/imageop.h
+++ b/src/develop/imageop.h
@@ -68,10 +68,9 @@
 #include "common/gui_module_api.h"
 #include "common/opencl.h"
 
-#include "control/settings.h"
+#include "history/history.h"   // dt_dev_operation_t, both structs' `op` member
 #include "pixel/format.h"
 #include "develop/pixelpipe_hb.h"
-#include "widgets/togglebutton.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -342,8 +341,10 @@ typedef struct dt_iop_module_t
   } raster_mask;
   /** child widget which is added to the GtkExpander. copied from module_so_t. */
   GtkWidget *widget;
-  /** off button, somewhere in header, common to all plug-ins. */
-  GtkDarktableToggleButton *off;
+  /** off button, somewhere in header, common to all plug-ins. A GtkDarktableToggleButton
+   * underneath; declared as the base type so this header does not feed widgets/ to all
+   * ~122 of its consumers — every external user already casts via GTK_TOGGLE_BUTTON(). */
+  GtkWidget *off;
   /** this is the module header, contains label and buttons */
   GtkWidget *header;
   /** this is the module mask indicator, inside header */

--- a/src/develop/imageop_gui.c
+++ b/src/develop/imageop_gui.c
@@ -42,6 +42,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <time.h>
+#include "widgets/togglebutton.h"
 
 typedef struct dt_module_param_t
 {

--- a/src/develop/imageop_gui.h
+++ b/src/develop/imageop_gui.h
@@ -26,6 +26,7 @@
 #define DT_DEVELOP_IMAGEOP_GUI_H
 
 #include "develop/imageop.h"
+#include "widgets/paint.h"   // DTGTKCairoPaintIconFunc, named in three declarations below
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/develop/masks.h
+++ b/src/develop/masks.h
@@ -118,7 +118,6 @@ GList dev->forms
 #include "develop/develop.h"     // dt_develop_t, and dt_iop_module_t through imageop.h
 #include "develop/pixelpipe.h"
 #include "widgets/draw.h"
-#include "control/control.h"
 
 #include <assert.h>
 

--- a/src/develop/masks/brush.c
+++ b/src/develop/masks/brush.c
@@ -34,6 +34,7 @@
     You should have received a copy of the GNU General Public License
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
+#include "control/control.h"
 #include "system/macros.h"
 #include "system/openmp.h"
 #include "system/mem_alloc.h"

--- a/src/develop/masks/ellipse.c
+++ b/src/develop/masks/ellipse.c
@@ -33,6 +33,7 @@
     You should have received a copy of the GNU General Public License
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
+#include "control/control.h"
 #include "system/macros.h"
 #include "system/openmp.h"
 #include "common/logging.h"

--- a/src/develop/masks/masks.c
+++ b/src/develop/masks/masks.c
@@ -61,6 +61,7 @@
 #include "math/math.h"
 #include "common/conf.h"
 #include "develop/blend.h"
+#include "develop/blend_gui.h"
 #include "develop/dev_pixelpipe.h"
 #include "develop/imageop.h"
 #include "develop/imageop_gui.h"

--- a/src/develop/masks/masks_gui.c
+++ b/src/develop/masks/masks_gui.c
@@ -16,6 +16,7 @@
     You should have received a copy of the GNU General Public License
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
+#include "control/control.h"
 #include "system/macros.h"
 #include "system/mem_alloc.h"
 #include "develop/masks.h"

--- a/src/develop/masks/masks_gui.c
+++ b/src/develop/masks/masks_gui.c
@@ -30,6 +30,7 @@
 
 #include <math.h>
 #include <stdlib.h>
+#include "widgets/togglebutton.h"
 
 #define DT_MASKS_SHAPE_BUTTON_COUNT 5
 

--- a/src/develop/masks/polygon.c
+++ b/src/develop/masks/polygon.c
@@ -38,6 +38,7 @@
     You should have received a copy of the GNU General Public License
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
+#include "control/control.h"
 #include "system/macros.h"
 #include "system/openmp.h"
 #include "system/mem_alloc.h"

--- a/src/develop/pixelpipe_gpu.c
+++ b/src/develop/pixelpipe_gpu.c
@@ -2,6 +2,7 @@
     Private OpenCL pixelpipe backend.
 */
 
+#include "control/control.h"
 #include "system/macros.h"
 #include "develop/iop_profile.h"
 #include "common/logging.h"

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -77,7 +77,6 @@
 #include "develop/pixelpipe_process.h"
 #include "develop/tiling.h"
 #include "develop/masks.h"
-#include "gui/color_picker_proxy.h"
 
 #include <assert.h>
 #include <inttypes.h>

--- a/src/gui/actions/display.c
+++ b/src/gui/actions/display.c
@@ -31,6 +31,7 @@
 #include "gui/window_manager.h"
 
 #include <gtk/gtk.h>
+#include "control/signal.h"
 
 
 /** FULL SCREEN MODE **/

--- a/src/gui/color_picker_proxy.c
+++ b/src/gui/color_picker_proxy.c
@@ -43,6 +43,7 @@
 #include <inttypes.h>
 #include <math.h>
 #include <string.h>
+#include "widgets/togglebutton.h"
 
 /*
   The color_picker_proxy code is an interface which links the UI

--- a/src/gui/dtgtk/thumbnail.c
+++ b/src/gui/dtgtk/thumbnail.c
@@ -64,6 +64,7 @@
 #include "gui/application.h"
 #include "widgets/label.h"
 #include "widgets/widget_style.h"
+#include "control/signal.h"
 
 /**
  * @file thumbnail.c

--- a/src/gui/preferences.c
+++ b/src/gui/preferences.c
@@ -79,6 +79,7 @@
 #include "widgets/gtkentry.h"
 #include "widgets/label.h"
 #include "widgets/widget_style.h"
+#include "control/signal.h"
 #ifdef GDK_WINDOWING_QUARTZ
 #include "osx/osx.h"
 #endif

--- a/src/gui/presets.h
+++ b/src/gui/presets.h
@@ -35,15 +35,11 @@
 
 #include "develop/blend.h"
 
-// format flags stored into the presets database; the FOR_NOT_ variants are negated to keep existing presets
-typedef enum dt_gui_presets_format_flag_t
-{
-  FOR_LDR = 1 << 0,
-  FOR_RAW = 1 << 1,
-  FOR_HDR = 1 << 2,
-  FOR_NOT_MONO = 1 << 3,
-  FOR_NOT_COLOR = 1 << 4
-} dt_gui_presets_format_flag_t;
+// The preset format flags (FOR_RAW, FOR_LDR, ...) used to be defined here. They are
+// persisted database vocabulary — database/preset_repository.h documents its `format` and
+// `excluded` fields in terms of them — so they live in history/presets.h now, with the
+// preset code that owns the concept. This include keeps every existing consumer working.
+#include "history/presets.h"
 
 typedef struct dt_gui_presets_edit_dialog_t
 {

--- a/src/gui/presets.h
+++ b/src/gui/presets.h
@@ -39,6 +39,7 @@
 // persisted database vocabulary — database/preset_repository.h documents its `format` and
 // `excluded` fields in terms of them — so they live in history/presets.h now, with the
 // preset code that owns the concept. This include keeps every existing consumer working.
+#include "history/history.h"   // dt_dev_operation_t, named throughout
 #include "history/presets.h"
 
 typedef struct dt_gui_presets_edit_dialog_t

--- a/src/gui/window_manager.c
+++ b/src/gui/window_manager.c
@@ -34,6 +34,7 @@
 #include "gui/dtgtk/thumbtable.h"
 #include "widgets/accelerators.h"
 #include "widgets/widget_style.h"
+#include "control/signal.h"
 
 #define WINDOW_DEBUG 0
 

--- a/src/history/history.h
+++ b/src/history/history.h
@@ -37,6 +37,18 @@
 #include <gtk/gtk.h>
 #include <inttypes.h>
 
+/**
+ * @brief The string identifying an operation in the history stack ("exposure",
+ * "colorbalancergb", ...): the identity every history item, preset row and raster-mask
+ * source reference is keyed on.
+ *
+ * @details Lived in `control/settings.h` historically, which used it for nothing — while
+ * `develop/imageop.h` trailed `control/signal.h` into all 122 of its consumers just to
+ * reach this one typedef. It keeps the `dt_dev_` prefix for now; renaming a symbol this
+ * widespread is its own change, not a relocation's.
+ */
+typedef char dt_dev_operation_t[20];
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/src/history/presets.h
+++ b/src/history/presets.h
@@ -29,6 +29,25 @@
 
 #include <glib.h>
 
+/**
+ * @brief Which image kinds a preset applies to. Persisted in the presets database
+ * (`database/preset_repository.h` documents its `format` and `excluded` row fields in
+ * terms of these), matched against the image at auto-apply time
+ * (`develop/dev_history.c`), and set by each module's preset registration.
+ *
+ * @details The FOR_NOT_ variants are negated to keep existing presets valid. Lived in
+ * `gui/presets.h` historically, but nothing about it is GUI: it is preset vocabulary,
+ * written to disk.
+ */
+typedef enum dt_presets_format_flag_t
+{
+  FOR_LDR = 1 << 0,
+  FOR_RAW = 1 << 1,
+  FOR_HDR = 1 << 2,
+  FOR_NOT_MONO = 1 << 3,
+  FOR_NOT_COLOR = 1 << 4
+} dt_presets_format_flag_t;
+
 /** save preset to file */
 void dt_presets_save_to_file(const int rowid, const char *preset_name, const char *filedir);
 

--- a/src/imageio/imageio_core.c
+++ b/src/imageio/imageio_core.c
@@ -125,6 +125,7 @@
 #include <string.h>
 #include <strings.h>
 #include "imageio/imageio_profile.h"
+#include "control/signal.h"
 
 /**
  * @brief Map Exiv2 preview MIME types to decoder format identifiers.

--- a/src/imageio/imageio_core.c
+++ b/src/imageio/imageio_core.c
@@ -105,7 +105,6 @@
 #include "common/styles.h"
 #include "common/conf.h"
 #include "control/control.h"
-#include "develop/blend.h"
 #include "develop/develop.h"
 #include "develop/imageop.h"
 

--- a/src/iop/ashift.c
+++ b/src/iop/ashift.c
@@ -146,6 +146,8 @@
 #include "math/nelder_mead_simplex.h"
 #include "widgets/collapsible_section.h"
 #include "widgets/label.h"
+#include "widgets/togglebutton.h"
+#include "control/signal.h"
 
 
 DT_MODULE_INTROSPECTION(5, dt_iop_ashift_params_t)

--- a/src/iop/basicadj.c
+++ b/src/iop/basicadj.c
@@ -64,6 +64,8 @@
 
 #include "gui/color_picker_proxy.h"
 #include "develop/tiling.h"
+#include "widgets/togglebutton.h"
+#include "control/signal.h"
 
 DT_MODULE_INTROSPECTION(2, dt_iop_basicadj_params_t)
 

--- a/src/iop/channelmixerrgb.c
+++ b/src/iop/channelmixerrgb.c
@@ -47,6 +47,7 @@
 #include "config.h"
 #endif
 #include "widgets/bauhaus.h"
+#include "widgets/collapsible_section.h"
 #include "system/macros.h"
 #include "system/openmp.h"
 #include "system/target_clones.h"

--- a/src/iop/channelmixerrgb.c
+++ b/src/iop/channelmixerrgb.c
@@ -89,6 +89,7 @@
 #include "widgets/label.h"
 #include "widgets/notebook.h"
 #include "gui/screen_metrics.h"
+#include "control/signal.h"
 
 DT_MODULE_INTROSPECTION(3, dt_iop_channelmixer_rgb_params_t)
 

--- a/src/iop/clipping.c
+++ b/src/iop/clipping.c
@@ -100,6 +100,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include "widgets/notebook.h"
+#include "control/signal.h"
 
 DT_MODULE_INTROSPECTION(5, dt_iop_clipping_params_t)
 

--- a/src/iop/colorbalance.c
+++ b/src/iop/colorbalance.c
@@ -70,6 +70,7 @@ http://www.youtube.com/watch?v=JVoUgR6bhBc
 
 //#include <gtk/gtk.h>
 #include <stdlib.h>
+#include "control/signal.h"
 
 // these are not in a state to be useful. but they look nice. too bad i couldn't map the enhanced mode with
 // negative values to the wheels :(

--- a/src/iop/colorchecker.c
+++ b/src/iop/colorchecker.c
@@ -54,6 +54,8 @@
 #include "metadata/exif.h"
 #include "develop/develop.h"
 #include "develop/imageop.h"
+#include "gui/color_picker_proxy.h"
+#include "widgets/collapsible_section.h"
 #include "develop/imageop_math.h"
 #include "math/openmp_maths.h"
 #include "widgets/drawingarea.h"

--- a/src/iop/colorin.c
+++ b/src/iop/colorin.c
@@ -97,6 +97,7 @@
 #include <strings.h>
 
 #include "imageio/imageio_profile.h"
+#include "control/signal.h"
 
 // max iccprofile file name length
 // must be in synch with dt_colorspaces_color_profile_t

--- a/src/iop/colormapping.c
+++ b/src/iop/colormapping.c
@@ -68,6 +68,7 @@
 #include <string.h>
 #include "widgets/label.h"
 #include "gui/screen_metrics.h"
+#include "control/signal.h"
 
 /**
  * color transfer somewhat based on the glorious paper `color transfer between images'

--- a/src/iop/colorzones.c
+++ b/src/iop/colorzones.c
@@ -88,6 +88,7 @@
 #include "widgets/notebook.h"
 #include "widgets/scroll_wrap.h"
 #include "gui/screen_metrics.h"
+#include "widgets/togglebutton.h"
 
 DT_MODULE_INTROSPECTION(5, dt_iop_colorzones_params_t)
 

--- a/src/iop/drawlayer.c
+++ b/src/iop/drawlayer.c
@@ -159,6 +159,7 @@ typedef struct drawlayer_wait_dialog_t
 
 #include "drawlayer/conf.c"
 #include "drawlayer/coordinates.c"
+#include "control/signal.h"
 
 /** @brief Convert one display-space brush color snapshot to pipeline space. */
 static void _brush_pipeline_color_from_display(dt_iop_module_t *self, const float display_rgb[3], float pipeline_rgb[3])

--- a/src/iop/drawlayer.c
+++ b/src/iop/drawlayer.c
@@ -38,7 +38,6 @@
 #include "common/conf.h"
 #include "control/control.h"
 #include "control/jobs.h"
-#include "develop/blend.h"
 #include "develop/dev_history.h"
 #include "develop/develop.h"
 #include "develop/imageop.h"

--- a/src/iop/exposure.c
+++ b/src/iop/exposure.c
@@ -80,6 +80,7 @@
 #include "control/control.h"
 #include "develop/develop.h"
 #include "develop/imageop.h"
+#include "widgets/collapsible_section.h"
 #include "develop/imageop_math.h"
 #include "develop/imageop_gui.h"
 #include "develop/pixelpipe.h"

--- a/src/iop/filmic.c
+++ b/src/iop/filmic.c
@@ -68,6 +68,7 @@
 #include "widgets/label.h"
 #include "widgets/scroll_wrap.h"
 #include "gui/screen_metrics.h"
+#include "widgets/togglebutton.h"
 
 #define DT_GUI_CURVE_EDITOR_INSET DT_PIXEL_APPLY_DPI(1)
 

--- a/src/iop/filmicrgb.c
+++ b/src/iop/filmicrgb.c
@@ -91,6 +91,7 @@
 #include "widgets/scroll_wrap.h"
 #include "widgets/widget_style.h"
 #include "gui/screen_metrics.h"
+#include "widgets/togglebutton.h"
 
 #define INVERSE_SQRT_3 0.5773502691896258f
 #define SAFETY_MARGIN 0.01f

--- a/src/iop/lens.cc
+++ b/src/iop/lens.cc
@@ -101,6 +101,7 @@
 #include <lensfun.h>
 #include "widgets/popup.h"
 #include "widgets/widget_style.h"
+#include "control/signal.h"
 
 extern "C" {
 

--- a/src/iop/levels.c
+++ b/src/iop/levels.c
@@ -70,6 +70,8 @@
 #include "system/simd.h"
 #include "common/module_versioning.h"
 #include "develop/imageop.h"
+#include "gui/color_picker_proxy.h"
+#include "widgets/collapsible_section.h"
 #include "develop/imageop_math.h"
 #include "develop/imageop_gui.h"
 #include "math/openmp_maths.h"

--- a/src/iop/lut3d.c
+++ b/src/iop/lut3d.c
@@ -69,6 +69,7 @@
 #include <unistd.h>
 #include <dirent.h>
 #include "widgets/widget_style.h"
+#include "control/signal.h"
 #if defined (_WIN32)
 #include "win/getdelim.h"
 #endif // defined (_WIN32)

--- a/src/iop/rawprepare.c
+++ b/src/iop/rawprepare.c
@@ -61,6 +61,7 @@
 #include <stdint.h>
 #include <stdlib.h>
 #include "widgets/label.h"
+#include "control/signal.h"
 
 DT_MODULE_INTROSPECTION(2, dt_iop_rawprepare_params_t)
 

--- a/src/iop/retouch.c
+++ b/src/iop/retouch.c
@@ -63,6 +63,7 @@
 #include "common/imagebuf.h"
 #include "common/opencl.h"
 #include "develop/blend.h"
+#include "develop/blend_gui.h"
 #include "develop/imageop_math.h"
 #include "develop/imageop_gui.h"
 #include "develop/masks.h"

--- a/src/iop/retouch.c
+++ b/src/iop/retouch.c
@@ -74,6 +74,7 @@
 #include <stdlib.h>
 #include "widgets/label.h"
 #include "gui/screen_metrics.h"
+#include "control/signal.h"
 
 // this is the version of the modules parameters,
 // and includes version information about compile-time dt

--- a/src/iop/retouch.c
+++ b/src/iop/retouch.c
@@ -46,6 +46,7 @@
 #include "common/conf.h"
 #include "config.h"
 #endif
+#include "control/control.h"
 #include "widgets/bauhaus.h"
 #include "system/macros.h"
 #include "system/openmp.h"

--- a/src/iop/rgbcurve.c
+++ b/src/iop/rgbcurve.c
@@ -67,6 +67,7 @@
 #include "widgets/notebook.h"
 #include "widgets/scroll_wrap.h"
 #include "gui/screen_metrics.h"
+#include "widgets/togglebutton.h"
 
 #define DT_GUI_CURVE_EDITOR_INSET DT_PIXEL_APPLY_DPI(1)
 #define DT_IOP_RGBCURVE_RES 256

--- a/src/iop/rgblevels.c
+++ b/src/iop/rgblevels.c
@@ -54,6 +54,8 @@
 #include "widgets/notebook.h"
 #include "widgets/scroll_wrap.h"
 #include "gui/screen_metrics.h"
+#include "widgets/togglebutton.h"
+#include "control/signal.h"
 
 #define DT_GUI_CURVE_EDITOR_INSET DT_PIXEL_APPLY_DPI(5)
 

--- a/src/iop/splittoningrgb.c
+++ b/src/iop/splittoningrgb.c
@@ -53,6 +53,7 @@
 #include "widgets/label.h"
 #include "widgets/notebook.h"
 #include "gui/screen_metrics.h"
+#include "control/signal.h"
 
 DT_MODULE_INTROSPECTION(1, dt_iop_splittoning_rgb_params_t)
 

--- a/src/iop/spots.c
+++ b/src/iop/spots.c
@@ -52,6 +52,7 @@
 #include "common/module_versioning.h"
 #include "control/control.h"
 #include "develop/blend.h"
+#include "develop/blend_gui.h"
 #include "develop/imageop.h"
 #include "develop/imageop_gui.h"
 #include "develop/masks.h"

--- a/src/iop/temperature.c
+++ b/src/iop/temperature.c
@@ -90,6 +90,7 @@
 #include "widgets/collapsible_section.h"
 #include "widgets/label.h"
 #include "widgets/widget_style.h"
+#include "widgets/togglebutton.h"
 
 DT_MODULE_INTROSPECTION(3, dt_iop_temperature_params_t)
 

--- a/src/iop/toneequal.c
+++ b/src/iop/toneequal.c
@@ -144,6 +144,9 @@
 #include "widgets/widget_style.h"
 #include "gui/screen_metrics.h"
 
+#include "control/signal.h"
+#include "widgets/togglebutton.h"
+
 #ifdef _OPENMP
 #include <omp.h>
 #endif

--- a/src/iop/zonesystem.c
+++ b/src/iop/zonesystem.c
@@ -67,6 +67,7 @@
 #include "pixel/gaussian.h"
 #include "math/math.h"
 #include "control/control.h"
+#include "control/signal.h"
 #include "develop/develop.h"
 #include "common/logging.h"
 #include "develop/imageop.h"

--- a/src/libs/duplicate.c
+++ b/src/libs/duplicate.c
@@ -56,6 +56,7 @@
 #include "widgets/scroll_wrap.h"
 #include "widgets/widget_settings.h"
 #include "widgets/widget_style.h"
+#include "control/signal.h"
 
 DT_MODULE(1)
 

--- a/src/libs/histogram.c
+++ b/src/libs/histogram.c
@@ -90,6 +90,7 @@
 #include "widgets/scroll_wrap.h"
 #include "widgets/widget_style.h"
 #include "gui/screen_metrics.h"
+#include "widgets/togglebutton.h"
 
 #ifdef GDK_WINDOWING_QUARTZ
 #endif

--- a/src/libs/history.c
+++ b/src/libs/history.c
@@ -57,6 +57,7 @@
 #include "common/styles.h"
 #include "develop/develop.h"
 #include "develop/masks.h"
+#include "develop/blend_gui.h"
 
 #include "gui/application.h"
 #include "libs/lib.h"

--- a/src/libs/history.c
+++ b/src/libs/history.c
@@ -64,6 +64,7 @@
 #include <complex.h>
 #include "widgets/label.h"
 #include "widgets/scroll_wrap.h"
+#include "control/signal.h"
 
 DT_MODULE(1)
 

--- a/src/libs/lib.c
+++ b/src/libs/lib.c
@@ -80,6 +80,7 @@
 #include "widgets/label.h"
 #include "widgets/popup.h"
 #include "widgets/widget_style.h"
+#include "control/signal.h"
 
 
 typedef enum dt_action_element_lib_t

--- a/src/libs/location.c
+++ b/src/libs/location.c
@@ -52,6 +52,7 @@
 #include "widgets/accelerators.h"
 #include "widgets/container.h"
 #include "widgets/widget_settings.h"
+#include "control/signal.h"
 
 DT_MODULE(1)
 

--- a/src/libs/masks.c
+++ b/src/libs/masks.c
@@ -53,6 +53,8 @@
 #include "views/view.h"
 #include "widgets/scroll_wrap.h"
 
+#include "widgets/togglebutton.h"
+#include "control/signal.h"
 #ifdef GDK_WINDOWING_QUARTZ
 #include "osx/osx.h"
 #endif

--- a/src/libs/masks.c
+++ b/src/libs/masks.c
@@ -44,6 +44,7 @@
 #include "common/module_versioning.h"
 #include "control/control.h"
 #include "develop/blend.h"
+#include "develop/blend_gui.h"
 #include "develop/develop.h"
 #include "develop/imageop.h"
 #include "widgets/draw.h"

--- a/src/libs/navigation.c
+++ b/src/libs/navigation.c
@@ -57,6 +57,7 @@
 #include "widgets/popup.h"
 #include "widgets/scroll_wrap.h"
 #include "gui/screen_metrics.h"
+#include "control/signal.h"
 
 DT_MODULE(1)
 

--- a/src/libs/print_settings.c
+++ b/src/libs/print_settings.c
@@ -67,6 +67,8 @@
 #include <glib/gstdio.h>
 #include "widgets/label.h"
 #include "imageio/imageio_profile.h"
+#include "widgets/togglebutton.h"
+#include "control/signal.h"
 
 DT_MODULE(4)
 

--- a/src/libs/print_settings.c
+++ b/src/libs/print_settings.c
@@ -37,6 +37,7 @@
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#include "control/control.h"
 #include "common/conf.h"
 #include "caches/mipmap_cache.h"
 #include <glib.h>

--- a/src/libs/tools/filter.c
+++ b/src/libs/tools/filter.c
@@ -62,6 +62,7 @@
 #include "widgets/bauhaus.h"
 #include "widgets/popup.h"
 #include "widgets/widget_style.h"
+#include "widgets/togglebutton.h"
 
 DT_MODULE(1)
 

--- a/src/metadata/notify.c
+++ b/src/metadata/notify.c
@@ -60,6 +60,19 @@ void dt_metadata_tags_changed(void)
   if(handler) handler();
 }
 
+static dt_metadata_geotags_changed_handler_t _geotags_changed_handler = NULL;
+
+void dt_metadata_set_geotags_changed_handler(dt_metadata_geotags_changed_handler_t handler)
+{
+  _geotags_changed_handler = handler;
+}
+
+void dt_metadata_geotags_changed(const GList *imgs)
+{
+  dt_metadata_geotags_changed_handler_t handler = _geotags_changed_handler;
+  if(handler) handler(imgs);
+}
+
 // clang-format off
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py
 // vim: shiftwidth=2 expandtab tabstop=2 cindent

--- a/src/metadata/notify.h
+++ b/src/metadata/notify.h
@@ -80,6 +80,18 @@ void dt_metadata_set_tags_changed_handler(dt_metadata_tags_changed_handler_t han
 /** @brief Raise it. Internal to the module. */
 void dt_metadata_tags_changed(void);
 
+/**
+ * @brief The geo-location of these images changed. Whoever is showing a map, or the
+ *        geotag panel, should look again.
+ *
+ * @details Carries the image list because the signal it replaces did. The handler does
+ * the copying, at the raise site, exactly as the old call sites used to: @p imgs stays
+ * the caller's, and a handler that needs to keep it copies it.
+ */
+typedef void (*dt_metadata_geotags_changed_handler_t)(const GList *imgs);
+void dt_metadata_set_geotags_changed_handler(dt_metadata_geotags_changed_handler_t handler);
+void dt_metadata_geotags_changed(const GList *imgs);
+
 G_END_DECLS
 
 #endif // DT_METADATA_NOTIFY_H

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -129,6 +129,8 @@
 #include "widgets/label.h"
 #include "widgets/widget_style.h"
 #include "gui/screen_metrics.h"
+#include "widgets/togglebutton.h"
+#include "control/signal.h"
 
 #ifndef G_SOURCE_FUNC // Defined for glib >= 2.58
 #define G_SOURCE_FUNC(f) ((GSourceFunc) (void (*)(void)) (f))

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -108,7 +108,10 @@
 #include "gui/color_picker_proxy.h"
 #include "gui/application.h"
 #include "develop/gui_throttle.h"
-#include "develop/blend_gui.h"
+// include-cleaner reports this unused while dt_iop_gui_blend_data_t is dereferenced
+// six times in _toggle_mask_visibility_callback() -- the cast from the void*
+// mod->blend_data seems to defeat its attribution. The definition is required.
+#include "develop/blend_gui.h"  // NOLINT(misc-include-cleaner)
 #include "gui/guides.h"
 #include "libs/colorpicker.h"
 #include "libs/lib.h"

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -108,6 +108,7 @@
 #include "gui/color_picker_proxy.h"
 #include "gui/application.h"
 #include "develop/gui_throttle.h"
+#include "develop/blend_gui.h"
 #include "gui/guides.h"
 #include "libs/colorpicker.h"
 #include "libs/lib.h"

--- a/src/views/print.c
+++ b/src/views/print.c
@@ -48,6 +48,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include "widgets/widget_settings.h"
+#include "control/signal.h"
 
 DT_MODULE(1)
 

--- a/src/views/studio_capture.c
+++ b/src/views/studio_capture.c
@@ -49,6 +49,7 @@
 
 #include <gdk/gdkkeysyms.h>
 #include <math.h>
+#include "control/signal.h"
 
 DT_MODULE(1)
 

--- a/src/views/view.c
+++ b/src/views/view.c
@@ -101,6 +101,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <strings.h>
+#include "control/signal.h"
 
 #define DECORATION_SIZE_LIMIT 40
 


### PR DESCRIPTION
First two tranches of `doc/develop-split.md` — the cheapest cuts with the largest fan-out, fully specified by the survey, blocking on no design decision.

## T0 — deletions

- `dt_develop_t` loses `histogram_pre_tonecurve/levels` (+ `_max` twins: allocated, freed, read by nothing tree-wide) and `loading_cache` (declared, never referenced).
- `pixelpipe_hb.c` loses `gui/color_picker_proxy.h` (zero symbols).
- `dev_history.c` loses `gui/presets.h` — **not** the way the survey predicted. The claim was "no symbol used"; the nofeatures build said otherwise: the `FOR_RAW`/`FOR_LDR`/… flags at the auto-apply site come through it, unprefixed and invisible to a `dt_`-shaped grep. They are *persisted database vocabulary* (`preset_repository.h` documents its row fields in terms of them), so they moved to `history/presets.h`; `gui/presets.h` keeps an include so consumers are untouched.

## T1a — `imageop.h` stops feeding GTK and the control loop to 122 files

Each upward include existed for one thing: `widgets/togglebutton.h` for the concrete type of `->off` (every external user already casts via `GTK_TOGGLE_BUTTON()` — it's `GtkWidget*` now), and `control/settings.h` for `dt_dev_operation_t` — a typedef control/ defined and **never used**. It is the history-stack operation identity (its own doc comment says so) and lives in `history/history.h` now.

Pulling a line that fed 122 files surfaced every rider: **30 files** reached `control/signal.h` through it and **20** reached `widgets/togglebutton.h`. All got explicit includes — legal at their layers — except `common/image.c` (layer 1), whose three signal raises were the real find and are inverted: TAG_CHANGED through the existing `dt_metadata_tags_changed()`, GEOTAG_CHANGED through a new geotags handler in `metadata/notify.h` (the handler copies the list at the raise site, exactly where the old sites copied it), IMAGE_IMPORT through a new `common/image_notify.h` — the same seam shape as `thumbnail_notify.h` next door.

## T1b — the blending GUI leaves `blend.h`

`dt_iop_gui_blend_data_t` (~60 widget fields) + the `dt_iop_gui_*_blending()` API → new `develop/blend_gui.h`, taking the three includes that existed only for it. **blend.h now contains zero GTK types.** The seven blend name tables travel the other way: extern'd in blend.h but *defined* in blend_gui.c while backend `supervisor.c` reads them — a GUI-less link one dead widget file away from breaking. Definitions now in blend.c. Four IOPs rode blend.h for widgets it never advertised (`collapsible_section`, `color_picker_proxy`); each now names its supplier. `drawlayer.c` and `imageio_core.c` included blend.h for zero symbols — dropped.

## T1c — `masks.h` drops `control/control.h`

The include named **zero symbols**. Eight riders surfaced (`dev_history.c`, three mask shape files, `masks_gui.c`, `pixelpipe_gpu.c`, `libs/print_settings.c`, `iop/retouch.c`) — all reaching `dt_control_log`/`dt_toast_log`/redraws through it. Each now names its supplier; every one of those call sites is a T2/T3 inversion target, and the explicit include is how the debt stays countable until then.

## Process notes, honestly

Mechanical include insertion put **four of ~60 includes inside platform/feature conditionals** — after `osx/osx.h` (QUARTZ), `win/dtwin.h` (_WIN32), `<omp.h>` (_OPENMP — caught **only** by the nofeatures build), and inside zonesystem's `RSVG_CAIRO_H` hack. All relocated; `check_conditional_includes.sh` and the three-config build are what caught them. One insertion (`views.c`) targeted uses inside a block comment my filter couldn't see — clang-tidy caught it, include removed. One include-cleaner **false positive** is annotated NOLINT with the reason: `darkroom.c` dereferences `dt_iop_gui_blend_data_t` six times but the cast from the `void*` `blend_data` defeats attribution.

## Verification

Release, Debug (`-Werror`), nofeatures all build; ctest 7/7; all seven gates pass (conditional-includes and unused-includes post-commit); layering 189, baseline held — every one of the ~60 new include edges is downward. No pixel-touching change anywhere in the diff (types, includes, dead code, notification routing), so no export A/B for this one.

After this lands, **90 IOPs stop receiving GTK and the control loop through develop headers**. Next per the plan: T2 (message/notification inversions in the pipeline files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)