### PR TITLE
Develop T3a: the history engine loses its widgets

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -184,6 +184,7 @@ FILE(GLOB SOURCE_FILES
   "develop/develop.c"
   "develop/gui_throttle.c"
   "develop/dev_history.c"
+  "develop/dev_history_gui.c"
   "develop/dev_pixelpipe.c"
   "develop/dev_snapshot.c"
   "develop/imageop.c"

--- a/src/darktable.c
+++ b/src/darktable.c
@@ -142,6 +142,7 @@
 #include "common/l10n.h"
 #include "metadata/metadata.h"
 #include "common/image_notify.h"
+#include "develop/dev_history_gui.h"
 #include "develop/pipeline_notify.h"
 #include "history/notify.h"
 #include "history/presets.h"
@@ -1513,6 +1514,7 @@ int dt_init(int argc, char *argv[], const gboolean init_gui, const gboolean load
    * further up: the signal system does not exist until the line above, and nothing can
    * edit a tag before it does. */
   dt_metadata_set_tags_changed_handler(_metadata_tags_changed);
+  dt_dev_history_gui_init();
   dt_metadata_set_geotags_changed_handler(_metadata_geotags_changed);
   dt_image_notify_set_imported_handler(_image_imported);
   dt_pipeline_set_message_handler(_pipeline_message);

--- a/src/darktable.c
+++ b/src/darktable.c
@@ -778,6 +778,11 @@ static void _history_notify(const char *message)
   dt_control_log("%s", message);
 }
 
+static void _history_toast(const char *message)
+{
+  dt_toast_log("%s", message);
+}
+
 static void _history_changed(const dt_history_change_t what)
 {
   switch(what)
@@ -787,6 +792,9 @@ static void _history_changed(const dt_history_change_t what)
       break;
     case DT_HISTORY_CHANGE_STYLES:
       DT_DEBUG_CONTROL_SIGNAL_RAISE(dt_control_signal_get_global(), DT_SIGNAL_STYLE_CHANGED);
+      break;
+    case DT_HISTORY_CHANGE_DEVELOP:
+      DT_DEBUG_CONTROL_SIGNAL_RAISE(dt_control_signal_get_global(), DT_SIGNAL_DEVELOP_HISTORY_CHANGE);
       break;
   }
 }
@@ -1402,6 +1410,7 @@ int dt_init(int argc, char *argv[], const gboolean init_gui, const gboolean load
   dt_database_set_renamed_handler(_database_renamed);
   dt_metadata_set_notify_handler(_metadata_notify);
   dt_history_set_message_handler(_history_notify);
+  dt_history_set_toast_handler(_history_toast);
   dt_presets_set_autoapply_resolver(_presets_can_autoapply);
   dt_history_set_operation_name_resolver(_history_operation_name);
 

--- a/src/develop/dev_history.c
+++ b/src/develop/dev_history.c
@@ -563,6 +563,13 @@ GList *dt_history_duplicate(GList *hist)
 }
 
 /* Installed by dt_dev_history_gui_init(); absent under ansel-cli and in tests. */
+static dt_dev_history_commit_gui_handler_t _commit_gui_handler = NULL;
+
+void dt_dev_history_set_commit_gui_handler(dt_dev_history_commit_gui_handler_t handler)
+{
+  _commit_gui_handler = handler;
+}
+
 static dt_dev_history_undo_restore_gui_handler_t _undo_restore_gui_handler = NULL;
 
 void dt_dev_history_set_undo_restore_gui_handler(dt_dev_history_undo_restore_gui_handler_t handler)
@@ -989,192 +996,11 @@ uint64_t dt_dev_history_compute_hash(dt_develop_t *dev)
 }
 
 
-/* ---------------------------------------------------------------------------------------
- * Throttling the history commit, at the one place every widget already goes through.
- *
- * A history commit is not cheap: it records an undo step, takes history_mutex as writer,
- * rehashes the whole history, writes the image cache, rebuilds the masks list, schedules a
- * DB+XMP write, and finally tells the pipes their history changed -- which also raises their
- * `shutdown` atomic, so the worker abandons the frame it is rendering. Running that per step
- * of a slider drag or a combobox scroll blocks the GUI thread often enough that the widget
- * cannot even repaint its own value, and aborts each render before it can finish.
- *
- * Widgets used to dodge that by deferring their own `value-changed` emission through
- * gui_throttle (bauhaus, and a copy of the same dance in nine curve modules). That put the
- * policy in every widget that wanted it and left every other widget without it. The commit
- * is deferred here instead, where all of them already arrive.
- *
- * TWO RULES, and the difference between them matters:
- *
- * 1. NOTHING IS MERGED. A tempting optimisation is to collapse pending requests into one
- *    carrying the union of their flags; do not. Drawn masks, raster masks, module
- *    enable/disable, the mask manager and plain parameter edits each commit differently, and
- *    any merging rule is somewhere to silently drop one of them. The queue is FIFO and every
- *    distinct request is kept, in order.
- *
- * 2. A REPEAT OF THE PENDING TAIL IS NOT A NEW REQUEST. If the last thing queued is already
- *    "commit `module`, enable=`enable`" and that is exactly what is being asked for again,
- *    there is nothing to add: the queued request reads module->params when it drains, so it
- *    necessarily commits the newest value. This is consecutive-duplicate suppression against
- *    the TAIL only -- never a search of the queue, never a combination of two different
- *    requests -- so ordering is exactly preserved. It is what keeps a 300-tick scroll from
- *    queueing 300 commits, which is the whole point: a transient intermediate value of an
- *    ongoing gesture is not a history event.
- *
- * This is a batching window, not a debounce: the timer is armed by the first request and is
- * NOT re-armed by the ones that follow, so a sustained drag keeps committing once per window
- * instead of freezing until the user stops moving.
- *
- * dt_dev_add_history_item_ext() is NOT throttled and never was. Anything that must land
- * before the next statement (bulk history loads, style application, image duplication)
- * already goes through it.
- *
- * GUI thread only, like the commit path it serves ("always called from GUI controls" below),
- * hence no lock -- same contract as gui_throttle's own queue.
- */
+/* The pending-commit throttle queue lives in dev_history_gui.c: it exists to coalesce
+ * slider-drag input on the GTK main loop, and its headless timeout is zero -- the
+ * engine entry it drains into is dt_dev_history_commit_item_now() below. */
 
-typedef struct dt_dev_pending_commit_t
-{
-  dt_develop_t *dev;
-  dt_iop_module_t *module;
-  gboolean enable;
-} dt_dev_pending_commit_t;
-
-static GQueue _pending_commits = G_QUEUE_INIT;
-static guint _pending_commit_source = 0;
-
-static void _commit_history_item_now(dt_develop_t *dev, dt_iop_module_t *module, gboolean enable);
-
-static gboolean _drain_pending_commits(gpointer user_data)
-{
-  (void)user_data;
-
-  _pending_commit_source = 0;
-
-  // Detach the queue before draining: a commit can trigger another one (a module reacting in
-  // post_history_commit), which would push onto the queue we are iterating.
-  GQueue ready = G_QUEUE_INIT;
-  ready.head = _pending_commits.head;
-  ready.tail = _pending_commits.tail;
-  ready.length = _pending_commits.length;
-  g_queue_init(&_pending_commits);
-
-  while(!g_queue_is_empty(&ready))
-  {
-    dt_dev_pending_commit_t *request = (dt_dev_pending_commit_t *)g_queue_pop_head(&ready);
-    _commit_history_item_now(request->dev, request->module, request->enable);
-    dt_free(request);
-  }
-
-  return G_SOURCE_REMOVE;
-}
-
-static void _queue_pending_commit(dt_develop_t *dev, dt_iop_module_t *module, const gboolean enable)
-{
-  // A zero timeout means the user turned throttling off in the preferences (and is also what
-  // a headless run gets, since nothing ever sets one there). Same call, same place, just now.
-  const guint timeout_ms = dt_gui_throttle_get_timeout_ms();
-  if(timeout_ms == 0)
-  {
-    _commit_history_item_now(dev, module, enable);
-    return;
-  }
-
-  // Rule 2 above: a repeat of what is already queued at the tail adds nothing.
-  const dt_dev_pending_commit_t *tail = (const dt_dev_pending_commit_t *)_pending_commits.tail
-                                        ? (const dt_dev_pending_commit_t *)_pending_commits.tail->data
-                                        : NULL;
-  if(!IS_NULL_PTR(tail) && tail->dev == dev && tail->module == module && tail->enable == enable) return;
-
-  dt_dev_pending_commit_t *queued = (dt_dev_pending_commit_t *)calloc(1, sizeof(*queued));
-  if(IS_NULL_PTR(queued))
-  {
-    // Out of memory for a 24-byte record: commit now rather than lose the edit.
-    _commit_history_item_now(dev, module, enable);
-    return;
-  }
-
-  queued->dev = dev;
-  queued->module = module;
-  queued->enable = enable;
-  g_queue_push_tail(&_pending_commits, queued);
-
-  if(!_pending_commit_source)
-    _pending_commit_source = g_timeout_add(timeout_ms, _drain_pending_commits, NULL);
-}
-
-void dt_dev_history_flush_pending_commits(dt_develop_t *dev)
-{
-  // Run them, do not drop them: a pending request IS the user's last edit, and dropping it
-  // would lose the value they left a slider on. Callers invoke this while `dev` is still
-  // whole -- before any pipe node, iop or history teardown -- so committing here is safe,
-  // and it is the only moment at which it still is. A request draining after teardown is the
-  // race CLAUDE.md documents, which corrupts the heap and crashes somewhere unrelated.
-  if(_pending_commit_source)
-  {
-    g_source_remove(_pending_commit_source);
-    _pending_commit_source = 0;
-  }
-
-  GList *iter = _pending_commits.head;
-  while(iter)
-  {
-    GList *next = g_list_next(iter);
-    dt_dev_pending_commit_t *request = (dt_dev_pending_commit_t *)iter->data;
-    if(IS_NULL_PTR(dev) || request->dev == dev)
-    {
-      g_queue_delete_link(&_pending_commits, iter);
-      _commit_history_item_now(request->dev, request->module, request->enable);
-      dt_free(request);
-    }
-    iter = next;
-  }
-
-  // Something else's requests may remain (another dev): give them their timer back.
-  if(!g_queue_is_empty(&_pending_commits))
-  {
-    const guint timeout_ms = dt_gui_throttle_get_timeout_ms();
-    if(timeout_ms > 0) _pending_commit_source = g_timeout_add(timeout_ms, _drain_pending_commits, NULL);
-    else _drain_pending_commits(NULL);
-  }
-}
-
-void dt_dev_history_drop_pending_commits(dt_develop_t *dev)
-{
-  // Last-resort counterpart to the flush, for a `dev` that is already too far gone to commit
-  // to. Nothing should normally be left here by the time this runs.
-  GList *iter = _pending_commits.head;
-  while(iter)
-  {
-    GList *next = g_list_next(iter);
-    dt_dev_pending_commit_t *request = (dt_dev_pending_commit_t *)iter->data;
-    if(IS_NULL_PTR(dev) || request->dev == dev)
-    {
-      g_queue_delete_link(&_pending_commits, iter);
-      dt_free(request);
-    }
-    iter = next;
-  }
-
-  if(_pending_commit_source && g_queue_is_empty(&_pending_commits))
-  {
-    g_source_remove(_pending_commit_source);
-    _pending_commit_source = 0;
-  }
-}
-
-
-// The next 2 functions are always called from GUI controls setting parameters
-// This is why they directly start a pipeline recompute.
-// Otherwise, please keep GUI and pipeline fully separated.
-
-void dt_dev_add_history_item_real(dt_develop_t *dev, dt_iop_module_t *module, gboolean enable, gboolean redraw)
-{
-  (void)redraw;
-  _queue_pending_commit(dev, module, enable);
-}
-
-static void _commit_history_item_now(dt_develop_t *dev, dt_iop_module_t *module, gboolean enable)
+void dt_dev_history_commit_item_now(dt_develop_t *dev, dt_iop_module_t *module, gboolean enable)
 {
   gboolean add_new_pipe_node = FALSE;
 
@@ -1254,20 +1080,11 @@ static void _commit_history_item_now(dt_develop_t *dev, dt_iop_module_t *module,
 
   dt_dev_masks_list_update(dev);
 
-  if(!IS_NULL_PTR(dt_gui_get_global()) && dev->gui_attached && !IS_NULL_PTR(module))
-  {
-    // If module params change the geometry of the ROI,
-    // update immediately so we avoid drawing glitches.
-    if(module->modify_roi_in || module->modify_roi_out)
-      dt_dev_get_thumbnail_size(dev);
-    
-
-    // Changing a parameter of a disabled module enables it,
-    // so update the GUI toggle state to reflect it.
-    dt_gui_freeze_begin(); // don't run GUI callbacks when setting GUI state
-    dt_iop_gui_set_enable_button(module);
-    dt_gui_freeze_end();
-  }
+  // The post-commit presentation work -- refreshing the viewport size when the module
+  // changes ROI geometry, and syncing the enable toggle a param edit may have flipped --
+  // is the GUI half's (dev_history_gui.c), reached through the handler.
+  if(dev->gui_attached && !IS_NULL_PTR(module) && _commit_gui_handler)
+    _commit_gui_handler(dev, module);
   
   // Save history straight away. Regular GUI edits are the only place where
   // we accept an asynchronous write because `dev` is the long-lived darkroom
@@ -1566,42 +1383,8 @@ void dt_dev_pop_history_items(dt_develop_t *dev)
   if(dt_gui_get_global() && dev->gui_attached) dt_gui_freeze_end();
 }
 
-void dt_dev_history_gui_update(dt_develop_t *dev)
-{
-  if(!dev->gui_attached) return;
-
-  // Match the live module instances to the reloaded history before touching GTK.
-  // This loop may remove obsolete instances or expose instances newly created
-  // while reading a style/history from the database.
-  dt_pthread_rwlock_wrlock(&dev->history_mutex);
-  dt_dev_history_refresh_nodes_ext(dev, &dev->iop, dev->history);
-  dt_pthread_rwlock_unlock(&dev->history_mutex);
-
-  dt_gui_freeze_begin();
-
-  for(GList *module = g_list_first(dev->iop); module; module = g_list_next(module))
-  {
-    dt_iop_module_t *mod = (dt_iop_module_t *)(module->data);
-
-    // History reload is backend-only and creates new multi-instances without
-    // GTK state. Attach every missing GUI here, after releasing history_mutex,
-    // so styles and global history actions expose their complete module set.
-    if(!dt_iop_is_hidden(mod) && IS_NULL_PTR(mod->expander))
-    {
-      if(IS_NULL_PTR(mod->widget)) dt_iop_gui_init(mod);
-      dt_iop_gui_set_expander(mod);
-    }
-
-    // Parameters, enabled state, headers and blending controls may all have
-    // changed, therefore refresh every module rather than only history entries.
-    dt_iop_gui_update(mod);
-  }
-
-  dt_dev_masks_list_change(dev);
-  dt_gui_freeze_end();
-
-  dt_dev_signal_modules_moved(dev);
-}
+/* dt_dev_history_gui_update() lives in dev_history_gui.c: it attaches missing GTK
+ * expanders and refreshes every module widget after a backend history reload. */
 
 void dt_dev_history_pixelpipe_update(dt_develop_t *dev, gboolean rebuild)
 {
@@ -2721,7 +2504,8 @@ void dt_dev_history_compress_or_truncate(dt_develop_t *dev)
  * @param history_list History list.
  * @return 0 on success, non-zero on error.
  */
-static int _check_deleted_instances(dt_develop_t *dev, GList **_iop_list, GList *history_list)
+static int _check_deleted_instances(dt_develop_t *dev, GList **_iop_list, GList *history_list,
+                                    GList **removed_gui_modules)
 {
   GList *iop_list = *_iop_list;
   int deleted_module_found = 0;
@@ -2795,21 +2579,6 @@ static int _check_deleted_instances(dt_develop_t *dev, GList **_iop_list, GList 
     {
       deleted_module_found = 1;
 
-      if(dev->gui_module == mod) dt_iop_request_focus(NULL);
-
-      dt_gui_freeze_begin();
-
-      // we remove the plugin effectively
-      if(!dt_iop_is_hidden(mod))
-      {
-        // we just hide the module to avoid lots of gtk critical warnings
-        gtk_widget_hide(mod->expander);
-
-        // this is copied from dt_iop_gui_delete_callback(), not sure why the above sentence...
-        dt_iop_gui_cleanup_module(mod);
-        gtk_widget_destroy(mod->widget);
-      }
-
       iop_list = g_list_delete_link(iop_list, modules);
 
       // remove the module reference from all snapshots
@@ -2818,7 +2587,13 @@ static int _check_deleted_instances(dt_develop_t *dev, GList **_iop_list, GList 
       // don't delete the module, a pipe may still need it
       dev->alliop = g_list_append(dev->alliop, mod);
 
-      dt_gui_freeze_end();
+      // Its widgets used to be destroyed RIGHT HERE, under history_mutex as writer --
+      // GTK teardown inside the engine lock. The caller collects the removed instances
+      // and destroys their widgets after the lock is released; the module is already
+      // unlinked from the iop list and parked in alliop, so nothing re-touches it in
+      // the meantime.
+      if(removed_gui_modules)
+        *removed_gui_modules = g_list_append(*removed_gui_modules, mod);
 
       // and reset the list
       modules = iop_list;
@@ -2968,7 +2743,8 @@ static int _create_deleted_modules(GList **_iop_list, GList *history_list)
 
 // returns 1 if the topology of the pipe has changed, aka it needs a full rebuild
 // 0 means only internal parameters of pipe nodes have change, so it's a mere resync
-int dt_dev_history_refresh_nodes_ext(dt_develop_t *dev, GList **iop, GList *history)
+int dt_dev_history_refresh_nodes_ext(dt_develop_t *dev, GList **iop, GList *history,
+                                     GList **removed_gui_modules)
 {
   GList *iop_list = *iop;
 
@@ -2988,7 +2764,7 @@ int dt_dev_history_refresh_nodes_ext(dt_develop_t *dev, GList **iop, GList *hist
     pipe_remove = 1;
 
   // check if this is a redo of a delete module or an undo of an add module
-  if(_check_deleted_instances(dev, &iop_list, history))
+  if(_check_deleted_instances(dev, &iop_list, history, removed_gui_modules))
     pipe_remove = 1;
 
   *iop = iop_list;

--- a/src/develop/dev_history.c
+++ b/src/develop/dev_history.c
@@ -61,6 +61,7 @@
 #include "control/control.h"
 #include "common/conf.h"
 #include "history/history.h"
+#include "history/notify.h"
 #include "history/presets.h"   // FOR_RAW/FOR_LDR/... matched against the image at auto-apply
 #include "database/history_repository.h"
 
@@ -83,7 +84,6 @@
 #include <glib.h>
 #include "common/hash.h"
 #include "gui/application.h"
-#include "control/signal.h"
 
 static void _process_history_db_entry(dt_develop_t *dev, const int32_t imgid, const int id, const int num,
                                       const int modversion, const char *operation, const void *module_params,
@@ -674,8 +674,11 @@ static void _pop_undo(gpointer user_data, dt_undo_type_t type, dt_undo_data_t da
 
   // Ensure all UI pieces (history treeview, iop order, etc.) resync after undo/redo.
   // Undo callbacks bypass dt_dev_undo_end_record(), so we need to raise the change signal here.
-  if(dt_gui_get_global() && dev->gui_attached && dev == dt_dev_get_global())
-    DT_DEBUG_CONTROL_SIGNAL_RAISE(dt_control_signal_get_global(), DT_SIGNAL_DEVELOP_HISTORY_CHANGE);
+  // The interactive session's panels resync through the changed-handler; the
+  // dev == dt_dev_get_global() test is engine knowledge (only the interactive dev has
+  // panels), so it stays here rather than in the handler.
+  if(dev->gui_attached && dev == dt_dev_get_global())
+    dt_history_changed(DT_HISTORY_CHANGE_DEVELOP);
 }
 
 void dt_dev_history_undo_start_record(dt_develop_t *dev)
@@ -1623,7 +1626,7 @@ void dt_apply_dev_history_update(dt_develop_t *dev)
   // stale ROI -- same fix as _history_apply_history_end() in libs/history.c.
   if(dev->gui_attached) dt_dev_get_thumbnail_size(dev);
   dt_dev_history_pixelpipe_update(dev, TRUE);
-  DT_DEBUG_CONTROL_SIGNAL_RAISE(dt_control_signal_get_global(), DT_SIGNAL_DEVELOP_HISTORY_CHANGE);
+  dt_history_changed(DT_HISTORY_CHANGE_DEVELOP);
 }
 
 /**
@@ -1654,11 +1657,11 @@ void dt_dev_history_notify_change(dt_develop_t *dev, const int32_t imgid)
 {
   if(IS_NULL_PTR(dev) || imgid <= 0) return;
 
-  if(dt_gui_get_global() && dev->gui_attached)
+  if(dev->gui_attached)
   {
     const guint states = dt_dev_mask_history_overload(dev->history, 250);
     if(states > 250)
-      dt_toast_log(_("Image #%i history is storing %d mask states. n"
+      dt_history_toast(_("Image #%i history is storing %d mask states. n"
                      "Consider compressing history and removing unused masks to keep reads/writes manageable."),
                      imgid, states);
   }
@@ -2122,8 +2125,8 @@ static int _sync_params(dt_dev_history_item_t *hist, const void *module_params, 
       fprintf(stderr, "[dev_read_history] module `%s' %s version mismatch: history is %d, dt %d.\n", hist->module->op,
               preset, modversion, hist->module->version());
 
-      dt_control_log(_("module `%s' %s version mismatch: %d != %d"), hist->module->op,
-                      preset, hist->module->version(), modversion);
+      dt_history_message(_("module `%s' %s version mismatch: %d != %d"), hist->module->op,
+                         preset, hist->module->version(), modversion);
 
       dt_free(preset);
       return 1;

--- a/src/develop/dev_history.c
+++ b/src/develop/dev_history.c
@@ -71,7 +71,6 @@
 #include "develop/iop_order.h"
 #include "develop/dev_history.h"
 #include "develop/blend.h"
-#include "develop/blend_gui.h"
 #include "develop/develop.h"
 #include "develop/imageop.h"
 #include "develop/masks.h"
@@ -563,6 +562,14 @@ GList *dt_history_duplicate(GList *hist)
   return g_list_reverse(result);  // list was built in reverse order, so un-reverse it
 }
 
+/* Installed by dt_dev_history_gui_init(); absent under ansel-cli and in tests. */
+static dt_dev_history_undo_restore_gui_handler_t _undo_restore_gui_handler = NULL;
+
+void dt_dev_history_set_undo_restore_gui_handler(dt_dev_history_undo_restore_gui_handler_t handler)
+{
+  _undo_restore_gui_handler = handler;
+}
+
 typedef struct dt_undo_history_t
 {
   GList *before_snapshot, *after_snapshot;
@@ -665,11 +672,9 @@ static void _pop_undo(gpointer user_data, dt_undo_type_t type, dt_undo_data_t da
   {
     dt_masks_set_edit_mode(dev->gui_module, hist->mask_edit_mode);
     dev->gui_module->request_mask_display = hist->request_mask_display;
-    dt_iop_gui_update_blendif(dev->gui_module);
-    dt_iop_gui_blend_data_t *bd = (dt_iop_gui_blend_data_t *)(dev->gui_module->blend_data);
-    if(bd)
-      gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(bd->showmask),
-                                   hist->request_mask_display == DT_DEV_PIXELPIPE_DISPLAY_MASK);
+    // the blending panel's widgets are the GUI half's to poke (dev_history_gui.c)
+    if(_undo_restore_gui_handler)
+      _undo_restore_gui_handler(dev, hist->mask_edit_mode, hist->request_mask_display);
   }
 
   // Ensure all UI pieces (history treeview, iop order, etc.) resync after undo/redo.

--- a/src/develop/dev_history.h
+++ b/src/develop/dev_history.h
@@ -351,6 +351,22 @@ void dt_dev_write_history(struct dt_develop_t *dev, gboolean async);
 void dt_dev_history_gui_update(struct dt_develop_t *dev);
 
 /**
+ * @brief Restores the presentation half of an undo record: the blending panel's mask
+ * toggles for the focused module.
+ *
+ * @details Undo records capture `mask_edit_mode` and `request_mask_display` alongside the
+ * history snapshot, because undoing an edit should also undo what the user was LOOKING at.
+ * Restoring the data half is the engine's job; restoring the widgets is not, so the engine
+ * calls this handler -- installed by dt_dev_history_gui_init(), absent headless -- with the
+ * recorded values (dt_masks_edit_mode_t and dt_dev_pixelpipe_display_mask_t, widened to
+ * int so this header does not need their enums).
+ */
+typedef void (*dt_dev_history_undo_restore_gui_handler_t)(struct dt_develop_t *dev,
+                                                          int mask_edit_mode,
+                                                          int request_mask_display);
+void dt_dev_history_set_undo_restore_gui_handler(dt_dev_history_undo_restore_gui_handler_t handler);
+
+/**
  * @brief Rebuild or resync pixelpipes after backend history changes.
  *
  * @param dev Develop context.

--- a/src/develop/dev_history.h
+++ b/src/develop/dev_history.h
@@ -348,7 +348,20 @@ void dt_dev_write_history(struct dt_develop_t *dev, gboolean async);
  *
  * @param dev Develop context.
  */
+/* Implemented in dev_history_gui.c: attaches missing expanders and refreshes every module
+ * widget after a backend history reload. Declared here because its callers are the ones
+ * already driving the engine, and the signature carries no GTK type. */
 void dt_dev_history_gui_update(struct dt_develop_t *dev);
+
+/**
+ * @brief Commit one history item immediately -- record undo, take history_mutex as
+ * writer, write through, resync the pipes.
+ *
+ * @details The engine core behind dt_dev_add_history_item(): that entry (implemented in
+ * dev_history_gui.c) coalesces slider-drag input through a GTK main-loop timer and drains
+ * into this. Call it directly only where queueing would be wrong.
+ */
+void dt_dev_history_commit_item_now(struct dt_develop_t *dev, struct dt_iop_module_t *module, gboolean enable);
 
 /**
  * @brief Restores the presentation half of an undo record: the blending panel's mask
@@ -365,6 +378,12 @@ typedef void (*dt_dev_history_undo_restore_gui_handler_t)(struct dt_develop_t *d
                                                           int mask_edit_mode,
                                                           int request_mask_display);
 void dt_dev_history_set_undo_restore_gui_handler(dt_dev_history_undo_restore_gui_handler_t handler);
+
+/** @brief Post-commit presentation work: viewport-size refresh for geometry-changing
+ *  modules, and the enable-toggle sync a param edit may have flipped. Installed by
+ *  dt_dev_history_gui_init(); the engine calls it after each immediate commit. */
+typedef void (*dt_dev_history_commit_gui_handler_t)(struct dt_develop_t *dev, struct dt_iop_module_t *module);
+void dt_dev_history_set_commit_gui_handler(dt_dev_history_commit_gui_handler_t handler);
 
 /**
  * @brief Rebuild or resync pixelpipes after backend history changes.
@@ -617,7 +636,13 @@ dt_dev_history_item_t *dt_dev_history_get_last_item_by_module(GList *history_lis
  * @param history History list.
  * @return 0 on success, non-zero on error.
  */
-int dt_dev_history_refresh_nodes_ext(struct dt_develop_t *dev, GList **iop, GList *history);
+/** @param removed_gui_modules When non-NULL, receives the instances unlinked from @p iop.
+ * Their widgets are NOT touched here -- they used to be destroyed inside history_mutex,
+ * which is exactly the GTK-inside-the-engine-lock hazard this parameter removes. The
+ * caller (dt_dev_history_gui_update() in dev_history_gui.c) destroys them after unlock
+ * and frees the list; the modules themselves stay parked in dev->alliop. */
+int dt_dev_history_refresh_nodes_ext(struct dt_develop_t *dev, GList **iop, GList *history,
+                                     GList **removed_gui_modules);
 
 /** truncate history stack */
 void dt_dev_history_truncate(struct dt_develop_t *dev, const int32_t imgid);

--- a/src/develop/dev_history_gui.c
+++ b/src/develop/dev_history_gui.c
@@ -1,0 +1,54 @@
+/*
+    This file is part of Ansel,
+    Copyright (C) 2026 Aurélien PIERRE.
+
+    Ansel is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Ansel is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Ansel.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "develop/dev_history_gui.h"
+
+#include "develop/blend_gui.h"
+#include "develop/dev_history.h"
+#include "develop/develop.h"
+#include "develop/imageop.h"
+#include "develop/pixelpipe_hb.h"
+#include "system/macros.h"
+
+#include <gtk/gtk.h>
+
+/* Undoing an edit also undoes what the user was LOOKING at: the recorded mask-edit view
+ * for the focused module. The data half (dt_masks_set_edit_mode, request_mask_display) is
+ * restored by the engine; this pokes the blending panel's widgets to match. */
+static void _undo_restore_gui(dt_develop_t *dev, const int mask_edit_mode,
+                              const int request_mask_display)
+{
+  (void)mask_edit_mode;   // consumed by the engine's dt_masks_set_edit_mode() call
+
+  dt_iop_gui_update_blendif(dev->gui_module);
+  dt_iop_gui_blend_data_t *bd = (dt_iop_gui_blend_data_t *)(dev->gui_module->blend_data);
+  if(bd)
+    gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(bd->showmask),
+                                 request_mask_display == DT_DEV_PIXELPIPE_DISPLAY_MASK);
+}
+
+void dt_dev_history_gui_init(void)
+{
+  dt_dev_history_set_undo_restore_gui_handler(_undo_restore_gui);
+}
+
+// clang-format off
+// modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py
+// vim: shiftwidth=2 expandtab tabstop=2 cindent
+// kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;
+// clang-format on

--- a/src/develop/dev_history_gui.c
+++ b/src/develop/dev_history_gui.c
@@ -20,6 +20,7 @@
 
 #include "develop/blend_gui.h"
 #include "develop/dev_history.h"
+#include "develop/gui_throttle.h"
 #include "develop/develop.h"
 #include "develop/imageop.h"
 #include "develop/pixelpipe_hb.h"
@@ -42,9 +43,263 @@ static void _undo_restore_gui(dt_develop_t *dev, const int mask_edit_mode,
                                  request_mask_display == DT_DEV_PIXELPIPE_DISPLAY_MASK);
 }
 
+void dt_dev_history_gui_update(dt_develop_t *dev)
+{
+  if(!dev->gui_attached) return;
+
+  // Match the live module instances to the reloaded history before touching GTK.
+  // This loop may remove obsolete instances or expose instances newly created
+  // while reading a style/history from the database.
+  GList *removed = NULL;
+  dt_pthread_rwlock_wrlock(&dev->history_mutex);
+  dt_dev_history_refresh_nodes_ext(dev, &dev->iop, dev->history, &removed);
+  dt_pthread_rwlock_unlock(&dev->history_mutex);
+
+  dt_gui_freeze_begin();
+
+  // Destroy the widgets of the instances the reconciliation removed -- AFTER the lock,
+  // which is the point of the removed-list protocol (see dev_history.h); the modules are
+  // parked in dev->alliop and already unlinked, so nothing else touches them.
+  for(GList *l = removed; l; l = g_list_next(l))
+  {
+    dt_iop_module_t *mod = (dt_iop_module_t *)l->data;
+    if(dev->gui_module == mod) dt_iop_request_focus(NULL);
+    if(!dt_iop_is_hidden(mod) && mod->expander)
+    {
+      // hide first to avoid a burst of gtk critical warnings from the live container
+      gtk_widget_hide(mod->expander);
+      dt_iop_gui_cleanup_module(mod);
+      gtk_widget_destroy(mod->widget);
+    }
+  }
+  g_list_free(removed);
+
+  for(GList *module = g_list_first(dev->iop); module; module = g_list_next(module))
+  {
+    dt_iop_module_t *mod = (dt_iop_module_t *)(module->data);
+
+    // History reload is backend-only and creates new multi-instances without
+    // GTK state. Attach every missing GUI here, after releasing history_mutex,
+    // so styles and global history actions expose their complete module set.
+    if(!dt_iop_is_hidden(mod) && IS_NULL_PTR(mod->expander))
+    {
+      if(IS_NULL_PTR(mod->widget)) dt_iop_gui_init(mod);
+      dt_iop_gui_set_expander(mod);
+    }
+
+    // Parameters, enabled state, headers and blending controls may all have
+    // changed, therefore refresh every module rather than only history entries.
+    dt_iop_gui_update(mod);
+  }
+
+  dt_dev_masks_list_change(dev);
+  dt_gui_freeze_end();
+
+  dt_dev_signal_modules_moved(dev);
+}
+/* ---------------------------------------------------------------------------------------
+ * Throttling the history commit, at the one place every widget already goes through.
+ *
+ * A history commit is not cheap: it records an undo step, takes history_mutex as writer,
+ * rehashes the whole history, writes the image cache, rebuilds the masks list, schedules a
+ * DB+XMP write, and finally tells the pipes their history changed -- which also raises their
+ * `shutdown` atomic, so the worker abandons the frame it is rendering. Running that per step
+ * of a slider drag or a combobox scroll blocks the GUI thread often enough that the widget
+ * cannot even repaint its own value, and aborts each render before it can finish.
+ *
+ * Widgets used to dodge that by deferring their own `value-changed` emission through
+ * gui_throttle (bauhaus, and a copy of the same dance in nine curve modules). That put the
+ * policy in every widget that wanted it and left every other widget without it. The commit
+ * is deferred here instead, where all of them already arrive.
+ *
+ * TWO RULES, and the difference between them matters:
+ *
+ * 1. NOTHING IS MERGED. A tempting optimisation is to collapse pending requests into one
+ *    carrying the union of their flags; do not. Drawn masks, raster masks, module
+ *    enable/disable, the mask manager and plain parameter edits each commit differently, and
+ *    any merging rule is somewhere to silently drop one of them. The queue is FIFO and every
+ *    distinct request is kept, in order.
+ *
+ * 2. A REPEAT OF THE PENDING TAIL IS NOT A NEW REQUEST. If the last thing queued is already
+ *    "commit `module`, enable=`enable`" and that is exactly what is being asked for again,
+ *    there is nothing to add: the queued request reads module->params when it drains, so it
+ *    necessarily commits the newest value. This is consecutive-duplicate suppression against
+ *    the TAIL only -- never a search of the queue, never a combination of two different
+ *    requests -- so ordering is exactly preserved. It is what keeps a 300-tick scroll from
+ *    queueing 300 commits, which is the whole point: a transient intermediate value of an
+ *    ongoing gesture is not a history event.
+ *
+ * This is a batching window, not a debounce: the timer is armed by the first request and is
+ * NOT re-armed by the ones that follow, so a sustained drag keeps committing once per window
+ * instead of freezing until the user stops moving.
+ *
+ * dt_dev_add_history_item_ext() is NOT throttled and never was. Anything that must land
+ * before the next statement (bulk history loads, style application, image duplication)
+ * already goes through it.
+ *
+ * GUI thread only, like the commit path it serves ("always called from GUI controls" below),
+ * hence no lock -- same contract as gui_throttle's own queue.
+ */
+
+typedef struct dt_dev_pending_commit_t
+{
+  dt_develop_t *dev;
+  dt_iop_module_t *module;
+  gboolean enable;
+} dt_dev_pending_commit_t;
+
+static GQueue _pending_commits = G_QUEUE_INIT;
+static guint _pending_commit_source = 0;
+
+
+static gboolean _drain_pending_commits(gpointer user_data)
+{
+  (void)user_data;
+
+  _pending_commit_source = 0;
+
+  // Detach the queue before draining: a commit can trigger another one (a module reacting in
+  // post_history_commit), which would push onto the queue we are iterating.
+  GQueue ready = G_QUEUE_INIT;
+  ready.head = _pending_commits.head;
+  ready.tail = _pending_commits.tail;
+  ready.length = _pending_commits.length;
+  g_queue_init(&_pending_commits);
+
+  while(!g_queue_is_empty(&ready))
+  {
+    dt_dev_pending_commit_t *request = (dt_dev_pending_commit_t *)g_queue_pop_head(&ready);
+    dt_dev_history_commit_item_now(request->dev, request->module, request->enable);
+    dt_free(request);
+  }
+
+  return G_SOURCE_REMOVE;
+}
+
+static void _queue_pending_commit(dt_develop_t *dev, dt_iop_module_t *module, const gboolean enable)
+{
+  // A zero timeout means the user turned throttling off in the preferences (and is also what
+  // a headless run gets, since nothing ever sets one there). Same call, same place, just now.
+  const guint timeout_ms = dt_gui_throttle_get_timeout_ms();
+  if(timeout_ms == 0)
+  {
+    dt_dev_history_commit_item_now(dev, module, enable);
+    return;
+  }
+
+  // Rule 2 above: a repeat of what is already queued at the tail adds nothing.
+  const dt_dev_pending_commit_t *tail = (const dt_dev_pending_commit_t *)_pending_commits.tail
+                                        ? (const dt_dev_pending_commit_t *)_pending_commits.tail->data
+                                        : NULL;
+  if(!IS_NULL_PTR(tail) && tail->dev == dev && tail->module == module && tail->enable == enable) return;
+
+  dt_dev_pending_commit_t *queued = (dt_dev_pending_commit_t *)calloc(1, sizeof(*queued));
+  if(IS_NULL_PTR(queued))
+  {
+    // Out of memory for a 24-byte record: commit now rather than lose the edit.
+    dt_dev_history_commit_item_now(dev, module, enable);
+    return;
+  }
+
+  queued->dev = dev;
+  queued->module = module;
+  queued->enable = enable;
+  g_queue_push_tail(&_pending_commits, queued);
+
+  if(!_pending_commit_source)
+    _pending_commit_source = g_timeout_add(timeout_ms, _drain_pending_commits, NULL);
+}
+
+void dt_dev_history_flush_pending_commits(dt_develop_t *dev)
+{
+  // Run them, do not drop them: a pending request IS the user's last edit, and dropping it
+  // would lose the value they left a slider on. Callers invoke this while `dev` is still
+  // whole -- before any pipe node, iop or history teardown -- so committing here is safe,
+  // and it is the only moment at which it still is. A request draining after teardown is the
+  // race CLAUDE.md documents, which corrupts the heap and crashes somewhere unrelated.
+  if(_pending_commit_source)
+  {
+    g_source_remove(_pending_commit_source);
+    _pending_commit_source = 0;
+  }
+
+  GList *iter = _pending_commits.head;
+  while(iter)
+  {
+    GList *next = g_list_next(iter);
+    dt_dev_pending_commit_t *request = (dt_dev_pending_commit_t *)iter->data;
+    if(IS_NULL_PTR(dev) || request->dev == dev)
+    {
+      g_queue_delete_link(&_pending_commits, iter);
+      dt_dev_history_commit_item_now(request->dev, request->module, request->enable);
+      dt_free(request);
+    }
+    iter = next;
+  }
+
+  // Something else's requests may remain (another dev): give them their timer back.
+  if(!g_queue_is_empty(&_pending_commits))
+  {
+    const guint timeout_ms = dt_gui_throttle_get_timeout_ms();
+    if(timeout_ms > 0) _pending_commit_source = g_timeout_add(timeout_ms, _drain_pending_commits, NULL);
+    else _drain_pending_commits(NULL);
+  }
+}
+
+void dt_dev_history_drop_pending_commits(dt_develop_t *dev)
+{
+  // Last-resort counterpart to the flush, for a `dev` that is already too far gone to commit
+  // to. Nothing should normally be left here by the time this runs.
+  GList *iter = _pending_commits.head;
+  while(iter)
+  {
+    GList *next = g_list_next(iter);
+    dt_dev_pending_commit_t *request = (dt_dev_pending_commit_t *)iter->data;
+    if(IS_NULL_PTR(dev) || request->dev == dev)
+    {
+      g_queue_delete_link(&_pending_commits, iter);
+      dt_free(request);
+    }
+    iter = next;
+  }
+
+  if(_pending_commit_source && g_queue_is_empty(&_pending_commits))
+  {
+    g_source_remove(_pending_commit_source);
+    _pending_commit_source = 0;
+  }
+}
+
+
+// The next 2 functions are always called from GUI controls setting parameters
+// This is why they directly start a pipeline recompute.
+// Otherwise, please keep GUI and pipeline fully separated.
+
+void dt_dev_add_history_item_real(dt_develop_t *dev, dt_iop_module_t *module, gboolean enable, gboolean redraw)
+{
+  (void)redraw;
+  _queue_pending_commit(dev, module, enable);
+}
+
+/* After each immediate commit: keep the viewport geometry and the enable toggle honest. */
+static void _commit_gui(dt_develop_t *dev, dt_iop_module_t *module)
+{
+  // If module params change the geometry of the ROI, update immediately so we avoid
+  // drawing glitches.
+  if(module->modify_roi_in || module->modify_roi_out)
+    dt_dev_get_thumbnail_size(dev);
+
+  // Changing a parameter of a disabled module enables it, so update the GUI toggle state
+  // to reflect it -- frozen, so setting the state does not run its callbacks.
+  dt_gui_freeze_begin();
+  dt_iop_gui_set_enable_button(module);
+  dt_gui_freeze_end();
+}
+
 void dt_dev_history_gui_init(void)
 {
   dt_dev_history_set_undo_restore_gui_handler(_undo_restore_gui);
+  dt_dev_history_set_commit_gui_handler(_commit_gui);
 }
 
 // clang-format off

--- a/src/develop/dev_history_gui.h
+++ b/src/develop/dev_history_gui.h
@@ -1,0 +1,51 @@
+/*
+    This file is part of Ansel,
+    Copyright (C) 2026 Aurélien PIERRE.
+
+    Ansel is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Ansel is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Ansel.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+/** @file develop/dev_history_gui.h
+ *
+ * @brief The GTK half of the history engine, following the blend.c/blend_gui.c pattern.
+ *
+ * @details `dev_history.c` is the history ENGINE -- item lifecycle, commit, replay,
+ * DB read/write, all under `history_mutex` discipline. What lives here is the part that
+ * touches widgets: the handlers the engine calls when presentation state rides along with
+ * an operation (undo records restoring the mask-edit view), installed once at GUI startup.
+ * With nothing installed -- ansel-cli, a unit test -- the engine skips the calls, which is
+ * what headless means.
+ */
+
+#ifndef DT_DEVELOP_DEV_HISTORY_GUI_H
+#define DT_DEVELOP_DEV_HISTORY_GUI_H
+
+#include <glib.h>
+
+G_BEGIN_DECLS
+
+/** @brief Install the history engine's GUI handlers. Called once from dt_init() beside
+ *  the other handler installs -- safe under ansel-cli too, because every handler fires
+ *  only for a dev with a focused GUI module, which a headless dev never has. */
+void dt_dev_history_gui_init(void);
+
+G_END_DECLS
+
+#endif // DT_DEVELOP_DEV_HISTORY_GUI_H
+
+// clang-format off
+// modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py
+// vim: shiftwidth=2 expandtab tabstop=2 cindent
+// kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;
+// clang-format on

--- a/src/history/notify.c
+++ b/src/history/notify.c
@@ -50,6 +50,30 @@ void dt_history_message(const char *format, ...)
   }
 }
 
+static dt_history_toast_handler_t _toast_handler = NULL;
+
+void dt_history_set_toast_handler(dt_history_toast_handler_t handler)
+{
+  _toast_handler = handler;
+}
+
+void dt_history_toast(const char *format, ...)
+{
+  dt_history_toast_handler_t handler = _toast_handler;
+  if(handler == NULL) return;
+
+  va_list args;
+  va_start(args, format);
+  gchar *message = g_strdup_vprintf(format, args);
+  va_end(args);
+
+  if(message)
+  {
+    handler(message);
+    dt_free(message);
+  }
+}
+
 void dt_history_set_changed_handler(dt_history_changed_handler_t handler)
 {
   _changed_handler = handler;

--- a/src/history/notify.h
+++ b/src/history/notify.h
@@ -55,6 +55,11 @@ void dt_history_set_message_handler(dt_history_message_handler_t handler);
  *  string is translated at the call site, because only the call site knows the plural. */
 void dt_history_message(const char *format, ...) G_GNUC_PRINTF(1, 2);
 
+/** @brief Same contract, transient acknowledgement flavour. Was dt_toast_log(). */
+typedef void (*dt_history_toast_handler_t)(const char *message);
+void dt_history_set_toast_handler(dt_history_toast_handler_t handler);
+void dt_history_toast(const char *format, ...) G_GNUC_PRINTF(1, 2);
+
 /** @brief What changed. Each value stands for one signal this code used to raise itself. */
 typedef enum dt_history_change_t
 {
@@ -62,7 +67,11 @@ typedef enum dt_history_change_t
    *  DT_SIGNAL_TAG_CHANGED. */
   DT_HISTORY_CHANGE_TAGS = 0,
   /** A style was created, edited, renamed or deleted. Was DT_SIGNAL_STYLE_CHANGED. */
-  DT_HISTORY_CHANGE_STYLES
+  DT_HISTORY_CHANGE_STYLES,
+  /** The development history of the interactive session changed -- after an undo, or a
+   *  bulk apply. Whoever is showing the history panel or the module order should resync.
+   *  Was DT_SIGNAL_DEVELOP_HISTORY_CHANGE. */
+  DT_HISTORY_CHANGE_DEVELOP
 } dt_history_change_t;
 
 /**


### PR DESCRIPTION
Fourth tranche of `doc/develop-split.md` — the first of T3's three GUI-half extractions, on the smallest file. Three commits, reviewable independently.

## 1 — Four broadcast sites → `history/notify.h`

The engine raised `DT_SIGNAL_DEVELOP_HISTORY_CHANGE` itself (post-undo, post-bulk-apply), toasted the mask-states warning, and logged the module version mismatch. `dt_history_changed()` gains `DT_HISTORY_CHANGE_DEVELOP`; the notify pair gains a toast channel. The `dev == dt_dev_get_global()` guard stays at the call site — only the interactive dev has panels, and that is engine knowledge. `control/signal.h` leaves the file.

## 2 — Undo records stop poking the blending panel

`dt_undo_history_t` records `mask_edit_mode`/`request_mask_display` — undoing an edit also undoes what the user was *looking at*. The data half of the restore stays engine; the widget half (blendif refresh + showmask toggle) goes through a restore handler implemented in the new **`develop/dev_history_gui.c`** and installed from `dt_init()`. That was the last reason `dev_history.c` included `blend_gui.h` — one of the three backend leak sites T1b made visible, now paid off.

## 3 — The engine loses its widgets entirely

- **`dt_dev_history_gui_update()` moves whole** (expander attach + module refresh after backend reload).
- **The pending-commit throttle queue moves with it** — it coalesces slider-drag input on the GTK main loop, and its headless timeout is zero, so `dt_dev_add_history_item_real()` is GUI input policy, not engine. The core it drains into is public now: `dt_dev_history_commit_item_now()`.
- **`_check_deleted_instances()` stops destroying widgets inside `history_mutex` as writer** — the hazard the survey ranked hardest in this file. Engine unlinks, parks in `dev->alliop`, scrubs undo refs, and reports on a removed-list out-parameter; the GUI half destroys after unlock, inside its own freeze window. Same teardown, opposite side of the lock.
- The post-commit presentation block (viewport refresh + enable-toggle sync) is the third handler.

**Result: zero direct GTK or `dt_iop_gui_*` calls in `dev_history.c`** (was 330 GUI lines of 3100).

## Deliberately left, stated not hidden

- Twelve `dt_gui_freeze`/`dt_dev_get_thumbnail_size` gates inside engine functions — headless-safe as they stand; hoisting them into GUI-side wrappers renames call sites tree-wide and is a mechanical follow-up.
- The async DB-write job scheduling (`control/jobs`) — pending a decision on who owns background scheduling.

## Verification

Release, Debug (`-Werror`), nofeatures; ctest 7/7; all seven gates. Headless export A/B on decoded pixels (`_DSC9410.NEF`, `--export_masks 1` — the history **replay** path runs headless): zero differing pixels vs the pre-series reference.

**What only a GUI session exercises**: undo/redo restoring the mask-edit view, slider-drag throttling (the queue moved TUs — behaviour identical by construction), and history reload after style apply / instance deletion (the deferred widget teardown). Worth a darkroom pass on those three before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)