### PR TITLE
Develop T2: the pipeline states facts; the control loop stops being its address

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -193,6 +193,7 @@ FILE(GLOB SOURCE_FILES
   "develop/pixelpipe.c"
   "caches/pixelpipe_cache.c"
   "develop/pixelpipe_cpu.c"
+  "develop/pipeline_notify.c"
   "develop/pixelpipe_gpu.c"
   "develop/supervisor.c"
   "develop/blend.c"

--- a/src/darktable.c
+++ b/src/darktable.c
@@ -142,6 +142,7 @@
 #include "common/l10n.h"
 #include "metadata/metadata.h"
 #include "common/image_notify.h"
+#include "develop/pipeline_notify.h"
 #include "history/notify.h"
 #include "history/presets.h"
 #include "metadata/notify.h"
@@ -739,6 +740,23 @@ static void _metadata_notify(const dt_metadata_notice_t kind, const char *messag
     dt_toast_log("%s", message);
   else
     dt_control_log("%s", message);
+}
+
+/* The pipeline worker names what it is chewing on; the banner and its repaint are ours.
+ * Called from worker threads, as the calls it replaces were -- dt_set_main_message()
+ * under log_mutex and the centre redraw are both worker-safe. */
+static void _pipeline_busy(const char *message_or_null)
+{
+  dt_control_t *const control = dt_control_get_global();
+  dt_pthread_mutex_lock(&control->log_mutex);
+  dt_set_main_message(message_or_null ? g_strdup(message_or_null) : NULL);
+  dt_pthread_mutex_unlock(&control->log_mutex);
+  dt_control_queue_redraw_center();
+}
+
+static void _pipeline_message(const char *message)
+{
+  dt_control_log("%s", message);
 }
 
 /* The geotag list is copied here, at the raise site, exactly where the old call sites
@@ -1488,6 +1506,8 @@ int dt_init(int argc, char *argv[], const gboolean init_gui, const gboolean load
   dt_metadata_set_tags_changed_handler(_metadata_tags_changed);
   dt_metadata_set_geotags_changed_handler(_metadata_geotags_changed);
   dt_image_notify_set_imported_handler(_image_imported);
+  dt_pipeline_set_message_handler(_pipeline_message);
+  dt_pipeline_set_busy_handler(_pipeline_busy);
   // Same reason for these two: they raise signals, so they wait for the signal system.
   dt_history_set_changed_handler(_history_changed);
   dt_history_set_images_changed_handler(_history_images_changed);

--- a/src/develop/blend.c
+++ b/src/develop/blend.c
@@ -39,6 +39,7 @@
     You should have received a copy of the GNU General Public License
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
+#include "develop/pipeline_notify.h"
 #include "system/macros.h"
 #include "develop/iop_profile.h"
 #include "system/openmp.h"
@@ -50,7 +51,6 @@
 #include "pixel/guided_filter.h"
 #include "common/imagebuf.h"
 #include "common/opencl.h"
-#include "control/control.h"
 #include "develop/imageop.h"
 #include "develop/masks.h"
 #include "develop/pixelpipe_hb.h"
@@ -418,7 +418,7 @@ static void _refine_with_detail_mask(struct dt_iop_module_t *self, const struct 
   return;
 
   error:
-  dt_control_log(_("detail mask blending error"));
+  dt_pipeline_message(_("detail mask blending error"));
   dt_pixelpipe_cache_free_align(warp_mask);
   dt_pixelpipe_cache_free_align(lum);
   dt_pixelpipe_cache_free_align(tmp);
@@ -698,7 +698,7 @@ int dt_develop_blend_process(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *p
   if(oscale != iscale || xoffs < 0 || yoffs < 0
      || ((xoffs > 0 || yoffs > 0) && (owidth + xoffs > iwidth || oheight + yoffs > iheight)))
   {
-    dt_control_log(_("skipped blending in module '%s': roi's do not match"), self->op);
+    dt_pipeline_message(_("skipped blending in module '%s': roi's do not match"), self->op);
     return 0;
   }
 
@@ -724,7 +724,7 @@ int dt_develop_blend_process(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *p
   float *const restrict _mask = dt_pixelpipe_cache_alloc_align_float(buffsize, pipe);
   if(IS_NULL_PTR(_mask))
   {
-    dt_control_log(_("could not allocate buffer for blending"));
+    dt_pipeline_message(_("could not allocate buffer for blending"));
     return 1;
   }
   int raster_error = 0;
@@ -763,7 +763,7 @@ int dt_develop_blend_process(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *p
         float *const restrict drawn_mask = dt_pixelpipe_cache_alloc_align_float(buffsize, pipe);
         if(IS_NULL_PTR(drawn_mask))
         {
-          dt_control_log(_("could not allocate buffer for blending"));
+          dt_pipeline_message(_("could not allocate buffer for blending"));
           dt_pixelpipe_cache_free_align(_mask);
           return 1;
         }
@@ -1096,7 +1096,7 @@ static void _refine_with_detail_mask_cl(struct dt_iop_module_t *self, const stru
   return;
 
   error:
-  dt_control_log(_("detail mask CL blending problem"));
+  dt_pipeline_message(_("detail mask CL blending problem"));
   dt_pixelpipe_cache_free_align(lum);
   dt_opencl_release_mem_object(tmp);
   dt_opencl_release_mem_object(blur);
@@ -1154,7 +1154,7 @@ int dt_develop_blend_process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_t
   if(oscale != iscale || xoffs < 0 || yoffs < 0
      || ((xoffs > 0 || yoffs > 0) && (owidth + xoffs > iwidth || oheight + yoffs > iheight)))
   {
-    dt_control_log(_("skipped blending in module '%s': roi's do not match"), self->op);
+    dt_pipeline_message(_("skipped blending in module '%s': roi's do not match"), self->op);
     return 0;
   }
 
@@ -1185,7 +1185,7 @@ int dt_develop_blend_process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_t
   float *_mask = dt_pixelpipe_cache_alloc_align_float(buffsize, pipe);
   if(IS_NULL_PTR(_mask))
   {
-    dt_control_log(_("could not allocate buffer for blending"));
+    dt_pipeline_message(_("could not allocate buffer for blending"));
     return 1;
   }
   float *const mask = _mask;

--- a/src/develop/pipeline_notify.c
+++ b/src/develop/pipeline_notify.c
@@ -1,0 +1,84 @@
+/*
+    This file is part of Ansel,
+    Copyright (C) 2026 Aurélien PIERRE.
+
+    Ansel is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Ansel is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Ansel.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "develop/pipeline_notify.h"
+
+#include "system/mem_alloc.h"
+
+#include <stdarg.h>
+
+/* Written once, at startup, before any pipeline exists; read from the worker threads.
+ * A lock would be guarding against a race nobody can create. */
+static dt_pipeline_message_handler_t _message_handler = NULL;
+static dt_pipeline_busy_handler_t _busy_handler = NULL;
+
+void dt_pipeline_set_message_handler(dt_pipeline_message_handler_t handler)
+{
+  _message_handler = handler;
+}
+
+void dt_pipeline_message(const char *format, ...)
+{
+  dt_pipeline_message_handler_t handler = _message_handler;
+  if(handler == NULL) return;  // headless export, or a unit test: nothing to tell
+
+  va_list args;
+  va_start(args, format);
+  gchar *message = g_strdup_vprintf(format, args);
+  va_end(args);
+
+  if(message)
+  {
+    handler(message);
+    dt_free(message);
+  }
+}
+
+void dt_pipeline_set_busy_handler(dt_pipeline_busy_handler_t handler)
+{
+  _busy_handler = handler;
+}
+
+void dt_pipeline_busy_printf(const char *format, ...)
+{
+  dt_pipeline_busy_handler_t handler = _busy_handler;
+  if(handler == NULL) return;
+
+  va_list args;
+  va_start(args, format);
+  gchar *message = g_strdup_vprintf(format, args);
+  va_end(args);
+
+  if(message)
+  {
+    handler(message);
+    dt_free(message);
+  }
+}
+
+void dt_pipeline_busy_clear(void)
+{
+  dt_pipeline_busy_handler_t handler = _busy_handler;
+  if(handler) handler(NULL);
+}
+
+// clang-format off
+// modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py
+// vim: shiftwidth=2 expandtab tabstop=2 cindent
+// kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;
+// clang-format on

--- a/src/develop/pipeline_notify.h
+++ b/src/develop/pipeline_notify.h
@@ -1,0 +1,83 @@
+/*
+    This file is part of Ansel,
+    Copyright (C) 2026 Aurélien PIERRE.
+
+    Ansel is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Ansel is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Ansel.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+/** @file develop/pipeline_notify.h
+ *
+ * @brief Everything the pixel pipeline says to whoever is watching: messages for the
+ * user, and the busy banner naming the module being processed.
+ *
+ * @details Tiling failures, blending allocation errors, OpenCL fallbacks and the
+ * per-module progress banner were raised by the worker thread calling straight into
+ * `control/` — dt_control_log(), dt_set_main_message() under control->log_mutex, forced
+ * centre redraws. That made every pure pixel file (tiling.c, blend.c, pixelpipe_gpu.c,
+ * the raster-mask transport) carry control/control.h for a handful of user-facing
+ * strings, and made the pipeline unbuildable without the control loop.
+ *
+ * Inverted the same way as metadata/notify.h, history/notify.h and
+ * common/image_notify.h: the pipeline states the fact; whoever is running it decides
+ * what that looks like. With no handler installed — ansel-cli, a unit test — the message
+ * is dropped, which is what a headless export wants.
+ *
+ * Both handlers are called from pipeline worker threads, exactly as the calls they
+ * replace were; dt_control_log() and dt_control_queue_redraw_center() are worker-safe
+ * today and the darktable.c handlers keep that contract.
+ */
+
+#ifndef DT_DEVELOP_PIPELINE_NOTIFY_H
+#define DT_DEVELOP_PIPELINE_NOTIFY_H
+
+#include <glib.h>
+
+G_BEGIN_DECLS
+
+/** @brief Receives one formatted, already-translated message for the user.
+ *  Was dt_control_log() from pipeline code. */
+typedef void (*dt_pipeline_message_handler_t)(const char *message);
+
+/** @brief Install the handler, or NULL to remove it. Messages raised with none
+ *  installed are dropped. */
+void dt_pipeline_set_message_handler(dt_pipeline_message_handler_t handler);
+
+/** @brief Tell the user something went sideways in the pipe. Internal to the pipeline:
+ *  the format string is translated at the call site. */
+void dt_pipeline_message(const char *format, ...) G_GNUC_PRINTF(1, 2);
+
+/**
+ * @brief Receives the busy-banner text, or NULL when processing finished and the banner
+ * should clear. Was dt_set_main_message() under control->log_mutex plus a forced centre
+ * redraw; the handler owns both. The string is the callee's only for the duration of the
+ * call — copy it to keep it.
+ */
+typedef void (*dt_pipeline_busy_handler_t)(const char *message_or_null);
+void dt_pipeline_set_busy_handler(dt_pipeline_busy_handler_t handler);
+
+/** @brief Publish what the pipe is chewing on ("Processing module `%s' ..."). */
+void dt_pipeline_busy_printf(const char *format, ...) G_GNUC_PRINTF(1, 2);
+
+/** @brief Processing finished; clear the banner. */
+void dt_pipeline_busy_clear(void);
+
+G_END_DECLS
+
+#endif // DT_DEVELOP_PIPELINE_NOTIFY_H
+
+// clang-format off
+// modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py
+// vim: shiftwidth=2 expandtab tabstop=2 cindent
+// kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;
+// clang-format on

--- a/src/develop/pixelpipe_gpu.c
+++ b/src/develop/pixelpipe_gpu.c
@@ -2,7 +2,7 @@
     Private OpenCL pixelpipe backend.
 */
 
-#include "control/control.h"
+#include "develop/pipeline_notify.h"
 #include "system/macros.h"
 #include "develop/iop_profile.h"
 #include "common/logging.h"
@@ -674,25 +674,25 @@ error:
     switch(fit_reason)
     {
       case DT_OPENCL_FIT_ALLOC_LIMIT:
-        dt_control_log(_("OpenCL failed for module `%s`: image buffer needs %" G_GSIZE_FORMAT
+        dt_pipeline_message(_("OpenCL failed for module `%s`: image buffer needs %" G_GSIZE_FORMAT
                          " MiB but the largest allocation the device allows is %" G_GSIZE_FORMAT
                          " MiB; falling back to CPU"),
                        module->name(), (size_t)(fit_needed / (1024 * 1024)),
                        (size_t)(fit_limit / (1024 * 1024)));
         break;
       case DT_OPENCL_FIT_AVAILABLE:
-        dt_control_log(_("OpenCL failed for module `%s`: image buffer needs %" G_GSIZE_FORMAT
+        dt_pipeline_message(_("OpenCL failed for module `%s`: image buffer needs %" G_GSIZE_FORMAT
                          " MiB but only %" G_GSIZE_FORMAT " MiB are free on the device; falling back to CPU"),
                        module->name(), (size_t)(fit_needed / (1024 * 1024)),
                        (size_t)(fit_limit / (1024 * 1024)));
         break;
       case DT_OPENCL_FIT_DIMENSION:
-        dt_control_log(_("OpenCL failed for module `%s`: image dimensions %" G_GSIZE_FORMAT "x%" G_GSIZE_FORMAT
+        dt_pipeline_message(_("OpenCL failed for module `%s`: image dimensions %" G_GSIZE_FORMAT "x%" G_GSIZE_FORMAT
                          " exceed the device limits; falling back to CPU"),
                        module->name(), precheck_width, precheck_height);
         break;
       default: // DT_OPENCL_FIT_OK / UNINITED: the buffer fit, the GPU failed for another reason
-        dt_control_log(_("OpenCL failed for module `%s`; falling back to CPU"), module->name());
+        dt_pipeline_message(_("OpenCL failed for module `%s`; falling back to CPU"), module->name());
         break;
     }
     return pixelpipe_process_on_CPU(pipe, piece, previous_piece, tiling, pixelpipe_flow,

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -51,6 +51,7 @@
     You should have received a copy of the GNU General Public License
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
+#include "develop/pipeline_notify.h"
 #include "colorprofiles/profile_types.h"
 #include "system/capabilities.h"
 #include "system/sys_resources.h"
@@ -61,7 +62,6 @@
 #include "system/atomic.h"
 #include "common/opencl.h"
 #include "develop/iop_order.h"
-#include "control/control.h"
 #include "control/signal.h"
 #include "develop/blend.h"
 #include "develop/dev_pixelpipe.h"
@@ -969,15 +969,11 @@ static int dt_dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe,
   if(pipe->dev->gui_attached)
   {
     gchar *module_label = dt_history_item_get_name(module);
-    dt_control_t *const control = dt_control_get_global();
-    dt_pthread_mutex_lock(&control->log_mutex);
-    dt_set_main_message(g_strdup_printf(_("Processing module `%s` for pipeline %s (%ix%i px @ %0.f%%)..."),
-                                        module_label, dt_pixelpipe_get_pipe_name(pipe->type),
-                                        piece->roi_out.width, piece->roi_out.height,
-                                        piece->roi_out.scale * 100.f));
-    dt_pthread_mutex_unlock(&control->log_mutex);
+    dt_pipeline_busy_printf(_("Processing module `%s` for pipeline %s (%ix%i px @ %0.f%%)..."),
+                            module_label, dt_pixelpipe_get_pipe_name(pipe->type),
+                            piece->roi_out.width, piece->roi_out.height,
+                            piece->roi_out.scale * 100.f);
     dt_free(module_label);
-    dt_control_queue_redraw_center();
   }
 
   dt_pixel_cache_entry_t *output_entry = NULL;
@@ -1194,13 +1190,7 @@ static int dt_dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe,
     dt_dev_pixelpipe_cache_flag_auto_destroy(output_entry);
 
   if(pipe->dev->gui_attached)
-  {
-    dt_control_t *const control = dt_control_get_global();
-    dt_pthread_mutex_lock(&control->log_mutex);
-    dt_set_main_message(NULL);
-    dt_pthread_mutex_unlock(&control->log_mutex);
-    dt_control_queue_redraw_center();
-  }
+    dt_pipeline_busy_clear();
 
   // From here on we only publish/inspect the finished output. Keep the writable lock strictly
   // around cacheline allocation and backend processing, then release it at one visible point
@@ -1299,12 +1289,12 @@ static void _print_opencl_errors(int error, dt_dev_pixelpipe_t *pipe)
   {
     case 1:
       dt_print(DT_DEBUG_OPENCL, "[opencl] Opencl errors; disabling opencl for %s pipeline!\n", dt_pixelpipe_get_pipe_name(pipe->type));
-      dt_control_log(_("Ansel discovered problems with your OpenCL setup; disabling OpenCL for %s pipeline!"), dt_pixelpipe_get_pipe_name(pipe->type));
+      dt_pipeline_message(_("Ansel discovered problems with your OpenCL setup; disabling OpenCL for %s pipeline!"), dt_pixelpipe_get_pipe_name(pipe->type));
       break;
     case 2:
       dt_print(DT_DEBUG_OPENCL,
                  "[opencl] Too many opencl errors; disabling opencl for this session!\n");
-      dt_control_log(_("Ansel discovered problems with your OpenCL setup; disabling OpenCL for this session!"));
+      dt_pipeline_message(_("Ansel discovered problems with your OpenCL setup; disabling OpenCL for this session!"));
       break;
     default:
       break;

--- a/src/develop/pixelpipe_raster_masks.c
+++ b/src/develop/pixelpipe_raster_masks.c
@@ -1,4 +1,3 @@
-#include "widgets/label.h"
 /**
  * @file pixelpipe_raster_masks.c
  * @brief Raster-mask retrieval and transport through already-processed pipeline nodes.
@@ -12,6 +11,11 @@
  * under dedicated keys; consumers copy those side-band buffers and optionally distort them through downstream
  * modules until they reach the requested stage.
  */
+
+// This file is textually #included into pixelpipe_hb.c (see the doc block above), so
+// these guarded includes fold into that TU; they are named here because THIS file uses them.
+#include "common/glib_utils.h"        // dt_string_replace
+#include "develop/pipeline_notify.h"  // dt_pipeline_message
 
 /**
  * @brief Check that the raster-mask provider/consumer relation is still valid in the current pipe.
@@ -30,7 +34,7 @@ static gboolean _dt_dev_raster_mask_check(dt_dev_pixelpipe_iop_t *source_piece,
 {
   gboolean success = TRUE;
   gchar *clean_target_name = !IS_NULL_PTR(target_module)
-      ? delete_underscore(target_module->name())
+      ? dt_string_replace(target_module->name(), "_")
       : g_strdup(_("export"));
   gchar *target_name = !IS_NULL_PTR(target_module)
       ? g_strdup_printf("%s (%s)", clean_target_name, target_module->multi_name)
@@ -52,14 +56,14 @@ static gboolean _dt_dev_raster_mask_check(dt_dev_pixelpipe_iop_t *source_piece,
     }
     else if(IS_NULL_PTR(current_piece))
     {
-      gchar *clean_source_name = delete_underscore(source_piece->module->name());
+      gchar *clean_source_name = dt_string_replace(source_piece->module->name(), "_");
       hint = g_strdup_printf(_("- Check if the module %s (%s) providing the masks has not been moved above %s.\n"),
                              clean_source_name,
                              source_piece->module->multi_name, clean_target_name);
       dt_free(clean_source_name);
     }
 
-    dt_control_log(_("The %s module is trying to reuse a mask from a module but it can't be found.\n"
+    dt_pipeline_message(_("The %s module is trying to reuse a mask from a module but it can't be found.\n"
                      "\n%s"),
                    target_name, hint ? hint : "");
     dt_free(hint);
@@ -70,9 +74,9 @@ static gboolean _dt_dev_raster_mask_check(dt_dev_pixelpipe_iop_t *source_piece,
 
   if(success && !source_piece->enabled)
   {
-    gchar *clean_source_name = delete_underscore(source_piece->module->name());
+    gchar *clean_source_name = dt_string_replace(source_piece->module->name(), "_");
     gchar *source_name = g_strdup_printf("%s (%s)", clean_source_name, source_piece->module->multi_name);
-    dt_control_log(_("The `%s` module is trying to reuse a mask from disabled module `%s`.\n"
+    dt_pipeline_message(_("The `%s` module is trying to reuse a mask from disabled module `%s`.\n"
                      "Disabled modules cannot provide their masks to other modules.\n"
                      "\n- Please enable `%s` or change the raster mask in `%s`."),
                    target_name, source_name, source_name, target_name);
@@ -97,7 +101,7 @@ float *dt_dev_get_raster_mask(dt_dev_pixelpipe_t *pipe, const dt_iop_module_t *r
   if(!IS_NULL_PTR(error)) *error = 0;
 
   gchar *clean_target_name = !IS_NULL_PTR(target_module)
-      ? delete_underscore(target_module->name())
+      ? dt_string_replace(target_module->name(), "_")
       : g_strdup(_("export"));
   gchar *target_name = !IS_NULL_PTR(target_module)
       ? g_strdup_printf("%s (%s)", clean_target_name, target_module->multi_name)
@@ -137,7 +141,7 @@ float *dt_dev_get_raster_mask(dt_dev_pixelpipe_t *pipe, const dt_iop_module_t *r
     const uint64_t raster_hash
         = dt_dev_pixelpipe_raster_mask_hash(source_piece, raster_mask_id);
 
-    gchar *clean_source_name = delete_underscore(source_piece->module->name());
+    gchar *clean_source_name = dt_string_replace(source_piece->module->name(), "_");
     gchar *source_name = g_strdup_printf("%s (%s)", clean_source_name, source_piece->module->multi_name);
     dt_pixel_cache_entry_t *raster_entry = NULL;
     void *cache_data = NULL;
@@ -263,7 +267,7 @@ float *dt_dev_get_raster_mask(dt_dev_pixelpipe_t *pipe, const dt_iop_module_t *r
 
       if(module->module == target_module)
       {
-        gchar *clean_module_name = delete_underscore(module->module->name());
+        gchar *clean_module_name = dt_string_replace(module->module->name(), "_");
         dt_print(DT_DEBUG_MASKS, "[raster masks] found mask id %i from %s for module %s (%s) in pipe %s\n",
                  raster_mask_id, source_name, clean_module_name,
                  module->module->multi_name, dt_pixelpipe_get_pipe_name(pipe->type));

--- a/src/develop/tiling.c
+++ b/src/develop/tiling.c
@@ -32,11 +32,11 @@
 */
 
 
+#include "develop/pipeline_notify.h"
 #include "system/sys_resources.h"
 #include "caches/pixelpipe_cache_alloc.h"
 #include "develop/tiling.h"
 #include "common/opencl.h"
-#include "control/control.h"
 #include "develop/pixelpipe.h"
 #include "math/nelder_mead_simplex.h"
 
@@ -469,7 +469,7 @@ static int _default_process_tiling_ptp(struct dt_iop_module_t *self, const struc
   return 0;
 
 error:
-  dt_control_log(_("tiling failed for module '%s'. output might be garbled."), self->op);
+  dt_pipeline_message(_("tiling failed for module '%s'. output might be garbled."), self->op);
 // fall through
 
 fallback:
@@ -803,7 +803,7 @@ static int _default_process_tiling_roi(struct dt_iop_module_t *self, const struc
   return 0;
 
 error:
-  dt_control_log(_("tiling failed for module '%s'. output might be garbled."), self->op);
+  dt_pipeline_message(_("tiling failed for module '%s'. output might be garbled."), self->op);
 // fall through
 
 fallback:


### PR DESCRIPTION
Third tranche of `doc/develop-split.md`, after #1133.

Fifteen call sites across the five pure pixel files raised user-facing messages by calling straight into `control/` from worker threads — `dt_control_log` for tiling failures (×2), blending errors (×7), OpenCL fallbacks (×6), raster-mask troubles (×2) — plus the per-module busy banner in `pixelpipe_hb.c`: `dt_set_main_message()` under `control->log_mutex` with a forced centre redraw, and its clearing twin.

**`develop/pipeline_notify.h`** inverts both channels — the fourth use of the seam shape (`metadata/notify.h`, `history/notify.h`, `common/image_notify.h`). The pipeline states the fact; `darktable.c` installs handlers doing exactly what the old call sites did (the banner handler owns `log_mutex` + `dt_set_main_message` + the redraw; the `g_strdup` moves into the handler since the seam owns the formatted string). With no handler installed the message is dropped — which is what a headless export wants, and what `ansel-cli` now gets without a control loop in the pixel path.

`pixelpipe_raster_masks.c` also stops using `widgets/label.h`'s `delete_underscore()` — which is `dt_string_replace(s, "_")` and nothing else, the same discovery `history.c` made in #1130. That file is textually `#include`d into `pixelpipe_hb.c`, so its two guarded includes are now named in the file that uses them rather than inherited from the host TU.

## Measurable outcome

- `tiling.c`, `blend.c`, `pixelpipe_gpu.c`: **zero `control/` includes.**
- `pixelpipe_raster_masks.c`: **zero upward includes.**
- `pixelpipe_hb.c`: down to `control/signal.h` for the one `CACHELINE_READY` raise that is T5's business — the cache-wait manager moves whole, not piecemeal.

## Verification

- Release, Debug (`-Werror`), nofeatures build; ctest 7/7; all seven gates pass.
- Headless export A/B on decoded pixel arrays (`_DSC9410.NEF`, `--export_masks 1`, i.e. **through the no-handler path this PR creates**): zero differing pixels, max abs diff 0, against the pre-series reference.
- The GUI-visible side (busy banner appears and clears, error toasts on tiling/OpenCL failure) is behaviour-preserving by construction — same calls, moved into a handler — but only a GUI session with a failure provoked exercises the toast paths; worth a glance in the darkroom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)