### PR TITLE
Develop T4a: the module GUI becomes an owned object (D3 = 3b)

### DIFF
--- a/src/develop/blend_gui.c
+++ b/src/develop/blend_gui.c
@@ -421,7 +421,7 @@ static gboolean _blendif_are_output_channels_used(const dt_develop_blend_params_
 
 static gboolean _blendif_clean_output_channels(dt_iop_module_t *module)
 {
-  const dt_iop_gui_blend_data_t *const bd = (dt_iop_gui_blend_data_t *)module->blend_data;
+  const dt_iop_gui_blend_data_t *const bd = (dt_iop_gui_blend_data_t *)module->gui->blend_data;
   if(IS_NULL_PTR(bd) || !bd->blendif_support || !bd->blendif_inited) return FALSE;
 
   gboolean changed = FALSE;
@@ -698,7 +698,7 @@ static float magnifier_scale_callback(GtkWidget *self, float inval, int dir)
 static int _blendop_blendif_disp_alternative_worker(GtkWidget *widget, dt_iop_module_t *module, int mode,
                                                     float (*scale_callback)(GtkWidget*, float, int), const char *label)
 {
-  dt_iop_gui_blend_data_t *data = module->blend_data;
+  dt_iop_gui_blend_data_t *data = module->gui->blend_data;
   GtkDarktableGradientSlider *slider = (GtkDarktableGradientSlider *)widget;
 
   int in_out = (slider == data->filter[1].slider) ? 1 : 0;
@@ -740,7 +740,7 @@ static void _blendop_blendif_log_scale_toggled(GtkToggleButton *button, dt_iop_m
 {
   if(dt_gui_widgets_suppressed()) return;
 
-  dt_iop_gui_blend_data_t *data = !IS_NULL_PTR(module) ? module->blend_data : NULL;
+  dt_iop_gui_blend_data_t *data = !IS_NULL_PTR(module) ? module->gui->blend_data : NULL;
   if(IS_NULL_PTR(data) || IS_NULL_PTR(data->channel)) return;
 
   const int in_out = GTK_WIDGET(button) == data->filter[1].log_scale ? 1 : 0;
@@ -796,7 +796,7 @@ static inline int _blendif_print_digits_picker(float value)
 
 static void _update_gradient_slider_pickers(GtkWidget *callback_dummy, dt_iop_module_t *module)
 {
-  dt_iop_gui_blend_data_t *data = module->blend_data;
+  dt_iop_gui_blend_data_t *data = module->gui->blend_data;
   if(callback_dummy == data->colorpicker_set_values
      && !gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(data->colorpicker_set_values)))
   {
@@ -867,7 +867,7 @@ static void _update_gradient_slider_pickers(GtkWidget *callback_dummy, dt_iop_mo
 
 static void _blendop_blendif_update_tab(dt_iop_module_t *module, const int tab)
 {
-  dt_iop_gui_blend_data_t *data = module->blend_data;
+  dt_iop_gui_blend_data_t *data = module->gui->blend_data;
   dt_develop_blend_params_t *bp = module->blend_params;
   dt_develop_blend_params_t *dp = module->default_blendop_params;
   const float epsilon = 1e-6f;
@@ -1145,12 +1145,12 @@ static gboolean _blendop_blendif_showmask_clicked(GtkToggleButton *button, GdkEv
                                  module->request_mask_display != DT_DEV_PIXELPIPE_DISPLAY_NONE);
 
     module->enabled = TRUE;
-    if(module->off) gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(module->off), TRUE);
+    if(module->gui->off) gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(module->gui->off), TRUE);
 
     dt_gui_freeze_begin();
     // (re)set the header mask indicator too
-    if(module->mask_indicator)
-      gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(module->mask_indicator),
+    if(module->gui->mask_indicator)
+      gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(module->gui->mask_indicator),
                                    module->request_mask_display != DT_DEV_PIXELPIPE_DISPLAY_NONE);
     dt_gui_freeze_end();
 
@@ -1172,7 +1172,7 @@ static void _blendop_masks_mode_changed(GtkToggleButton *togglebutton, dt_iop_mo
   const unsigned int bit = GPOINTER_TO_UINT(g_object_get_data(G_OBJECT(togglebutton), "mask-bit"));
   if(!bit) return;
   if(IS_NULL_PTR(module)) return;
-  if(IS_NULL_PTR(module->blend_data)) return;
+  if(IS_NULL_PTR(module->gui) || IS_NULL_PTR(module->gui->blend_data)) return;
 
   uint32_t mask_mode = module->blend_params->mask_mode;
   const gboolean active = gtk_toggle_button_get_active(togglebutton);
@@ -1215,7 +1215,7 @@ static void _blendop_masks_mode_changed(GtkToggleButton *togglebutton, dt_iop_mo
       break;
   }
 
-  dt_iop_gui_blend_data_t *data = module->blend_data;
+  dt_iop_gui_blend_data_t *data = module->gui->blend_data;
   _blendop_masks_mode_callback(mask_mode, data);
   dt_iop_add_remove_mask_indicator(module);
   DT_DEBUG_CONTROL_SIGNAL_RAISE(dt_control_signal_get_global(), DT_SIGNAL_DEVELOP_MASKS_GUI_CHANGED);
@@ -1242,7 +1242,7 @@ static gboolean _blendop_blendif_invert(GtkButton *button, GdkEventButton *event
 {
   if(dt_gui_widgets_suppressed()) return TRUE;
 
-  const dt_iop_gui_blend_data_t *data = module->blend_data;
+  const dt_iop_gui_blend_data_t *data = module->gui->blend_data;
 
   unsigned int toggle_mask = 0;
 
@@ -1289,7 +1289,7 @@ static gboolean _blendop_masks_shape_can_start(GtkWidget *button, dt_iop_module_
 static gboolean _blendop_masks_show_and_edit(GtkWidget *widget, GdkEventButton *event, dt_iop_module_t *self)
 {
   if(dt_gui_widgets_suppressed()) return FALSE;
-  dt_iop_gui_blend_data_t *bd = (dt_iop_gui_blend_data_t *)self->blend_data;
+  dt_iop_gui_blend_data_t *bd = (dt_iop_gui_blend_data_t *)self->gui->blend_data;
 
   if(event->button == 1)
   {
@@ -1626,8 +1626,8 @@ static gboolean _blendop_masks_group_name_focus_out(GtkWidget *widget, GdkEventF
 static void _blendop_masks_refresh_lists(dt_iop_module_t *module)
 {
   if(IS_NULL_PTR(module)) return;
-  if(IS_NULL_PTR(module->blend_data)) return;
-  dt_iop_gui_blend_data_t *bd = (dt_iop_gui_blend_data_t *)module->blend_data;
+  if(IS_NULL_PTR(module->gui) || IS_NULL_PTR(module->gui->blend_data)) return;
+  dt_iop_gui_blend_data_t *bd = (dt_iop_gui_blend_data_t *)module->gui->blend_data;
   if(IS_NULL_PTR(bd)) return;
   if(!GTK_IS_TREE_VIEW(bd->masks_treeview)) return;
   if(!GTK_IS_TREE_VIEW(bd->masks_group_treeview)) return;
@@ -1791,9 +1791,9 @@ static void _blendop_masks_all_name_edited(GtkCellRendererText *cell, gchar *pat
 {
   (void)cell;
   if(IS_NULL_PTR(module)) return;
-  if(IS_NULL_PTR(module->blend_data)) return;
+  if(IS_NULL_PTR(module->gui) || IS_NULL_PTR(module->gui->blend_data)) return;
 
-  dt_iop_gui_blend_data_t *bd = (dt_iop_gui_blend_data_t *)module->blend_data;
+  dt_iop_gui_blend_data_t *bd = (dt_iop_gui_blend_data_t *)module->gui->blend_data;
   GtkTreeModel *model = gtk_tree_view_get_model(GTK_TREE_VIEW(bd->masks_treeview));
   if(!GTK_IS_TREE_MODEL(model)) return;
 
@@ -1849,9 +1849,9 @@ static void _blendop_masks_all_toggled(GtkCellRendererToggle *cell, gchar *path_
   (void)cell;
   if(dt_gui_widgets_suppressed()) return;
   if(IS_NULL_PTR(module)) return;
-  if(IS_NULL_PTR(module->blend_data)) return;
+  if(IS_NULL_PTR(module->gui) || IS_NULL_PTR(module->gui->blend_data)) return;
 
-  dt_iop_gui_blend_data_t *bd = (dt_iop_gui_blend_data_t *)module->blend_data;
+  dt_iop_gui_blend_data_t *bd = (dt_iop_gui_blend_data_t *)module->gui->blend_data;
   GtkTreeModel *model = gtk_tree_view_get_model(GTK_TREE_VIEW(bd->masks_treeview));
   if(!GTK_IS_TREE_MODEL(model)) return;
 
@@ -1955,10 +1955,10 @@ static void _blendop_masks_all_duplicate_callback(GtkWidget *menu_item, dt_iop_m
 static void _blendop_masks_all_rename_callback(GtkWidget *menu_item, dt_iop_module_t *module)
 {
   if(IS_NULL_PTR(module)) return;
-  if(IS_NULL_PTR(module->blend_data)) return;
+  if(IS_NULL_PTR(module->gui) || IS_NULL_PTR(module->gui->blend_data)) return;
 
   const int formid = GPOINTER_TO_INT(g_object_get_data(G_OBJECT(menu_item), "blend-formid"));
-  dt_iop_gui_blend_data_t *bd = (dt_iop_gui_blend_data_t *)module->blend_data;
+  dt_iop_gui_blend_data_t *bd = (dt_iop_gui_blend_data_t *)module->gui->blend_data;
   GtkTreeView *view = GTK_TREE_VIEW(bd->masks_treeview);
   GtkTreeModel *model = gtk_tree_view_get_model(view);
   if(!GTK_IS_TREE_MODEL(model)) return;
@@ -1980,7 +1980,7 @@ static gboolean _blendop_masks_all_handle_left_click(GtkWidget *treeview, GtkTre
   if(IS_NULL_PTR(module)) return FALSE;
   if(IS_NULL_PTR(path) || IS_NULL_PTR(column)) return FALSE;
 
-  dt_iop_gui_blend_data_t *bd = (dt_iop_gui_blend_data_t *)module->blend_data;
+  dt_iop_gui_blend_data_t *bd = (dt_iop_gui_blend_data_t *)module->gui->blend_data;
   if(IS_NULL_PTR(bd) || column != bd->all_shapes_col) return FALSE;
 
   GtkTreeModel *model = gtk_tree_view_get_model(GTK_TREE_VIEW(treeview));
@@ -2022,7 +2022,7 @@ static gboolean _blendop_masks_all_button_pressed(GtkWidget *treeview, GdkEventB
   // Handle left click on the per-row delete icon column.
   if(event->button == GDK_BUTTON_PRIMARY && !IS_NULL_PTR(column))
   {
-    dt_iop_gui_blend_data_t *bd = (dt_iop_gui_blend_data_t *)module->blend_data;
+    dt_iop_gui_blend_data_t *bd = (dt_iop_gui_blend_data_t *)module->gui->blend_data;
     if(!IS_NULL_PTR(bd) && column == bd->all_shapes_delete_col)
     {
       GtkTreeModel *model = gtk_tree_view_get_model(GTK_TREE_VIEW(treeview));
@@ -2237,7 +2237,7 @@ static void _blendop_masks_group_duplicate_callback(GtkWidget *menu_item, dt_iop
 
 static void _blendop_masks_edit_list_toggle(GtkToggleButton *togglebutton, dt_iop_module_t *module)
 {
-  dt_iop_gui_blend_data_t *bd = (dt_iop_gui_blend_data_t *)module->blend_data;
+  dt_iop_gui_blend_data_t *bd = (dt_iop_gui_blend_data_t *)module->gui->blend_data;
 
   if(!GTK_IS_TOGGLE_BUTTON(togglebutton)) return;
 
@@ -2437,7 +2437,7 @@ static gboolean _blendop_masks_group_handle_action_click(GtkWidget *treeview, Gt
                                                          GtkTreeViewColumn *column, dt_iop_module_t *module)
 {
   if(IS_NULL_PTR(module) || IS_NULL_PTR(path) || IS_NULL_PTR(column)) return FALSE;
-  dt_iop_gui_blend_data_t *bd = (dt_iop_gui_blend_data_t *)module->blend_data;
+  dt_iop_gui_blend_data_t *bd = (dt_iop_gui_blend_data_t *)module->gui->blend_data;
   if(IS_NULL_PTR(bd)) return FALSE;
   if(column != bd->group_unlink_col && column != bd->group_delete_col) return FALSE;
 
@@ -2503,7 +2503,7 @@ static gboolean _blendop_masks_group_button_pressed(GtkWidget *treeview, GdkEven
 
   if(formid <= 0 || parentid <= 0) return TRUE;
 
-  dt_iop_gui_blend_data_t *bd = (dt_iop_gui_blend_data_t *)module->blend_data;
+  dt_iop_gui_blend_data_t *bd = (dt_iop_gui_blend_data_t *)module->gui->blend_data;
   dt_masks_form_t *parent_group = dt_masks_get_from_id(module->dev, parentid);
   const int list_length = (parent_group && (parent_group->type & DT_MASKS_GROUP))
                               ? g_list_length(parent_group->points)
@@ -2521,7 +2521,7 @@ static gboolean _blendop_masks_group_query_tooltip(GtkWidget *treeview, gint x, 
                                                    GtkTooltip *tooltip, dt_iop_module_t *module)
 {
   if(IS_NULL_PTR(module) || keyboard_tip) return FALSE;
-  dt_iop_gui_blend_data_t *bd = (dt_iop_gui_blend_data_t *)module->blend_data;
+  dt_iop_gui_blend_data_t *bd = (dt_iop_gui_blend_data_t *)module->gui->blend_data;
   if(IS_NULL_PTR(bd)) return FALSE;
 
   gint bx = 0, by = 0;
@@ -2574,8 +2574,8 @@ static gboolean _blendop_masks_group_find_row(GtkTreeModel *model, GtkTreeIter *
 // the masks library treeview does, so live opacity changes don't rebuild and collapse the tree.
 static void _blendop_masks_group_update_row(dt_iop_module_t *module, const int formid, const int parentid)
 {
-  if(IS_NULL_PTR(module) || IS_NULL_PTR(module->blend_data)) return;
-  dt_iop_gui_blend_data_t *bd = (dt_iop_gui_blend_data_t *)module->blend_data;
+  if(IS_NULL_PTR(module) || IS_NULL_PTR(module->gui) || IS_NULL_PTR(module->gui->blend_data)) return;
+  dt_iop_gui_blend_data_t *bd = (dt_iop_gui_blend_data_t *)module->gui->blend_data;
   if(!GTK_IS_TREE_VIEW(bd->masks_group_treeview)) return;
   GtkTreeModel *model = gtk_tree_view_get_model(GTK_TREE_VIEW(bd->masks_group_treeview));
   if(!GTK_IS_TREE_STORE(model)) return;
@@ -2616,7 +2616,7 @@ static void _blendop_masks_handler_callback(gpointer instance, const int formid,
 gboolean blend_color_picker_apply(dt_iop_module_t *module, GtkWidget *picker, dt_dev_pixelpipe_t *pipe,
                                   dt_dev_pixelpipe_iop_t *piece)
 {
-  dt_iop_gui_blend_data_t *data = module->blend_data;
+  dt_iop_gui_blend_data_t *data = module->gui->blend_data;
 
   if(picker == data->colorpicker_set_values)
   {
@@ -2885,7 +2885,7 @@ static gboolean _blendif_change_blend_colorspace(dt_iop_module_t *module, dt_dev
       }
     }
 
-    dt_iop_gui_blend_data_t *bd = module->blend_data;
+    dt_iop_gui_blend_data_t *bd = module->gui->blend_data;
     const int cst_old = _blendop_blendif_get_picker_colorspace(bd);
     dt_dev_add_history_item(module->dev, module, FALSE, TRUE);
     dt_iop_gui_update(module);
@@ -2908,13 +2908,13 @@ static void _blendif_select_colorspace(GtkMenuItem *menuitem, dt_iop_module_t *m
   dt_develop_blend_colorspace_t cst = GPOINTER_TO_INT(g_object_get_data(G_OBJECT(menuitem), "dt-blend-cst"));
   if(_blendif_change_blend_colorspace(module, cst))
   {
-    gtk_widget_queue_draw(module->widget);
+    gtk_widget_queue_draw(module->gui->widget);
   }
 }
 
 static void _blendif_show_output_channels(GtkMenuItem *menuitem, dt_iop_module_t *module)
 {
-  dt_iop_gui_blend_data_t *bd = (dt_iop_gui_blend_data_t *)module->blend_data;
+  dt_iop_gui_blend_data_t *bd = (dt_iop_gui_blend_data_t *)module->gui->blend_data;
   if(IS_NULL_PTR(bd) || !bd->blendif_support || !bd->blendif_inited) return;
   if(!bd->output_channels_shown)
   {
@@ -2925,7 +2925,7 @@ static void _blendif_show_output_channels(GtkMenuItem *menuitem, dt_iop_module_t
 
 static void _blendif_hide_output_channels(GtkMenuItem *menuitem, dt_iop_module_t *module)
 {
-  dt_iop_gui_blend_data_t *bd = (dt_iop_gui_blend_data_t *)module->blend_data;
+  dt_iop_gui_blend_data_t *bd = (dt_iop_gui_blend_data_t *)module->gui->blend_data;
   if(IS_NULL_PTR(bd) || !bd->blendif_support || !bd->blendif_inited) return;
   if(bd->output_channels_shown)
   {
@@ -2941,7 +2941,7 @@ static void _blendif_hide_output_channels(GtkMenuItem *menuitem, dt_iop_module_t
 static void _blendif_options_callback(GtkButton *button, GdkEventButton *event, dt_iop_module_t *module)
 {
   if(event->button != 1 && event->button != 2) return;
-  const dt_iop_gui_blend_data_t *bd = (dt_iop_gui_blend_data_t *)module->blend_data;
+  const dt_iop_gui_blend_data_t *bd = (dt_iop_gui_blend_data_t *)module->gui->blend_data;
   if(IS_NULL_PTR(bd) || !bd->blendif_support || !bd->blendif_inited) return;
 
   GtkWidget *mi;
@@ -3043,7 +3043,7 @@ static void _blendop_blendif_channel_mask_view(GtkWidget *widget, dt_iop_module_
   // So the not-so-clever workaround inherited from darktable was to flush all cache lines when requesting mask preview,
   // which flushed lines that could be reused later and were only temporarily not needed.
 
-  dt_iop_gui_blend_data_t *data = module->blend_data;
+  dt_iop_gui_blend_data_t *data = module->gui->blend_data;
 
   dt_dev_pixelpipe_display_mask_t new_request_mask_display = module->request_mask_display | mode;
 
@@ -3091,7 +3091,7 @@ static void _blendop_blendif_channel_mask_view_toggle(GtkWidget *widget, dt_iop_
   // So the not-so-clever workaround inherited from darktable was to flush all cache lines when requesting mask preview,
   // which flushed lines that could be reused later and were only temporarily not needed.
 
-  dt_iop_gui_blend_data_t *data = module->blend_data;
+  dt_iop_gui_blend_data_t *data = module->gui->blend_data;
 
   dt_dev_pixelpipe_display_mask_t new_request_mask_display = module->request_mask_display & ~DT_DEV_PIXELPIPE_DISPLAY_STICKY;
 
@@ -3141,7 +3141,7 @@ static void _blendop_blendif_channel_mask_view_toggle(GtkWidget *widget, dt_iop_
  */
 static void _blendop_blendif_sync_channel_display_buttons(dt_iop_module_t *module)
 {
-  dt_iop_gui_blend_data_t *data = !IS_NULL_PTR(module) ? module->blend_data : NULL;
+  dt_iop_gui_blend_data_t *data = !IS_NULL_PTR(module) ? module->gui->blend_data : NULL;
   if(IS_NULL_PTR(data)) return;
 
   const gboolean channel_active
@@ -3171,7 +3171,7 @@ static void _blendop_blendif_channel_display_toggled(GtkToggleButton *button, dt
 {
   if(dt_gui_widgets_suppressed()) return;
 
-  dt_iop_gui_blend_data_t *data = !IS_NULL_PTR(module) ? module->blend_data : NULL;
+  dt_iop_gui_blend_data_t *data = !IS_NULL_PTR(module) ? module->gui->blend_data : NULL;
   if(IS_NULL_PTR(data) || IS_NULL_PTR(data->channel)) return;
 
   const int in_out = GTK_WIDGET(button) == data->filter[1].channel_display ? 1 : 0;
@@ -3237,7 +3237,7 @@ static gboolean _blendop_blendif_enter(GtkWidget *widget, GdkEventCrossing *even
   // which flushed lines that could be reused later and were only temporarily not needed.
 
   if(dt_gui_widgets_suppressed()) return FALSE;
-  dt_iop_gui_blend_data_t *data = module->blend_data;
+  dt_iop_gui_blend_data_t *data = module->gui->blend_data;
 
   dt_dev_pixelpipe_display_mask_t mode = 0;
 
@@ -3304,7 +3304,7 @@ static gboolean _blendop_blendif_leave_delayed(gpointer data)
   // which flushed lines that could be reused later and were only temporarily not needed.
 
   dt_iop_module_t *module = (dt_iop_module_t *)data;
-  dt_iop_gui_blend_data_t *bd = module->blend_data;
+  dt_iop_gui_blend_data_t *bd = module->gui->blend_data;
   int reprocess = 0;
 
   dt_pthread_mutex_lock(&bd->lock);
@@ -3331,7 +3331,7 @@ static gboolean _blendop_blendif_leave_delayed(gpointer data)
 static gboolean _blendop_blendif_leave(GtkWidget *widget, GdkEventCrossing *event, dt_iop_module_t *module)
 {
   if(dt_gui_widgets_suppressed()) return FALSE;
-  dt_iop_gui_blend_data_t *data = module->blend_data;
+  dt_iop_gui_blend_data_t *data = module->gui->blend_data;
 
   // do not immediately switch-off mask/channel display in case user leaves gradient only briefly.
   // instead we activate a handler function that gets triggered after some timeout
@@ -3469,7 +3469,7 @@ void dt_iop_gui_update_blendif(dt_iop_module_t *module)
   // the preview at the far end of the pipe.
   // So the not-so-clever workaround inherited from darktable was to flush all cache lines when requesting mask preview,
   // which flushed lines that could be reused later and were only temporarily not needed.
-  dt_iop_gui_blend_data_t *bd = module->blend_data;
+  dt_iop_gui_blend_data_t *bd = module->gui->blend_data;
 
   if(IS_NULL_PTR(bd) || !bd->blendif_support || !bd->blendif_inited) return;
 
@@ -3540,7 +3540,7 @@ void dt_iop_gui_update_blendif(dt_iop_module_t *module)
 
 void dt_iop_gui_init_blendif(GtkBox *blendw, dt_iop_module_t *module, GtkWidget *blendif_header)
 {
-  dt_iop_gui_blend_data_t *bd = (dt_iop_gui_blend_data_t *)module->blend_data;
+  dt_iop_gui_blend_data_t *bd = (dt_iop_gui_blend_data_t *)module->gui->blend_data;
 
   bd->blendif_box = blendw;
 
@@ -3701,7 +3701,7 @@ void dt_iop_gui_init_blendif(GtkBox *blendw, dt_iop_module_t *module, GtkWidget 
 
 void dt_iop_gui_init_contours(GtkBox *blendw, dt_iop_module_t *module)
 {
-  dt_iop_gui_blend_data_t *bd = (dt_iop_gui_blend_data_t *)module->blend_data;
+  dt_iop_gui_blend_data_t *bd = (dt_iop_gui_blend_data_t *)module->gui->blend_data;
 
   gtk_box_pack_start(blendw, bd->details_slider, FALSE, FALSE, 0);
   gtk_box_pack_start(blendw, bd->blur_radius_slider, FALSE, FALSE, 0);
@@ -3713,7 +3713,7 @@ void dt_iop_gui_init_contours(GtkBox *blendw, dt_iop_module_t *module)
 
 void dt_masks_iop_update(dt_iop_module_t *module)
 {
-  dt_iop_gui_blend_data_t *bd = (dt_iop_gui_blend_data_t *)module->blend_data;
+  dt_iop_gui_blend_data_t *bd = module->gui ? (dt_iop_gui_blend_data_t *)module->gui->blend_data : NULL;
   dt_develop_blend_params_t *bp = module->blend_params;
 
   if(IS_NULL_PTR(bd) || !bd->masks_support || !bd->masks_inited) return;
@@ -3789,7 +3789,7 @@ void dt_masks_iop_update(dt_iop_module_t *module)
 
 void dt_iop_gui_init_masks(GtkBox *blendw, dt_iop_module_t *module)
 {
-  dt_iop_gui_blend_data_t *bd = (dt_iop_gui_blend_data_t *)module->blend_data;
+  dt_iop_gui_blend_data_t *bd = (dt_iop_gui_blend_data_t *)module->gui->blend_data;
 
   bd->masks_box = blendw;
 
@@ -4110,7 +4110,7 @@ static void _raster_value_changed_callback(GtkWidget *widget, struct dt_iop_modu
 
 void dt_iop_gui_update_raster(dt_iop_module_t *module)
 {
-  dt_iop_gui_blend_data_t *bd = (dt_iop_gui_blend_data_t *)module->blend_data;
+  dt_iop_gui_blend_data_t *bd = (dt_iop_gui_blend_data_t *)module->gui->blend_data;
   dt_develop_blend_params_t *bp = module->blend_params;
 
   if(IS_NULL_PTR(bd) || !bd->masks_support || !bd->raster_inited) return;
@@ -4135,7 +4135,7 @@ static void _raster_polarity_callback(GtkToggleButton *togglebutton, dt_iop_modu
 
 void dt_iop_gui_init_raster(GtkBox *blendw, dt_iop_module_t *module)
 {
-  dt_iop_gui_blend_data_t *bd = (dt_iop_gui_blend_data_t *)module->blend_data;
+  dt_iop_gui_blend_data_t *bd = (dt_iop_gui_blend_data_t *)module->gui->blend_data;
 
   bd->raster_box = blendw;
 
@@ -4169,8 +4169,8 @@ void dt_iop_gui_init_raster(GtkBox *blendw, dt_iop_module_t *module)
 
 void dt_iop_gui_cleanup_blending(dt_iop_module_t *module)
 {
-  if(IS_NULL_PTR(module->blend_data)) return;
-  dt_iop_gui_blend_data_t *bd = (dt_iop_gui_blend_data_t *)module->blend_data;
+  if(IS_NULL_PTR(module->gui) || IS_NULL_PTR(module->gui->blend_data)) return;
+  dt_iop_gui_blend_data_t *bd = (dt_iop_gui_blend_data_t *)module->gui->blend_data;
 
   dt_iop_gui_cleanup_blending_body(module);
   DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(dt_control_signal_get_global(), G_CALLBACK(_blendop_masks_handler_callback), module);
@@ -4183,8 +4183,8 @@ void dt_iop_gui_cleanup_blending(dt_iop_module_t *module)
   dt_pthread_mutex_unlock(&bd->lock);
   dt_pthread_mutex_destroy(&bd->lock);
 
-  dt_free(module->blend_data);
-  module->blend_data = NULL;
+  dt_free(module->gui->blend_data);
+  module->gui->blend_data = NULL;
 }
 
 
@@ -4242,9 +4242,9 @@ static GtkWidget *_blendop_create_enable_toggle(dt_iop_module_t *module, const u
 
 static void _blendop_update_top_enable_label(dt_iop_module_t *module)
 {
-  if(IS_NULL_PTR(module) || !module->blend_data) return;
+  if(IS_NULL_PTR(module) || !module->gui->blend_data) return;
 
-  dt_iop_gui_blend_data_t *bd = (dt_iop_gui_blend_data_t *)module->blend_data;
+  dt_iop_gui_blend_data_t *bd = (dt_iop_gui_blend_data_t *)module->gui->blend_data;
   if(!GTK_IS_BUTTON(bd->top_enable)) return;
 
   gchar *clean_name = delete_underscore(module->name());
@@ -4320,7 +4320,7 @@ static void _blendop_sync_toggle_state(GtkWidget *toggle, const gboolean availab
 
 void dt_iop_gui_update_blending(dt_iop_module_t *module)
 {
-  dt_iop_gui_blend_data_t *bd = (dt_iop_gui_blend_data_t *)module->blend_data;
+  dt_iop_gui_blend_data_t *bd = (dt_iop_gui_blend_data_t *)module->gui->blend_data;
 
   if(!(module->flags() & IOP_FLAGS_SUPPORTS_BLENDING) || IS_NULL_PTR(bd)) return;
 
@@ -4632,9 +4632,9 @@ void dt_iop_gui_blending_lose_focus(dt_iop_module_t *module)
 
   const int has_mask_display = module->request_mask_display & (DT_DEV_PIXELPIPE_DISPLAY_MASK | DT_DEV_PIXELPIPE_DISPLAY_CHANNEL);
 
-  if((module->flags() & IOP_FLAGS_SUPPORTS_BLENDING) && module->blend_data)
+  if((module->flags() & IOP_FLAGS_SUPPORTS_BLENDING) && module->gui->blend_data)
   {
-    dt_iop_gui_blend_data_t *bd = (dt_iop_gui_blend_data_t *)module->blend_data;
+    dt_iop_gui_blend_data_t *bd = (dt_iop_gui_blend_data_t *)module->gui->blend_data;
     if(bd->showmask)
       _blendop_toggle_button_set_active(bd->showmask, FALSE);
     module->request_mask_display = DT_DEV_PIXELPIPE_DISPLAY_NONE;
@@ -4669,17 +4669,19 @@ void dt_iop_gui_blending_lose_focus(dt_iop_module_t *module)
 
 void dt_iop_gui_blending_reload_defaults(dt_iop_module_t *module)
 {
-  if(IS_NULL_PTR(module)) return;
-  dt_iop_gui_blend_data_t *bd = module->blend_data;
+  // reached from dt_iop_load_default_params() -- the module-defaults path, which runs
+  // headless too; every other entry in this file exists only under a live GUI
+  if(IS_NULL_PTR(module) || IS_NULL_PTR(module->gui)) return;
+  dt_iop_gui_blend_data_t *bd = module->gui->blend_data;
   if(IS_NULL_PTR(bd) || !bd->blendif_support || !bd->blendif_inited) return;
   bd->output_channels_shown = FALSE;
 }
 
 void dt_iop_gui_cleanup_blending_body(dt_iop_module_t *module)
 {
-  if(IS_NULL_PTR(module) || !module->blend_data) return;
+  if(IS_NULL_PTR(module) || !module->gui->blend_data) return;
 
-  dt_iop_gui_blend_data_t *bd = (dt_iop_gui_blend_data_t *)module->blend_data;
+  dt_iop_gui_blend_data_t *bd = (dt_iop_gui_blend_data_t *)module->gui->blend_data;
   if(IS_NULL_PTR(bd->blending_box)) return;
   dt_pthread_mutex_lock(&bd->lock);
   if(bd->timeout_handle)
@@ -4767,16 +4769,16 @@ void dt_iop_gui_cleanup_blending_body(dt_iop_module_t *module)
   bd->raster_inited = 0;
   bd->blend_modes_csp = DEVELOP_BLEND_CS_NONE;
   bd->channel_tabs_csp = DEVELOP_BLEND_CS_NONE;
-  module->fusion_slider = NULL;
+  module->gui->fusion_slider = NULL;
 }
 
 void dt_iop_gui_init_blending_body(GtkWidget *container, dt_iop_module_t *module)
 {
   if(IS_NULL_PTR(container) || !GTK_IS_WIDGET(container)) return;
   if(!(module->flags() & IOP_FLAGS_SUPPORTS_BLENDING)) return;
-  if(IS_NULL_PTR(module->blend_data)) return;
+  if(IS_NULL_PTR(module->gui) || IS_NULL_PTR(module->gui->blend_data)) return;
 
-  dt_iop_gui_blend_data_t *bd = (dt_iop_gui_blend_data_t *)module->blend_data;
+  dt_iop_gui_blend_data_t *bd = (dt_iop_gui_blend_data_t *)module->gui->blend_data;
   if(bd->blending_box) return;
 
   dt_gui_freeze_begin();
@@ -4875,7 +4877,7 @@ void dt_iop_gui_init_blending_body(GtkWidget *container, dt_iop_module_t *module
   dt_bauhaus_widget_set_field(bd->opacity_slider, &module->blend_params->opacity, DT_INTROSPECTION_TYPE_FLOAT);
   dt_bauhaus_widget_set_label(bd->opacity_slider, N_("opacity"));
   dt_bauhaus_slider_set_format(bd->opacity_slider, "%");
-  module->fusion_slider = bd->opacity_slider;
+  module->gui->fusion_slider = bd->opacity_slider;
   gtk_widget_set_tooltip_text(bd->opacity_slider, _("set the opacity of the blending"));
   g_object_set_data(G_OBJECT(bd->opacity_slider), "dt-blendop-header-update", GINT_TO_POINTER(TRUE));
   gtk_box_pack_start(GTK_BOX(bd->blending_box), bd->opacity_slider, TRUE, TRUE, 0);
@@ -5008,10 +5010,10 @@ void dt_iop_gui_init_blending_body(GtkWidget *container, dt_iop_module_t *module
 
 void dt_iop_gui_init_blending(dt_iop_module_t *module)
 {
-  if(!(module->flags() & IOP_FLAGS_SUPPORTS_BLENDING) || module->blend_data) return;
+  if(!(module->flags() & IOP_FLAGS_SUPPORTS_BLENDING) || module->gui->blend_data) return;
 
-  module->blend_data = g_malloc0(sizeof(dt_iop_gui_blend_data_t));
-  dt_iop_gui_blend_data_t *bd = (dt_iop_gui_blend_data_t *)module->blend_data;
+  module->gui->blend_data = g_malloc0(sizeof(dt_iop_gui_blend_data_t));
+  dt_iop_gui_blend_data_t *bd = (dt_iop_gui_blend_data_t *)module->gui->blend_data;
 
   bd->module = module;
   bd->csp = DEVELOP_BLEND_CS_NONE;

--- a/src/develop/dev_history_gui.c
+++ b/src/develop/dev_history_gui.c
@@ -16,6 +16,7 @@
     along with Ansel.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#include "develop/imageop_gui.h"
 #include "widgets/widget_settings.h"
 #include "develop/dev_history_gui.h"
 
@@ -38,7 +39,9 @@ static void _undo_restore_gui(dt_develop_t *dev, const int mask_edit_mode,
   (void)mask_edit_mode;   // consumed by the engine's dt_masks_set_edit_mode() call
 
   dt_iop_gui_update_blendif(dev->gui_module);
-  dt_iop_gui_blend_data_t *bd = (dt_iop_gui_blend_data_t *)(dev->gui_module->blend_data);
+  dt_iop_gui_blend_data_t *bd = dev->gui_module && dev->gui_module->gui
+                                  ? (dt_iop_gui_blend_data_t *)dev->gui_module->gui->blend_data
+                                  : NULL;
   if(bd)
     gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(bd->showmask),
                                  request_mask_display == DT_DEV_PIXELPIPE_DISPLAY_MASK);
@@ -65,12 +68,12 @@ void dt_dev_history_gui_update(dt_develop_t *dev)
   {
     dt_iop_module_t *mod = (dt_iop_module_t *)l->data;
     if(dev->gui_module == mod) dt_iop_request_focus(NULL);
-    if(!dt_iop_is_hidden(mod) && mod->expander)
+    if(!dt_iop_is_hidden(mod) && mod->gui && mod->gui->expander)
     {
       // hide first to avoid a burst of gtk critical warnings from the live container
-      gtk_widget_hide(mod->expander);
+      gtk_widget_hide(mod->gui->expander);
+      // frees mod->gui and destroys the whole expander/header/widget tree itself
       dt_iop_gui_cleanup_module(mod);
-      gtk_widget_destroy(mod->widget);
     }
   }
   g_list_free(removed);
@@ -82,9 +85,10 @@ void dt_dev_history_gui_update(dt_develop_t *dev)
     // History reload is backend-only and creates new multi-instances without
     // GTK state. Attach every missing GUI here, after releasing history_mutex,
     // so styles and global history actions expose their complete module set.
-    if(!dt_iop_is_hidden(mod) && IS_NULL_PTR(mod->expander))
+    if(!dt_iop_is_hidden(mod) && (IS_NULL_PTR(mod->gui) || IS_NULL_PTR(mod->gui->expander)))
     {
-      if(IS_NULL_PTR(mod->widget)) dt_iop_gui_init(mod);
+      // a backend-created instance has no gui struct at all -- that IS "never initialised"
+      if(IS_NULL_PTR(mod->gui) || IS_NULL_PTR(mod->gui->widget)) dt_iop_gui_init(mod);
       dt_iop_gui_set_expander(mod);
     }
 

--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -68,6 +68,7 @@
 #include <strings.h>
 #include <unistd.h>
 
+#include "develop/imageop_gui.h"
 #include "widgets/widget_settings.h"
 #include "system/atomic.h"
 #include "history/history.h"
@@ -1416,18 +1417,20 @@ void _dev_module_update_multishow(dt_develop_t *dev, struct dt_iop_module_t *mod
                                  ? dt_ioppr_check_can_move_before_iop(dev->iop, module, mod_prev)
                                  : -1.0;
 
-  module->multi_show_new = !(module->flags() & IOP_FLAGS_ONE_INSTANCE);
+  if(IS_NULL_PTR(module->gui)) return;   // headless module: no buttons to update
+
+  module->gui->multi_show_new = !(module->flags() & IOP_FLAGS_ONE_INSTANCE);
   // Never allow deleting the base instance (multi_priority == 0) nor modules limited to one instance.
-  module->multi_show_close =
+  module->gui->multi_show_close =
       (nb_instances > 1 && module->multi_priority > 0 && !(module->flags() & IOP_FLAGS_ONE_INSTANCE));
   if(!IS_NULL_PTR(mod_next))
-    module->multi_show_up = move_next;
+    module->gui->multi_show_up = move_next;
   else
-    module->multi_show_up = 0;
+    module->gui->multi_show_up = 0;
   if(!IS_NULL_PTR(mod_prev))
-    module->multi_show_down = move_prev;
+    module->gui->multi_show_down = move_prev;
   else
-    module->multi_show_down = 0;
+    module->gui->multi_show_down = 0;
 
   // If it's an additional instance supposed to be added by an history item after
   // the current history_end cursor, conceptually it doesn't exist yet,
@@ -1435,7 +1438,7 @@ void _dev_module_update_multishow(dt_develop_t *dev, struct dt_iop_module_t *mod
   if(nb_instances > 1
      && module->multi_priority > 0
      && !g_hash_table_contains(state->modules_in_history, module))
-    gtk_widget_hide(module->expander);
+    gtk_widget_hide(module->gui->expander);
 }
 
 // FIXME: this function should just disappear, as it mixes concepts from multi-instances from before

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -63,6 +63,7 @@
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#include "develop/imageop_gui.h"
 #include "develop/masks_gui.h"
 #include "darktable.h"
 #include "widgets/widget_settings.h"
@@ -324,7 +325,6 @@ void dt_iop_default_init(dt_iop_module_t *module)
   module->default_params = (dt_iop_params_t *)calloc(1, param_size);
 
   module->default_enabled = 0;
-  module->gui_data = NULL;
 
   dt_introspection_field_t *i = module->so->get_introspection_linear();
   while(i->header.type != DT_INTROSPECTION_TYPE_NONE)
@@ -398,9 +398,9 @@ static void _iop_ensure_visible(dt_gui_module_t *m)
   dt_iop_module_t *module = (dt_iop_module_t *)m;
   if(IS_NULL_PTR(module)) return;
 
-  if(!IS_NULL_PTR(module->expander))
+  if(module->gui && !IS_NULL_PTR(module->gui->expander))
   {
-    g_object_set_data(G_OBJECT(module->expander), "dt-modulegroups-switch-from-active-once",
+    g_object_set_data(G_OBJECT(module->gui->expander), "dt-modulegroups-switch-from-active-once",
                       GINT_TO_POINTER(TRUE));
     dt_iop_gui_set_expanded(module, TRUE, TRUE);
   }
@@ -477,12 +477,12 @@ int dt_iop_load_module_so(void *m, const char *libname, const char *module_name)
   return 0;
 }
 
+/* The old inline widget members were zeroed here at load; the gui struct is calloc'd by
+ * dt_iop_gui_init() when (and only when) a GUI attaches, so a headless load must not
+ * touch module->gui at all -- it is NULL by design. */
 int dt_iop_load_module_by_so(dt_iop_module_t *module, dt_iop_module_so_t *so, dt_develop_t *dev)
 {
   module->dev = dev;
-  module->widget = NULL;
-  module->header = NULL;
-  module->off = NULL;
   module->hide_enable_button = 0;
   module->request_color_pick = DT_REQUEST_COLORPICK_OFF;
   module->request_histogram = DT_REQUEST_ONLY_IN_GUI;
@@ -522,9 +522,6 @@ int dt_iop_load_module_by_so(dt_iop_module_t *module, dt_iop_module_so_t *so, dt
   module->process_plain = so->process_plain;
   module->have_introspection = so->have_introspection;
 
-  module->reset_button = NULL;
-  module->presets_button = NULL;
-  module->fusion_slider = NULL;
 
   module->global_data = so->data;
 
@@ -718,7 +715,7 @@ void dt_iop_reload_defaults(dt_iop_module_t *module)
     dt_iop_load_default_params(module);
   }
 
-  if(module->header) dt_iop_gui_update_header(module);
+  if(module->gui && module->gui->header) dt_iop_gui_update_header(module);
 }
 
 

--- a/src/develop/imageop.h
+++ b/src/develop/imageop.h
@@ -313,15 +313,20 @@ typedef struct dt_iop_module_t
   dt_iop_params_t *params, *default_params;
   /** size of individual params struct. */
   int32_t params_size;
-  /** parameters needed if a gui is attached. will be NULL if in export/batch mode. */
-  dt_iop_gui_data_t *gui_data;
-  dt_pthread_mutex_t gui_lock;
   /** other stuff that may be needed by the module, not only in gui mode. */
   dt_iop_global_data_t *global_data;
+
+  /**
+   * The module's interactive half: every widget pointer, the per-module GUI data blob and
+   * its lock, the blending panel state. Allocated by dt_iop_gui_init(), freed by
+   * dt_iop_gui_cleanup_module(), and NULL for every headless module -- "does this module
+   * have a GUI" is this pointer, asked once, instead of fifteen widget NULL-checks.
+   * Defined in develop/imageop_gui.h; this header carries only the name.
+   */
+  struct dt_iop_module_gui_t *gui;
+
   /** blending params */
   struct dt_develop_blend_params_t *blend_params, *default_blendop_params;
-  /** holder for blending ui control */
-  gpointer blend_data;
   struct {
     struct {
       /** if this module generates a mask, is it used later on? needed to decide if the mask should be stored.
@@ -339,29 +344,7 @@ typedef struct dt_iop_module_t
       int id;
     } sink;
   } raster_mask;
-  /** child widget which is added to the GtkExpander. copied from module_so_t. */
-  GtkWidget *widget;
-  /** off button, somewhere in header, common to all plug-ins. A GtkDarktableToggleButton
-   * underneath; declared as the base type so this header does not feed widgets/ to all
-   * ~122 of its consumers — every external user already casts via GTK_TOGGLE_BUTTON(). */
-  GtkWidget *off;
-  /** this is the module header, contains label and buttons */
-  GtkWidget *header;
-  /** this is the module mask indicator, inside header */
-  GtkWidget *mask_indicator;
-  /** expander containing the widget and flag to store expanded state */
-  GtkWidget *expander;
-  gboolean expanded;
-  /** reset parameters button */
-  GtkWidget *reset_button;
-  /** show preset menu button */
-  GtkWidget *presets_button;
-  /** fusion slider */
-  GtkWidget *fusion_slider;
 
-  /** show/hide guide button and combobox */
-  GtkWidget *guides_toggle;
-  GtkWidget *guides_combo;
 
   /** the corresponding SO object */
   dt_iop_module_so_t *so;
@@ -369,14 +352,7 @@ typedef struct dt_iop_module_t
   /** multi-instances things */
   int multi_priority; // user may change this
   char multi_name[128]; // user may change this name
-  gboolean multi_show_close;
-  gboolean multi_show_up;
-  gboolean multi_show_down;
-  gboolean multi_show_new;
-  GtkWidget *multimenu_button;
 
-  /** delayed-event handling */
-  guint timeout_handle;
 
   int (*process_plain)(struct dt_iop_module_t *self, const struct dt_dev_pixelpipe_t *pipe,
                        const struct dt_dev_pixelpipe_iop_t *piece, const void *const i, void *const o);
@@ -417,18 +393,18 @@ gboolean dt_iop_is_hidden(dt_iop_module_t *module);
 /** Check if the module is currently visible in GUI */
 gboolean dt_iop_is_visible(dt_iop_module_t *module);
 
-/** enter a GUI critical section by acquiring gui_data->lock **/
-static inline void dt_iop_gui_enter_critical_section(dt_iop_module_t *const module)
-  ACQUIRE(&module->gui_lock)
-{
-  dt_pthread_mutex_lock(&module->gui_lock);
-}
-/** leave a GUI critical section by releasing gui_data->lock **/
-static inline void dt_iop_gui_leave_critical_section(dt_iop_module_t *const module)
-  RELEASE(&module->gui_lock)
-{
-  dt_pthread_mutex_unlock(&module->gui_lock);
-}
+/** enter/leave a GUI critical section by acquiring gui->gui_lock. Implemented in
+ * imageop_gui.c; tolerate headless callers (no GUI, no GUI data to protect), so
+ * common/iop-autoset.c and friends can call them without seeing the gui struct. */
+void dt_iop_gui_enter_critical_section(dt_iop_module_t *const module);
+void dt_iop_gui_leave_critical_section(dt_iop_module_t *const module);
+
+/** widget-identity helpers for gui/ callers that must not see the gui struct through this
+ * header's forward declaration (the struct lives in imageop_gui.h, layer-wise above them
+ * until the T6 re-stratification). Implemented in imageop_gui.c; all NULL-safe. */
+GtkWidget *dt_iop_gui_get_off(dt_iop_module_t *module);
+gboolean dt_iop_gui_owns_widget(const dt_iop_module_t *module, const GtkWidget *target);
+
 /** cleans up gui of module and of blendops */
 void dt_iop_gui_cleanup_module(dt_iop_module_t *module);
 /** updates the enable button state. (take into account module->enabled and module->hide_enable_button  */
@@ -596,23 +572,8 @@ const char **dt_iop_set_description(dt_iop_module_t *module, const char *main_te
                                     const char *purpose, const char *input,
                                     const char *process, const char *output);
 
-static inline dt_iop_gui_data_t *_iop_gui_alloc(dt_iop_module_t *module, size_t size)
-{
-  // Align so that DT_ALIGNED_ARRAY may be used within gui_data struct
-  module->gui_data = (dt_iop_gui_data_t*)dt_calloc_align(size);
-  dt_pthread_mutex_init(&module->gui_lock,NULL);
-  return module->gui_data;
-}
-#define IOP_GUI_ALLOC(module) \
-  (dt_iop_##module##_gui_data_t *)_iop_gui_alloc(self,sizeof(dt_iop_##module##_gui_data_t))
-
-#define IOP_GUI_FREE \
-  dt_pthread_mutex_destroy(&self->gui_lock);       \
-  if(self->gui_data){                              \
-    dt_free_align(self->gui_data);                 \
-    self->gui_data = NULL;                         \
-  }                                                \
-  self->gui_data = NULL;
+/* _iop_gui_alloc and IOP_GUI_ALLOC/IOP_GUI_FREE live in imageop_gui.h, with the
+ * dt_iop_module_gui_t they operate on. */
 
 /* bring up module rename dialog */
 void dt_iop_gui_rename_module(dt_iop_module_t *module);

--- a/src/develop/imageop_gui.c
+++ b/src/develop/imageop_gui.c
@@ -208,8 +208,8 @@ GtkWidget *dt_bauhaus_slider_from_params(dt_iop_module_t *self, const char *para
     dt_free(str);
   }
 
-  if(!self->widget) self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_GUI_BOX_SPACING);
-  gtk_box_pack_start(GTK_BOX(self->widget), slider, FALSE, FALSE, 0);
+  if(!self->gui->widget) self->gui->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_GUI_BOX_SPACING);
+  gtk_box_pack_start(GTK_BOX(self->gui->widget), slider, FALSE, FALSE, 0);
 
   dt_bauhaus_widget_t *w = DT_BAUHAUS_WIDGET(slider);
   w->use_default_callback = TRUE;
@@ -274,8 +274,8 @@ GtkWidget *dt_bauhaus_combobox_from_params(dt_iop_module_t *self, const char *pa
     dt_free(str);
   }
 
-  if(!self->widget) self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_GUI_BOX_SPACING);
-  gtk_box_pack_start(GTK_BOX(self->widget), combobox, FALSE, FALSE, 0);
+  if(!self->gui->widget) self->gui->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_GUI_BOX_SPACING);
+  gtk_box_pack_start(GTK_BOX(self->gui->widget), combobox, FALSE, FALSE, 0);
 
   dt_bauhaus_widget_t *w = DT_BAUHAUS_WIDGET(combobox);
   w->use_default_callback = TRUE;
@@ -318,8 +318,8 @@ GtkWidget *dt_bauhaus_toggle_from_params(dt_iop_module_t *self, const char *para
   _add_widget_to_module_list(self, button);
 
   dt_free(str);
-  if(!self->widget) self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_GUI_BOX_SPACING);
-  gtk_box_pack_start(GTK_BOX(self->widget), button, FALSE, FALSE, 0);
+  if(!self->gui->widget) self->gui->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_GUI_BOX_SPACING);
+  gtk_box_pack_start(GTK_BOX(self->gui->widget), button, FALSE, FALSE, 0);
 
   return button;
 }
@@ -422,7 +422,7 @@ static void _iop_color_picker_data_ready_callback(gpointer instance, gpointer us
   dt_print(DT_DEBUG_DEV, "[picker] dispatch module=%s picker=%p pipe=%p hash=%" PRIu64 "\n",
            module->op, (void *)picker, (void *)pipe, piece ? piece->global_hash : 0);
 
-  if(!module->blend_data || !blend_color_picker_apply(module, picker, pipe, (dt_dev_pixelpipe_iop_t *)piece))
+  if(!module->gui->blend_data || !blend_color_picker_apply(module, picker, pipe, (dt_dev_pixelpipe_iop_t *)piece))
     module->color_picker_apply(module, picker, pipe, (dt_dev_pixelpipe_iop_t *)piece);
 }
 
@@ -470,7 +470,7 @@ static void _gui_delete_callback(GtkButton *button, dt_iop_module_t *module)
   if(!dt_iop_is_hidden(module))
   {
     // we just hide the module to avoid lots of gtk critical warnings
-    gtk_widget_hide(module->expander);
+    gtk_widget_hide(module->gui->expander);
 
     dt_iop_gui_cleanup_module(module);
     dt_gui_refocus_center();
@@ -535,7 +535,9 @@ static void _gui_delete_callback(GtkButton *button, dt_iop_module_t *module)
 
 gboolean dt_iop_gui_module_is_visible(dt_iop_module_t *module)
 {
-  GtkWidget *expander = module->expander;
+  // callers walk the full dev->iop list: hidden modules (gamma, basebuffer, ...) never get
+  // gui_init() and keep module->gui == NULL -- they are simply not visible
+  GtkWidget *expander = module->gui ? module->gui->expander : NULL;
   return (expander && gtk_widget_is_visible(expander) && !dt_iop_is_hidden(module));
 }
 
@@ -587,7 +589,7 @@ dt_iop_module_t *dt_iop_gui_duplicate(dt_iop_module_t *base, gboolean copy_param
 
     /* add module to right panel */
     dt_iop_gui_set_expander(module);
-    dt_gui_get_global()->scroll_to_header_once = module->expander;
+    dt_gui_get_global()->scroll_to_header_once = module->gui->expander;
 
     dt_iop_reload_defaults(module); // some modules like profiled denoise update the gui in reload_defaults
 
@@ -607,7 +609,7 @@ dt_iop_module_t *dt_iop_gui_duplicate(dt_iop_module_t *base, gboolean copy_param
 
     dt_iop_request_focus(module);
     dt_iop_gui_set_expanded(module, TRUE, FALSE);
-    if(base != module && !IS_NULL_PTR(base->expander)) _gui_set_single_expanded(base, FALSE);
+    if(base != module && !IS_NULL_PTR(base->gui->expander)) _gui_set_single_expanded(base, FALSE);
     dt_iop_gui_update_blending(module);
 
     if(module->dev->gui_attached)
@@ -726,7 +728,9 @@ static gboolean _rename_module_resize(GtkWidget *entry, GdkEventKey *event, dt_i
 
 void dt_iop_gui_rename_module(dt_iop_module_t *module)
 {
-  GtkWidget *focused = gtk_container_get_focus_child(GTK_CONTAINER(module->header));
+  // dt_iop_gui_duplicate() returns NULL when the instance could not be created
+  if(IS_NULL_PTR(module) || IS_NULL_PTR(module->gui) || IS_NULL_PTR(module->gui->header)) return;
+  GtkWidget *focused = gtk_container_get_focus_child(GTK_CONTAINER(module->gui->header));
   if(focused && GTK_IS_ENTRY(focused)) return;
 
   GtkWidget *entry = gtk_entry_new();
@@ -748,7 +752,7 @@ void dt_iop_gui_rename_module(dt_iop_module_t *module)
   g_signal_connect(entry, "style-updated", G_CALLBACK(_rename_module_resize), module);
   g_signal_connect(entry, "changed", G_CALLBACK(_rename_module_resize), module);
 
-  gtk_box_pack_start(GTK_BOX(module->header), entry, TRUE, TRUE, 0);
+  gtk_box_pack_start(GTK_BOX(module->gui->header), entry, TRUE, TRUE, 0);
   gtk_widget_show(entry);
   gtk_widget_grab_focus(entry);
 }
@@ -804,19 +808,19 @@ static gboolean _gui_multiinstance_callback(GtkButton *button, GdkEventButton *e
   item = gtk_menu_item_new_with_label(_("new instance"));
   // gtk_widget_set_tooltip_text(item, _("add a new instance of this module to the pipe"));
   g_signal_connect(G_OBJECT(item), "activate", G_CALLBACK(_gui_copy_callback), module);
-  gtk_widget_set_sensitive(item, module->multi_show_new);
+  gtk_widget_set_sensitive(item, module->gui->multi_show_new);
   gtk_menu_shell_append(menu, item);
 
   item = gtk_menu_item_new_with_label(_("duplicate instance"));
   // gtk_widget_set_tooltip_text(item, _("add a copy of this instance to the pipe"));
   g_signal_connect(G_OBJECT(item), "activate", G_CALLBACK(_gui_duplicate_callback), module);
-  gtk_widget_set_sensitive(item, module->multi_show_new);
+  gtk_widget_set_sensitive(item, module->gui->multi_show_new);
   gtk_menu_shell_append(menu, item);
 
   item = gtk_menu_item_new_with_label(_("delete"));
   // gtk_widget_set_tooltip_text(item, _("delete this instance"));
   g_signal_connect(G_OBJECT(item), "activate", G_CALLBACK(_gui_delete_callback), module);
-  gtk_widget_set_sensitive(item, module->multi_show_close);
+  gtk_widget_set_sensitive(item, module->gui->multi_show_close);
   gtk_menu_shell_append(menu, item);
 
   gtk_menu_shell_append(GTK_MENU_SHELL(menu), gtk_separator_menu_item_new());
@@ -825,12 +829,12 @@ static gboolean _gui_multiinstance_callback(GtkButton *button, GdkEventButton *e
   g_signal_connect(G_OBJECT(item), "activate", G_CALLBACK(_gui_rename_callback), module);
   gtk_menu_shell_append(menu, item);
 
-  if(!IS_NULL_PTR(module->expander))
+  if(!IS_NULL_PTR(module->gui->expander))
   {
-    g_object_set_data(G_OBJECT(module->expander), DT_IOP_HEADER_MENU_OPEN, GINT_TO_POINTER(TRUE));
+    g_object_set_data(G_OBJECT(module->gui->expander), DT_IOP_HEADER_MENU_OPEN, GINT_TO_POINTER(TRUE));
     g_signal_connect_data(G_OBJECT(menu), "deactivate",
                           G_CALLBACK(_iop_plugin_header_menu_deactivate),
-                          g_object_ref(module->expander), (GClosureNotify)g_object_unref, 0);
+                          g_object_ref(module->gui->expander), (GClosureNotify)g_object_unref, 0);
   }
 
   dt_gui_menu_popup(GTK_MENU(menu), GTK_WIDGET(button), GDK_GRAVITY_SOUTH_EAST, GDK_GRAVITY_NORTH_EAST);
@@ -876,12 +880,15 @@ static void _gui_off_callback(GtkToggleButton *togglebutton, gpointer user_data)
 
 gboolean dt_iop_is_visible(dt_iop_module_t *module)
 {
-  return !dt_iop_is_hidden(module) && !IS_NULL_PTR(module->expander) && gtk_widget_is_visible(module->expander);
+  // module->gui is NULL for hidden modules, and for visible ones between dev->iop
+  // construction and gui_init() during darkroom entry
+  return !dt_iop_is_hidden(module) && !IS_NULL_PTR(module->gui) && !IS_NULL_PTR(module->gui->expander)
+         && gtk_widget_is_visible(module->gui->expander);
 }
 
 static void _iop_panel_label(dt_iop_module_t *module)
 {
-  GtkWidget *lab = dt_gui_container_nth_child(GTK_CONTAINER(module->header), IOP_MODULE_LABEL);
+  GtkWidget *lab = dt_gui_container_nth_child(GTK_CONTAINER(module->gui->header), IOP_MODULE_LABEL);
   lab = gtk_bin_get_child(GTK_BIN(lab));
   gtk_widget_set_name(lab, "iop-panel-label");
 
@@ -921,7 +928,8 @@ static void _iop_panel_label(dt_iop_module_t *module)
 
 void dt_iop_gui_update_header(dt_iop_module_t *module)
 {
-  if (IS_NULL_PTR(module->header))                  /* some modules such as overexposed don't actually have a header */
+  if (IS_NULL_PTR(module->gui)) return;                  /* module has no GUI half at all */
+  if (IS_NULL_PTR(module->gui->header))                  /* some modules such as overexposed don't actually have a header */
     return;
 
   // set panel name to display correct multi-instance
@@ -949,30 +957,34 @@ void dt_iop_gui_set_enable_button_icon(GtkWidget *w, dt_iop_module_t *module)
 
 void dt_iop_gui_set_enable_button(dt_iop_module_t *module)
 {
-  if(IS_NULL_PTR(module)) return;
+  if(IS_NULL_PTR(module) || IS_NULL_PTR(module->gui)) return;
 
-  if(module->off)
+  if(module->gui->off)
   {
-    gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(module->off), module->enabled);
+    gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(module->gui->off), module->enabled);
     if(module->hide_enable_button)
-      gtk_widget_set_sensitive(GTK_WIDGET(module->off), FALSE);
+      gtk_widget_set_sensitive(GTK_WIDGET(module->gui->off), FALSE);
     else
-      gtk_widget_set_sensitive(GTK_WIDGET(module->off), TRUE);
+      gtk_widget_set_sensitive(GTK_WIDGET(module->gui->off), TRUE);
 
-    dt_gui_remove_class(GTK_WIDGET(module->off), "dt_iop_enable_forced_on");
-    dt_gui_remove_class(GTK_WIDGET(module->off), "dt_iop_enable_forced_off");
+    dt_gui_remove_class(GTK_WIDGET(module->gui->off), "dt_iop_enable_forced_on");
+    dt_gui_remove_class(GTK_WIDGET(module->gui->off), "dt_iop_enable_forced_off");
     if(module->hide_enable_button)
     {
-      dt_gui_add_class(GTK_WIDGET(module->off),
+      dt_gui_add_class(GTK_WIDGET(module->gui->off),
                        module->enabled ? "dt_iop_enable_forced_on" : "dt_iop_enable_forced_off");
     }
 
-    dt_iop_gui_set_enable_button_icon(GTK_WIDGET(module->off), module);
+    dt_iop_gui_set_enable_button_icon(GTK_WIDGET(module->gui->off), module);
   }
 }
 
 void dt_iop_gui_init(dt_iop_module_t *module)
 {
+  // The module's interactive half exists from here until dt_iop_gui_cleanup_module();
+  // its absence IS the headless flag (see dt_iop_module_gui_t in imageop_gui.h).
+  if(IS_NULL_PTR(module->gui)) module->gui = (dt_iop_module_gui_t *)calloc(1, sizeof(dt_iop_module_gui_t));
+
   // Suppress widget value-changed callbacks for the whole GUI build. Setting a slider's soft
   // range (etc.) in gui_init emits "value-changed", which would re-enter the module's
   // gui_changed handler before its sibling widgets exist and crash on dt_bauhaus_*(NULL)
@@ -1025,8 +1037,11 @@ static void _iop_gui_widget_gone(gpointer user_data, GObject *where_the_object_w
   dt_iop_module_t *module = (dt_iop_module_t *)user_data;
   if(IS_NULL_PTR(module)) return;
 
-  if(module->header == (GtkWidget *)where_the_object_was) module->header = NULL;
-  if(module->expander == (GtkWidget *)where_the_object_was) module->expander = NULL;
+  if(!IS_NULL_PTR(module->gui))
+  {
+    if(module->gui->header == (GtkWidget *)where_the_object_was) module->gui->header = NULL;
+    if(module->gui->expander == (GtkWidget *)where_the_object_was) module->gui->expander = NULL;
+  }
 
   if(IS_NULL_PTR(dt_gui_get_global())) return;
 
@@ -1038,12 +1053,15 @@ static void _iop_gui_widget_gone(gpointer user_data, GObject *where_the_object_w
 void dt_iop_gui_cleanup_module(dt_iop_module_t *module)
 {
   if(IS_NULL_PTR(module)) return;
+  // backend-only modules (hidden, or loaded without gui_init -- see studio-capture.md)
+  // have nothing to clean up here
+  if(IS_NULL_PTR(module->gui)) return;
   dt_gui_module_t *mod = (dt_gui_module_t *)module;
   if(!IS_NULL_PTR(module->dev) && module->dev->gui_module == module) module->dev->gui_module = NULL;
 
   // remove multiple delayed gtk_widget_queue_draw triggers
-  if(module->widget)
-    while(g_idle_remove_by_data(module->widget));
+  if(module->gui->widget)
+    while(g_idle_remove_by_data(module->gui->widget));
 
   // Detach accels. accel_path is only ever set by dt_iop_gui_init() (never for a module that was
   // only backend-loaded, e.g. studio_capture's dev->iop -- see studio-capture.md): a NULL path
@@ -1082,54 +1100,57 @@ void dt_iop_gui_cleanup_module(dt_iop_module_t *module)
   }
   // History refresh can delete pipeline-only modules created for ordering/history
   // resolution. They have a module GUI cleanup callback but no module GUI data.
-  if(module->gui_cleanup && !IS_NULL_PTR(module->gui_data))
+  if(module->gui_cleanup && !IS_NULL_PTR(dt_iop_gui_data(module)))
     module->gui_cleanup(module);
   dt_iop_gui_cleanup_blending(module);
 
   // size-allocate callbacks can still read scroll targets while GTK tears down widgets
   if(!IS_NULL_PTR(dt_gui_get_global()))
   {
-    if(dt_gui_get_global()->scroll_to[0] == module->header || dt_gui_get_global()->scroll_to[0] == module->expander)
+    if(dt_gui_get_global()->scroll_to[0] == module->gui->header || dt_gui_get_global()->scroll_to[0] == module->gui->expander)
       dt_gui_get_global()->scroll_to[0] = NULL;
-    if(dt_gui_get_global()->scroll_to[1] == module->header || dt_gui_get_global()->scroll_to[1] == module->expander)
+    if(dt_gui_get_global()->scroll_to[1] == module->gui->header || dt_gui_get_global()->scroll_to[1] == module->gui->expander)
       dt_gui_get_global()->scroll_to[1] = NULL;
-    if(dt_gui_get_global()->scroll_to_header_once == module->expander)
+    if(dt_gui_get_global()->scroll_to_header_once == module->gui->expander)
       dt_gui_get_global()->scroll_to_header_once = NULL;
   }
 
   /* Release the transient widget tree explicitly. In normal GUI lifetime, these
    * widgets are parented and get destroyed by container teardown. During module
    * probe/init paths, they can stay unparented and would otherwise leak. */
-  if(!IS_NULL_PTR(module->expander) && GTK_IS_WIDGET(module->expander))
+  if(!IS_NULL_PTR(module->gui->expander) && GTK_IS_WIDGET(module->gui->expander))
   {
-    GtkWidget *expander = module->expander;
+    GtkWidget *expander = module->gui->expander;
     g_object_ref_sink(expander);
     gtk_widget_destroy(expander);
     g_object_unref(expander);
   }
   else
   {
-    if(!IS_NULL_PTR(module->header) && GTK_IS_WIDGET(module->header))
+    if(!IS_NULL_PTR(module->gui->header) && GTK_IS_WIDGET(module->gui->header))
     {
-      GtkWidget *header = module->header;
+      GtkWidget *header = module->gui->header;
       g_object_ref_sink(header);
       gtk_widget_destroy(header);
       g_object_unref(header);
     }
 
-    if(!IS_NULL_PTR(module->widget) && GTK_IS_WIDGET(module->widget))
+    if(!IS_NULL_PTR(module->gui->widget) && GTK_IS_WIDGET(module->gui->widget))
     {
-      GtkWidget *widget = module->widget;
+      GtkWidget *widget = module->gui->widget;
       g_object_ref_sink(widget);
       gtk_widget_destroy(widget);
       g_object_unref(widget);
     }
   }
 
-  module->widget = NULL;
-  module->header = NULL;
-  module->expander = NULL;
-  module->off = NULL;
+  module->gui->widget = NULL;
+  module->gui->header = NULL;
+  module->gui->expander = NULL;
+  module->gui->off = NULL;
+
+  dt_free(module->gui);
+  module->gui = NULL;
 }
 
 void dt_iop_gui_update(dt_iop_module_t *module)
@@ -1137,7 +1158,7 @@ void dt_iop_gui_update(dt_iop_module_t *module)
   dt_gui_freeze_begin();
   if(!dt_iop_is_hidden(module))
   {
-    if(module->gui_data)
+    if(dt_iop_gui_data(module))
     {
       dt_bauhaus_update_module(module);
 
@@ -1202,12 +1223,13 @@ static void _presets_popup_callback(GtkButton *button, dt_iop_module_t *module)
 
   dt_gui_presets_popup_menu_show_for_module(module);
 
-  if(!IS_NULL_PTR(module->expander) && !IS_NULL_PTR(dt_gui_get_global()->presets_popup_menu))
+  if(!IS_NULL_PTR(module->gui) && !IS_NULL_PTR(module->gui->expander)
+     && !IS_NULL_PTR(dt_gui_get_global()->presets_popup_menu))
   {
-    g_object_set_data(G_OBJECT(module->expander), DT_IOP_HEADER_MENU_OPEN, GINT_TO_POINTER(TRUE));
+    g_object_set_data(G_OBJECT(module->gui->expander), DT_IOP_HEADER_MENU_OPEN, GINT_TO_POINTER(TRUE));
     g_signal_connect_data(G_OBJECT(dt_gui_get_global()->presets_popup_menu), "deactivate",
                           G_CALLBACK(_iop_plugin_header_menu_deactivate),
-                          g_object_ref(module->expander), (GClosureNotify)g_object_unref, 0);
+                          g_object_ref(module->gui->expander), (GClosureNotify)g_object_unref, 0);
   }
 
   dt_gui_menu_popup(dt_gui_get_global()->presets_popup_menu, GTK_WIDGET(button), GDK_GRAVITY_SOUTH_EAST, GDK_GRAVITY_NORTH_EAST);
@@ -1221,12 +1243,12 @@ void dt_iop_request_focus(dt_iop_module_t *module)
   if(dt_gui_widgets_suppressed() || (out_focus_module == module)) return;
 
   dev->gui_module = module;
-  if(!IS_NULL_PTR(module))
+  if(!IS_NULL_PTR(module) && !IS_NULL_PTR(module->gui))
   {
     const gboolean scroll_new_instance_to_header
-      = (dt_gui_get_global()->scroll_to_header_once == module->expander
-         && !IS_NULL_PTR(module->header) && GTK_IS_WIDGET(module->header));
-    dt_gui_get_global()->scroll_to[1] = scroll_new_instance_to_header ? module->header : module->expander;
+      = (dt_gui_get_global()->scroll_to_header_once == module->gui->expander
+         && !IS_NULL_PTR(module->gui->header) && GTK_IS_WIDGET(module->gui->header));
+    dt_gui_get_global()->scroll_to[1] = scroll_new_instance_to_header ? module->gui->header : module->gui->expander;
   }
 
   /* lets lose the focus of previous focus module*/
@@ -1263,7 +1285,7 @@ void dt_iop_request_focus(dt_iop_module_t *module)
     dt_iop_gui_blending_lose_focus(out_focus_module);
 
     /* redraw the expander */
-    gtk_widget_queue_draw(out_focus_module->expander);
+    if(!IS_NULL_PTR(out_focus_module->gui)) gtk_widget_queue_draw(out_focus_module->gui->expander);
 
     /* and finally collection restore hinter messages */
     dt_collection_hint_message(dt_collection_get_global());
@@ -1284,8 +1306,11 @@ void dt_iop_request_focus(dt_iop_module_t *module)
     if(module->gui_focus) module->gui_focus(module, TRUE);
 
     /* redraw the expander */
-    gtk_widget_queue_draw(module->expander);
-    gtk_widget_grab_focus(module->expander);
+    if(!IS_NULL_PTR(module->gui))
+    {
+      gtk_widget_queue_draw(module->gui->expander);
+      gtk_widget_grab_focus(module->gui->expander);
+    }
 
     /* set the focus on the first child to enable arrow-key navigation and accessibility stuff */
     GList *widget_list = ((dt_gui_module_t *)module)->widget_list;
@@ -1315,15 +1340,17 @@ void dt_iop_request_focus(dt_iop_module_t *module)
 
 static void _gui_set_single_expanded(dt_iop_module_t *module, gboolean expanded)
 {
-  if(IS_NULL_PTR(module->expander)) return;
+  // reached for every module in dev->iop via the collapse_others fan-out: gui-less
+  // (hidden / not-yet-inited) modules have nothing to collapse
+  if(IS_NULL_PTR(module->gui) || IS_NULL_PTR(module->gui->expander)) return;
 
   /* update expander arrow state */
-  dtgtk_expander_set_expanded(DTGTK_EXPANDER(module->expander), expanded);
+  dtgtk_expander_set_expanded(DTGTK_EXPANDER(module->gui->expander), expanded);
 
   /* store expanded state of module.
    * we do that first, so update_expanded won't think it should be visible
    * and undo our changes right away. */
-  module->expanded = expanded;
+  module->gui->expanded = expanded;
 
   /* show / hide plugin widget */
   if(expanded)
@@ -1333,7 +1360,7 @@ static void _gui_set_single_expanded(dt_iop_module_t *module, gboolean expanded)
 
     /* focus the current module */
     for(int k = 0; k < DT_UI_CONTAINER_SIZE; k++)
-      dt_ui_container_focus_widget(dt_gui_get_ui(), k, module->expander);
+      dt_ui_container_focus_widget(dt_gui_get_ui(), k, module->gui->expander);
 
     /* redraw center, iop might have post expose */
     dt_control_queue_redraw_center();
@@ -1348,9 +1375,9 @@ static void _gui_set_single_expanded(dt_iop_module_t *module, gboolean expanded)
   }
 
   if(expanded)
-    dt_gui_add_class(module->expander, "expanded");
+    dt_gui_add_class(module->gui->expander, "expanded");
   else
-    dt_gui_remove_class(module->expander, "expanded");
+    dt_gui_remove_class(module->gui->expander, "expanded");
 
   char var[1024];
   snprintf(var, sizeof(var), "plugins/darkroom/%s/expanded", module->op);
@@ -1365,7 +1392,7 @@ void _iop_dim_all_but(dt_iop_module_t *module, gboolean dim)
     dt_iop_module_t *m = (dt_iop_module_t *)iop->data;
 
     // Handle invisible modules
-    if(IS_NULL_PTR(m) || !m->expander) continue;
+    if(IS_NULL_PTR(m) || !m->gui || !m->gui->expander) continue;
 
     if(dim && m != module)
       dt_gui_add_class(gtk_widget_get_parent(dt_iop_gui_get_pluginui(m)), "module-dimmed");
@@ -1376,7 +1403,7 @@ void _iop_dim_all_but(dt_iop_module_t *module, gboolean dim)
 
 void dt_iop_gui_set_expanded(dt_iop_module_t *module, gboolean expanded, gboolean collapse_others)
 {
-  if(IS_NULL_PTR(module) || !module->expander) return;
+  if(IS_NULL_PTR(module) || !module->gui || !module->gui->expander) return;
   if(collapse_others)
   {
     for(GList *iop = g_list_first(module->dev->iop); iop; iop = g_list_next(iop))
@@ -1388,16 +1415,16 @@ void dt_iop_gui_set_expanded(dt_iop_module_t *module, gboolean expanded, gboolea
 
   _gui_set_single_expanded(module, expanded);
   _iop_dim_all_but((expanded) ? module : NULL, expanded);
-  gtk_widget_queue_draw(module->widget);
+  gtk_widget_queue_draw(module->gui->widget);
 }
 
 void dt_iop_gui_update_expanded(dt_iop_module_t *module)
 {
-  if(IS_NULL_PTR(module->expander)) return;
+  if(IS_NULL_PTR(module->gui->expander)) return;
 
-  const gboolean expanded = module->expanded;
+  const gboolean expanded = module->gui->expanded;
 
-  dtgtk_expander_set_expanded(DTGTK_EXPANDER(module->expander), expanded);
+  dtgtk_expander_set_expanded(DTGTK_EXPANDER(module->gui->expander), expanded);
 }
 
 static gboolean _iop_plugin_body_button_press(GtkWidget *w, GdkEventButton *e, gpointer user_data)
@@ -1433,8 +1460,8 @@ static gboolean _iop_plugin_header_activate(GtkWidget* self, gboolean group_cycl
 static gboolean _iop_plugin_header_child_button_press(GtkWidget *widget, GdkEventButton *event, gpointer user_data)
 {
   dt_iop_module_t *module = (dt_iop_module_t *)user_data;
-  if(module && module->expander)
-    g_object_set_data(G_OBJECT(module->expander), "dt-module-header-child-click", GINT_TO_POINTER(TRUE));
+  if(module && module->gui->expander)
+    g_object_set_data(G_OBJECT(module->gui->expander), "dt-module-header-child-click", GINT_TO_POINTER(TRUE));
 
   return FALSE;
 }
@@ -1448,8 +1475,8 @@ static gboolean _iop_plugin_focus_accel(GtkAccelGroup *accel_group, GObject *acc
 
   // Accel search explicitly targets a module, so allow modulegroups to leave
   // the Pipeline tab once for this focus request.
-  if(iop->expander)
-    g_object_set_data(G_OBJECT(iop->expander), "dt-modulegroups-switch-from-active-once",
+  if(iop->gui->expander)
+    g_object_set_data(G_OBJECT(iop->gui->expander), "dt-modulegroups-switch-from-active-once",
                       GINT_TO_POINTER(TRUE));
 
   return module->focus(module, FALSE);
@@ -1463,8 +1490,8 @@ static gboolean _iop_plugin_enable_accel(GtkAccelGroup *accel_group, GObject *ac
 
   // Direct actions from accel search should prioritize Pipeline when they focus
   // the edited module right after applying the change.
-  if(!IS_NULL_PTR(module->expander))
-    g_object_set_data(G_OBJECT(module->expander), "dt-modulegroups-prefer-active-once",
+  if(!IS_NULL_PTR(module->gui->expander))
+    g_object_set_data(G_OBJECT(module->gui->expander), "dt-modulegroups-prefer-active-once",
                       GINT_TO_POINTER(TRUE));
 
   // Kind of ugly to go through history to change module GUI state
@@ -1488,11 +1515,11 @@ static gboolean _iop_plugin_header_button_press(GtkWidget *w, GdkEventButton *e,
   dt_iop_module_t *module = (dt_iop_module_t *)user_data;
   if(IS_NULL_PTR(module)) return FALSE;
 
-  if(!IS_NULL_PTR(module->expander)
-     && (g_object_get_data(G_OBJECT(module->expander), DT_IOP_HEADER_MENU_OPEN)
-         || g_object_get_data(G_OBJECT(module->expander), DT_IOP_HEADER_MENU_DISMISS_CLICK)))
+  if(!IS_NULL_PTR(module->gui->expander)
+     && (g_object_get_data(G_OBJECT(module->gui->expander), DT_IOP_HEADER_MENU_OPEN)
+         || g_object_get_data(G_OBJECT(module->gui->expander), DT_IOP_HEADER_MENU_DISMISS_CLICK)))
   {
-    g_object_set_data(G_OBJECT(module->expander), DT_IOP_HEADER_IGNORE_RELEASE, GINT_TO_POINTER(TRUE));
+    g_object_set_data(G_OBJECT(module->gui->expander), DT_IOP_HEADER_IGNORE_RELEASE, GINT_TO_POINTER(TRUE));
     return TRUE;
   }
 
@@ -1502,7 +1529,7 @@ static gboolean _iop_plugin_header_button_press(GtkWidget *w, GdkEventButton *e,
 
   if(e->button == 1)
   {
-    if(module->expander) g_object_set_data(G_OBJECT(module->expander), "dt-module-dragged", NULL);
+    if(module->gui->expander) g_object_set_data(G_OBJECT(module->gui->expander), "dt-module-dragged", NULL);
 
     if(!dt_modifier_is(e->state, GDK_CONTROL_MASK))
     {
@@ -1510,8 +1537,8 @@ static gboolean _iop_plugin_header_button_press(GtkWidget *w, GdkEventButton *e,
     }
     else
     {
-      if(module->expander)
-        g_object_set_data(G_OBJECT(module->expander), DT_IOP_HEADER_IGNORE_RELEASE, GINT_TO_POINTER(TRUE));
+      if(module->gui->expander)
+        g_object_set_data(G_OBJECT(module->gui->expander), DT_IOP_HEADER_IGNORE_RELEASE, GINT_TO_POINTER(TRUE));
       dt_iop_gui_rename_module(module);
       return TRUE;
     }
@@ -1530,36 +1557,36 @@ static gboolean _iop_plugin_header_button_release(GtkWidget *w, GdkEventButton *
   if(e->button != 1 || e->type != GDK_BUTTON_RELEASE) return FALSE;
 
   dt_iop_module_t *module = (dt_iop_module_t *)user_data;
-  if(IS_NULL_PTR(module) || !module->expander) return FALSE;
+  if(IS_NULL_PTR(module) || !module->gui->expander) return FALSE;
 
-  if(g_object_get_data(G_OBJECT(module->expander), DT_IOP_HEADER_IGNORE_RELEASE))
+  if(g_object_get_data(G_OBJECT(module->gui->expander), DT_IOP_HEADER_IGNORE_RELEASE))
   {
-    g_object_set_data(G_OBJECT(module->expander), DT_IOP_HEADER_IGNORE_RELEASE, NULL);
+    g_object_set_data(G_OBJECT(module->gui->expander), DT_IOP_HEADER_IGNORE_RELEASE, NULL);
     return TRUE;
   }
 
-  if(g_object_get_data(G_OBJECT(module->expander), DT_IOP_HEADER_MENU_OPEN)
-     || g_object_get_data(G_OBJECT(module->expander), DT_IOP_HEADER_MENU_DISMISS_CLICK))
+  if(g_object_get_data(G_OBJECT(module->gui->expander), DT_IOP_HEADER_MENU_OPEN)
+     || g_object_get_data(G_OBJECT(module->gui->expander), DT_IOP_HEADER_MENU_DISMISS_CLICK))
   {
     return TRUE;
   }
 
-  if(g_object_get_data(G_OBJECT(module->expander), "dt-module-header-child-click"))
+  if(g_object_get_data(G_OBJECT(module->gui->expander), "dt-module-header-child-click"))
   {
-    g_object_set_data(G_OBJECT(module->expander), "dt-module-header-child-click", NULL);
+    g_object_set_data(G_OBJECT(module->gui->expander), "dt-module-header-child-click", NULL);
     return FALSE;
   }
 
-  if(g_object_get_data(G_OBJECT(module->expander), "dt-module-dragged"))
+  if(g_object_get_data(G_OBJECT(module->gui->expander), "dt-module-dragged"))
   {
-    g_object_set_data(G_OBJECT(module->expander), "dt-module-dragged", NULL);
+    g_object_set_data(G_OBJECT(module->gui->expander), "dt-module-dragged", NULL);
     return TRUE;
   }
 
   // make gtk scroll to the module once it updated its allocation size
   const gboolean collapse_others = dt_modifier_is(e->state, GDK_SHIFT_MASK) ? FALSE : TRUE;
   dt_iop_request_focus(module);
-  dt_iop_gui_set_expanded(module, !module->expanded, collapse_others);
+  dt_iop_gui_set_expanded(module, !module->gui->expanded, collapse_others);
 
   return TRUE;
 }
@@ -1569,7 +1596,7 @@ static void _display_mask_indicator_callback(GtkToggleButton *bt, dt_iop_module_
   if(dt_gui_widgets_suppressed()) return;
 
   const gboolean is_active = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(bt));
-  const dt_iop_gui_blend_data_t *bd = (dt_iop_gui_blend_data_t *)module->blend_data;
+  const dt_iop_gui_blend_data_t *bd = (dt_iop_gui_blend_data_t *)module->gui->blend_data;
 
   module->request_mask_display
       &= ~(DT_DEV_PIXELPIPE_DISPLAY_MASK | DT_DEV_PIXELPIPE_DISPLAY_CHANNEL
@@ -1605,7 +1632,7 @@ static void _mask_indicator_get_usage(dt_iop_module_t *module, gboolean *top_ena
 
   if(IS_NULL_PTR(module) || IS_NULL_PTR(module->blend_params)) return;
 
-  const dt_iop_gui_blend_data_t *bd = (const dt_iop_gui_blend_data_t *)module->blend_data;
+  const dt_iop_gui_blend_data_t *bd = (const dt_iop_gui_blend_data_t *)module->gui->blend_data;
   gboolean top = FALSE;
   gboolean raster = FALSE;
   gboolean drawn = FALSE;
@@ -1642,7 +1669,7 @@ static gboolean _mask_indicator_tooltip(GtkWidget *treeview, gint x, gint y, gbo
   (void)kb_mode;
 
   gboolean res = FALSE;
-  if(module->mask_indicator)
+  if(module->gui->mask_indicator)
   {
     gchar *type = _("unknown mask");
     gchar *text;
@@ -1696,15 +1723,15 @@ static gboolean _mask_indicator_tooltip(GtkWidget *treeview, gint x, gint y, gbo
 
 void dt_iop_add_remove_mask_indicator(dt_iop_module_t *module)
 {
-  if(IS_NULL_PTR(module) || IS_NULL_PTR(module->mask_indicator)) return;
+  if(IS_NULL_PTR(module) || IS_NULL_PTR(module->gui) || IS_NULL_PTR(module->gui->mask_indicator)) return;
 
   const gboolean support_blending = (module->flags() & IOP_FLAGS_SUPPORTS_BLENDING) == IOP_FLAGS_SUPPORTS_BLENDING;
 
   if(!support_blending || !module->blend_params)
   {
-    gtk_widget_set_visible(GTK_WIDGET(module->mask_indicator), FALSE);
-    gtk_widget_set_has_tooltip(GTK_WIDGET(module->mask_indicator), FALSE);
-    gtk_widget_set_sensitive(GTK_WIDGET(module->mask_indicator), FALSE);
+    gtk_widget_set_visible(GTK_WIDGET(module->gui->mask_indicator), FALSE);
+    gtk_widget_set_has_tooltip(GTK_WIDGET(module->gui->mask_indicator), FALSE);
+    gtk_widget_set_sensitive(GTK_WIDGET(module->gui->mask_indicator), FALSE);
     return;
   }
 
@@ -1713,9 +1740,9 @@ void dt_iop_add_remove_mask_indicator(dt_iop_module_t *module)
 
   const gboolean use_masks = top_enabled && (raster_used || drawn_used || parametric_used);
 
-  gtk_widget_set_visible(GTK_WIDGET(module->mask_indicator), use_masks);
-  gtk_widget_set_sensitive(GTK_WIDGET(module->mask_indicator), module->enabled);
-  gtk_widget_set_has_tooltip(GTK_WIDGET(module->mask_indicator), use_masks);
+  gtk_widget_set_visible(GTK_WIDGET(module->gui->mask_indicator), use_masks);
+  gtk_widget_set_sensitive(GTK_WIDGET(module->gui->mask_indicator), module->enabled);
+  gtk_widget_set_has_tooltip(GTK_WIDGET(module->gui->mask_indicator), use_masks);
 }
 
 gboolean _iop_tooltip_callback(GtkWidget *widget, gint x, gint y, gboolean keyboard_mode,
@@ -1802,7 +1829,7 @@ void dt_iop_gui_set_expander(dt_iop_module_t *module)
 
   dt_gui_add_class(pluginui_frame, "dt_plugin_ui");
 
-  module->header = header;
+  module->gui->header = header;
 
   /* setup the header box */
   g_signal_connect(G_OBJECT(header_evb), "button-press-event", G_CALLBACK(_iop_plugin_header_button_press), module);
@@ -1849,11 +1876,11 @@ void dt_iop_gui_set_expander(dt_iop_module_t *module)
                    G_CALLBACK(_iop_plugin_header_child_button_press), module);
   g_signal_connect(G_OBJECT(hw[IOP_MODULE_MASK]), "query-tooltip",
                     G_CALLBACK(_mask_indicator_tooltip), module);
-  module->mask_indicator = hw[IOP_MODULE_MASK];
+  module->gui->mask_indicator = hw[IOP_MODULE_MASK];
 
   /* add multi instances menu button */
   hw[IOP_MODULE_INSTANCE] = dtgtk_button_new(dtgtk_cairo_paint_multiinstance, 0, NULL);
-  module->multimenu_button = GTK_WIDGET(hw[IOP_MODULE_INSTANCE]);
+  module->gui->multimenu_button = GTK_WIDGET(hw[IOP_MODULE_INSTANCE]);
   gtk_widget_set_tooltip_text(GTK_WIDGET(hw[IOP_MODULE_INSTANCE]),
                               _("multiple instance actions\nright-click creates new instance"));
   g_signal_connect(G_OBJECT(hw[IOP_MODULE_INSTANCE]), "button-press-event",
@@ -1865,7 +1892,7 @@ void dt_iop_gui_set_expander(dt_iop_module_t *module)
 
   /* add reset button */
   hw[IOP_MODULE_RESET] = dtgtk_button_new(dtgtk_cairo_paint_reset, 0, NULL);
-  module->reset_button = GTK_WIDGET(hw[IOP_MODULE_RESET]);
+  module->gui->reset_button = GTK_WIDGET(hw[IOP_MODULE_RESET]);
   gtk_widget_set_tooltip_text(GTK_WIDGET(hw[IOP_MODULE_RESET]), _("reset parameters\nctrl+click to reapply any automatic presets"));
   g_signal_connect(G_OBJECT(hw[IOP_MODULE_RESET]), "button-press-event",
                    G_CALLBACK(_iop_plugin_header_child_button_press), module);
@@ -1873,7 +1900,7 @@ void dt_iop_gui_set_expander(dt_iop_module_t *module)
 
   /* add preset button if module has implementation */
   hw[IOP_MODULE_PRESETS] = dtgtk_button_new(dtgtk_cairo_paint_presets, 0, NULL);
-  module->presets_button = GTK_WIDGET(hw[IOP_MODULE_PRESETS]);
+  module->gui->presets_button = GTK_WIDGET(hw[IOP_MODULE_PRESETS]);
   if(!(module->flags() & IOP_FLAGS_ONE_INSTANCE))
     gtk_widget_set_tooltip_text(GTK_WIDGET(hw[IOP_MODULE_PRESETS]), _("presets\nright-click to apply on new instance"));
   g_signal_connect(G_OBJECT(hw[IOP_MODULE_PRESETS]), "button-press-event",
@@ -1890,7 +1917,7 @@ void dt_iop_gui_set_expander(dt_iop_module_t *module)
                    G_CALLBACK(_iop_plugin_header_child_button_press), module);
   g_signal_connect(G_OBJECT(switch_button), "toggled", G_CALLBACK(_gui_off_callback), module);
 
-  module->off = switch_button;
+  module->gui->off = switch_button;
   gtk_widget_set_sensitive(GTK_WIDGET(switch_button), !module->hide_enable_button);
 
   /* Wrap the switch in a plain box so the CSS spacing trick that visually tucks it
@@ -1936,34 +1963,37 @@ void dt_iop_gui_set_expander(dt_iop_module_t *module)
   }
 
   /* initialize blending state if supported; the detached widget is hosted by the masks lib */
-  gtk_box_pack_start(GTK_BOX(iopw), module->widget, TRUE, TRUE, 0);
+  gtk_box_pack_start(GTK_BOX(iopw), module->gui->widget, TRUE, TRUE, 0);
   dt_iop_gui_init_blending(module);
-  dt_gui_add_class(module->widget, "dt_plugin_ui_main");
-  dt_gui_add_help_link(module->widget, dt_get_help_url(module->op));
+  dt_gui_add_class(module->gui->widget, "dt_plugin_ui_main");
+  dt_gui_add_help_link(module->gui->widget, dt_get_help_url(module->op));
   gtk_widget_hide(iopw);
 
-  module->expander = expander;
+  module->gui->expander = expander;
   g_object_weak_ref(G_OBJECT(header), _iop_gui_widget_gone, module);
   g_object_weak_ref(G_OBJECT(expander), _iop_gui_widget_gone, module);
 
   /* update header */
   dt_iop_gui_update_header(module);
 
-  gtk_widget_set_hexpand(module->widget, FALSE);
-  gtk_widget_set_vexpand(module->widget, FALSE);
+  gtk_widget_set_hexpand(module->gui->widget, FALSE);
+  gtk_widget_set_vexpand(module->gui->widget, FALSE);
 
   dt_ui_container_add_widget(dt_gui_get_ui(), DT_UI_CONTAINER_PANEL_RIGHT_CENTER, expander);
 }
 
 GtkWidget *dt_iop_gui_get_widget(dt_iop_module_t *module)
 {
-  return dtgtk_expander_get_body(DTGTK_EXPANDER(module->expander));
+  // NULL for a module with no GUI half, the way the flat module->expander was NULL before
+  if(IS_NULL_PTR(module) || IS_NULL_PTR(module->gui) || IS_NULL_PTR(module->gui->expander)) return NULL;
+  return dtgtk_expander_get_body(DTGTK_EXPANDER(module->gui->expander));
 }
 
 GtkWidget *dt_iop_gui_get_pluginui(dt_iop_module_t *module)
 {
   // return gtkframe (pluginui_frame)
-  return dtgtk_expander_get_frame(DTGTK_EXPANDER(module->expander));
+  if(IS_NULL_PTR(module) || IS_NULL_PTR(module->gui) || IS_NULL_PTR(module->gui->expander)) return NULL;
+  return dtgtk_expander_get_frame(DTGTK_EXPANDER(module->gui->expander));
 }
 
 void dt_iop_gui_changed(dt_iop_module_t *action, GtkWidget *widget, gpointer data)
@@ -2115,6 +2145,26 @@ void dt_bauhaus_value_changed_default_callback(GtkWidget *widget)
       fprintf(stderr, "[dt_bauhaus_value_changed_default_callback] invalid bauhaus widget type encountered for %s %s: %i\n", w->label, w->module->name, w->type);
   }
 }
+void dt_iop_gui_enter_critical_section(dt_iop_module_t *const module)
+{
+  if(module->gui) dt_pthread_mutex_lock(&module->gui->gui_lock);
+}
+
+void dt_iop_gui_leave_critical_section(dt_iop_module_t *const module)
+{
+  if(module->gui) dt_pthread_mutex_unlock(&module->gui->gui_lock);
+}
+
+GtkWidget *dt_iop_gui_get_off(dt_iop_module_t *module)
+{
+  return module && module->gui ? module->gui->off : NULL;
+}
+
+gboolean dt_iop_gui_owns_widget(const dt_iop_module_t *module, const GtkWidget *target)
+{
+  return module->gui && (module->gui->expander == (const void *)target || module->gui->header == (const void *)target);
+}
+
 // clang-format off
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py
 // vim: shiftwidth=2 expandtab tabstop=2 cindent

--- a/src/develop/imageop_gui.h
+++ b/src/develop/imageop_gui.h
@@ -26,6 +26,82 @@
 #define DT_DEVELOP_IMAGEOP_GUI_H
 
 #include "develop/imageop.h"
+
+/**
+ * @brief The interactive half of a module instance, owned by the GUI.
+ *
+ * @details Held by dt_iop_module_t as an opaque pointer: allocated in dt_iop_gui_init(),
+ * freed in dt_iop_gui_cleanup_module(), NULL whenever no GUI is attached to the module
+ * (export, thumbnails, ansel-cli, tests). Member names are unchanged from their previous
+ * life directly on dt_iop_module_t: call sites read `module->gui->widget` where they read
+ * `module->widget` before.
+ */
+typedef struct dt_iop_module_gui_t
+{
+  /** parameters needed if a gui is attached. will be NULL if in export/batch mode. */
+  dt_iop_gui_data_t *gui_data;
+  dt_pthread_mutex_t gui_lock;
+  /** holder for blending ui control */
+  gpointer blend_data;
+  /** child widget which is added to the GtkExpander. copied from module_so_t. */
+  GtkWidget *widget;
+  /** off button, somewhere in header, common to all plug-ins. A GtkDarktableToggleButton
+   * underneath; declared as the base type so this header does not feed widgets/ to all
+   * ~122 of its consumers — every external user already casts via GTK_TOGGLE_BUTTON(). */
+  GtkWidget *off;
+  /** this is the module header, contains label and buttons */
+  GtkWidget *header;
+  /** this is the module mask indicator, inside header */
+  GtkWidget *mask_indicator;
+  /** expander containing the widget and flag to store expanded state */
+  GtkWidget *expander;
+  gboolean expanded;
+  /** reset parameters button */
+  GtkWidget *reset_button;
+  /** show preset menu button */
+  GtkWidget *presets_button;
+  /** fusion slider */
+  GtkWidget *fusion_slider;
+  /** show/hide guide button and combobox */
+  GtkWidget *guides_toggle;
+  GtkWidget *guides_combo;
+  gboolean multi_show_close;
+  gboolean multi_show_up;
+  gboolean multi_show_down;
+  gboolean multi_show_new;
+  GtkWidget *multimenu_button;
+  /** delayed-event handling */
+  guint timeout_handle;
+} dt_iop_module_gui_t;
+
+
+/** @brief The module's GUI data blob, NULL-safe for headless callers: IOP process()
+ *  implementations read it for darkroom-only feedback and must get NULL, not a crash,
+ *  when no GUI exists. */
+static inline dt_iop_gui_data_t *dt_iop_gui_data(const struct dt_iop_module_t *m)
+{
+  return m->gui ? m->gui->gui_data : NULL;
+}
+
+static inline dt_iop_gui_data_t *_iop_gui_alloc(dt_iop_module_t *module, size_t size)
+{
+  // Align so that DT_ALIGNED_ARRAY may be used within gui_data struct
+  module->gui->gui_data = (dt_iop_gui_data_t*)dt_calloc_align(size);
+  dt_pthread_mutex_init(&module->gui->gui_lock,NULL);
+  return module->gui->gui_data;
+}
+#define IOP_GUI_ALLOC(module) \
+  (dt_iop_##module##_gui_data_t *)_iop_gui_alloc(self,sizeof(dt_iop_##module##_gui_data_t))
+
+#define IOP_GUI_FREE                                    \
+  dt_pthread_mutex_destroy(&self->gui->gui_lock);       \
+  if(self->gui->gui_data)                               \
+  {                                                     \
+    dt_free_align(self->gui->gui_data);                 \
+    self->gui->gui_data = NULL;                         \
+  }                                                     \
+  self->gui->gui_data = NULL;
+
 #include "widgets/paint.h"   // DTGTKCairoPaintIconFunc, named in three declarations below
 
 #ifdef __cplusplus

--- a/src/develop/masks/masks_gui.c
+++ b/src/develop/masks/masks_gui.c
@@ -2183,7 +2183,8 @@ gboolean dt_masks_form_exit_creation(dt_iop_module_t *module, dt_masks_form_gui_
       }
 
       dt_masks_iop_update(creation_module);
-      dt_iop_gui_blend_data_t *blend_data = (dt_iop_gui_blend_data_t *)creation_module->blend_data;
+      dt_iop_gui_blend_data_t *blend_data
+          = creation_module->gui ? (dt_iop_gui_blend_data_t *)creation_module->gui->blend_data : NULL;
       if(!IS_NULL_PTR(dev) && !IS_NULL_PTR(dev->form_gui))
         dev->form_gui->edit_mode = DT_MASKS_EDIT_FULL;
       if(!IS_NULL_PTR(blend_data) && GTK_IS_TOGGLE_BUTTON(blend_data->masks_edit))
@@ -3375,9 +3376,9 @@ void dt_masks_reset_form_gui(dt_develop_t *dev)
   dt_masks_shape_buttons_deactivate_all(NULL);
   dt_iop_module_t *module = dev->gui_module;
   if(!IS_NULL_PTR(module) && (module->flags() & IOP_FLAGS_SUPPORTS_BLENDING) && !(module->flags() & IOP_FLAGS_NO_MASKS)
-    && !IS_NULL_PTR(module->blend_data))
+    && !IS_NULL_PTR(module->gui) && !IS_NULL_PTR(module->gui->blend_data))
   {
-    dt_iop_gui_blend_data_t *blend_data = (dt_iop_gui_blend_data_t *)module->blend_data;
+    dt_iop_gui_blend_data_t *blend_data = (dt_iop_gui_blend_data_t *)module->gui->blend_data;
     blend_data->masks_shown = DT_MASKS_EDIT_OFF;
     if(!IS_NULL_PTR(blend_data->masks_edit))
       gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(blend_data->masks_edit), 0);
@@ -3391,9 +3392,9 @@ void dt_masks_reset_show_masks_icons(dt_develop_t *dev)
   {
     dt_iop_module_t *module = (dt_iop_module_t *)module_node->data;
     if(module && (module->flags() & IOP_FLAGS_SUPPORTS_BLENDING) && !(module->flags() & IOP_FLAGS_NO_MASKS)
-    && !IS_NULL_PTR(module->blend_data))
+    && !IS_NULL_PTR(module->gui) && !IS_NULL_PTR(module->gui->blend_data))
     {
-      dt_iop_gui_blend_data_t *blend_data = (dt_iop_gui_blend_data_t *)module->blend_data;
+      dt_iop_gui_blend_data_t *blend_data = (dt_iop_gui_blend_data_t *)module->gui->blend_data;
       blend_data->masks_shown = DT_MASKS_EDIT_OFF;
       if(!IS_NULL_PTR(blend_data->masks_edit))
       {
@@ -3460,7 +3461,7 @@ void dt_masks_iop_combo_populate(GtkWidget *widget, void *data)
   // we ensure that the module has focus
   dt_iop_module_t *module = (dt_iop_module_t *)data;
   dt_iop_request_focus(module);
-  dt_iop_gui_blend_data_t *blend_data = (dt_iop_gui_blend_data_t *)module->blend_data;
+  dt_iop_gui_blend_data_t *blend_data = (dt_iop_gui_blend_data_t *)module->gui->blend_data;
 
   // we determine a higher approx of the entry number
   const guint forms_count = g_list_length(module->dev->forms);
@@ -3542,7 +3543,7 @@ void dt_masks_iop_combo_populate(GtkWidget *widget, void *data)
 void dt_masks_iop_value_changed_callback(GtkWidget *widget, struct dt_iop_module_t *module)
 {
   // we get the corresponding value
-  dt_iop_gui_blend_data_t *blend_data = (dt_iop_gui_blend_data_t *)module->blend_data;
+  dt_iop_gui_blend_data_t *blend_data = (dt_iop_gui_blend_data_t *)module->gui->blend_data;
 
   int selection_index = dt_bauhaus_combobox_get(blend_data->masks_combo);
   if(selection_index == 0) return;
@@ -4202,7 +4203,7 @@ void apply_operation(struct dt_masks_form_group_t *group_entry, const dt_masks_s
 void dt_masks_set_edit_mode(struct dt_iop_module_t *module, dt_masks_edit_mode_t value)
 {
   if(IS_NULL_PTR(module)) return;
-  dt_iop_gui_blend_data_t *blend_data = (dt_iop_gui_blend_data_t *)module->blend_data;
+  dt_iop_gui_blend_data_t *blend_data = module->gui ? (dt_iop_gui_blend_data_t *)module->gui->blend_data : NULL;
   if(IS_NULL_PTR(blend_data)) return;
 
   dt_masks_form_t *group_form = NULL;

--- a/src/gui/color_picker_proxy.c
+++ b/src/gui/color_picker_proxy.c
@@ -761,8 +761,8 @@ static gboolean _color_picker_callback_button_press(GtkWidget *button, GdkEventB
     if(prior_picker->module) prior_picker->module->request_color_pick = DT_REQUEST_COLORPICK_OFF;
   }
 
-  if(module && module->off)
-    gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(module->off), TRUE);
+  GtkWidget *off = dt_iop_gui_get_off(module);
+  if(off) gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(off), TRUE);
 
   const GdkModifierType state = !IS_NULL_PTR(e) ? e->state : dt_key_modifier_state();
   const gboolean ctrl_key_pressed = dt_modifier_is(state, GDK_CONTROL_MASK) || (!IS_NULL_PTR(e) && e->button == 3);

--- a/src/gui/presets.c
+++ b/src/gui/presets.c
@@ -799,7 +799,7 @@ void dt_gui_presets_apply_preset(const gchar* name, dt_iop_module_t *module)
 
   dt_iop_gui_update(module);
   dt_dev_add_history_item(dt_dev_get_global(), module, FALSE, TRUE);
-  gtk_widget_queue_draw(module->widget);
+  gtk_widget_queue_draw(dt_iop_gui_get_widget(module));
 }
 
 static void _menuitem_pick_preset(GtkMenuItem *menuitem, dt_iop_module_t *module)
@@ -860,8 +860,11 @@ static gboolean _menuitem_button_released_preset(GtkMenuItem *menuitem, GdkEvent
   else if (event->button == 3)
   {
     dt_iop_module_t *new_module = dt_iop_gui_duplicate(module, FALSE);
-    if(new_module) _menuitem_pick_preset(menuitem, new_module);
-    dt_iop_gui_rename_module(new_module);
+    if(new_module)
+    {
+      _menuitem_pick_preset(menuitem, new_module);
+      dt_iop_gui_rename_module(new_module);
+    }
   }
 
   return FALSE;

--- a/src/gui/window_manager.c
+++ b/src/gui/window_manager.c
@@ -323,7 +323,7 @@ static gboolean _ui_scroll_target_is_live_widget(const GtkWidget *target, const 
     {
       const dt_iop_module_t *module = (const dt_iop_module_t *)iops->data;
       if(IS_NULL_PTR(module)) continue;
-      if(module->expander == target || module->header == target) return TRUE;
+      if(dt_iop_gui_owns_widget(module, target)) return TRUE;
     }
   }
 

--- a/src/iop/ashift.c
+++ b/src/iop/ashift.c
@@ -663,7 +663,7 @@ int legacy_params(dt_iop_module_t *self, const void *const old_params, const int
 // or the GUI private copy if editing.
 dt_iop_ashift_params_t * _get_ashift_params(dt_iop_module_t *self)
 {
-  dt_iop_ashift_gui_data_t *g = (dt_iop_ashift_gui_data_t *)self->gui_data;
+  dt_iop_ashift_gui_data_t *g = (dt_iop_ashift_gui_data_t *)dt_iop_gui_data(self);
   if(!IS_NULL_PTR(g) && g->editing)
     return &g->new_params;
   else
@@ -1604,7 +1604,7 @@ error:
 // get image from buffer, analyze for structure and save results
 static int _get_structure(dt_iop_module_t *module, dt_iop_ashift_enhance_t enhance)
 {
-  dt_iop_ashift_gui_data_t *g = (dt_iop_ashift_gui_data_t *)module->gui_data;
+  dt_iop_ashift_gui_data_t *g = (dt_iop_ashift_gui_data_t *)dt_iop_gui_data(module);
 
   float *buffer = NULL;
   int width = 0;
@@ -1630,6 +1630,10 @@ static int _get_structure(dt_iop_module_t *module, dt_iop_ashift_enhance_t enhan
   }
   dt_iop_gui_leave_critical_section(module);
 
+  // declared before the first `goto error` and NULL-initialised, so the error path may
+  // free it unconditionally -- line_detect() can fail after allocating
+  dt_iop_ashift_line_t *lines = NULL;
+
   if(IS_NULL_PTR(buffer)) goto error;
 
   // get rid of old structural data
@@ -1637,8 +1641,9 @@ static int _get_structure(dt_iop_module_t *module, dt_iop_ashift_enhance_t enhan
   g->vertical_count = 0;
   g->horizontal_count = 0;
   dt_free(g->lines);
+  g->lines = NULL;   // freed without NULLing: an error return below left this dangling,
+                     // and the next call's dt_free(g->lines) was a double free
 
-  dt_iop_ashift_line_t *lines;
   int lines_count;
   int vertical_count;
   int horizontal_count;
@@ -1677,6 +1682,7 @@ static int _get_structure(dt_iop_module_t *module, dt_iop_ashift_enhance_t enhan
   return TRUE;
 
 error:
+  dt_free(lines);
   dt_free(buffer);
   return FALSE;
 }
@@ -1914,7 +1920,7 @@ static void ransac(const dt_iop_ashift_line_t *lines, int *index_set, int *inout
 // the chance of a convergent fitting
 static int _remove_outliers(dt_iop_module_t *module)
 {
-  dt_iop_ashift_gui_data_t *g = (dt_iop_ashift_gui_data_t *)module->gui_data;
+  dt_iop_ashift_gui_data_t *g = (dt_iop_ashift_gui_data_t *)dt_iop_gui_data(module);
 
   const int width = g->lines_in_width;
   const int height = g->lines_in_height;
@@ -2163,7 +2169,7 @@ static double model_fitness(double *params, void *data)
 // setup all data structures for fitting and call NM simplex
 static dt_iop_ashift_nmsresult_t nmsfit(dt_iop_module_t *module, dt_iop_ashift_params_t *p, dt_iop_ashift_fitaxis_t dir)
 {
-  dt_iop_ashift_gui_data_t *g = (dt_iop_ashift_gui_data_t *)module->gui_data;
+  dt_iop_ashift_gui_data_t *g = (dt_iop_ashift_gui_data_t *)dt_iop_gui_data(module);
 
   if(IS_NULL_PTR(g->lines)) return NMS_NOT_ENOUGH_LINES;
   if(dir == ASHIFT_FIT_NONE) return NMS_SUCCESS;
@@ -2520,7 +2526,7 @@ static double crop_fitness(double *params, void *data)
 // (and optionally the aspect angle) that delivers the largest overall crop area.
 static void do_crop(dt_iop_module_t *self, dt_iop_ashift_params_t *p)
 {
-  dt_iop_ashift_gui_data_t *g = (dt_iop_ashift_gui_data_t *)self->gui_data;
+  dt_iop_ashift_gui_data_t *g = (dt_iop_ashift_gui_data_t *)dt_iop_gui_data(self);
 
   // Resetting the crop does not depend on pipeline geometry. Do it before looking up buf_in so
   // "off" also works during initialization or after a cache-only preview pass.
@@ -2761,7 +2767,7 @@ static void _draw_basic_line(dt_iop_ashift_line_t *line, float x1, float y1, flo
 
 static void _gui_update_structure_states(dt_iop_module_t *self, gboolean enable)
 {
-  dt_iop_ashift_gui_data_t *g = (dt_iop_ashift_gui_data_t *)self->gui_data;
+  dt_iop_ashift_gui_data_t *g = (dt_iop_ashift_gui_data_t *)dt_iop_gui_data(self);
   gtk_widget_set_sensitive(g->fit_v, enable);
   gtk_widget_set_sensitive(g->fit_h, enable);
   gtk_widget_set_sensitive(g->fit_both, enable);
@@ -2772,7 +2778,7 @@ static void _draw_save_lines_to_params(dt_iop_module_t *self)
   // to save drawn lines in parameters, we only need extremas positions
   // this positions needs to be saved in "original image" reference
 
-  dt_iop_ashift_gui_data_t *g = (dt_iop_ashift_gui_data_t *)self->gui_data;
+  dt_iop_ashift_gui_data_t *g = (dt_iop_ashift_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_ashift_params_t *p = _get_ashift_params(self);
   if(IS_NULL_PTR(g) || IS_NULL_PTR(p)) return;
 
@@ -2819,7 +2825,7 @@ static gboolean _draw_retrieve_lines_from_params(dt_iop_module_t *self, dt_iop_a
   // so we need to translate them in module input reference
   // and to compute length and ... values
 
-  dt_iop_ashift_gui_data_t *g = (dt_iop_ashift_gui_data_t *)self->gui_data;
+  dt_iop_ashift_gui_data_t *g = (dt_iop_ashift_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_ashift_params_t *p = _get_ashift_params(self);
   if(IS_NULL_PTR(g) || IS_NULL_PTR(p)) return FALSE;
 
@@ -2914,7 +2920,7 @@ static gboolean _draw_retrieve_lines_from_params(dt_iop_module_t *self, dt_iop_a
 // helper function to clean structural data
 static int _do_clean_structure(dt_iop_module_t *module, dt_iop_ashift_params_t *p, gboolean save_drawn)
 {
-  dt_iop_ashift_gui_data_t *g = (dt_iop_ashift_gui_data_t *)module->gui_data;
+  dt_iop_ashift_gui_data_t *g = (dt_iop_ashift_gui_data_t *)dt_iop_gui_data(module);
 
   if(g->fitting) return FALSE;
 
@@ -2940,7 +2946,7 @@ static int _do_clean_structure(dt_iop_module_t *module, dt_iop_ashift_params_t *
 static int _do_get_structure_auto(dt_iop_module_t *self, dt_iop_ashift_params_t *p,
                                   dt_iop_ashift_enhance_t enhance)
 {
-  dt_iop_ashift_gui_data_t *g = (dt_iop_ashift_gui_data_t *)self->gui_data;
+  dt_iop_ashift_gui_data_t *g = (dt_iop_ashift_gui_data_t *)dt_iop_gui_data(self);
 
   if(g->fitting) return FALSE;
 
@@ -2998,7 +3004,7 @@ error:
 // initialise the lines structure method
 static void _do_get_structure_lines(dt_iop_module_t *self)
 {
-  dt_iop_ashift_gui_data_t *g = (dt_iop_ashift_gui_data_t *)self->gui_data;
+  dt_iop_ashift_gui_data_t *g = (dt_iop_ashift_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_ashift_params_t *p = _get_ashift_params(self);
 
   // Manual line drawing only needs the module input geometry, never the pixel buffer (unlike
@@ -3025,7 +3031,7 @@ static void _do_get_structure_lines(dt_iop_module_t *self)
 // initialise the quad structure method
 static void _do_get_structure_quad(dt_iop_module_t *self)
 {
-  dt_iop_ashift_gui_data_t *g = (dt_iop_ashift_gui_data_t *)self->gui_data;
+  dt_iop_ashift_gui_data_t *g = (dt_iop_ashift_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_ashift_params_t *p = _get_ashift_params(self);
 
   // The manual perspective rectangle only needs the module input geometry, never the pixel buffer
@@ -3084,7 +3090,7 @@ static void _do_get_structure_quad(dt_iop_module_t *self)
 // helper function to start parameter fit and report about errors
 static void do_fit(dt_iop_module_t *module, dt_iop_ashift_params_t *p, dt_iop_ashift_fitaxis_t dir)
 {
-  dt_iop_ashift_gui_data_t *g = (dt_iop_ashift_gui_data_t *)module->gui_data;
+  dt_iop_ashift_gui_data_t *g = (dt_iop_ashift_gui_data_t *)dt_iop_gui_data(module);
 
   if(g->fitting) return;
 
@@ -3162,7 +3168,7 @@ int process(struct dt_iop_module_t *self, const dt_dev_pixelpipe_t *pipe, const 
   const dt_iop_roi_t *const roi_in = &piece->roi_in;
   const dt_iop_roi_t *const roi_out = &piece->roi_out;
   dt_iop_ashift_data_t *data = (dt_iop_ashift_data_t *)piece->data;
-  dt_iop_ashift_gui_data_t *g = (dt_iop_ashift_gui_data_t *)self->gui_data;
+  dt_iop_ashift_gui_data_t *g = (dt_iop_ashift_gui_data_t *)dt_iop_gui_data(self);
 
   const int ch = piece->dsc_in.channels;
   const int ch_width = ch * roi_in->width;
@@ -3298,7 +3304,7 @@ int process_cl(struct dt_iop_module_t *self, const dt_dev_pixelpipe_t *pipe, con
   const dt_iop_roi_t *const roi_out = &piece->roi_out;
   dt_iop_ashift_data_t *d = (dt_iop_ashift_data_t *)piece->data;
   dt_iop_ashift_global_data_t *gd = (dt_iop_ashift_global_data_t *)self->global_data;
-  dt_iop_ashift_gui_data_t *g = (dt_iop_ashift_gui_data_t *)self->gui_data;
+  dt_iop_ashift_gui_data_t *g = (dt_iop_ashift_gui_data_t *)dt_iop_gui_data(self);
 
   const int devid = pipe->devid;
   const int iwidth = roi_in->width;
@@ -3557,7 +3563,7 @@ static uint64_t _get_lines_hash(const dt_iop_ashift_line_t *lines, const int lin
 static int update_colors(struct dt_iop_module_t *self, dt_iop_ashift_points_idx_t *points_idx,
                          int points_lines_count)
 {
-  dt_iop_ashift_gui_data_t *g = (dt_iop_ashift_gui_data_t *)self->gui_data;
+  dt_iop_ashift_gui_data_t *g = (dt_iop_ashift_gui_data_t *)dt_iop_gui_data(self);
 
   // is the display flipped relative to the original image?
   const int isflipped = g->isflipped;
@@ -3591,7 +3597,7 @@ static int get_points(struct dt_iop_module_t *self, const dt_iop_ashift_line_t *
                       dt_iop_ashift_points_idx_t **points_idx, int *points_lines_count, float scale)
 {
   dt_develop_t *dev = self->dev;
-  dt_iop_ashift_gui_data_t *g = (dt_iop_ashift_gui_data_t *)self->gui_data;
+  dt_iop_ashift_gui_data_t *g = (dt_iop_ashift_gui_data_t *)dt_iop_gui_data(self);
 
   dt_iop_ashift_points_idx_t *my_points_idx = NULL;
   float *my_points = NULL;
@@ -3768,7 +3774,7 @@ void gui_post_expose(struct dt_iop_module_t *self, cairo_t *cr, int32_t width, i
                      int32_t pointerx, int32_t pointery)
 {
   dt_develop_t *dev = self->dev;
-  dt_iop_ashift_gui_data_t *g = (dt_iop_ashift_gui_data_t *)self->gui_data;
+  dt_iop_ashift_gui_data_t *g = (dt_iop_ashift_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_ashift_params_t *p = _get_ashift_params(self);
   if(IS_NULL_PTR(g) || IS_NULL_PTR(p)) return;
 
@@ -4218,7 +4224,7 @@ static void _draw_recompute_line_length(dt_iop_ashift_line_t *line)
 
 int mouse_moved(struct dt_iop_module_t *self, double x, double y, double pressure, int which)
 {
-  dt_iop_ashift_gui_data_t *g = (dt_iop_ashift_gui_data_t *)self->gui_data;
+  dt_iop_ashift_gui_data_t *g = (dt_iop_ashift_gui_data_t *)dt_iop_gui_data(self);
   if(IS_NULL_PTR(g)) return FALSE;
 
   if(g->straightening)
@@ -4466,7 +4472,7 @@ int mouse_moved(struct dt_iop_module_t *self, double x, double y, double pressur
 int button_pressed(struct dt_iop_module_t *self, double x, double y, double pressure, int which, int type,
                    uint32_t state)
 {
-  dt_iop_ashift_gui_data_t *g = (dt_iop_ashift_gui_data_t *)self->gui_data;
+  dt_iop_ashift_gui_data_t *g = (dt_iop_ashift_gui_data_t *)dt_iop_gui_data(self);
   if(IS_NULL_PTR(g)) return FALSE;
   gboolean handled = FALSE;
 
@@ -4720,7 +4726,7 @@ int button_pressed(struct dt_iop_module_t *self, double x, double y, double pres
 
 int button_released(struct dt_iop_module_t *self, double x, double y, int which, uint32_t state)
 {
-  dt_iop_ashift_gui_data_t *g = (dt_iop_ashift_gui_data_t *)self->gui_data;
+  dt_iop_ashift_gui_data_t *g = (dt_iop_ashift_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_ashift_params_t *p = _get_ashift_params(self);
   if(IS_NULL_PTR(g)) return FALSE;
   const float wd = self->dev->roi.preview_width;
@@ -4903,7 +4909,7 @@ int button_released(struct dt_iop_module_t *self, double x, double y, int which,
 
 int scrolled(struct dt_iop_module_t *self, double x, double y, int up, uint32_t state)
 {
-  dt_iop_ashift_gui_data_t *g = (dt_iop_ashift_gui_data_t *)self->gui_data;
+  dt_iop_ashift_gui_data_t *g = (dt_iop_ashift_gui_data_t *)dt_iop_gui_data(self);
   if(IS_NULL_PTR(g)) return FALSE;
 
   // do nothing if visibility of lines is switched off or no lines available
@@ -4981,7 +4987,7 @@ int scrolled(struct dt_iop_module_t *self, double x, double y, int up, uint32_t 
 
 void _make_controls_sensitive(dt_iop_module_t *self, const gboolean sensitive)
 {
-  dt_iop_ashift_gui_data_t *g = (dt_iop_ashift_gui_data_t *)self->gui_data;
+  dt_iop_ashift_gui_data_t *g = (dt_iop_ashift_gui_data_t *)dt_iop_gui_data(self);
   gtk_widget_set_sensitive(g->structure_auto, sensitive);
   gtk_widget_set_sensitive(g->structure_lines, sensitive);
   gtk_widget_set_sensitive(g->structure_quad, sensitive);
@@ -4991,7 +4997,7 @@ void _make_controls_sensitive(dt_iop_module_t *self, const gboolean sensitive)
 
 void gui_changed(dt_iop_module_t *self, GtkWidget *w, void *previous)
 {
-  dt_iop_ashift_gui_data_t *g = (dt_iop_ashift_gui_data_t *)self->gui_data;
+  dt_iop_ashift_gui_data_t *g = (dt_iop_ashift_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_ashift_params_t *p = _get_ashift_params(self);
 
 #ifdef ASHIFT_DEBUG
@@ -5027,7 +5033,7 @@ void gui_changed(dt_iop_module_t *self, GtkWidget *w, void *previous)
 
 void gui_reset(struct dt_iop_module_t *self)
 {
-  dt_iop_ashift_gui_data_t *g = (dt_iop_ashift_gui_data_t *)self->gui_data;
+  dt_iop_ashift_gui_data_t *g = (dt_iop_ashift_gui_data_t *)dt_iop_gui_data(self);
   g->editing = FALSE;
   g->jobcode = ASHIFT_JOBCODE_NONE;
   g->jobparams = 0;
@@ -5052,7 +5058,7 @@ void gui_reset(struct dt_iop_module_t *self)
 static void fitting_option_changed(GtkWidget *widget, gpointer user_data)
 {
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
-  dt_iop_ashift_gui_data_t *g = (dt_iop_ashift_gui_data_t *)self->gui_data;
+  dt_iop_ashift_gui_data_t *g = (dt_iop_ashift_gui_data_t *)dt_iop_gui_data(self);
   g->fitting_mode = dt_bauhaus_combobox_get(widget);
 }
 
@@ -5062,7 +5068,7 @@ static void cropmode_callback(GtkWidget *widget, gpointer user_data)
 
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
   dt_iop_ashift_params_t *p = _get_ashift_params(self);
-  dt_iop_ashift_gui_data_t *g = (dt_iop_ashift_gui_data_t *)self->gui_data;
+  dt_iop_ashift_gui_data_t *g = (dt_iop_ashift_gui_data_t *)dt_iop_gui_data(self);
   const int crop_mode = dt_bauhaus_combobox_get(g->cropmode);
   dt_conf_set_int("plugins/darkroom/ashift/autocrop_value", crop_mode);
 
@@ -5103,7 +5109,7 @@ static int _event_fit_v_button_clicked(GtkWidget *widget, GdkEventButton *event,
 
   if(event->button == 1)
   {
-    dt_iop_ashift_gui_data_t *g = (dt_iop_ashift_gui_data_t *)self->gui_data;
+    dt_iop_ashift_gui_data_t *g = (dt_iop_ashift_gui_data_t *)dt_iop_gui_data(self);
     dt_iop_ashift_params_t *p = _get_ashift_params(self);
     const gboolean swap_axes = _ashift_orientation_swaps_axes(self);
 
@@ -5151,7 +5157,7 @@ static int _event_fit_h_button_clicked(GtkWidget *widget, GdkEventButton *event,
 
   if(event->button == 1)
   {
-    dt_iop_ashift_gui_data_t *g = (dt_iop_ashift_gui_data_t *)self->gui_data;
+    dt_iop_ashift_gui_data_t *g = (dt_iop_ashift_gui_data_t *)dt_iop_gui_data(self);
     dt_iop_ashift_params_t *p = _get_ashift_params(self);
     const gboolean swap_axes = _ashift_orientation_swaps_axes(self);
 
@@ -5199,7 +5205,7 @@ static int _event_fit_both_button_clicked(GtkWidget *widget, GdkEventButton *eve
 
   if(event->button == 1)
   {
-    dt_iop_ashift_gui_data_t *g = (dt_iop_ashift_gui_data_t *)self->gui_data;
+    dt_iop_ashift_gui_data_t *g = (dt_iop_ashift_gui_data_t *)dt_iop_gui_data(self);
     dt_iop_ashift_params_t *p = _get_ashift_params(self);
 
     dt_iop_ashift_fitaxis_t fitaxis = ASHIFT_FIT_NONE;
@@ -5248,7 +5254,7 @@ static int _event_structure_auto_clicked(GtkWidget *widget, GdkEventButton *even
 
   if(event->button == 1)
   {
-    dt_iop_ashift_gui_data_t *g = (dt_iop_ashift_gui_data_t *)self->gui_data;
+    dt_iop_ashift_gui_data_t *g = (dt_iop_ashift_gui_data_t *)dt_iop_gui_data(self);
     dt_iop_ashift_params_t *p = _get_ashift_params(self);
 
     _do_clean_structure(self, p, TRUE);
@@ -5299,7 +5305,7 @@ static int _event_structure_auto_clicked(GtkWidget *widget, GdkEventButton *even
 static int _event_structure_quad_clicked(GtkWidget *widget, GdkEventButton *event, gpointer user_data)
 {
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
-  dt_iop_ashift_gui_data_t *g = (dt_iop_ashift_gui_data_t *)self->gui_data;
+  dt_iop_ashift_gui_data_t *g = (dt_iop_ashift_gui_data_t *)dt_iop_gui_data(self);
   if(dt_gui_widgets_suppressed()) return FALSE;
   if(!g->editing) return FALSE;
 
@@ -5324,7 +5330,7 @@ static int _event_structure_quad_clicked(GtkWidget *widget, GdkEventButton *even
 static int _event_structure_lines_clicked(GtkWidget *widget, GdkEventButton *event, gpointer user_data)
 {
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
-  dt_iop_ashift_gui_data_t *g = (dt_iop_ashift_gui_data_t *)self->gui_data;
+  dt_iop_ashift_gui_data_t *g = (dt_iop_ashift_gui_data_t *)dt_iop_gui_data(self);
   if(dt_gui_widgets_suppressed()) return FALSE;
   if(!g->editing) return FALSE;
 
@@ -5348,7 +5354,7 @@ static int _event_structure_lines_clicked(GtkWidget *widget, GdkEventButton *eve
 
 static void _enter_edit_mode(GtkToggleButton* button, struct dt_iop_module_t *self)
 {
-  dt_iop_ashift_gui_data_t *g = (dt_iop_ashift_gui_data_t *)self->gui_data;
+  dt_iop_ashift_gui_data_t *g = (dt_iop_ashift_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_ashift_params_t *p = (dt_iop_ashift_params_t *)self->params;
   if(!self->enabled) dt_dev_add_history_item(self->dev, self, TRUE, TRUE);
 
@@ -5402,7 +5408,7 @@ static void _enter_edit_mode(GtkToggleButton* button, struct dt_iop_module_t *se
 
 static void _event_commit_clicked(GtkButton *button, dt_iop_module_t *self)
 {
-  dt_iop_ashift_gui_data_t *g = (dt_iop_ashift_gui_data_t *)self->gui_data;
+  dt_iop_ashift_gui_data_t *g = (dt_iop_ashift_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_ashift_params_t *p = (dt_iop_ashift_params_t *)self->params;
 
   // Close edit mode on commit
@@ -5430,7 +5436,7 @@ static void _event_commit_clicked(GtkButton *button, dt_iop_module_t *self)
 
 static void _run_pending_preview_job(dt_iop_module_t *self)
 {
-  dt_iop_ashift_gui_data_t *g = (dt_iop_ashift_gui_data_t *)self->gui_data;
+  dt_iop_ashift_gui_data_t *g = (dt_iop_ashift_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_ashift_params_t *p = _get_ashift_params(self);
 
   dt_iop_ashift_jobcode_t jobcode = g->jobcode;
@@ -5476,7 +5482,7 @@ static void _event_process_after_preview_callback(gpointer instance, gpointer us
 {
   (void)instance;
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
-  dt_iop_ashift_gui_data_t *g = (dt_iop_ashift_gui_data_t *)self->gui_data;
+  dt_iop_ashift_gui_data_t *g = (dt_iop_ashift_gui_data_t *)dt_iop_gui_data(self);
   if(IS_NULL_PTR(g) || g->jobcode == ASHIFT_JOBCODE_NONE || dt_gui_widgets_suppressed()) return;
 
   _run_pending_preview_job(self);
@@ -5494,7 +5500,7 @@ static void _event_process_after_preview_callback(gpointer instance, gpointer us
 static void _event_process_after_ui_callback(gpointer instance, gpointer user_data)
 {
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
-  dt_iop_ashift_gui_data_t *g = (dt_iop_ashift_gui_data_t *)self->gui_data;
+  dt_iop_ashift_gui_data_t *g = (dt_iop_ashift_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_ashift_params_t *p = _get_ashift_params(self);
 
   (void)instance;
@@ -5519,7 +5525,7 @@ void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pix
                    dt_dev_pixelpipe_iop_t *piece)
 {
   dt_iop_ashift_data_t *d = (dt_iop_ashift_data_t *)piece->data;
-  dt_iop_ashift_gui_data_t *g = (dt_iop_ashift_gui_data_t *)self->gui_data;
+  dt_iop_ashift_gui_data_t *g = (dt_iop_ashift_gui_data_t *)dt_iop_gui_data(self);
 
   const gboolean editing = !IS_NULL_PTR(g) && g->editing;
   dt_iop_ashift_params_t *p = editing ? &g->new_params : (dt_iop_ashift_params_t *)p1;
@@ -5578,7 +5584,7 @@ void cleanup_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev
 
 void gui_update(struct dt_iop_module_t *self)
 {
-  dt_iop_ashift_gui_data_t *g = (dt_iop_ashift_gui_data_t *)self->gui_data;
+  dt_iop_ashift_gui_data_t *g = (dt_iop_ashift_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_ashift_params_t *p = _get_ashift_params(self);
 
   // Slider labels (image-orientation dependent), widget defaults and the per-image edit-mode state
@@ -5723,7 +5729,7 @@ void cleanup_global(dt_iop_module_so_t *module)
 // adjust labels of lens shift parameters according to flip status of image
 static gboolean _event_draw(GtkWidget *widget, cairo_t *cr, dt_iop_module_t *self)
 {
-  dt_iop_ashift_gui_data_t *g = (dt_iop_ashift_gui_data_t *)self->gui_data;
+  dt_iop_ashift_gui_data_t *g = (dt_iop_ashift_gui_data_t *)dt_iop_gui_data(self);
   if(dt_gui_widgets_suppressed()) return FALSE;
 
   dt_iop_gui_enter_critical_section(self);
@@ -5796,7 +5802,7 @@ void gui_init(struct dt_iop_module_t *self)
   g->draw_near_point = -1;
   g->draw_line_move = -1;
 
-  self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_GUI_BOX_SPACING);
+  self->gui->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_GUI_BOX_SPACING);
 
   GtkWidget *box = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, DT_GUI_BOX_SPACING);
 
@@ -5808,9 +5814,9 @@ void gui_init(struct dt_iop_module_t *self)
   gtk_box_pack_start(GTK_BOX(box), g->commit_button, TRUE, TRUE, 0);
   gtk_widget_set_sensitive(g->commit_button, FALSE);
 
-  gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(box), TRUE, TRUE, 0);
+  gtk_box_pack_start(GTK_BOX(self->gui->widget), GTK_WIDGET(box), TRUE, TRUE, 0);
 
-  GtkWidget *main_box = self->widget;
+  GtkWidget *main_box = self->gui->widget;
 
   dt_gui_new_collapsible_section
     (&g->cs,
@@ -5818,7 +5824,7 @@ void gui_init(struct dt_iop_module_t *self)
      _("Manual settings"),
      GTK_BOX(main_box), GTK_PACK_END);
 
-  self->widget = GTK_WIDGET(g->cs.container);
+  self->gui->widget = GTK_WIDGET(g->cs.container);
 
   g->rotation = dt_bauhaus_slider_from_params(self, N_("rotation"));
   dt_bauhaus_slider_set_format(g->rotation, "\302\260");
@@ -5836,7 +5842,7 @@ void gui_init(struct dt_iop_module_t *self)
   dt_bauhaus_slider_set_soft_range(g->shear, -SHEAR_RANGE, SHEAR_RANGE);
 
   g->mode = dt_bauhaus_combobox_from_params(self, "mode");
-  self->widget = g->specifics = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_GUI_BOX_SPACING);
+  self->gui->widget = g->specifics = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_GUI_BOX_SPACING);
 
   g->f_length = dt_bauhaus_slider_from_params(self, "f_length");
   dt_bauhaus_slider_set_soft_range(g->f_length, 10.0f, 1000.0f);
@@ -5858,7 +5864,7 @@ void gui_init(struct dt_iop_module_t *self)
 
   gtk_box_pack_start(GTK_BOX(g->cs.container), g->specifics, TRUE, TRUE, 0);
 
-  self->widget = main_box;
+  self->gui->widget = main_box;
 
   GtkGrid *auto_grid = GTK_GRID(gtk_grid_new());
   gtk_grid_set_row_spacing(auto_grid, DT_GUI_BOX_SPACING);
@@ -5893,10 +5899,10 @@ void gui_init(struct dt_iop_module_t *self)
   gtk_grid_attach(auto_grid, g->fit_both, 3, 1, 1, 1);
 
   gtk_widget_show_all(GTK_WIDGET(auto_grid));
-  gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(auto_grid), TRUE, TRUE, 0);
+  gtk_box_pack_start(GTK_BOX(self->gui->widget), GTK_WIDGET(auto_grid), TRUE, TRUE, 0);
 
   GtkWidget *helpers = dt_ui_section_label_new(_("Fitting options"));
-  gtk_box_pack_start(GTK_BOX(self->widget), helpers, TRUE, TRUE, 0);
+  gtk_box_pack_start(GTK_BOX(self->gui->widget), helpers, TRUE, TRUE, 0);
 
   const gchar *option_labels[] = { _("rotation, lens shift, shear"),
                                    _("rotation, lens shift"),
@@ -5905,7 +5911,7 @@ void gui_init(struct dt_iop_module_t *self)
   g->fitting_option
       = dt_bauhaus_combobox_new_full(dt_bauhaus_get_global(), DT_GUI_MODULE(self), _("Fit for"), NULL, ASHIFT_FITTING_ALL,
                                      (GtkCallback)fitting_option_changed, self, option_labels);
-  gtk_box_pack_start(GTK_BOX(self->widget), g->fitting_option, TRUE, TRUE, 0);
+  gtk_box_pack_start(GTK_BOX(self->gui->widget), g->fitting_option, TRUE, TRUE, 0);
 
   const gchar *crop_labels[] = { _("off"), _("largest area"), _("original format"), NULL };
   g->cropmode
@@ -5914,9 +5920,9 @@ void gui_init(struct dt_iop_module_t *self)
                                      (GtkCallback)cropmode_callback, self, crop_labels);
   dt_bauhaus_combobox_set_default(g->cropmode,
                                   ((dt_iop_ashift_params_t *)self->default_params)->cropmode);
-  gtk_box_pack_start(GTK_BOX(self->widget), g->cropmode, FALSE, FALSE, 0);
+  gtk_box_pack_start(GTK_BOX(self->gui->widget), g->cropmode, FALSE, FALSE, 0);
 
-  self->widget = main_box;
+  self->gui->widget = main_box;
 
   gtk_widget_set_tooltip_text(g->rotation, _("rotate image\nright-click and drag to define a horizontal or vertical line by drawing on the image"));
   gtk_widget_set_tooltip_text(g->lensshift_v, _("apply lens shift correction in one direction"));
@@ -5964,7 +5970,7 @@ void gui_init(struct dt_iop_module_t *self)
                    (gpointer)self);
   g_signal_connect(G_OBJECT(g->structure_auto), "button-press-event", G_CALLBACK(_event_structure_auto_clicked),
                    (gpointer)self);
-  g_signal_connect(G_OBJECT(self->widget), "draw", G_CALLBACK(_event_draw), self);
+  g_signal_connect(G_OBJECT(self->gui->widget), "draw", G_CALLBACK(_event_draw), self);
 
   /* Pending GUI jobs run once the preview pipe published a fresh render: by then process() has
      captured g->buf. The UI-pipe-finished hook only refreshes the overlay geometry. */
@@ -5980,7 +5986,7 @@ void gui_cleanup(struct dt_iop_module_t *self)
   DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(dt_control_signal_get_global(), G_CALLBACK(_event_process_after_ui_callback), self);
   dt_iop_set_cache_bypass(self, FALSE);
 
-  dt_iop_ashift_gui_data_t *g = (dt_iop_ashift_gui_data_t *)self->gui_data;
+  dt_iop_ashift_gui_data_t *g = (dt_iop_ashift_gui_data_t *)dt_iop_gui_data(self);
   if(g->lines)
   {
     dt_free(g->lines);

--- a/src/iop/atrous.c
+++ b/src/iop/atrous.c
@@ -329,7 +329,7 @@ static int process_wavelets(struct dt_iop_module_t *self, const struct dt_dev_pi
 
   if(self->dev->gui_attached && !dt_dev_pixelpipe_has_preview_output(self->dev, pipe, roi_out))
   {
-    dt_iop_atrous_gui_data_t *g = (dt_iop_atrous_gui_data_t *)self->gui_data;
+    dt_iop_atrous_gui_data_t *g = (dt_iop_atrous_gui_data_t *)dt_iop_gui_data(self);
     if(!IS_NULL_PTR(g)) g->num_samples = get_samples(g->sample, d, roi_in, piece);
     // tries to acquire gdk lock and this prone to deadlock:
     // dt_control_queue_draw(GTK_WIDGET(g->area));
@@ -538,7 +538,7 @@ int process_cl(struct dt_iop_module_t *self, const dt_dev_pixelpipe_t *pipe, con
 
   if(self->dev->gui_attached && !dt_dev_pixelpipe_has_preview_output(self->dev, pipe, roi_out))
   {
-    dt_iop_atrous_gui_data_t *g = (dt_iop_atrous_gui_data_t *)self->gui_data;
+    dt_iop_atrous_gui_data_t *g = (dt_iop_atrous_gui_data_t *)dt_iop_gui_data(self);
     if(!IS_NULL_PTR(g)) g->num_samples = get_samples(g->sample, d, roi_in, piece);
     // dt_control_queue_redraw_widget(GTK_WIDGET(g->area));
     // tries to acquire gdk lock and this prone to deadlock:
@@ -1075,7 +1075,7 @@ void init_presets(dt_iop_module_so_t *self)
 
 static void reset_mix(dt_iop_module_t *self)
 {
-  dt_iop_atrous_gui_data_t *c = (dt_iop_atrous_gui_data_t *)self->gui_data;
+  dt_iop_atrous_gui_data_t *c = (dt_iop_atrous_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_atrous_params_t *p = (dt_iop_atrous_params_t *)self->params;
   c->drag_params = *p;
   dt_gui_freeze_begin();
@@ -1086,7 +1086,7 @@ static void reset_mix(dt_iop_module_t *self)
 void gui_update(struct dt_iop_module_t *self)
 {
   reset_mix(self);
-  gtk_widget_queue_draw(self->widget);
+  gtk_widget_queue_draw(self->gui->widget);
 }
 
 
@@ -1095,7 +1095,7 @@ void gui_update(struct dt_iop_module_t *self)
 static gboolean area_enter_notify(GtkWidget *widget, GdkEventCrossing *event, gpointer user_data)
 {
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
-  dt_iop_atrous_gui_data_t *c = (dt_iop_atrous_gui_data_t *)self->gui_data;
+  dt_iop_atrous_gui_data_t *c = (dt_iop_atrous_gui_data_t *)dt_iop_gui_data(self);
   if(!c->dragging) c->mouse_y = fabs(c->mouse_y);
   c->in_curve = TRUE;
   gtk_widget_queue_draw(widget);
@@ -1105,7 +1105,7 @@ static gboolean area_enter_notify(GtkWidget *widget, GdkEventCrossing *event, gp
 static gboolean area_leave_notify(GtkWidget *widget, GdkEventCrossing *event, gpointer user_data)
 {
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
-  dt_iop_atrous_gui_data_t *c = (dt_iop_atrous_gui_data_t *)self->gui_data;
+  dt_iop_atrous_gui_data_t *c = (dt_iop_atrous_gui_data_t *)dt_iop_gui_data(self);
   if(!c->dragging) c->mouse_y = -fabs(c->mouse_y);
   c->in_curve = FALSE;
   gtk_widget_queue_draw(widget);
@@ -1126,7 +1126,7 @@ static void get_params(dt_iop_atrous_params_t *p, const int ch, const double mou
 static gboolean area_draw(GtkWidget *widget, cairo_t *crf, gpointer user_data)
 {
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
-  dt_iop_atrous_gui_data_t *c = (dt_iop_atrous_gui_data_t *)self->gui_data;
+  dt_iop_atrous_gui_data_t *c = (dt_iop_atrous_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_atrous_params_t p = *(dt_iop_atrous_params_t *)self->params;
 
   const float mix = c->in_curve ? 1.0f : p.mix;
@@ -1147,7 +1147,7 @@ static gboolean area_draw(GtkWidget *widget, cairo_t *crf, gpointer user_data)
   cairo_t *cr = cairo_create(cst);
   // clear bg, match color of the notebook tabs:
   GdkRGBA bright_bg_color, graph_bg;
-  GtkStyleContext *context = gtk_widget_get_style_context(self->expander);
+  GtkStyleContext *context = gtk_widget_get_style_context(self->gui->expander);
   gboolean color_found = gtk_style_context_lookup_color (context, "graph_overlay", &bright_bg_color);
   if(!color_found)
   {
@@ -1438,7 +1438,7 @@ static gboolean area_draw(GtkWidget *widget, cairo_t *crf, gpointer user_data)
 static gboolean area_motion_notify(GtkWidget *widget, GdkEventMotion *event, gpointer user_data)
 {
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
-  dt_iop_atrous_gui_data_t *c = (dt_iop_atrous_gui_data_t *)self->gui_data;
+  dt_iop_atrous_gui_data_t *c = (dt_iop_atrous_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_atrous_params_t *p = (dt_iop_atrous_params_t *)self->params;
   const int inset = INSET;
   GtkAllocation allocation;
@@ -1521,20 +1521,20 @@ static gboolean area_button_press(GtkWidget *widget, GdkEventButton *event, gpoi
     // reset current curve
     dt_iop_atrous_params_t *p = (dt_iop_atrous_params_t *)self->params;
     dt_iop_atrous_params_t *d = (dt_iop_atrous_params_t *)self->default_params;
-    dt_iop_atrous_gui_data_t *c = (dt_iop_atrous_gui_data_t *)self->gui_data;
+    dt_iop_atrous_gui_data_t *c = (dt_iop_atrous_gui_data_t *)dt_iop_gui_data(self);
     reset_mix(self);
     for(int k = 0; k < BANDS; k++)
     {
       p->x[c->channel2][k] = d->x[c->channel2][k];
       p->y[c->channel2][k] = d->y[c->channel2][k];
     }
-    gtk_widget_queue_draw(self->widget);
+    gtk_widget_queue_draw(self->gui->widget);
     dt_dev_add_history_item(self->dev, self, TRUE, TRUE);
   }
   else if(event->button == 1)
   {
     // set active point
-    dt_iop_atrous_gui_data_t *c = (dt_iop_atrous_gui_data_t *)self->gui_data;
+    dt_iop_atrous_gui_data_t *c = (dt_iop_atrous_gui_data_t *)dt_iop_gui_data(self);
     reset_mix(self);
     const int inset = INSET;
     GtkAllocation allocation;
@@ -1555,7 +1555,7 @@ static gboolean area_button_release(GtkWidget *widget, GdkEventButton *event, gp
   if(event->button == 1)
   {
     dt_iop_module_t *self = (dt_iop_module_t *)user_data;
-    dt_iop_atrous_gui_data_t *c = (dt_iop_atrous_gui_data_t *)self->gui_data;
+    dt_iop_atrous_gui_data_t *c = (dt_iop_atrous_gui_data_t *)dt_iop_gui_data(self);
     c->dragging = 0;
     reset_mix(self);
     return TRUE;
@@ -1566,7 +1566,7 @@ static gboolean area_button_release(GtkWidget *widget, GdkEventButton *event, gp
 static gboolean area_scrolled(GtkWidget *widget, GdkEventScroll *event, gpointer user_data)
 {
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
-  dt_iop_atrous_gui_data_t *c = (dt_iop_atrous_gui_data_t *)self->gui_data;
+  dt_iop_atrous_gui_data_t *c = (dt_iop_atrous_gui_data_t *)dt_iop_gui_data(self);
 
   int delta_y;
   if(dt_gui_get_scroll_unit_deltas(event, NULL, &delta_y))
@@ -1580,10 +1580,10 @@ static gboolean area_scrolled(GtkWidget *widget, GdkEventScroll *event, gpointer
 static void tab_switch(GtkNotebook *notebook, GtkWidget *page, guint page_num, gpointer user_data)
 {
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
-  dt_iop_atrous_gui_data_t *c = (dt_iop_atrous_gui_data_t *)self->gui_data;
+  dt_iop_atrous_gui_data_t *c = (dt_iop_atrous_gui_data_t *)dt_iop_gui_data(self);
   if(dt_gui_widgets_suppressed()) return;
   c->channel = c->channel2 = (atrous_channel_t)page_num;
-  gtk_widget_queue_draw(self->widget);
+  gtk_widget_queue_draw(self->gui->widget);
 }
 
 static void mix_callback(GtkWidget *slider, gpointer user_data)
@@ -1592,7 +1592,7 @@ static void mix_callback(GtkWidget *slider, gpointer user_data)
   if(dt_gui_widgets_suppressed()) return;
   dt_iop_atrous_params_t *p = (dt_iop_atrous_params_t *)self->params;
   p->mix = dt_bauhaus_slider_get(slider);
-  gtk_widget_queue_draw(self->widget);
+  gtk_widget_queue_draw(self->gui->widget);
   dt_dev_add_history_item(self->dev, self, TRUE, TRUE);
 }
 
@@ -1610,12 +1610,12 @@ void gui_init(struct dt_iop_module_t *self)
     (void)dt_draw_curve_add_point(c->minmax_curve, p->x[ch][k], p->y[ch][k]);
   c->mouse_x = c->mouse_y = c->mouse_pick = -1.0;
   c->dragging = 0;
-  self->timeout_handle = 0;
+  self->gui->timeout_handle = 0;
   c->x_move = -1;
   c->mouse_radius = 1.0 / BANDS;
   c->in_curve = FALSE;
 
-  self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_GUI_BOX_SPACING);
+  self->gui->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_GUI_BOX_SPACING);
 
   c->channel_tabs = dt_ui_notebook_new();
   dt_ui_notebook_page(c->channel_tabs, N_("luma"), _("change lightness at each feature size"));
@@ -1624,12 +1624,12 @@ void gui_init(struct dt_iop_module_t *self)
   gtk_widget_show(gtk_notebook_get_nth_page(c->channel_tabs, c->channel));
   gtk_notebook_set_current_page(c->channel_tabs, c->channel);
   g_signal_connect(G_OBJECT(c->channel_tabs), "switch_page", G_CALLBACK(tab_switch), self);
-  gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(c->channel_tabs), FALSE, FALSE, 0);
+  gtk_box_pack_start(GTK_BOX(self->gui->widget), GTK_WIDGET(c->channel_tabs), FALSE, FALSE, 0);
 
   // graph
   c->area = GTK_DRAWING_AREA(gtk_drawing_area_new());
   gtk_widget_set_hexpand(GTK_WIDGET(c->area), TRUE);
-  gtk_box_pack_start(GTK_BOX(self->widget),
+  gtk_box_pack_start(GTK_BOX(self->gui->widget),
                      dt_ui_resizable_drawing_area(GTK_WIDGET(c->area),
                                                   "plugins/darkroom/atrous/graphheight", 280, 100),
                      FALSE, FALSE, 0);
@@ -1656,7 +1656,7 @@ void gui_init(struct dt_iop_module_t *self)
 
 void gui_cleanup(struct dt_iop_module_t *self)
 {
-  dt_iop_atrous_gui_data_t *c = (dt_iop_atrous_gui_data_t *)self->gui_data;
+  dt_iop_atrous_gui_data_t *c = (dt_iop_atrous_gui_data_t *)dt_iop_gui_data(self);
   dt_conf_set_int("plugins/darkroom/atrous/gui_channel", c->channel);
   dt_draw_curve_destroy(c->minmax_curve);
 

--- a/src/iop/basebuffer.c
+++ b/src/iop/basebuffer.c
@@ -19,6 +19,7 @@
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif
+#include "develop/imageop_gui.h"
 
 #include "system/openmp.h"
 #include "system/target_clones.h"
@@ -195,7 +196,6 @@ void init(dt_iop_module_t *self)
   self->default_enabled = 1;
   self->hide_enable_button = 1;
   self->params_size = sizeof(dt_iop_basebuffer_params_t);
-  self->gui_data = NULL;
 }
 
 void cleanup(dt_iop_module_t *self)

--- a/src/iop/basecurve.c
+++ b/src/iop/basecurve.c
@@ -961,13 +961,13 @@ void cleanup_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev
 void gui_update(struct dt_iop_module_t *self)
 {
   dt_iop_basecurve_params_t *p = (dt_iop_basecurve_params_t *)self->params;
-  dt_iop_basecurve_gui_data_t *g = (dt_iop_basecurve_gui_data_t *)self->gui_data;
+  dt_iop_basecurve_gui_data_t *g = (dt_iop_basecurve_gui_data_t *)dt_iop_gui_data(self);
 
   gtk_widget_set_visible(g->exposure_step, p->exposure_fusion != 0);
   gtk_widget_set_visible(g->exposure_bias, p->exposure_fusion != 0);
 
   // gui curve is read directly from params during expose event.
-  gtk_widget_queue_draw(self->widget);
+  gtk_widget_queue_draw(self->gui->widget);
 }
 
 static float eval_grey(float x)
@@ -1016,7 +1016,7 @@ static float to_lin(const float x, const float base)
 static gboolean dt_iop_basecurve_draw(GtkWidget *widget, cairo_t *crf, gpointer user_data)
 {
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
-  dt_iop_basecurve_gui_data_t *c = (dt_iop_basecurve_gui_data_t *)self->gui_data;
+  dt_iop_basecurve_gui_data_t *c = (dt_iop_basecurve_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_basecurve_params_t *p = (dt_iop_basecurve_params_t *)self->params;
 
   int nodes = p->basecurve_nodes[0];
@@ -1211,7 +1211,7 @@ static inline int _add_node(dt_iop_basecurve_node_t *basecurve, int *nodes, floa
 
 static void dt_iop_basecurve_sanity_check(dt_iop_module_t *self, GtkWidget *widget)
 {
-  dt_iop_basecurve_gui_data_t *c = (dt_iop_basecurve_gui_data_t *)self->gui_data;
+  dt_iop_basecurve_gui_data_t *c = (dt_iop_basecurve_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_basecurve_params_t *p = (dt_iop_basecurve_params_t *)self->params;
 
   int ch = 0;
@@ -1243,7 +1243,7 @@ static gboolean _move_point_internal(dt_iop_module_t *self, GtkWidget *widget, f
 static gboolean dt_iop_basecurve_motion_notify(GtkWidget *widget, GdkEventMotion *event, gpointer user_data)
 {
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
-  dt_iop_basecurve_gui_data_t *c = (dt_iop_basecurve_gui_data_t *)self->gui_data;
+  dt_iop_basecurve_gui_data_t *c = (dt_iop_basecurve_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_basecurve_params_t *p = (dt_iop_basecurve_params_t *)self->params;
   int ch = 0;
   int nodes = p->basecurve_nodes[ch];
@@ -1314,7 +1314,7 @@ static gboolean dt_iop_basecurve_button_press(GtkWidget *widget, GdkEventButton 
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
   dt_iop_basecurve_params_t *p = (dt_iop_basecurve_params_t *)self->params;
   dt_iop_basecurve_params_t *d = (dt_iop_basecurve_params_t *)self->default_params;
-  dt_iop_basecurve_gui_data_t *c = (dt_iop_basecurve_gui_data_t *)self->gui_data;
+  dt_iop_basecurve_gui_data_t *c = (dt_iop_basecurve_gui_data_t *)dt_iop_gui_data(self);
 
   int ch = 0;
   int nodes = p->basecurve_nodes[ch];
@@ -1376,7 +1376,7 @@ static gboolean dt_iop_basecurve_button_press(GtkWidget *widget, GdkEventButton 
           }
 
           dt_dev_add_history_item(self->dev, self, TRUE, TRUE);
-          gtk_widget_queue_draw(self->widget);
+          gtk_widget_queue_draw(self->gui->widget);
         }
       }
       return TRUE;
@@ -1393,7 +1393,7 @@ static gboolean dt_iop_basecurve_button_press(GtkWidget *widget, GdkEventButton 
       }
       c->selected = -2; // avoid motion notify re-inserting immediately.
       dt_dev_add_history_item(self->dev, self, TRUE, TRUE);
-      gtk_widget_queue_draw(self->widget);
+      gtk_widget_queue_draw(self->gui->widget);
       return TRUE;
     }
   }
@@ -1403,7 +1403,7 @@ static gboolean dt_iop_basecurve_button_press(GtkWidget *widget, GdkEventButton 
     {
       float reset_value = c->selected == 0 ? 0 : 1;
       basecurve[c->selected].y = basecurve[c->selected].x = reset_value;
-      gtk_widget_queue_draw(self->widget);
+      gtk_widget_queue_draw(self->gui->widget);
       dt_dev_add_history_item(self->dev, self, TRUE, TRUE);
       return TRUE;
     }
@@ -1416,7 +1416,7 @@ static gboolean dt_iop_basecurve_button_press(GtkWidget *widget, GdkEventButton 
     basecurve[nodes - 1].x = basecurve[nodes - 1].y = 0;
     c->selected = -2; // avoid re-insertion of that point immediately after this
     p->basecurve_nodes[ch]--;
-    gtk_widget_queue_draw(self->widget);
+    gtk_widget_queue_draw(self->gui->widget);
     dt_dev_add_history_item(self->dev, self, TRUE, TRUE);
     return TRUE;
   }
@@ -1437,7 +1437,7 @@ static gboolean area_resized(GtkWidget *widget, GdkEvent *event, gpointer user_d
 static gboolean _move_point_internal(dt_iop_module_t *self, GtkWidget *widget, float dx, float dy, guint state)
 {
   dt_iop_basecurve_params_t *p = (dt_iop_basecurve_params_t *)self->params;
-  dt_iop_basecurve_gui_data_t *c = (dt_iop_basecurve_gui_data_t *)self->gui_data;
+  dt_iop_basecurve_gui_data_t *c = (dt_iop_basecurve_gui_data_t *)dt_iop_gui_data(self);
 
   int ch = 0;
   dt_iop_basecurve_node_t *basecurve = p->basecurve[ch];
@@ -1457,7 +1457,7 @@ static gboolean _move_point_internal(dt_iop_module_t *self, GtkWidget *widget, f
 static gboolean _scrolled(GtkWidget *widget, GdkEventScroll *event, gpointer user_data)
 {
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
-  dt_iop_basecurve_gui_data_t *c = (dt_iop_basecurve_gui_data_t *)self->gui_data;
+  dt_iop_basecurve_gui_data_t *c = (dt_iop_basecurve_gui_data_t *)dt_iop_gui_data(self);
 
   if(c->selected < 0) return TRUE;
 
@@ -1474,7 +1474,7 @@ static gboolean _scrolled(GtkWidget *widget, GdkEventScroll *event, gpointer use
 static gboolean dt_iop_basecurve_key_press(GtkWidget *widget, GdkEventKey *event, gpointer user_data)
 {
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
-  dt_iop_basecurve_gui_data_t *c = (dt_iop_basecurve_gui_data_t *)self->gui_data;
+  dt_iop_basecurve_gui_data_t *c = (dt_iop_basecurve_gui_data_t *)dt_iop_gui_data(self);
 
   if(c->selected < 0) return TRUE;
   guint key = dt_keys_mainpad_alternatives(event->keyval);
@@ -1512,7 +1512,7 @@ static gboolean dt_iop_basecurve_key_press(GtkWidget *widget, GdkEventKey *event
 void gui_changed(dt_iop_module_t *self, GtkWidget *w, void *previous)
 {
   dt_iop_basecurve_params_t *p = (dt_iop_basecurve_params_t *)self->params;
-  dt_iop_basecurve_gui_data_t *g = (dt_iop_basecurve_gui_data_t *)self->gui_data;
+  dt_iop_basecurve_gui_data_t *g = (dt_iop_basecurve_gui_data_t *)dt_iop_gui_data(self);
 
   if(w == g->fusion)
   {
@@ -1533,7 +1533,7 @@ void gui_changed(dt_iop_module_t *self, GtkWidget *w, void *previous)
 static void logbase_callback(GtkWidget *slider, gpointer user_data)
 {
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
-  dt_iop_basecurve_gui_data_t *g = (dt_iop_basecurve_gui_data_t *)self->gui_data;
+  dt_iop_basecurve_gui_data_t *g = (dt_iop_basecurve_gui_data_t *)dt_iop_gui_data(self);
   g->loglogscale = eval_grey(dt_bauhaus_slider_get(g->logbase));
   gtk_widget_queue_draw(GTK_WIDGET(g->area));
 }
@@ -1551,15 +1551,15 @@ void gui_init(struct dt_iop_module_t *self)
   c->mouse_x = c->mouse_y = -1.0;
   c->selected = -1;
   c->loglogscale = 0;
-  self->timeout_handle = 0;
+  self->gui->timeout_handle = 0;
 
-  self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_GUI_BOX_SPACING);
+  self->gui->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_GUI_BOX_SPACING);
 
   c->area = GTK_DRAWING_AREA(gtk_drawing_area_new());
   gtk_widget_set_hexpand(GTK_WIDGET(c->area), TRUE);
   gtk_widget_set_tooltip_text(GTK_WIDGET(c->area), _("abscissa: input, ordinate: output. works on RGB channels"));
   g_object_set_data(G_OBJECT(c->area), "iop-instance", self);
-  gtk_box_pack_start(GTK_BOX(self->widget),
+  gtk_box_pack_start(GTK_BOX(self->gui->widget),
                      dt_ui_resizable_drawing_area(GTK_WIDGET(c->area),
                                                   "plugins/darkroom/basecurve/graphheight", 280, 100),
                      FALSE, FALSE, 0);
@@ -1591,7 +1591,7 @@ void gui_init(struct dt_iop_module_t *self)
   gtk_widget_set_visible(c->exposure_bias, p->exposure_fusion != 0 ? TRUE : FALSE);
   c->logbase = dt_bauhaus_slider_new_with_range(dt_bauhaus_get_global(), DT_GUI_MODULE(self), 0.0f, 40.0f, 0, 0.0f, 2);
   dt_bauhaus_widget_set_label(c->logbase, N_("scale for graph"));
-  gtk_box_pack_start(GTK_BOX(self->widget), c->logbase , TRUE, TRUE, 0);  g_signal_connect(G_OBJECT(c->logbase), "value-changed", G_CALLBACK(logbase_callback), self);
+  gtk_box_pack_start(GTK_BOX(self->gui->widget), c->logbase , TRUE, TRUE, 0);  g_signal_connect(G_OBJECT(c->logbase), "value-changed", G_CALLBACK(logbase_callback), self);
 
   gtk_widget_add_events(GTK_WIDGET(c->area), GDK_POINTER_MOTION_MASK | dt_widget_scroll_mask()
                                            | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK
@@ -1609,7 +1609,7 @@ void gui_init(struct dt_iop_module_t *self)
 
 void gui_cleanup(struct dt_iop_module_t *self)
 {
-  dt_iop_basecurve_gui_data_t *c = (dt_iop_basecurve_gui_data_t *)self->gui_data;
+  dt_iop_basecurve_gui_data_t *c = (dt_iop_basecurve_gui_data_t *)dt_iop_gui_data(self);
   dt_draw_curve_destroy(c->minmax_curve);
 
   IOP_GUI_FREE;

--- a/src/iop/basicadj.c
+++ b/src/iop/basicadj.c
@@ -195,7 +195,7 @@ int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, const dt
 
 static void _turn_select_region_off(struct dt_iop_module_t *self)
 {
-  dt_iop_basicadj_gui_data_t *g = (dt_iop_basicadj_gui_data_t *)self->gui_data;
+  dt_iop_basicadj_gui_data_t *g = (dt_iop_basicadj_gui_data_t *)dt_iop_gui_data(self);
   if(!IS_NULL_PTR(g))
   {
     g->button_down = g->draw_selected_region = 0;
@@ -223,12 +223,12 @@ static void _auto_levels_callback(GtkButton *button, dt_iop_module_t *self)
 {
   if(dt_gui_widgets_suppressed()) return;
 
-  dt_iop_basicadj_gui_data_t *g = (dt_iop_basicadj_gui_data_t *)self->gui_data;
+  dt_iop_basicadj_gui_data_t *g = (dt_iop_basicadj_gui_data_t *)dt_iop_gui_data(self);
 
   dt_iop_request_focus(self);
-  if(self->off)
+  if(self->gui->off)
   {
-    gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(self->off), 1);
+    gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(self->gui->off), 1);
     dt_dev_add_history_item(self->dev, self, TRUE, TRUE);
   }
 
@@ -249,12 +249,12 @@ static void _select_region_toggled_callback(GtkToggleButton *togglebutton, dt_io
 {
   if(dt_gui_widgets_suppressed()) return;
 
-  dt_iop_basicadj_gui_data_t *g = (dt_iop_basicadj_gui_data_t *)self->gui_data;
+  dt_iop_basicadj_gui_data_t *g = (dt_iop_basicadj_gui_data_t *)dt_iop_gui_data(self);
 
   dt_iop_request_focus(self);
-  if(self->off)
+  if(self->gui->off)
   {
-    gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(self->off), 1);
+    gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(self->gui->off), 1);
     dt_dev_add_history_item(self->dev, self, TRUE, TRUE);
   }
 
@@ -276,7 +276,7 @@ static void _develop_ui_pipe_finished_callback(gpointer instance, gpointer user_
 {
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
   dt_iop_basicadj_params_t *p = (dt_iop_basicadj_params_t *)self->params;
-  dt_iop_basicadj_gui_data_t *g = (dt_iop_basicadj_gui_data_t *)self->gui_data;
+  dt_iop_basicadj_gui_data_t *g = (dt_iop_basicadj_gui_data_t *)dt_iop_gui_data(self);
 
   if(IS_NULL_PTR(g)) return;
 
@@ -316,7 +316,7 @@ static void _signal_profile_user_changed(gpointer instance, uint8_t profile_type
     if(!self->enabled) return;
 
     dt_iop_basicadj_params_t *def = (dt_iop_basicadj_params_t *)self->default_params;
-    dt_iop_basicadj_gui_data_t *g = (dt_iop_basicadj_gui_data_t *)self->gui_data;
+    dt_iop_basicadj_gui_data_t *g = (dt_iop_basicadj_gui_data_t *)dt_iop_gui_data(self);
 
     const dt_iop_order_iccprofile_info_t *const work_profile
         = dt_ioppr_get_iop_work_profile_info(self, self->dev->iop);
@@ -342,7 +342,7 @@ static void _signal_profile_user_changed(gpointer instance, uint8_t profile_type
 int mouse_moved(struct dt_iop_module_t *self, double x, double y, double pressure, int which)
 {
   int handled = 0;
-  dt_iop_basicadj_gui_data_t *g = (dt_iop_basicadj_gui_data_t *)self->gui_data;
+  dt_iop_basicadj_gui_data_t *g = (dt_iop_basicadj_gui_data_t *)dt_iop_gui_data(self);
   if(!IS_NULL_PTR(g) && g->draw_selected_region && g->button_down && self->enabled)
   {
     float point[2] = { (float)x, (float)y };
@@ -363,7 +363,7 @@ int mouse_moved(struct dt_iop_module_t *self, double x, double y, double pressur
 int button_released(struct dt_iop_module_t *self, double x, double y, int which, uint32_t state)
 {
   int handled = 0;
-  dt_iop_basicadj_gui_data_t *g = (dt_iop_basicadj_gui_data_t *)self->gui_data;
+  dt_iop_basicadj_gui_data_t *g = (dt_iop_basicadj_gui_data_t *)dt_iop_gui_data(self);
   if(!IS_NULL_PTR(g) && g->draw_selected_region && self->enabled)
   {
     if(fabsf(g->posx_from - g->posx_to) > 1 && fabsf(g->posy_from - g->posy_to) > 1)
@@ -392,7 +392,7 @@ int button_pressed(struct dt_iop_module_t *self, double x, double y, double pres
                    uint32_t state)
 {
   int handled = 0;
-  dt_iop_basicadj_gui_data_t *g = (dt_iop_basicadj_gui_data_t *)self->gui_data;
+  dt_iop_basicadj_gui_data_t *g = (dt_iop_basicadj_gui_data_t *)dt_iop_gui_data(self);
   if(!IS_NULL_PTR(g) && g->draw_selected_region && self->enabled)
   {
     if((which == 3) || (which == 1 && type == GDK_2BUTTON_PRESS))
@@ -422,7 +422,7 @@ int button_pressed(struct dt_iop_module_t *self, double x, double y, double pres
 void gui_post_expose(struct dt_iop_module_t *self, cairo_t *cr, int32_t width, int32_t height, int32_t pointerx,
                      int32_t pointery)
 {
-  dt_iop_basicadj_gui_data_t *g = (dt_iop_basicadj_gui_data_t *)self->gui_data;
+  dt_iop_basicadj_gui_data_t *g = (dt_iop_basicadj_gui_data_t *)dt_iop_gui_data(self);
   if(IS_NULL_PTR(g) || !self->enabled) return;
   if(!g->draw_selected_region || !g->button_down) return;
   if(g->posx_from == g->posx_to && g->posy_from == g->posy_to) return;
@@ -465,7 +465,7 @@ void color_picker_apply(dt_iop_module_t *self, GtkWidget *picker, dt_dev_pixelpi
   (void)piece;
   if(dt_gui_widgets_suppressed()) return;
   dt_iop_basicadj_params_t *p = (dt_iop_basicadj_params_t *)self->params;
-  dt_iop_basicadj_gui_data_t *g = (dt_iop_basicadj_gui_data_t *)self->gui_data;
+  dt_iop_basicadj_gui_data_t *g = (dt_iop_basicadj_gui_data_t *)dt_iop_gui_data(self);
 
   const dt_iop_order_iccprofile_info_t *const work_profile = dt_ioppr_get_pipe_current_profile_info(self, pipe);
   p->middle_grey = (work_profile) ? (dt_ioppr_get_rgb_matrix_luminance(self->picked_color,
@@ -563,7 +563,7 @@ void cleanup_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev
 
 void gui_update(struct dt_iop_module_t *self)
 {
-  dt_iop_basicadj_gui_data_t *g = (dt_iop_basicadj_gui_data_t *)self->gui_data;
+  dt_iop_basicadj_gui_data_t *g = (dt_iop_basicadj_gui_data_t *)dt_iop_gui_data(self);
 
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->bt_select_region), g->draw_selected_region);
 }
@@ -575,7 +575,7 @@ void gui_focus(struct dt_iop_module_t *self, gboolean in)
 
 void change_image(struct dt_iop_module_t *self)
 {
-  dt_iop_basicadj_gui_data_t *g = (dt_iop_basicadj_gui_data_t *)self->gui_data;
+  dt_iop_basicadj_gui_data_t *g = (dt_iop_basicadj_gui_data_t *)dt_iop_gui_data(self);
 
   g->call_auto_exposure = 0;
   g->draw_selected_region = 0;
@@ -590,7 +590,7 @@ void gui_init(struct dt_iop_module_t *self)
 
   change_image(self);
 
-  self->widget = GTK_WIDGET(gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_GUI_BOX_SPACING));
+  self->gui->widget = GTK_WIDGET(gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_GUI_BOX_SPACING));
 
   g->sl_black_point = dt_bauhaus_slider_from_params(self, "black_point");
   dt_bauhaus_slider_set_soft_range(g->sl_black_point, -0.1, 0.1);
@@ -647,7 +647,7 @@ void gui_init(struct dt_iop_module_t *self)
   g_signal_connect(G_OBJECT(g->bt_select_region), "toggled", G_CALLBACK(_select_region_toggled_callback), self);
   gtk_box_pack_start(GTK_BOX(autolevels_box), g->bt_select_region, TRUE, TRUE, 0);
 
-  gtk_box_pack_start(GTK_BOX(self->widget), autolevels_box, TRUE, TRUE, 0);
+  gtk_box_pack_start(GTK_BOX(self->gui->widget), autolevels_box, TRUE, TRUE, 0);
 
   g->sl_clip = dt_bauhaus_slider_from_params(self, N_("clip"));
   dt_bauhaus_slider_set_digits(g->sl_clip, 3);
@@ -1291,7 +1291,7 @@ int process(struct dt_iop_module_t *self, const dt_dev_pixelpipe_t *pipe, const 
   const int ch = piece->dsc_in.channels;
   dt_iop_basicadj_data_t *d = (dt_iop_basicadj_data_t *)piece->data;
   dt_iop_basicadj_params_t *p = (dt_iop_basicadj_params_t *)&d->params;
-  dt_iop_basicadj_gui_data_t *g = (dt_iop_basicadj_gui_data_t *)self->gui_data;
+  dt_iop_basicadj_gui_data_t *g = (dt_iop_basicadj_gui_data_t *)dt_iop_gui_data(self);
 
   // process auto levels
   if(!IS_NULL_PTR(g) && dt_dev_pixelpipe_has_preview_output(self->dev, pipe, roi_out))

--- a/src/iop/bilat.c
+++ b/src/iop/bilat.c
@@ -362,7 +362,7 @@ int process(struct dt_iop_module_t *self, const dt_dev_pixelpipe_t *pipe, const 
 
 void gui_changed(dt_iop_module_t *self, GtkWidget *w, void *previous)
 {
-  dt_iop_bilat_gui_data_t *g = (dt_iop_bilat_gui_data_t *)self->gui_data;
+  dt_iop_bilat_gui_data_t *g = (dt_iop_bilat_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_bilat_params_t *p = (dt_iop_bilat_params_t *)self->params;
   if(w == g->highlights || w == g->shadows || w == g->midtone)
   {
@@ -398,7 +398,7 @@ void gui_changed(dt_iop_module_t *self, GtkWidget *w, void *previous)
 
 void gui_update(dt_iop_module_t *self)
 {
-  dt_iop_bilat_gui_data_t *g = (dt_iop_bilat_gui_data_t *)self->gui_data;
+  dt_iop_bilat_gui_data_t *g = (dt_iop_bilat_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_bilat_params_t *p = (dt_iop_bilat_params_t *)self->params;
 
   if(p->mode == s_mode_local_laplacian)

--- a/src/iop/blurs.c
+++ b/src/iop/blurs.c
@@ -680,7 +680,7 @@ void cleanup_global(dt_iop_module_so_t *module)
 void gui_changed(dt_iop_module_t *self, GtkWidget *w, void *previous)
 {
   dt_iop_blurs_params_t *p = (dt_iop_blurs_params_t *)self->params;
-  dt_iop_blurs_gui_data_t *g = (dt_iop_blurs_gui_data_t *)self->gui_data;
+  dt_iop_blurs_gui_data_t *g = (dt_iop_blurs_gui_data_t *)dt_iop_gui_data(self);
 
   if(IS_NULL_PTR(w) || w == g->type)
   {
@@ -730,7 +730,7 @@ void gui_changed(dt_iop_module_t *self, GtkWidget *w, void *previous)
 static gboolean dt_iop_tonecurve_draw(GtkWidget *widget, cairo_t *crf, gpointer user_data)
 {
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
-  dt_iop_blurs_gui_data_t *g = (dt_iop_blurs_gui_data_t *)self->gui_data;
+  dt_iop_blurs_gui_data_t *g = (dt_iop_blurs_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_blurs_params_t *p = (dt_iop_blurs_params_t *)self->params;
 
   GtkAllocation allocation;
@@ -783,7 +783,7 @@ void gui_init(dt_iop_module_t *self)
 {
   dt_iop_blurs_gui_data_t *g = IOP_GUI_ALLOC(blurs);
 
-  self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_GUI_BOX_SPACING);
+  self->gui->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_GUI_BOX_SPACING);
 
   // Image buffer to store the kernel look
   // Don't recompute it in the drawing function, only when a param is changed
@@ -794,7 +794,7 @@ void gui_init(dt_iop_module_t *self)
 
   g->area = GTK_DRAWING_AREA(dtgtk_drawing_area_new_with_aspect_ratio(1.f));
   g_signal_connect(G_OBJECT(g->area), "draw", G_CALLBACK(dt_iop_tonecurve_draw), self);
-  gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(g->area), TRUE, TRUE, 0);
+  gtk_box_pack_start(GTK_BOX(self->gui->widget), GTK_WIDGET(g->area), TRUE, TRUE, 0);
 
   g->radius = dt_bauhaus_slider_from_params(self, "radius");
   dt_bauhaus_slider_set_format(g->radius, " px");
@@ -820,7 +820,7 @@ void gui_init(dt_iop_module_t *self)
 
 void gui_cleanup(dt_iop_module_t *self)
 {
-  dt_iop_blurs_gui_data_t *g = (dt_iop_blurs_gui_data_t *)self->gui_data;
+  dt_iop_blurs_gui_data_t *g = (dt_iop_blurs_gui_data_t *)dt_iop_gui_data(self);
   dt_free_align(g->img);
   g->img = NULL;
   IOP_GUI_FREE;

--- a/src/iop/borders.c
+++ b/src/iop/borders.c
@@ -743,7 +743,7 @@ void init_presets(dt_iop_module_so_t *self)
 
 void color_picker_apply(dt_iop_module_t *self, GtkWidget *picker, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
 {
-  dt_iop_borders_gui_data_t *g = (dt_iop_borders_gui_data_t *)self->gui_data;
+  dt_iop_borders_gui_data_t *g = (dt_iop_borders_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_borders_params_t *p = (dt_iop_borders_params_t *)self->params;
 
   if(fabsf(p->color[0] - self->picked_color[0]) < 0.0001f
@@ -787,7 +787,7 @@ void color_picker_apply(dt_iop_module_t *self, GtkWidget *picker, dt_dev_pixelpi
 
 static void aspect_changed(GtkWidget *combo, dt_iop_module_t *self)
 {
-  dt_iop_borders_gui_data_t *g = (dt_iop_borders_gui_data_t *)self->gui_data;
+  dt_iop_borders_gui_data_t *g = (dt_iop_borders_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_borders_params_t *p = (dt_iop_borders_params_t *)self->params;
   const int which = dt_bauhaus_combobox_get(combo);
   const char *text = dt_bauhaus_combobox_get_text(combo);
@@ -809,7 +809,7 @@ static void aspect_changed(GtkWidget *combo, dt_iop_module_t *self)
 
 static void position_h_changed(GtkWidget *combo, dt_iop_module_t *self)
 {
-  dt_iop_borders_gui_data_t *g = (dt_iop_borders_gui_data_t *)self->gui_data;
+  dt_iop_borders_gui_data_t *g = (dt_iop_borders_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_borders_params_t *p = (dt_iop_borders_params_t *)self->params;
   const int which = dt_bauhaus_combobox_get(combo);
   const char *text = dt_bauhaus_combobox_get_text(combo);
@@ -831,7 +831,7 @@ static void position_h_changed(GtkWidget *combo, dt_iop_module_t *self)
 
 static void position_v_changed(GtkWidget *combo, dt_iop_module_t *self)
 {
-  dt_iop_borders_gui_data_t *g = (dt_iop_borders_gui_data_t *)self->gui_data;
+  dt_iop_borders_gui_data_t *g = (dt_iop_borders_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_borders_params_t *p = (dt_iop_borders_params_t *)self->params;
   const int which = dt_bauhaus_combobox_get(combo);
   const char *text = dt_bauhaus_combobox_get_text(combo);
@@ -853,7 +853,7 @@ static void position_v_changed(GtkWidget *combo, dt_iop_module_t *self)
 
 void gui_changed(dt_iop_module_t *self, GtkWidget *w, void *previous)
 {
-  dt_iop_borders_gui_data_t *g = (dt_iop_borders_gui_data_t *)self->gui_data;
+  dt_iop_borders_gui_data_t *g = (dt_iop_borders_gui_data_t *)dt_iop_gui_data(self);
 
   if (w == g->aspect_slider)
   {
@@ -906,7 +906,7 @@ static void frame_colorpick_color_set(GtkColorButton *widget, dt_iop_module_t *s
 
 void gui_update(struct dt_iop_module_t *self)
 {
-  dt_iop_borders_gui_data_t *g = (dt_iop_borders_gui_data_t *)self->gui_data;
+  dt_iop_borders_gui_data_t *g = (dt_iop_borders_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_borders_params_t *p = (dt_iop_borders_params_t *)self->params;
 
 // FIXME by hand
@@ -966,7 +966,7 @@ void gui_update(struct dt_iop_module_t *self)
 
 static void gui_init_aspect(struct dt_iop_module_t *self)
 {
-  dt_iop_borders_gui_data_t *g = (dt_iop_borders_gui_data_t *)self->gui_data;
+  dt_iop_borders_gui_data_t *g = (dt_iop_borders_gui_data_t *)dt_iop_gui_data(self);
 
   dt_bauhaus_combobox_add(g->aspect, _("image"));
   dt_bauhaus_combobox_add(g->aspect, _("3:1"));
@@ -999,7 +999,7 @@ static void gui_init_aspect(struct dt_iop_module_t *self)
 
 static void gui_init_positions(struct dt_iop_module_t *self)
 {
-  dt_iop_borders_gui_data_t *g = (dt_iop_borders_gui_data_t *)self->gui_data;
+  dt_iop_borders_gui_data_t *g = (dt_iop_borders_gui_data_t *)dt_iop_gui_data(self);
 
   dt_bauhaus_combobox_add(g->pos_h, _("center"));
   dt_bauhaus_combobox_add(g->pos_h, _("1/3"));
@@ -1041,7 +1041,7 @@ void gui_init(struct dt_iop_module_t *self)
   g->aspect = dt_bauhaus_combobox_new(dt_bauhaus_get_global(), DT_GUI_MODULE(self));
   dt_bauhaus_combobox_set_editable(g->aspect, 1);
   dt_bauhaus_widget_set_label(g->aspect, N_("aspect"));
-  gtk_box_pack_start(GTK_BOX(self->widget), g->aspect, TRUE, TRUE, 0);
+  gtk_box_pack_start(GTK_BOX(self->gui->widget), g->aspect, TRUE, TRUE, 0);
   gui_init_aspect(self);
   g_signal_connect(G_OBJECT(g->aspect), "value-changed", G_CALLBACK(aspect_changed), self);
   gtk_widget_set_tooltip_text(g->aspect, _("select the aspect ratio or right click and type your own (w:h)"));
@@ -1057,7 +1057,7 @@ void gui_init(struct dt_iop_module_t *self)
   g->pos_h = dt_bauhaus_combobox_new(dt_bauhaus_get_global(), DT_GUI_MODULE(self));
   dt_bauhaus_combobox_set_editable(g->pos_h, 1);
   dt_bauhaus_widget_set_label(g->pos_h, N_("horizontal position"));
-  gtk_box_pack_start(GTK_BOX(self->widget), g->pos_h, TRUE, TRUE, 0);
+  gtk_box_pack_start(GTK_BOX(self->gui->widget), g->pos_h, TRUE, TRUE, 0);
   g_signal_connect(G_OBJECT(g->pos_h), "value-changed", G_CALLBACK(position_h_changed), self);
   gtk_widget_set_tooltip_text(g->pos_h, _("select the horizontal position ratio relative to top "
                                           "or right click and type your own (y:h)"));
@@ -1067,7 +1067,7 @@ void gui_init(struct dt_iop_module_t *self)
   g->pos_v = dt_bauhaus_combobox_new(dt_bauhaus_get_global(), DT_GUI_MODULE(self));
   dt_bauhaus_combobox_set_editable(g->pos_v, 1);
   dt_bauhaus_widget_set_label(g->pos_v, N_("vertical position"));
-  gtk_box_pack_start(GTK_BOX(self->widget), g->pos_v, TRUE, TRUE, 0);
+  gtk_box_pack_start(GTK_BOX(self->gui->widget), g->pos_v, TRUE, TRUE, 0);
   g_signal_connect(G_OBJECT(g->pos_v), "value-changed", G_CALLBACK(position_v_changed), self);
   gtk_widget_set_tooltip_text(g->pos_v, _("select the vertical position ratio relative to left "
                                           "or right click and type your own (x:w)"));
@@ -1100,7 +1100,7 @@ void gui_init(struct dt_iop_module_t *self)
   gtk_box_pack_start(GTK_BOX(box), GTK_WIDGET(g->colorpick), FALSE, TRUE, 0);
   g->border_picker = dt_color_picker_new(self, DT_COLOR_PICKER_POINT, box);
   gtk_widget_set_tooltip_text(GTK_WIDGET(g->border_picker), _("pick border color from image"));
-  gtk_box_pack_start(GTK_BOX(self->widget), box, TRUE, TRUE, 0);
+  gtk_box_pack_start(GTK_BOX(self->gui->widget), box, TRUE, TRUE, 0);
 
   box = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, DT_GUI_BOX_SPACING);
   label = dt_iop_gui_reset_label_new(_("frame line color"), self, &p->color, 3 * sizeof(float));
@@ -1112,7 +1112,7 @@ void gui_init(struct dt_iop_module_t *self)
   gtk_box_pack_start(GTK_BOX(box), GTK_WIDGET(g->frame_colorpick), FALSE, TRUE, 0);
   g->frame_picker = dt_color_picker_new(self, DT_COLOR_PICKER_POINT, box);
   gtk_widget_set_tooltip_text(GTK_WIDGET(g->frame_picker), _("pick frame line color from image"));
-  gtk_box_pack_start(GTK_BOX(self->widget), box, TRUE, TRUE, 0);
+  gtk_box_pack_start(GTK_BOX(self->gui->widget), box, TRUE, TRUE, 0);
 }
 
 

--- a/src/iop/cacorrect.c
+++ b/src/iop/cacorrect.c
@@ -1461,7 +1461,7 @@ void cleanup_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev
 
 void gui_update(dt_iop_module_t *self)
 {
-  dt_iop_cacorrect_gui_data_t *g = (dt_iop_cacorrect_gui_data_t *)self->gui_data;
+  dt_iop_cacorrect_gui_data_t *g = (dt_iop_cacorrect_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_cacorrect_params_t *p = (dt_iop_cacorrect_params_t *)self->params;
 
   dt_image_t *img = &self->dev->image_storage;
@@ -1469,7 +1469,7 @@ void gui_update(dt_iop_module_t *self)
   const gboolean active = _cacorrect_supported(img);
   self->hide_enable_button = !active;
 
-  gtk_stack_set_visible_child_name(GTK_STACK(self->widget), active ? "raw" : "non_raw");
+  gtk_stack_set_visible_child_name(GTK_STACK(self->gui->widget), active ? "raw" : "non_raw");
 
   gtk_widget_set_visible(g->avoidshift, active);
   gtk_widget_set_visible(g->iterations, active);
@@ -1479,14 +1479,14 @@ void gui_update(dt_iop_module_t *self)
 
 void gui_changed(dt_iop_module_t *self, GtkWidget *w, void *previous)
 {
-  dt_iop_cacorrect_gui_data_t *g = (dt_iop_cacorrect_gui_data_t *)self->gui_data;
+  dt_iop_cacorrect_gui_data_t *g = (dt_iop_cacorrect_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_cacorrect_params_t *p = (dt_iop_cacorrect_params_t *)self->params;
 
   dt_image_t *img = &self->dev->image_storage;
 
   const gboolean active = _cacorrect_supported(img);
 
-  gtk_stack_set_visible_child_name(GTK_STACK(self->widget), active ? "raw" : "non_raw");
+  gtk_stack_set_visible_child_name(GTK_STACK(self->gui->widget), active ? "raw" : "non_raw");
 
   gtk_widget_set_visible(g->avoidshift, active);
   dt_bauhaus_combobox_set_from_value(g->iterations, p->iterations);
@@ -1502,7 +1502,7 @@ void gui_init(dt_iop_module_t *self)
 {
   dt_iop_cacorrect_gui_data_t *g = IOP_GUI_ALLOC(cacorrect);
 
-  GtkWidget *box_raw = self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_GUI_BOX_SPACING);
+  GtkWidget *box_raw = self->gui->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_GUI_BOX_SPACING);
 
   g->iterations = dt_bauhaus_combobox_from_params(self, "iterations");
   gtk_widget_set_tooltip_text(g->iterations, _("iteration runs, default is twice"));
@@ -1511,12 +1511,12 @@ void gui_init(dt_iop_module_t *self)
   gtk_widget_set_tooltip_text(g->avoidshift, _("activate colorshift correction for blue & red channels"));
 
   // start building top level widget
-  self->widget = gtk_stack_new();
-  gtk_stack_set_homogeneous(GTK_STACK(self->widget), FALSE);
-  gtk_stack_add_named(GTK_STACK(self->widget), box_raw, "raw");
+  self->gui->widget = gtk_stack_new();
+  gtk_stack_set_homogeneous(GTK_STACK(self->gui->widget), FALSE);
+  gtk_stack_add_named(GTK_STACK(self->gui->widget), box_raw, "raw");
 
   GtkWidget *label_non_raw = dt_ui_label_new(_("automatic chromatic aberration correction\nonly for Bayer raw files"));
-  gtk_stack_add_named(GTK_STACK(self->widget), label_non_raw, "non_raw");
+  gtk_stack_add_named(GTK_STACK(self->gui->widget), label_non_raw, "non_raw");
 }
 
 #undef CA_SIZE_MINIMUM

--- a/src/iop/cacorrectrgb.c
+++ b/src/iop/cacorrectrgb.c
@@ -741,7 +741,7 @@ int process(struct dt_iop_module_t *self, const dt_dev_pixelpipe_t *pipe, const 
 
 void gui_update(dt_iop_module_t *self)
 {
-  dt_iop_cacorrectrgb_gui_data_t *g = (dt_iop_cacorrectrgb_gui_data_t *)self->gui_data;
+  dt_iop_cacorrectrgb_gui_data_t *g = (dt_iop_cacorrectrgb_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_cacorrectrgb_params_t *p = (dt_iop_cacorrectrgb_params_t *)self->params;
   const dt_iop_cacorrectrgb_params_t *d = (const dt_iop_cacorrectrgb_params_t *)self->default_params;
 
@@ -772,7 +772,7 @@ void reload_defaults(dt_iop_module_t *module)
 void gui_init(dt_iop_module_t *self)
 {
   dt_iop_cacorrectrgb_gui_data_t *g = IOP_GUI_ALLOC(cacorrectrgb);
-  self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_GUI_BOX_SPACING);
+  self->gui->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_GUI_BOX_SPACING);
   g->guide_channel = dt_bauhaus_combobox_from_params(self, "guide_channel");
   gtk_widget_set_tooltip_text(g->guide_channel, _("channel used as a reference to\n"
                                            "correct the other channels.\n"
@@ -788,7 +788,7 @@ void gui_init(dt_iop_module_t *self)
                                              "high values can lead to overshooting\n"
                                              "and edge bleeding."));
 
-  gtk_box_pack_start(GTK_BOX(self->widget), dt_ui_section_label_new(_("advanced parameters")), TRUE, TRUE, 0);
+  gtk_box_pack_start(GTK_BOX(self->gui->widget), dt_ui_section_label_new(_("advanced parameters")), TRUE, TRUE, 0);
   g->mode = dt_bauhaus_combobox_from_params(self, "mode");
   gtk_widget_set_tooltip_text(g->mode, _("correction mode to use.\n"
                                          "can help with multiple\n"

--- a/src/iop/channelmixer.c
+++ b/src/iop/channelmixer.c
@@ -53,6 +53,7 @@
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif
+#include "develop/imageop_gui.h"
 #include "widgets/bauhaus.h"
 #include "colorprofiles/colorspaces.h"
 #include "develop/develop.h"
@@ -401,7 +402,7 @@ static void red_callback(GtkWidget *slider, gpointer user_data)
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
   if(dt_gui_widgets_suppressed()) return;
   dt_iop_channelmixer_params_t *p = (dt_iop_channelmixer_params_t *)self->params;
-  dt_iop_channelmixer_gui_data_t *g = (dt_iop_channelmixer_gui_data_t *)self->gui_data;
+  dt_iop_channelmixer_gui_data_t *g = (dt_iop_channelmixer_gui_data_t *)dt_iop_gui_data(self);
   const int output_channel_index = dt_bauhaus_combobox_get(g->output_channel);
   const float value = dt_bauhaus_slider_get(slider);
   if(output_channel_index >= 0 && value != p->red[output_channel_index])
@@ -416,7 +417,7 @@ static void green_callback(GtkWidget *slider, gpointer user_data)
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
   if(dt_gui_widgets_suppressed()) return;
   dt_iop_channelmixer_params_t *p = (dt_iop_channelmixer_params_t *)self->params;
-  dt_iop_channelmixer_gui_data_t *g = (dt_iop_channelmixer_gui_data_t *)self->gui_data;
+  dt_iop_channelmixer_gui_data_t *g = (dt_iop_channelmixer_gui_data_t *)dt_iop_gui_data(self);
   const int output_channel_index = dt_bauhaus_combobox_get(g->output_channel);
   const float value = dt_bauhaus_slider_get(slider);
   if(output_channel_index >= 0 && value != p->green[output_channel_index])
@@ -431,7 +432,7 @@ static void blue_callback(GtkWidget *slider, gpointer user_data)
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
   if(dt_gui_widgets_suppressed()) return;
   dt_iop_channelmixer_params_t *p = (dt_iop_channelmixer_params_t *)self->params;
-  dt_iop_channelmixer_gui_data_t *g = (dt_iop_channelmixer_gui_data_t *)self->gui_data;
+  dt_iop_channelmixer_gui_data_t *g = (dt_iop_channelmixer_gui_data_t *)dt_iop_gui_data(self);
   const int output_channel_index = dt_bauhaus_combobox_get(g->output_channel);
   const float value = dt_bauhaus_slider_get(slider);
   if(output_channel_index >= 0 && value != p->blue[output_channel_index])
@@ -446,7 +447,7 @@ static void output_callback(GtkComboBox *combo, gpointer user_data)
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
   if(dt_gui_widgets_suppressed()) return;
   dt_iop_channelmixer_params_t *p = (dt_iop_channelmixer_params_t *)self->params;
-  dt_iop_channelmixer_gui_data_t *g = (dt_iop_channelmixer_gui_data_t *)self->gui_data;
+  dt_iop_channelmixer_gui_data_t *g = (dt_iop_channelmixer_gui_data_t *)dt_iop_gui_data(self);
 
   const int output_channel_index = dt_bauhaus_combobox_get(g->output_channel);
   if(output_channel_index >= 0)
@@ -539,7 +540,7 @@ void cleanup_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev
 
 void gui_update(struct dt_iop_module_t *self)
 {
-  dt_iop_channelmixer_gui_data_t *g = (dt_iop_channelmixer_gui_data_t *)self->gui_data;
+  dt_iop_channelmixer_gui_data_t *g = (dt_iop_channelmixer_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_channelmixer_params_t *p = (dt_iop_channelmixer_params_t *)self->params;
 
   const int output_channel_index = dt_bauhaus_combobox_get(g->output_channel);
@@ -566,7 +567,7 @@ void gui_init(struct dt_iop_module_t *self)
   dt_iop_channelmixer_gui_data_t *g = IOP_GUI_ALLOC(channelmixer);
   dt_iop_channelmixer_params_t *p = (dt_iop_channelmixer_params_t *)self->default_params;
 
-  self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_GUI_BOX_SPACING);
+  self->gui->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_GUI_BOX_SPACING);
 
   /* output */
   g->output_channel = dt_bauhaus_combobox_new(dt_bauhaus_get_global(), DT_GUI_MODULE(self));
@@ -600,11 +601,11 @@ void gui_init(struct dt_iop_module_t *self)
   g_signal_connect(G_OBJECT(g->scale_blue), "value-changed", G_CALLBACK(blue_callback), self);
 
 
-  gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(g->output_channel), TRUE, TRUE, 0);
+  gtk_box_pack_start(GTK_BOX(self->gui->widget), GTK_WIDGET(g->output_channel), TRUE, TRUE, 0);
 
-  gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(g->scale_red), TRUE, TRUE, 0);
-  gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(g->scale_green), TRUE, TRUE, 0);
-  gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(g->scale_blue), TRUE, TRUE, 0);
+  gtk_box_pack_start(GTK_BOX(self->gui->widget), GTK_WIDGET(g->scale_red), TRUE, TRUE, 0);
+  gtk_box_pack_start(GTK_BOX(self->gui->widget), GTK_WIDGET(g->scale_green), TRUE, TRUE, 0);
+  gtk_box_pack_start(GTK_BOX(self->gui->widget), GTK_WIDGET(g->scale_blue), TRUE, TRUE, 0);
 }
 
 void init_presets(dt_iop_module_so_t *self)

--- a/src/iop/channelmixerrgb.c
+++ b/src/iop/channelmixerrgb.c
@@ -1151,7 +1151,7 @@ static void declare_cat_on_pipe(struct dt_iop_module_t *self, gboolean preset)
 
 static inline gboolean _is_another_module_cat_on_pipe(struct dt_iop_module_t *self)
 {
-  dt_iop_channelmixer_rgb_gui_data_t *g = (dt_iop_channelmixer_rgb_gui_data_t *)self->gui_data;
+  dt_iop_channelmixer_rgb_gui_data_t *g = (dt_iop_channelmixer_rgb_gui_data_t *)dt_iop_gui_data(self);
   if(IS_NULL_PTR(g)) return FALSE;
   return self->dev->proxy.chroma_adaptation && self->dev->proxy.chroma_adaptation != self;
 }
@@ -1919,7 +1919,7 @@ int process(struct dt_iop_module_t *self, const dt_dev_pixelpipe_t *pipe, const 
   dt_iop_channelmixer_rbg_data_t *data = (dt_iop_channelmixer_rbg_data_t *)piece->data;
   const struct dt_iop_order_iccprofile_info_t *const work_profile = dt_ioppr_get_pipe_current_profile_info(self, pipe);
   const struct dt_iop_order_iccprofile_info_t *const input_profile = dt_ioppr_get_pipe_input_profile_info(pipe);
-  dt_iop_channelmixer_rgb_gui_data_t *g = (dt_iop_channelmixer_rgb_gui_data_t *)self->gui_data;
+  dt_iop_channelmixer_rgb_gui_data_t *g = (dt_iop_channelmixer_rgb_gui_data_t *)dt_iop_gui_data(self);
 
   declare_cat_on_pipe(self, FALSE);
 
@@ -2284,7 +2284,7 @@ int mouse_moved(struct dt_iop_module_t *self, double x, double y, double pressur
 {
   if(!self->enabled) return 0;
 
-  dt_iop_channelmixer_rgb_gui_data_t *g = (dt_iop_channelmixer_rgb_gui_data_t *)self->gui_data;
+  dt_iop_channelmixer_rgb_gui_data_t *g = (dt_iop_channelmixer_rgb_gui_data_t *)dt_iop_gui_data(self);
   if(IS_NULL_PTR(g) || !g->is_profiling_started) return 0;
   if(g->box[0].x == -1.0f || g->box[1].y == -1.0f) return 0;
 
@@ -2357,7 +2357,7 @@ int button_pressed(struct dt_iop_module_t *self, double x, double y, double pres
 {
   if(!self->enabled) return 0;
 
-  dt_iop_channelmixer_rgb_gui_data_t *g = (dt_iop_channelmixer_rgb_gui_data_t *)self->gui_data;
+  dt_iop_channelmixer_rgb_gui_data_t *g = (dt_iop_channelmixer_rgb_gui_data_t *)dt_iop_gui_data(self);
   if(IS_NULL_PTR(g) || !g->is_profiling_started) return 0;
 
   dt_develop_t *dev = self->dev;
@@ -2405,7 +2405,7 @@ int button_released(struct dt_iop_module_t *self, double x, double y, int which,
 {
   if(!self->enabled) return 0;
 
-  dt_iop_channelmixer_rgb_gui_data_t *g = (dt_iop_channelmixer_rgb_gui_data_t *)self->gui_data;
+  dt_iop_channelmixer_rgb_gui_data_t *g = (dt_iop_channelmixer_rgb_gui_data_t *)dt_iop_gui_data(self);
   if(IS_NULL_PTR(g) || !g->is_profiling_started) return 0;
   if(g->box[0].x == -1.0f || g->box[1].y == -1.0f) return 0;
   if(!g->is_cursor_close || !g->drag_drop) return 0;
@@ -2439,7 +2439,7 @@ void gui_post_expose(struct dt_iop_module_t *self, cairo_t *cr, int32_t width, i
   const dt_iop_order_iccprofile_info_t *const work_profile = dt_ioppr_get_pipe_output_profile_info(self->dev->pipe);
   if(IS_NULL_PTR(work_profile)) return;
 
-  const dt_iop_channelmixer_rgb_gui_data_t *g = (const dt_iop_channelmixer_rgb_gui_data_t *)self->gui_data;
+  const dt_iop_channelmixer_rgb_gui_data_t *g = (const dt_iop_channelmixer_rgb_gui_data_t *)dt_iop_gui_data(self);
   if(IS_NULL_PTR(g) || !g->is_profiling_started) return;
 
   // Rescale and shift Cairo drawing coordinates
@@ -2610,7 +2610,7 @@ void gui_post_expose(struct dt_iop_module_t *self, cairo_t *cr, int32_t width, i
 
 void color_list_visibility(dt_iop_module_t *self, const int checker_cmbbx_index)
 {
-  dt_iop_channelmixer_rgb_gui_data_t *g = (dt_iop_channelmixer_rgb_gui_data_t *)self->gui_data;
+  dt_iop_channelmixer_rgb_gui_data_t *g = (dt_iop_channelmixer_rgb_gui_data_t *)dt_iop_gui_data(self);
 
   if(checker_cmbbx_index >= COLOR_CHECKER_USER_REF)
     if(dt_bauhaus_combobox_get_entry(GTK_WIDGET(g->checkers_color_list), 0) != NULL)
@@ -2638,7 +2638,7 @@ void color_list_visibility(dt_iop_module_t *self, const int checker_cmbbx_index)
  */
 void update_colorchecker_color_list(dt_iop_module_t *self)
 {
-  dt_iop_channelmixer_rgb_gui_data_t *g = (dt_iop_channelmixer_rgb_gui_data_t *)self->gui_data;
+  dt_iop_channelmixer_rgb_gui_data_t *g = (dt_iop_channelmixer_rgb_gui_data_t *)dt_iop_gui_data(self);
 
   if(!g) return;
   if(!g->colorcheckers) return;
@@ -2680,7 +2680,7 @@ void update_colorchecker_color_list(dt_iop_module_t *self)
 
 void update_colorchecker_list(dt_iop_module_t *self)
 {
-  dt_iop_channelmixer_rgb_gui_data_t *g = (dt_iop_channelmixer_rgb_gui_data_t *)self->gui_data;
+  dt_iop_channelmixer_rgb_gui_data_t *g = (dt_iop_channelmixer_rgb_gui_data_t *)dt_iop_gui_data(self);
   if(IS_NULL_PTR(g)) return;
 
   dt_colorchecker_label_list_cleanup(&(g->colorcheckers));
@@ -2715,7 +2715,7 @@ static void optimize_changed_callback(GtkWidget *widget, gpointer user_data)
 {
   if(dt_gui_widgets_suppressed()) return;
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
-  dt_iop_channelmixer_rgb_gui_data_t *g = (dt_iop_channelmixer_rgb_gui_data_t *)self->gui_data;
+  dt_iop_channelmixer_rgb_gui_data_t *g = (dt_iop_channelmixer_rgb_gui_data_t *)dt_iop_gui_data(self);
 
   const int i = dt_bauhaus_combobox_get(widget);
   dt_conf_set_int("darkroom/modules/channelmixerrgb/optimization", i);
@@ -2729,7 +2729,7 @@ static void checker_color_changed_callback(GtkWidget *widget, gpointer user_data
 {
   if(dt_gui_widgets_suppressed()) return;
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
-  dt_iop_channelmixer_rgb_gui_data_t *g = (dt_iop_channelmixer_rgb_gui_data_t *)self->gui_data;
+  dt_iop_channelmixer_rgb_gui_data_t *g = (dt_iop_channelmixer_rgb_gui_data_t *)dt_iop_gui_data(self);
 
   const int selected_cmbbx_index = dt_bauhaus_combobox_get(widget);
   dt_conf_set_int("darkroom/modules/channelmixerrgb/colorchecker_color", selected_cmbbx_index);
@@ -2761,7 +2761,7 @@ void checker_changed_callback(GtkWidget *widget, gpointer user_data)
 {
   if(dt_gui_widgets_suppressed()) return;
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
-  dt_iop_channelmixer_rgb_gui_data_t *g = (dt_iop_channelmixer_rgb_gui_data_t *)self->gui_data;
+  dt_iop_channelmixer_rgb_gui_data_t *g = (dt_iop_channelmixer_rgb_gui_data_t *)dt_iop_gui_data(self);
 
   const int checker_cmbbx_index = dt_bauhaus_combobox_get(widget);
   dt_conf_set_int("darkroom/modules/channelmixerrgb/colorchecker", checker_cmbbx_index);
@@ -2794,7 +2794,7 @@ static void safety_changed_callback(GtkWidget *widget, gpointer user_data)
 {
   if(dt_gui_widgets_suppressed()) return;
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
-  dt_iop_channelmixer_rgb_gui_data_t *g = (dt_iop_channelmixer_rgb_gui_data_t *)self->gui_data;
+  dt_iop_channelmixer_rgb_gui_data_t *g = (dt_iop_channelmixer_rgb_gui_data_t *)dt_iop_gui_data(self);
 
   dt_iop_gui_enter_critical_section(self);
   g->safety_margin = dt_bauhaus_slider_get(widget);
@@ -2809,14 +2809,14 @@ static void start_profiling_callback(GtkWidget *togglebutton, dt_iop_module_t *s
 {
   if(dt_gui_widgets_suppressed()) return;
   dt_iop_request_focus(self);
-  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(self->off), TRUE);
+  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(self->gui->off), TRUE);
 
   dt_develop_t *dev = self->dev;
   const float wd = dev->roi.preview_width;
   const float ht = dev->roi.preview_height;
   if(wd == 0.f || ht == 0.f) return;
 
-  dt_iop_channelmixer_rgb_gui_data_t *g = (dt_iop_channelmixer_rgb_gui_data_t *)self->gui_data;
+  dt_iop_channelmixer_rgb_gui_data_t *g = (dt_iop_channelmixer_rgb_gui_data_t *)dt_iop_gui_data(self);
   g->is_profiling_started = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(g->cs.toggle));
 
   // init bounding box
@@ -2831,7 +2831,7 @@ static void run_profile_callback(GtkWidget *widget, GdkEventButton *event, gpoin
 {
   if(dt_gui_widgets_suppressed()) return;
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
-  dt_iop_channelmixer_rgb_gui_data_t *g = (dt_iop_channelmixer_rgb_gui_data_t *)self->gui_data;
+  dt_iop_channelmixer_rgb_gui_data_t *g = (dt_iop_channelmixer_rgb_gui_data_t *)dt_iop_gui_data(self);
 
   dt_iop_gui_enter_critical_section(self);
   g->run_profile = TRUE;
@@ -2844,7 +2844,7 @@ static void run_validation_callback(GtkWidget *widget, GdkEventButton *event, gp
 {
   if(dt_gui_widgets_suppressed()) return;
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
-  dt_iop_channelmixer_rgb_gui_data_t *g = (dt_iop_channelmixer_rgb_gui_data_t *)self->gui_data;
+  dt_iop_channelmixer_rgb_gui_data_t *g = (dt_iop_channelmixer_rgb_gui_data_t *)dt_iop_gui_data(self);
 
   dt_iop_gui_enter_critical_section(self);
   g->run_validation = TRUE;
@@ -2857,7 +2857,7 @@ static void commit_profile_callback(GtkWidget *widget, GdkEventButton *event, gp
 {
   if(dt_gui_widgets_suppressed()) return;
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
-  dt_iop_channelmixer_rgb_gui_data_t *g = (dt_iop_channelmixer_rgb_gui_data_t *)self->gui_data;
+  dt_iop_channelmixer_rgb_gui_data_t *g = (dt_iop_channelmixer_rgb_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_channelmixer_rgb_params_t *p = (dt_iop_channelmixer_rgb_params_t *)self->params;
 
   if(!g->profile_ready) return;
@@ -2916,7 +2916,7 @@ static void commit_profile_callback(GtkWidget *widget, GdkEventButton *event, gp
 static void _develop_ui_pipe_finished_callback(gpointer instance, gpointer user_data)
 {
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
-  dt_iop_channelmixer_rgb_gui_data_t *g = (dt_iop_channelmixer_rgb_gui_data_t *)self->gui_data;
+  dt_iop_channelmixer_rgb_gui_data_t *g = (dt_iop_channelmixer_rgb_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_channelmixer_rgb_params_t *p = (dt_iop_channelmixer_rgb_params_t *)self->params;
 
   if(IS_NULL_PTR(g)) return;
@@ -2958,7 +2958,7 @@ static void _develop_ui_pipe_finished_callback(gpointer instance, gpointer user_
 static void _preview_pipe_finished_callback(gpointer instance, gpointer user_data)
 {
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
-  dt_iop_channelmixer_rgb_gui_data_t *g = (dt_iop_channelmixer_rgb_gui_data_t *)self->gui_data;
+  dt_iop_channelmixer_rgb_gui_data_t *g = (dt_iop_channelmixer_rgb_gui_data_t *)dt_iop_gui_data(self);
 
   dt_iop_gui_enter_critical_section(self);
   gtk_label_set_markup(GTK_LABEL(g->label_delta_E), g->delta_E_label_text);
@@ -2970,7 +2970,7 @@ void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pix
 {
   dt_iop_channelmixer_rgb_params_t *p = (dt_iop_channelmixer_rgb_params_t *)p1;
   dt_iop_channelmixer_rbg_data_t *d = (dt_iop_channelmixer_rbg_data_t *)piece->data;
-  dt_iop_channelmixer_rgb_gui_data_t *g = (dt_iop_channelmixer_rgb_gui_data_t *)self->gui_data;
+  dt_iop_channelmixer_rgb_gui_data_t *g = (dt_iop_channelmixer_rgb_gui_data_t *)dt_iop_gui_data(self);
 
   d->version = p->version;
 
@@ -3075,7 +3075,7 @@ void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pix
 static void update_illuminants(dt_iop_module_t *self)
 {
   dt_iop_channelmixer_rgb_params_t *p = (dt_iop_channelmixer_rgb_params_t *)self->params;
-  dt_iop_channelmixer_rgb_gui_data_t *g = (dt_iop_channelmixer_rgb_gui_data_t *)self->gui_data;
+  dt_iop_channelmixer_rgb_gui_data_t *g = (dt_iop_channelmixer_rgb_gui_data_t *)dt_iop_gui_data(self);
 
   if(p->adaptation == DT_ADAPTATION_RGB || p->adaptation == DT_ADAPTATION_LAST)
   {
@@ -3219,7 +3219,7 @@ static void update_illuminants(dt_iop_module_t *self)
 static void update_xy_color(dt_iop_module_t *self)
 {
   // update the fill background color of x, y sliders
-  dt_iop_channelmixer_rgb_gui_data_t *g = (dt_iop_channelmixer_rgb_gui_data_t *)self->gui_data;
+  dt_iop_channelmixer_rgb_gui_data_t *g = (dt_iop_channelmixer_rgb_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_channelmixer_rgb_params_t *p = (dt_iop_channelmixer_rgb_params_t *)self->params;
 
   if(IS_NULL_PTR(g) || IS_NULL_PTR(p) || IS_NULL_PTR(g->illum_x) || IS_NULL_PTR(g->illum_y)) return;
@@ -3260,7 +3260,7 @@ static void update_xy_color(dt_iop_module_t *self)
 static void paint_hue(dt_iop_module_t *self)
 {
   // update the fill background color of LCh sliders
-  dt_iop_channelmixer_rgb_gui_data_t *g = (dt_iop_channelmixer_rgb_gui_data_t *)self->gui_data;
+  dt_iop_channelmixer_rgb_gui_data_t *g = (dt_iop_channelmixer_rgb_gui_data_t *)dt_iop_gui_data(self);
 
   const float hue = dt_bauhaus_slider_get(g->hue_spot);
 
@@ -3310,7 +3310,7 @@ static void paint_hue(dt_iop_module_t *self)
  */
 static gboolean _channelmixerrgb_sync_primaries_from_params(dt_iop_module_t *self, float *error)
 {
-  dt_iop_channelmixer_rgb_gui_data_t *g = (dt_iop_channelmixer_rgb_gui_data_t *)self->gui_data;
+  dt_iop_channelmixer_rgb_gui_data_t *g = (dt_iop_channelmixer_rgb_gui_data_t *)dt_iop_gui_data(self);
   const dt_iop_channelmixer_rgb_params_t *const p = (dt_iop_channelmixer_rgb_params_t *)self->params;
   GtkWidget *const widgets[9]
       = { g->primaries_achromatic_hue, g->primaries_achromatic_purity, g->primaries_red_hue,
@@ -3341,7 +3341,7 @@ static gboolean _channelmixerrgb_sync_primaries_from_params(dt_iop_module_t *sel
 
 static void _channelmixerrgb_update_primaries_colors(dt_iop_module_t *self)
 {
-  dt_iop_channelmixer_rgb_gui_data_t *g = (dt_iop_channelmixer_rgb_gui_data_t *)self->gui_data;
+  dt_iop_channelmixer_rgb_gui_data_t *g = (dt_iop_channelmixer_rgb_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_channelmixer_rgb_params_t *p = (dt_iop_channelmixer_rgb_params_t *)self->params;
   const dt_iop_order_iccprofile_info_t *const work_profile = dt_ioppr_get_pipe_work_profile_info(self->dev->pipe);
   const dt_iop_order_iccprofile_info_t *const display_profile
@@ -3435,7 +3435,7 @@ static void _update_RGB_colors(dt_iop_module_t *self, float r, float g, float b,
  */
 static gboolean _channelmixerrgb_sync_simple_from_params(dt_iop_module_t *self, float *error)
 {
-  dt_iop_channelmixer_rgb_gui_data_t *g = (dt_iop_channelmixer_rgb_gui_data_t *)self->gui_data;
+  dt_iop_channelmixer_rgb_gui_data_t *g = (dt_iop_channelmixer_rgb_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_channelmixer_rgb_params_t *p = (dt_iop_channelmixer_rgb_params_t *)self->params;
   GtkWidget *const widgets[6]
       = { g->simple_theta, g->simple_psi, g->simple_stretch_1, g->simple_stretch_2, g->simple_coupling_1,
@@ -3477,7 +3477,7 @@ static gboolean _channelmixerrgb_sync_simple_from_params(dt_iop_module_t *self, 
  */
 static void _channelmixerrgb_update_simple_colors(dt_iop_module_t *self)
 {
-  dt_iop_channelmixer_rgb_gui_data_t *g = (dt_iop_channelmixer_rgb_gui_data_t *)self->gui_data;
+  dt_iop_channelmixer_rgb_gui_data_t *g = (dt_iop_channelmixer_rgb_gui_data_t *)dt_iop_gui_data(self);
   const dt_iop_channelmixer_rgb_params_t *p = (dt_iop_channelmixer_rgb_params_t *)self->params;
   const dt_iop_order_iccprofile_info_t *const work_profile = dt_ioppr_get_pipe_work_profile_info(self->dev->pipe);
   const dt_iop_order_iccprofile_info_t *const display_profile
@@ -3494,7 +3494,7 @@ static void _channelmixerrgb_update_simple_colors(dt_iop_module_t *self)
 
 static void update_illuminant_color(dt_iop_module_t *self)
 {
-  dt_iop_channelmixer_rgb_gui_data_t *g = (dt_iop_channelmixer_rgb_gui_data_t *)self->gui_data;
+  dt_iop_channelmixer_rgb_gui_data_t *g = (dt_iop_channelmixer_rgb_gui_data_t *)dt_iop_gui_data(self);
   if(IS_NULL_PTR(g)) return;
 
   if(!IS_NULL_PTR(g->illum_color))
@@ -3545,7 +3545,7 @@ static gboolean illuminant_color_draw(GtkWidget *widget, cairo_t *crf, gpointer 
 static gboolean target_color_draw(GtkWidget *widget, cairo_t *crf, gpointer user_data)
 {
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
-  dt_iop_channelmixer_rgb_gui_data_t *g = (dt_iop_channelmixer_rgb_gui_data_t *)self->gui_data;
+  dt_iop_channelmixer_rgb_gui_data_t *g = (dt_iop_channelmixer_rgb_gui_data_t *)dt_iop_gui_data(self);
 
   // Init
   GtkAllocation allocation;
@@ -3587,7 +3587,7 @@ static gboolean target_color_draw(GtkWidget *widget, cairo_t *crf, gpointer user
 static gboolean origin_color_draw(GtkWidget *widget, cairo_t *crf, gpointer user_data)
 {
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
-  dt_iop_channelmixer_rgb_gui_data_t *g = (dt_iop_channelmixer_rgb_gui_data_t *)self->gui_data;
+  dt_iop_channelmixer_rgb_gui_data_t *g = (dt_iop_channelmixer_rgb_gui_data_t *)dt_iop_gui_data(self);
 
   // Init
   GtkAllocation allocation;
@@ -3616,7 +3616,7 @@ static gboolean origin_color_draw(GtkWidget *widget, cairo_t *crf, gpointer user
 
 static void update_approx_cct(dt_iop_module_t *self)
 {
-  dt_iop_channelmixer_rgb_gui_data_t *g = (dt_iop_channelmixer_rgb_gui_data_t *)self->gui_data;
+  dt_iop_channelmixer_rgb_gui_data_t *g = (dt_iop_channelmixer_rgb_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_channelmixer_rgb_params_t *p = (dt_iop_channelmixer_rgb_params_t *)self->params;
 
   float x = p->x;
@@ -3674,7 +3674,7 @@ static void illum_xy_callback(GtkWidget *slider, gpointer user_data)
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
   if(dt_gui_widgets_suppressed()) return;
   dt_iop_channelmixer_rgb_params_t *p = (dt_iop_channelmixer_rgb_params_t *)self->params;
-  dt_iop_channelmixer_rgb_gui_data_t *g = (dt_iop_channelmixer_rgb_gui_data_t *)self->gui_data;
+  dt_iop_channelmixer_rgb_gui_data_t *g = (dt_iop_channelmixer_rgb_gui_data_t *)dt_iop_gui_data(self);
 
   dt_aligned_pixel_t Lch = { 0 };
   Lch[0] = 100.f;
@@ -3718,7 +3718,7 @@ void cleanup_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev
 
 void gui_reset(dt_iop_module_t *self)
 {
-  dt_iop_channelmixer_rgb_gui_data_t *g = (dt_iop_channelmixer_rgb_gui_data_t *)self->gui_data;
+  dt_iop_channelmixer_rgb_gui_data_t *g = (dt_iop_channelmixer_rgb_gui_data_t *)dt_iop_gui_data(self);
   g->is_profiling_started = FALSE;
   dt_iop_color_picker_reset(self, TRUE);
   gui_changed(self, NULL, NULL);
@@ -3727,7 +3727,7 @@ void gui_reset(dt_iop_module_t *self)
 void gui_update(struct dt_iop_module_t *self)
 {
   dt_iop_module_t *module = (dt_iop_module_t *)self;
-  dt_iop_channelmixer_rgb_gui_data_t *g = (dt_iop_channelmixer_rgb_gui_data_t *)self->gui_data;
+  dt_iop_channelmixer_rgb_gui_data_t *g = (dt_iop_channelmixer_rgb_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_channelmixer_rgb_params_t *p = (dt_iop_channelmixer_rgb_params_t *)module->params;
   float simple_error = INFINITY;
   float primaries_error = INFINITY;
@@ -3965,7 +3965,7 @@ static void _spot_settings_changed_callback(GtkWidget *slider, dt_iop_module_t *
 {
   if(dt_gui_widgets_suppressed()) return;
 
-  dt_iop_channelmixer_rgb_gui_data_t *g = (dt_iop_channelmixer_rgb_gui_data_t *)self->gui_data;
+  dt_iop_channelmixer_rgb_gui_data_t *g = (dt_iop_channelmixer_rgb_gui_data_t *)dt_iop_gui_data(self);
 
   dt_aligned_pixel_t Lch_target = { 0.f };
 
@@ -4008,7 +4008,7 @@ static void _channelmixerrgb_mixer_mode_callback(GtkWidget *combo, gpointer user
   if(dt_gui_widgets_suppressed()) return;
 
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
-  dt_iop_channelmixer_rgb_gui_data_t *g = (dt_iop_channelmixer_rgb_gui_data_t *)self->gui_data;
+  dt_iop_channelmixer_rgb_gui_data_t *g = (dt_iop_channelmixer_rgb_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_channelmixer_rgb_params_t *p = (dt_iop_channelmixer_rgb_params_t *)self->params;
   const dt_iop_channelmixer_rgb_mixer_mode_t mode = dt_bauhaus_combobox_get(combo);
 
@@ -4103,7 +4103,7 @@ static void _channelmixerrgb_simple_slider_callback(GtkWidget *slider, gpointer 
   if(dt_gui_widgets_suppressed()) return;
 
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
-  dt_iop_channelmixer_rgb_gui_data_t *g = (dt_iop_channelmixer_rgb_gui_data_t *)self->gui_data;
+  dt_iop_channelmixer_rgb_gui_data_t *g = (dt_iop_channelmixer_rgb_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_channelmixer_rgb_params_t *p = (dt_iop_channelmixer_rgb_params_t *)self->params;
   GtkWidget *const widgets[6]
       = { g->simple_theta, g->simple_psi, g->simple_stretch_1, g->simple_stretch_2, g->simple_coupling_1,
@@ -4148,7 +4148,7 @@ static void _channelmixerrgb_primaries_slider_callback(GtkWidget *slider, gpoint
   if(dt_gui_widgets_suppressed()) return;
 
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
-  dt_iop_channelmixer_rgb_gui_data_t *g = (dt_iop_channelmixer_rgb_gui_data_t *)self->gui_data;
+  dt_iop_channelmixer_rgb_gui_data_t *g = (dt_iop_channelmixer_rgb_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_channelmixer_rgb_params_t *p = (dt_iop_channelmixer_rgb_params_t *)self->params;
   GtkWidget *const widgets[9]
       = { g->primaries_achromatic_hue, g->primaries_achromatic_purity, g->primaries_red_hue,
@@ -4202,7 +4202,7 @@ static void _channelmixerrgb_primaries_slider_callback(GtkWidget *slider, gpoint
 void gui_changed(dt_iop_module_t *self, GtkWidget *w, void *previous)
 {
   dt_iop_channelmixer_rgb_params_t *p = (dt_iop_channelmixer_rgb_params_t *)self->params;
-  dt_iop_channelmixer_rgb_gui_data_t *g = (dt_iop_channelmixer_rgb_gui_data_t *)self->gui_data;
+  dt_iop_channelmixer_rgb_gui_data_t *g = (dt_iop_channelmixer_rgb_gui_data_t *)dt_iop_gui_data(self);
   const gboolean simple_widget
       = w == g->simple_theta || w == g->simple_psi || w == g->simple_stretch_1 || w == g->simple_stretch_2
         || w == g->simple_coupling_1 || w == g->simple_coupling_2;
@@ -4377,7 +4377,7 @@ void gui_changed(dt_iop_module_t *self, GtkWidget *w, void *previous)
 
 void _auto_set_illuminant(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe)
 {
-  dt_iop_channelmixer_rgb_gui_data_t *g = (dt_iop_channelmixer_rgb_gui_data_t *)self->gui_data;
+  dt_iop_channelmixer_rgb_gui_data_t *g = (dt_iop_channelmixer_rgb_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_channelmixer_rgb_params_t *p = (dt_iop_channelmixer_rgb_params_t *)self->params;
   const dt_iop_channelmixer_rgb_params_t previous = *p;
 
@@ -4827,7 +4827,7 @@ void gui_init(struct dt_iop_module_t *self)
   dt_ui_notebook_set_picker_owner(g->notebook, self);
 
   // Page CAT
-  self->widget = dt_ui_notebook_page(g->notebook, N_("CAT"), _("chromatic adaptation transform"));
+  self->gui->widget = dt_ui_notebook_page(g->notebook, N_("CAT"), _("chromatic adaptation transform"));
 
   g->adaptation = dt_bauhaus_combobox_from_params(self, N_("adaptation"));
   gtk_widget_set_tooltip_text(GTK_WIDGET(g->adaptation),
@@ -4858,7 +4858,7 @@ void gui_init(struct dt_iop_module_t *self)
   g->color_picker = dt_color_picker_new(self, DT_COLOR_PICKER_AREA, hbox);
   gtk_widget_set_tooltip_text(g->color_picker, _("set white balance to detected from area"));
 
-  gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(hbox), FALSE, FALSE, 0);
+  gtk_box_pack_start(GTK_BOX(self->gui->widget), GTK_WIDGET(hbox), FALSE, FALSE, 0);
 
   g->illuminant = dt_bauhaus_combobox_from_params(self, N_("illuminant"));
 
@@ -4872,14 +4872,14 @@ void gui_init(struct dt_iop_module_t *self)
   dt_bauhaus_widget_set_label(g->illum_x, N_("hue"));
   dt_bauhaus_slider_set_format(g->illum_x, "\302\260");
   g_signal_connect(G_OBJECT(g->illum_x), "value-changed", G_CALLBACK(illum_xy_callback), self);
-  gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(g->illum_x), FALSE, FALSE, 0);
+  gtk_box_pack_start(GTK_BOX(self->gui->widget), GTK_WIDGET(g->illum_x), FALSE, FALSE, 0);
 
   g->illum_y = dt_bauhaus_slider_new_with_range(dt_bauhaus_get_global(), DT_GUI_MODULE(self), 0., 100., 0, 0, 1);
   dt_bauhaus_widget_set_label(g->illum_y, N_("chroma"));
   dt_bauhaus_slider_set_format(g->illum_y, "%");
   dt_bauhaus_slider_set_hard_max(g->illum_y, ILLUM_Y_MAX);
   g_signal_connect(G_OBJECT(g->illum_y), "value-changed", G_CALLBACK(illum_xy_callback), self);
-  gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(g->illum_y), FALSE, FALSE, 0);
+  gtk_box_pack_start(GTK_BOX(self->gui->widget), GTK_WIDGET(g->illum_y), FALSE, FALSE, 0);
 
   dt_bauhaus_slider_set_soft_range(g->temperature, 3000., 7000.);
   dt_bauhaus_slider_set_digits(g->temperature, 0);
@@ -4896,7 +4896,7 @@ void gui_init(struct dt_iop_module_t *self)
     (&g->csspot,
      "plugins/darkroom/channelmixerrgb/expand_picker_mapping",
      _("spot color mapping"),
-     GTK_BOX(self->widget), GTK_PACK_END);
+     GTK_BOX(self->gui->widget), GTK_PACK_END);
 
   gtk_widget_set_tooltip_text(g->csspot.expander, _("use a color checker target to autoset CAT and channels"));
 
@@ -5002,7 +5002,7 @@ void gui_init(struct dt_iop_module_t *self)
   GtkWidget *first, *second, *third;
 #define MIXER_ROW(var, short, section, swap)                                   \
   gtk_box_pack_start(GTK_BOX(mixer_complete), dt_ui_section_label_new(section), FALSE, FALSE, 0); \
-  self->widget = mixer_complete;                                               \
+  self->gui->widget = mixer_complete;                                               \
   first = dt_bauhaus_slider_from_params(self, swap ? #var "[2]" : #var "[0]");\
   dt_bauhaus_slider_set_digits(first, 3);                                     \
   dt_bauhaus_widget_set_label(first, N_("input R"));                          \
@@ -5165,7 +5165,7 @@ void gui_init(struct dt_iop_module_t *self)
 
   GtkWidget *outputs_page = dt_ui_notebook_page(g->notebook, N_("Outputs"),
                                                 _("output colorfulness, brightness and B&W mixing"));
-  self->widget = outputs_page;
+  self->gui->widget = outputs_page;
 
 #define OUTPUT_SECTION(var, short, section, swap)                              \
   gtk_box_pack_start(GTK_BOX(outputs_page), dt_ui_section_label_new(section), FALSE, FALSE, 0); \
@@ -5194,9 +5194,9 @@ void gui_init(struct dt_iop_module_t *self)
   OUTPUT_SECTION(grey, grey, _("B&W"), FALSE)
 
   // start building top level widget
-  self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_GUI_BOX_SPACING);
+  self->gui->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_GUI_BOX_SPACING);
 
-  gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(g->notebook), FALSE, FALSE, 0);
+  gtk_box_pack_start(GTK_BOX(self->gui->widget), GTK_WIDGET(g->notebook), FALSE, FALSE, 0);
   const int saved_page = dt_conf_get_int("plugins/darkroom/channelmixerrgb/gui_page");
   const int active_page = saved_page > 2 ? 2 : CLAMP(saved_page, 0, 2);
   gtk_widget_show(gtk_notebook_get_nth_page(g->notebook, active_page));
@@ -5208,7 +5208,7 @@ void gui_init(struct dt_iop_module_t *self)
     (&g->cs,
      "plugins/darkroom/channelmixerrgb/expand_values",
      _("calibrate with a color checker"),
-     GTK_BOX(self->widget), GTK_PACK_END);
+     GTK_BOX(self->gui->widget), GTK_PACK_END);
 
   gtk_widget_set_tooltip_text(g->cs.toggle,
                               _("use a color checker target to autoset CAT and channels"));
@@ -5316,7 +5316,7 @@ void gui_cleanup(struct dt_iop_module_t *self)
                                      G_CALLBACK(_develop_ui_pipe_finished_callback), self);
   DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(dt_control_signal_get_global(), G_CALLBACK(_preview_pipe_finished_callback), self);
 
-  dt_iop_channelmixer_rgb_gui_data_t *g = (dt_iop_channelmixer_rgb_gui_data_t *)self->gui_data;
+  dt_iop_channelmixer_rgb_gui_data_t *g = (dt_iop_channelmixer_rgb_gui_data_t *)dt_iop_gui_data(self);
   dt_conf_set_int("plugins/darkroom/channelmixerrgb/gui_page", gtk_notebook_get_current_page (g->notebook));
 
   if(g->delta_E_in)

--- a/src/iop/clipping.c
+++ b/src/iop/clipping.c
@@ -688,7 +688,7 @@ void distort_mask(struct dt_iop_module_t *self, const struct dt_dev_pixelpipe_t 
 
 static int _iop_clipping_set_max_clip(struct dt_iop_module_t *self)
 {
-  dt_iop_clipping_gui_data_t *g = (dt_iop_clipping_gui_data_t *)self->gui_data;
+  dt_iop_clipping_gui_data_t *g = (dt_iop_clipping_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_clipping_params_t *p = (dt_iop_clipping_params_t *)self->params;
 
   // we want to know the size of the actual buffer
@@ -1230,7 +1230,7 @@ void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pix
 
 static void _event_preview_updated_callback(gpointer instance, dt_iop_module_t *self)
 {
-  dt_iop_clipping_gui_data_t *g = (dt_iop_clipping_gui_data_t *)self->gui_data;
+  dt_iop_clipping_gui_data_t *g = (dt_iop_clipping_gui_data_t *)dt_iop_gui_data(self);
   g->preview_ready = TRUE;
   DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(dt_control_signal_get_global(), G_CALLBACK(_event_preview_updated_callback), self);
   // force max size to be recomputed
@@ -1239,7 +1239,7 @@ static void _event_preview_updated_callback(gpointer instance, dt_iop_module_t *
 
 void gui_focus(struct dt_iop_module_t *self, gboolean in)
 {
-  dt_iop_clipping_gui_data_t *g = (dt_iop_clipping_gui_data_t *)self->gui_data;
+  dt_iop_clipping_gui_data_t *g = (dt_iop_clipping_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_clipping_params_t *p = (dt_iop_clipping_params_t *)self->params;
 
   dt_iop_set_cache_bypass(self, in);
@@ -1433,7 +1433,7 @@ static float _ratio_get_aspect(dt_iop_module_t *self, GtkWidget *combo)
 
 static void apply_box_aspect(dt_iop_module_t *self, _grab_region_t grab)
 {
-  dt_iop_clipping_gui_data_t *g = (dt_iop_clipping_gui_data_t *)self->gui_data;
+  dt_iop_clipping_gui_data_t *g = (dt_iop_clipping_gui_data_t *)dt_iop_gui_data(self);
 
   int iwd, iht;
   dt_dev_get_processed_size(self->dev, &iwd, &iht);
@@ -1602,7 +1602,7 @@ static void _float_to_fract(const char *num, int *n, int *d)
 
 static void aspect_presets_changed(GtkWidget *combo, dt_iop_module_t *self)
 {
-  dt_iop_clipping_gui_data_t *g = (dt_iop_clipping_gui_data_t *)self->gui_data;
+  dt_iop_clipping_gui_data_t *g = (dt_iop_clipping_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_clipping_params_t *p = (dt_iop_clipping_params_t *)self->params;
   const int which = dt_bauhaus_combobox_get(combo);
   int d = abs(p->ratio_d), n = p->ratio_n;
@@ -1738,7 +1738,7 @@ static void aspect_presets_changed(GtkWidget *combo, dt_iop_module_t *self)
 
 void gui_changed(dt_iop_module_t *self, GtkWidget *w, void *previous)
 {
-  dt_iop_clipping_gui_data_t *g = (dt_iop_clipping_gui_data_t *)self->gui_data;
+  dt_iop_clipping_gui_data_t *g = (dt_iop_clipping_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_clipping_params_t *p = (dt_iop_clipping_params_t *)self->params;
 
   dt_gui_freeze_begin();
@@ -1775,7 +1775,7 @@ void gui_changed(dt_iop_module_t *self, GtkWidget *w, void *previous)
 
 void gui_reset(struct dt_iop_module_t *self)
 {
-  dt_iop_clipping_gui_data_t *g = (dt_iop_clipping_gui_data_t *)self->gui_data;
+  dt_iop_clipping_gui_data_t *g = (dt_iop_clipping_gui_data_t *)dt_iop_gui_data(self);
   /* reset aspect preset to default */
   dt_conf_set_int("plugins/darkroom/clipping/ratio_d", 0);
   dt_conf_set_int("plugins/darkroom/clipping/ratio_n", 0);
@@ -1784,7 +1784,7 @@ void gui_reset(struct dt_iop_module_t *self)
 
 static void keystone_type_changed(GtkWidget *combo, dt_iop_module_t *self)
 {
-  dt_iop_clipping_gui_data_t *g = (dt_iop_clipping_gui_data_t *)self->gui_data;
+  dt_iop_clipping_gui_data_t *g = (dt_iop_clipping_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_clipping_params_t *p = (dt_iop_clipping_params_t *)self->params;
   const int which = dt_bauhaus_combobox_get(combo);
   if((which == 5) || (which == 4 && p->k_h == 0 && p->k_v == 0))
@@ -1822,7 +1822,7 @@ static void keystone_type_changed(GtkWidget *combo, dt_iop_module_t *self)
 
 static void keystone_type_populate(struct dt_iop_module_t *self, gboolean with_applied, int select)
 {
-  dt_iop_clipping_gui_data_t *g = (dt_iop_clipping_gui_data_t *)self->gui_data;
+  dt_iop_clipping_gui_data_t *g = (dt_iop_clipping_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_clipping_params_t *p = (dt_iop_clipping_params_t *)self->params;
   dt_bauhaus_combobox_clear(g->keystone_type);
   dt_bauhaus_combobox_add(g->keystone_type, _("none"));
@@ -1848,7 +1848,7 @@ static void keystone_type_populate(struct dt_iop_module_t *self, gboolean with_a
 
 void gui_update(struct dt_iop_module_t *self)
 {
-  dt_iop_clipping_gui_data_t *g = (dt_iop_clipping_gui_data_t *)self->gui_data;
+  dt_iop_clipping_gui_data_t *g = (dt_iop_clipping_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_clipping_params_t *p = (dt_iop_clipping_params_t *)self->params;
 
   int hvflip = 0;
@@ -1933,7 +1933,7 @@ void gui_update(struct dt_iop_module_t *self)
 static void hvflip_callback(GtkWidget *widget, dt_iop_module_t *self)
 {
   if(dt_gui_widgets_suppressed()) return;
-  dt_iop_clipping_gui_data_t *g = (dt_iop_clipping_gui_data_t *)self->gui_data;
+  dt_iop_clipping_gui_data_t *g = (dt_iop_clipping_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_clipping_params_t *p = (dt_iop_clipping_params_t *)self->params;
   const int flip = dt_bauhaus_combobox_get(widget);
   p->cw = copysignf(p->cw, (flip & 1) ? -1.0 : 1.0);
@@ -2012,7 +2012,7 @@ void gui_init(struct dt_iop_module_t *self)
 
   g->notebook = dt_ui_notebook_new();
 
-  self->widget = dt_ui_notebook_page(g->notebook, N_("main"), NULL);
+  self->gui->widget = dt_ui_notebook_page(g->notebook, N_("main"), NULL);
 
   g->hvflip = dt_bauhaus_combobox_new(dt_bauhaus_get_global(), DT_GUI_MODULE(self));
   dt_bauhaus_widget_set_label(g->hvflip, N_("flip"));
@@ -2022,7 +2022,7 @@ void gui_init(struct dt_iop_module_t *self)
   dt_bauhaus_combobox_add(g->hvflip, _("both"));
   g_signal_connect(G_OBJECT(g->hvflip), "value-changed", G_CALLBACK(hvflip_callback), self);
   gtk_widget_set_tooltip_text(g->hvflip, _("mirror image horizontally and/or vertically"));
-  gtk_box_pack_start(GTK_BOX(self->widget), g->hvflip, TRUE, TRUE, 0);
+  gtk_box_pack_start(GTK_BOX(self->gui->widget), g->hvflip, TRUE, TRUE, 0);
 
   g->angle = dt_bauhaus_slider_from_params(self, N_("angle"));
   dt_bauhaus_slider_set_factor(g->angle, -1.0);
@@ -2037,7 +2037,7 @@ void gui_init(struct dt_iop_module_t *self)
   dt_bauhaus_combobox_add(g->keystone_type, _("full"));
   gtk_widget_set_tooltip_text(g->keystone_type, _("set perspective correction for your image"));
   g_signal_connect(G_OBJECT(g->keystone_type), "value-changed", G_CALLBACK(keystone_type_changed), self);
-  gtk_box_pack_start(GTK_BOX(self->widget), g->keystone_type, TRUE, TRUE, 0);
+  gtk_box_pack_start(GTK_BOX(self->gui->widget), g->keystone_type, TRUE, TRUE, 0);
 
   g->crop_auto = dt_bauhaus_combobox_from_params(self, "crop_auto");
   gtk_widget_set_tooltip_text(g->crop_auto, _("automatically crop to avoid black edges"));
@@ -2157,9 +2157,9 @@ void gui_init(struct dt_iop_module_t *self)
                                                    "to enter custom aspect ratio open the combobox and type ratio in x:y or decimal format"));
   dt_bauhaus_widget_set_quad_paint(g->aspect_presets, dtgtk_cairo_paint_aspectflip, 0, NULL);
   g_signal_connect(G_OBJECT(g->aspect_presets), "quad-pressed", G_CALLBACK(aspect_flip), self);
-  gtk_box_pack_start(GTK_BOX(self->widget), g->aspect_presets, TRUE, TRUE, 0);
+  gtk_box_pack_start(GTK_BOX(self->gui->widget), g->aspect_presets, TRUE, TRUE, 0);
 
-  self->widget = dt_ui_notebook_page(g->notebook, _("margins"), NULL);
+  self->gui->widget = dt_ui_notebook_page(g->notebook, _("margins"), NULL);
 
   g->cx = dt_bauhaus_slider_from_params(self, "cx");
   dt_bauhaus_slider_set_digits(g->cx, 4);
@@ -2185,7 +2185,7 @@ void gui_init(struct dt_iop_module_t *self)
   dt_bauhaus_slider_set_format(g->ch, "%");
   gtk_widget_set_tooltip_text(g->ch, _("the bottom margin cannot overlap with the top margin"));
 
-  self->widget = GTK_WIDGET(g->notebook);
+  self->gui->widget = GTK_WIDGET(g->notebook);
 }
 
 static void free_aspect(gpointer data)
@@ -2197,7 +2197,7 @@ static void free_aspect(gpointer data)
 
 void gui_cleanup(struct dt_iop_module_t *self)
 {
-  dt_iop_clipping_gui_data_t *g = (dt_iop_clipping_gui_data_t *)self->gui_data;
+  dt_iop_clipping_gui_data_t *g = (dt_iop_clipping_gui_data_t *)dt_iop_gui_data(self);
   g_list_free_full(g->aspect_list, free_aspect);
   g->aspect_list = NULL;
 
@@ -2253,7 +2253,7 @@ void gui_post_expose(struct dt_iop_module_t *self, cairo_t *cr, int32_t width, i
                      int32_t pointerx, int32_t pointery)
 {
   dt_develop_t *dev = self->dev;
-  dt_iop_clipping_gui_data_t *g = (dt_iop_clipping_gui_data_t *)self->gui_data;
+  dt_iop_clipping_gui_data_t *g = (dt_iop_clipping_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_clipping_params_t *p = (dt_iop_clipping_params_t *)self->params;
   if(IS_NULL_PTR(g) || IS_NULL_PTR(p)) return;
 
@@ -2650,7 +2650,7 @@ static float dist_seg(float xa, float ya, float xb, float yb, float xc, float yc
 
 int mouse_moved(struct dt_iop_module_t *self, double x, double y, double pressure, int which)
 {
-  dt_iop_clipping_gui_data_t *g = (dt_iop_clipping_gui_data_t *)self->gui_data;
+  dt_iop_clipping_gui_data_t *g = (dt_iop_clipping_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_clipping_params_t *p = (dt_iop_clipping_params_t *)self->params;
   const dt_develop_t *dev = (const dt_develop_t *)self->dev;
 
@@ -3044,7 +3044,7 @@ static void commit_box(dt_iop_module_t *self, dt_iop_clipping_gui_data_t *g, dt_
 
 int button_released(struct dt_iop_module_t *self, double x, double y, int which, uint32_t state)
 {
-  dt_iop_clipping_gui_data_t *g = (dt_iop_clipping_gui_data_t *)self->gui_data;
+  dt_iop_clipping_gui_data_t *g = (dt_iop_clipping_gui_data_t *)dt_iop_gui_data(self);
   // we don't do anything if the image is not ready
   if(!g->preview_ready) return 0;
 
@@ -3092,7 +3092,7 @@ int button_pressed(struct dt_iop_module_t *self, double x, double y, double pres
                    uint32_t state)
 {
 
-  dt_iop_clipping_gui_data_t *g = (dt_iop_clipping_gui_data_t *)self->gui_data;
+  dt_iop_clipping_gui_data_t *g = (dt_iop_clipping_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_clipping_params_t *p = (dt_iop_clipping_params_t *)self->params;
   dt_develop_t *dev = self->dev;
 

--- a/src/iop/colorbalance.c
+++ b/src/iop/colorbalance.c
@@ -724,7 +724,7 @@ static inline void set_HSL_sliders(GtkWidget *hue, GtkWidget *sat, float RGB[4])
 
 static inline void _check_tuner_picker_labels(dt_iop_module_t *self)
 {
-  dt_iop_colorbalance_gui_data_t *g = (dt_iop_colorbalance_gui_data_t *)self->gui_data;
+  dt_iop_colorbalance_gui_data_t *g = (dt_iop_colorbalance_gui_data_t *)dt_iop_gui_data(self);
 
   if(g->luma_patches_flags[GAIN] == USER_SELECTED && g->luma_patches_flags[GAMMA] == USER_SELECTED
      && g->luma_patches_flags[LIFT] == USER_SELECTED)
@@ -744,7 +744,7 @@ static void apply_autogrey(dt_iop_module_t *self)
 {
   if(dt_gui_widgets_suppressed()) return;
   dt_iop_colorbalance_params_t *p = (dt_iop_colorbalance_params_t *)self->params;
-  dt_iop_colorbalance_gui_data_t *g = (dt_iop_colorbalance_gui_data_t *)self->gui_data;
+  dt_iop_colorbalance_gui_data_t *g = (dt_iop_colorbalance_gui_data_t *)dt_iop_gui_data(self);
 
   dt_aligned_pixel_t XYZ = { 0.0f };
   dt_aligned_pixel_t rgb = { 0.0f };
@@ -783,7 +783,7 @@ static void apply_lift_neutralize(dt_iop_module_t *self)
 {
   if(dt_gui_widgets_suppressed()) return;
   dt_iop_colorbalance_params_t *p = (dt_iop_colorbalance_params_t *)self->params;
-  dt_iop_colorbalance_gui_data_t *g = (dt_iop_colorbalance_gui_data_t *)self->gui_data;
+  dt_iop_colorbalance_gui_data_t *g = (dt_iop_colorbalance_gui_data_t *)dt_iop_gui_data(self);
 
   dt_aligned_pixel_t XYZ = { 0.0f };
   dt_Lab_to_XYZ((const float *)self->picked_color, XYZ);
@@ -822,7 +822,7 @@ static void apply_gamma_neutralize(dt_iop_module_t *self)
 {
   if(dt_gui_widgets_suppressed()) return;
   dt_iop_colorbalance_params_t *p = (dt_iop_colorbalance_params_t *)self->params;
-  dt_iop_colorbalance_gui_data_t *g = (dt_iop_colorbalance_gui_data_t *)self->gui_data;
+  dt_iop_colorbalance_gui_data_t *g = (dt_iop_colorbalance_gui_data_t *)dt_iop_gui_data(self);
 
   dt_aligned_pixel_t XYZ = { 0.0f };
   dt_Lab_to_XYZ((const float *)self->picked_color, XYZ);
@@ -861,7 +861,7 @@ static void apply_gain_neutralize(dt_iop_module_t *self)
 {
   if(dt_gui_widgets_suppressed()) return;
   dt_iop_colorbalance_params_t *p = (dt_iop_colorbalance_params_t *)self->params;
-  dt_iop_colorbalance_gui_data_t *g = (dt_iop_colorbalance_gui_data_t *)self->gui_data;
+  dt_iop_colorbalance_gui_data_t *g = (dt_iop_colorbalance_gui_data_t *)dt_iop_gui_data(self);
 
   dt_aligned_pixel_t XYZ = { 0.0f };
   dt_Lab_to_XYZ((const float *)self->picked_color, XYZ);
@@ -900,7 +900,7 @@ static void apply_lift_auto(dt_iop_module_t *self)
 {
   if(dt_gui_widgets_suppressed()) return;
   dt_iop_colorbalance_params_t *p = (dt_iop_colorbalance_params_t *)self->params;
-  dt_iop_colorbalance_gui_data_t *g = (dt_iop_colorbalance_gui_data_t *)self->gui_data;
+  dt_iop_colorbalance_gui_data_t *g = (dt_iop_colorbalance_gui_data_t *)dt_iop_gui_data(self);
 
   dt_aligned_pixel_t XYZ = { 0.0f };
   dt_Lab_to_XYZ((const float *)self->picked_color_min, XYZ);
@@ -924,7 +924,7 @@ static void apply_gamma_auto(dt_iop_module_t *self)
 {
   if(dt_gui_widgets_suppressed()) return;
   dt_iop_colorbalance_params_t *p = (dt_iop_colorbalance_params_t *)self->params;
-  dt_iop_colorbalance_gui_data_t *g = (dt_iop_colorbalance_gui_data_t *)self->gui_data;
+  dt_iop_colorbalance_gui_data_t *g = (dt_iop_colorbalance_gui_data_t *)dt_iop_gui_data(self);
 
   dt_aligned_pixel_t XYZ = { 0.0f };
   dt_Lab_to_XYZ((const float *)self->picked_color, XYZ);
@@ -949,7 +949,7 @@ static void apply_gain_auto(dt_iop_module_t *self)
 {
   if(dt_gui_widgets_suppressed()) return;
   dt_iop_colorbalance_params_t *p = (dt_iop_colorbalance_params_t *)self->params;
-  dt_iop_colorbalance_gui_data_t *g = (dt_iop_colorbalance_gui_data_t *)self->gui_data;
+  dt_iop_colorbalance_gui_data_t *g = (dt_iop_colorbalance_gui_data_t *)dt_iop_gui_data(self);
 
   dt_aligned_pixel_t XYZ = { 0.0f };
   dt_Lab_to_XYZ((const float *)self->picked_color_max, XYZ);
@@ -972,7 +972,7 @@ static void apply_gain_auto(dt_iop_module_t *self)
 static void apply_autocolor(dt_iop_module_t *self)
 {
   dt_iop_colorbalance_params_t *p = (dt_iop_colorbalance_params_t *)self->params;
-  dt_iop_colorbalance_gui_data_t *g = (dt_iop_colorbalance_gui_data_t *)self->gui_data;
+  dt_iop_colorbalance_gui_data_t *g = (dt_iop_colorbalance_gui_data_t *)dt_iop_gui_data(self);
 
   if(g->color_patches_flags[GAIN] == INVALID || g->color_patches_flags[GAMMA] == INVALID
      || g->color_patches_flags[LIFT] == INVALID)
@@ -1090,7 +1090,7 @@ static void apply_autocolor(dt_iop_module_t *self)
 static void apply_autoluma(dt_iop_module_t *self)
 {
   dt_iop_colorbalance_params_t *p = (dt_iop_colorbalance_params_t *)self->params;
-  dt_iop_colorbalance_gui_data_t *g = (dt_iop_colorbalance_gui_data_t *)self->gui_data;
+  dt_iop_colorbalance_gui_data_t *g = (dt_iop_colorbalance_gui_data_t *)dt_iop_gui_data(self);
 
   /*
    * If some luma patches were not picked by the user, take a
@@ -1141,7 +1141,7 @@ static void apply_autoluma(dt_iop_module_t *self)
 
 void color_picker_apply(dt_iop_module_t *self, GtkWidget *picker, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
 {
-  dt_iop_colorbalance_gui_data_t *g = (dt_iop_colorbalance_gui_data_t *)self->gui_data;
+  dt_iop_colorbalance_gui_data_t *g = (dt_iop_colorbalance_gui_data_t *)dt_iop_gui_data(self);
   if     (picker == g->hue_lift)
     apply_lift_neutralize(self);
   else if(picker == g->hue_gamma)
@@ -1327,7 +1327,7 @@ void gui_update(dt_iop_module_t *self)
 
 void gui_reset(dt_iop_module_t *self)
 {
-  dt_iop_colorbalance_gui_data_t *g = (dt_iop_colorbalance_gui_data_t *)self->gui_data;
+  dt_iop_colorbalance_gui_data_t *g = (dt_iop_colorbalance_gui_data_t *)dt_iop_gui_data(self);
 
   for (int k=0; k<LEVELS; k++)
   {
@@ -1348,7 +1348,7 @@ static void _configure_slider_blocks(gpointer instance, dt_iop_module_t *self);
 void gui_changed(dt_iop_module_t *self, GtkWidget *w, void *previous)
 {
   dt_iop_colorbalance_params_t *p = (dt_iop_colorbalance_params_t *)self->params;
-  dt_iop_colorbalance_gui_data_t *g = (dt_iop_colorbalance_gui_data_t *)self->gui_data;
+  dt_iop_colorbalance_gui_data_t *g = (dt_iop_colorbalance_gui_data_t *)dt_iop_gui_data(self);
 
   if(IS_NULL_PTR(w) || w == g->mode)
   {
@@ -1372,7 +1372,7 @@ static void controls_callback(GtkWidget *combo, dt_iop_module_t *self)
 {
   if(dt_gui_widgets_suppressed()) return;
 
-  dt_iop_colorbalance_gui_data_t *g = (dt_iop_colorbalance_gui_data_t *)self->gui_data;
+  dt_iop_colorbalance_gui_data_t *g = (dt_iop_colorbalance_gui_data_t *)dt_iop_gui_data(self);
 
   set_visible_widgets(g);
 
@@ -1502,7 +1502,7 @@ static gboolean dt_iop_area_draw(GtkWidget *widget, cairo_t *cr, dt_iop_module_t
 
 static void _configure_slider_blocks(gpointer instance, dt_iop_module_t *self)
 {
-  dt_iop_colorbalance_gui_data_t *g = (dt_iop_colorbalance_gui_data_t *)self->gui_data;
+  dt_iop_colorbalance_gui_data_t *g = (dt_iop_colorbalance_gui_data_t *)dt_iop_gui_data(self);
 
   GtkWidget *new_container = NULL;
   GtkWidget *old_container = gtk_bin_get_child(GTK_BIN(g->main_box));
@@ -1555,7 +1555,7 @@ static void which##_callback(GtkWidget *slider, gpointer user_data)             
 {                                                                                       \
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;                                 \
   dt_iop_colorbalance_params_t *p = (dt_iop_colorbalance_params_t *)self->params;       \
-  dt_iop_colorbalance_gui_data_t *g = (dt_iop_colorbalance_gui_data_t *)self->gui_data; \
+  dt_iop_colorbalance_gui_data_t *g = (dt_iop_colorbalance_gui_data_t *)dt_iop_gui_data(self); \
                                                                                         \
   if(dt_gui_widgets_suppressed()) return;                                                      \
                                                                                         \
@@ -1587,7 +1587,7 @@ void gui_init(dt_iop_module_t *self)
     g->luma_patches_flags[k] = INVALID;
   }
 
-  GtkWidget *mode_box = self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_GUI_BOX_SPACING);
+  GtkWidget *mode_box = self->gui->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_GUI_BOX_SPACING);
 
   // mode choice
   g->mode = dt_bauhaus_combobox_from_params(self, N_("mode"));
@@ -1599,7 +1599,7 @@ void gui_init(dt_iop_module_t *self)
   dt_bauhaus_combobox_add(g->controls, _("HSL"));
   dt_bauhaus_combobox_add(g->controls, _("RGBL"));
   dt_bauhaus_combobox_add(g->controls, _("both"));
-  gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(g->controls), TRUE, TRUE, 0);
+  gtk_box_pack_start(GTK_BOX(self->gui->widget), GTK_WIDGET(g->controls), TRUE, TRUE, 0);
   gtk_widget_set_tooltip_text(g->controls, _("color-grading mapping method"));
   g_signal_connect(G_OBJECT(g->controls), "value-changed", G_CALLBACK(controls_callback), self);
 
@@ -1607,7 +1607,7 @@ void gui_init(dt_iop_module_t *self)
   dt_bauhaus_combobox_set(g->controls, !g_strcmp0(mode, "RGBL") ? RGBL :
                                        !g_strcmp0(mode, "BOTH") ? BOTH : HSL);
 
-  g->master_box = self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_GUI_BOX_SPACING);
+  g->master_box = self->gui->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_GUI_BOX_SPACING);
 
   gtk_box_pack_start(GTK_BOX(g->master_box), dt_ui_section_label_new(_("master")), FALSE, FALSE, 0);
 
@@ -1704,7 +1704,7 @@ void gui_init(dt_iop_module_t *self)
   dt_bauhaus_widget_set_label(g->which##_##c, #n);                 \
 
 #define ADD_BLOCK(blk, which, section, text, span, satspan)                 \
-  g->blocks[blk] = self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_GUI_BOX_SPACING); \
+  g->blocks[blk] = self->gui->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_GUI_BOX_SPACING); \
                                                                             \
   sprintf(field_name, "%s[%d]", #which, CHANNEL_FACTOR);                    \
   g->which##_factor = dt_color_picker_new(self, DT_COLOR_PICKER_AREA,       \
@@ -1735,7 +1735,7 @@ void gui_init(dt_iop_module_t *self)
   gtk_widget_set_tooltip_text(g->hue_##which, _("select the hue"));         \
   g_signal_connect(G_OBJECT(g->hue_##which), "value-changed",               \
                    G_CALLBACK(which##_callback), self);                     \
-  gtk_box_pack_start(GTK_BOX(self->widget), g->hue_##which, TRUE, TRUE, 0); \
+  gtk_box_pack_start(GTK_BOX(self->gui->widget), g->hue_##which, TRUE, TRUE, 0); \
                                                                             \
   g->sat_##which = dt_bauhaus_slider_new_with_range_and_feedback(dt_bauhaus_get_global(), DT_GUI_MODULE(self),      \
                    0.0f, 100.0f, 0, 0.0f, 2, 0);                            \
@@ -1747,7 +1747,7 @@ void gui_init(dt_iop_module_t *self)
   gtk_widget_set_tooltip_text(g->sat_##which, _("select the saturation"));  \
   g_signal_connect(G_OBJECT(g->sat_##which), "value-changed",               \
                    G_CALLBACK(which##_callback), self);                     \
-  gtk_box_pack_start(GTK_BOX(self->widget), g->sat_##which, TRUE, TRUE, 0); \
+  gtk_box_pack_start(GTK_BOX(self->gui->widget), g->sat_##which, TRUE, TRUE, 0); \
                                                                             \
   ADD_CHANNEL(which, section, r, red, RED, text, span)                      \
   dt_bauhaus_slider_set_stop(g->which##_r, 0.0, 0.0, 1.0, 1.0);             \
@@ -1785,30 +1785,30 @@ void gui_init(dt_iop_module_t *self)
   ADD_BLOCK(2, gain,  N_("highlights"), gain_messages,  0.5f, 25.0f)
   _configure_slider_blocks(NULL, self);
 
-  g->optimizer_box = self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_GUI_BOX_SPACING);
+  g->optimizer_box = self->gui->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_GUI_BOX_SPACING);
 
-  gtk_box_pack_start(GTK_BOX(self->widget), dt_ui_section_label_new(_("auto optimizers")), FALSE, FALSE, 0);
+  gtk_box_pack_start(GTK_BOX(self->gui->widget), dt_ui_section_label_new(_("auto optimizers")), FALSE, FALSE, 0);
 
   g->auto_luma = dt_color_picker_new(self, DT_COLOR_PICKER_AREA,
                  dt_bauhaus_combobox_new(dt_bauhaus_get_global(), DT_GUI_MODULE(self)));
   dt_bauhaus_widget_set_label(g->auto_luma, N_("optimize luma"));
   gtk_widget_set_tooltip_text(g->auto_luma, _("fit the whole histogram and center the average luma"));
-  gtk_box_pack_start(GTK_BOX(self->widget), g->auto_luma, FALSE, FALSE, 0);
+  gtk_box_pack_start(GTK_BOX(self->gui->widget), g->auto_luma, FALSE, FALSE, 0);
 
   g->auto_color = dt_color_picker_new(self, DT_COLOR_PICKER_AREA,
                   dt_bauhaus_combobox_new(dt_bauhaus_get_global(), DT_GUI_MODULE(self)));
   dt_bauhaus_widget_set_label(g->auto_color, N_("neutralize colors"));
   gtk_widget_set_tooltip_text(g->auto_color, _("optimize the RGB curves to remove color casts"));
-  gtk_box_pack_start(GTK_BOX(self->widget), g->auto_color, FALSE, FALSE, 0);
+  gtk_box_pack_start(GTK_BOX(self->gui->widget), g->auto_color, FALSE, FALSE, 0);
 
   // start building top level widget
-  self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_GUI_BOX_SPACING);
+  self->gui->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_GUI_BOX_SPACING);
 
-  gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(mode_box), TRUE, TRUE, 0);
-  gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(g->master_box), TRUE, TRUE, 0);
-  gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(main_label_box), TRUE, TRUE, 0);
-  gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(g->main_box), TRUE, TRUE, 0);
-  gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(g->optimizer_box), TRUE, TRUE, 0);
+  gtk_box_pack_start(GTK_BOX(self->gui->widget), GTK_WIDGET(mode_box), TRUE, TRUE, 0);
+  gtk_box_pack_start(GTK_BOX(self->gui->widget), GTK_WIDGET(g->master_box), TRUE, TRUE, 0);
+  gtk_box_pack_start(GTK_BOX(self->gui->widget), GTK_WIDGET(main_label_box), TRUE, TRUE, 0);
+  gtk_box_pack_start(GTK_BOX(self->gui->widget), GTK_WIDGET(g->main_box), TRUE, TRUE, 0);
+  gtk_box_pack_start(GTK_BOX(self->gui->widget), GTK_WIDGET(g->optimizer_box), TRUE, TRUE, 0);
 
   DT_DEBUG_CONTROL_SIGNAL_CONNECT(dt_control_signal_get_global(), DT_SIGNAL_PREFERENCES_CHANGE,
                                   G_CALLBACK(_configure_slider_blocks), (gpointer)self);

--- a/src/iop/colorbalancergb.c
+++ b/src/iop/colorbalancergb.c
@@ -1110,7 +1110,7 @@ void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pix
   dt_iop_colorbalancergb_data_t *d = (dt_iop_colorbalancergb_data_t *)(piece->data);
   dt_iop_colorbalancergb_params_t *p = (dt_iop_colorbalancergb_params_t *)p1;
   const dt_iop_colorbalancergb_gui_data_t *gui
-      = (const dt_iop_colorbalancergb_gui_data_t *)self->gui_data;
+      = (const dt_iop_colorbalancergb_gui_data_t *)dt_iop_gui_data(self);
 
   // Synchronize the global mask-preview appearance into this node so normal processing never reads GUI config.
   d->checker_color_1[0] = CLAMP(dt_conf_get_float("plugins/darkroom/colorbalancergb/checker1/red"), 0.f, 1.f);
@@ -1398,7 +1398,7 @@ void pipe_RGB_to_Ych(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, const dt_a
 
 void color_picker_apply(dt_iop_module_t *self, GtkWidget *picker, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
 {
-  dt_iop_colorbalancergb_gui_data_t *g = (dt_iop_colorbalancergb_gui_data_t *)self->gui_data;
+  dt_iop_colorbalancergb_gui_data_t *g = (dt_iop_colorbalancergb_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_colorbalancergb_params_t *p = (dt_iop_colorbalancergb_params_t *)self->params;
 
   dt_aligned_pixel_t Ych = { 0.f };
@@ -1511,9 +1511,9 @@ static void mask_callback(GtkWidget *togglebutton, dt_iop_module_t *self)
   if(dt_gui_widgets_suppressed()) return;
   dt_iop_request_focus(self);
 
-  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(self->off), TRUE);
+  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(self->gui->off), TRUE);
 
-  dt_iop_colorbalancergb_gui_data_t *g = (dt_iop_colorbalancergb_gui_data_t *)self->gui_data;
+  dt_iop_colorbalancergb_gui_data_t *g = (dt_iop_colorbalancergb_gui_data_t *)dt_iop_gui_data(self);
 
   // if blend module is displaying mask do not display it here
   if(self->request_mask_display != DT_DEV_PIXELPIPE_DISPLAY_NONE)
@@ -1696,7 +1696,7 @@ static gboolean dt_iop_tonecurve_draw(GtkWidget *widget, cairo_t *crf, gpointer 
 
 void gui_changed(dt_iop_module_t *self, GtkWidget *w, void *previous)
 {
-  dt_iop_colorbalancergb_gui_data_t *g = (dt_iop_colorbalancergb_gui_data_t *)self->gui_data;
+  dt_iop_colorbalancergb_gui_data_t *g = (dt_iop_colorbalancergb_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_colorbalancergb_params_t *p = (dt_iop_colorbalancergb_params_t *)self->params;
 
    dt_gui_freeze_begin();
@@ -1722,7 +1722,7 @@ void gui_changed(dt_iop_module_t *self, GtkWidget *w, void *previous)
 
 void gui_update(dt_iop_module_t *self)
 {
-  dt_iop_colorbalancergb_gui_data_t *g = (dt_iop_colorbalancergb_gui_data_t *)self->gui_data;
+  dt_iop_colorbalancergb_gui_data_t *g = (dt_iop_colorbalancergb_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_colorbalancergb_params_t *p = (dt_iop_colorbalancergb_params_t *)self->params;
 
   dt_bauhaus_slider_set(g->hue_angle, p->hue_angle);
@@ -1803,7 +1803,7 @@ void gui_init(dt_iop_module_t *self)
   dt_ui_notebook_set_picker_owner(g->notebook, self);
 
   // Page master
-  self->widget = dt_ui_notebook_page(g->notebook, N_("master"), _("global grading"));
+  self->gui->widget = dt_ui_notebook_page(g->notebook, N_("master"), _("global grading"));
 
   g->hue_angle = dt_bauhaus_slider_from_params(self, "hue_angle");
   dt_bauhaus_slider_set_format(g->hue_angle, "\302\260");
@@ -1821,7 +1821,7 @@ void gui_init(dt_iop_module_t *self)
   dt_bauhaus_slider_set_format(g->contrast, "%");
   gtk_widget_set_tooltip_text(g->contrast, _("increase the contrast at constant chromaticity"));
 
-  gtk_box_pack_start(GTK_BOX(self->widget), dt_ui_section_label_new(_("linear chroma grading")), FALSE, FALSE, 0);
+  gtk_box_pack_start(GTK_BOX(self->gui->widget), dt_ui_section_label_new(_("linear chroma grading")), FALSE, FALSE, 0);
 
   g->chroma_global = dt_bauhaus_slider_from_params(self, "chroma_global");
   dt_bauhaus_slider_set_soft_range(g->chroma_global, -0.5, 0.5);
@@ -1844,7 +1844,7 @@ void gui_init(dt_iop_module_t *self)
   dt_bauhaus_slider_set_format(g->chroma_highlights, "%");
   gtk_widget_set_tooltip_text(g->chroma_highlights, _("increase colorfulness at same luminance mostly in highlights"));
 
-  gtk_box_pack_start(GTK_BOX(self->widget), dt_ui_section_label_new(_("perceptual saturation grading")), FALSE, FALSE, 0);
+  gtk_box_pack_start(GTK_BOX(self->gui->widget), dt_ui_section_label_new(_("perceptual saturation grading")), FALSE, FALSE, 0);
 
   g->saturation_global = dt_bauhaus_slider_from_params(self, "saturation_global");
   dt_bauhaus_slider_set_digits(g->saturation_global, 4);
@@ -1866,7 +1866,7 @@ void gui_init(dt_iop_module_t *self)
   dt_bauhaus_slider_set_format(g->saturation_highlights, "%");
   gtk_widget_set_tooltip_text(g->saturation_highlights, _("increase or decrease saturation proportionally to the original pixel saturation"));
 
-  gtk_box_pack_start(GTK_BOX(self->widget), dt_ui_section_label_new(_("perceptual brilliance grading")), FALSE, FALSE, 0);
+  gtk_box_pack_start(GTK_BOX(self->gui->widget), dt_ui_section_label_new(_("perceptual brilliance grading")), FALSE, FALSE, 0);
 
   g->brilliance_global = dt_bauhaus_slider_from_params(self, "brilliance_global");
   dt_bauhaus_slider_set_digits(g->brilliance_global, 4);
@@ -1889,9 +1889,9 @@ void gui_init(dt_iop_module_t *self)
   gtk_widget_set_tooltip_text(g->brilliance_highlights, _("increase or decrease brilliance proportionally to the original pixel brilliance"));
 
   // Page 4-ways
-  self->widget = dt_ui_notebook_page(g->notebook, N_("4 ways"), _("selective color grading"));
+  self->gui->widget = dt_ui_notebook_page(g->notebook, N_("4 ways"), _("selective color grading"));
 
-  gtk_box_pack_start(GTK_BOX(self->widget), dt_ui_section_label_new(_("global offset")), FALSE, FALSE, 0);
+  gtk_box_pack_start(GTK_BOX(self->gui->widget), dt_ui_section_label_new(_("global offset")), FALSE, FALSE, 0);
 
   g->global_Y = dt_bauhaus_slider_from_params(self, "global_Y");
   dt_bauhaus_slider_set_soft_range(g->global_Y, -0.05, 0.05);
@@ -1910,7 +1910,7 @@ void gui_init(dt_iop_module_t *self)
   dt_bauhaus_slider_set_format(g->global_C, "%");
   gtk_widget_set_tooltip_text(g->global_C, _("chroma of the global color offset"));
 
-  gtk_box_pack_start(GTK_BOX(self->widget), dt_ui_section_label_new(_("shadows lift")), FALSE, FALSE, 0);
+  gtk_box_pack_start(GTK_BOX(self->gui->widget), dt_ui_section_label_new(_("shadows lift")), FALSE, FALSE, 0);
 
   g->shadows_Y = dt_bauhaus_slider_from_params(self, "shadows_Y");
   dt_bauhaus_slider_set_soft_range(g->shadows_Y, -1.0, 1.0);
@@ -1929,7 +1929,7 @@ void gui_init(dt_iop_module_t *self)
   dt_bauhaus_slider_set_format(g->shadows_C, "%");
   gtk_widget_set_tooltip_text(g->shadows_C, _("chroma of the color gain in shadows"));
 
-  gtk_box_pack_start(GTK_BOX(self->widget), dt_ui_section_label_new(_("highlights gain")), FALSE, FALSE, 0);
+  gtk_box_pack_start(GTK_BOX(self->gui->widget), dt_ui_section_label_new(_("highlights gain")), FALSE, FALSE, 0);
 
   g->highlights_Y = dt_bauhaus_slider_from_params(self, "highlights_Y");
   dt_bauhaus_slider_set_soft_range(g->highlights_Y, -0.5, 0.5);
@@ -1948,7 +1948,7 @@ void gui_init(dt_iop_module_t *self)
   dt_bauhaus_slider_set_format(g->highlights_C, "%");
   gtk_widget_set_tooltip_text(g->highlights_C, _("chroma of the color gain in highlights"));
 
-  gtk_box_pack_start(GTK_BOX(self->widget), dt_ui_section_label_new(_("power")), FALSE, FALSE, 0);
+  gtk_box_pack_start(GTK_BOX(self->gui->widget), dt_ui_section_label_new(_("power")), FALSE, FALSE, 0);
 
   g->midtones_Y = dt_bauhaus_slider_from_params(self, "midtones_Y");
   dt_bauhaus_slider_set_soft_range(g->midtones_Y, -0.25, 0.25);
@@ -1968,18 +1968,18 @@ void gui_init(dt_iop_module_t *self)
   gtk_widget_set_tooltip_text(g->midtones_C, _("chroma of the color exponent in mid-tones"));
 
   // Page masks
-  self->widget = dt_ui_notebook_page(g->notebook, N_("masks"), _("isolate luminances"));
+  self->gui->widget = dt_ui_notebook_page(g->notebook, N_("masks"), _("isolate luminances"));
 
   g->saturation_formula = dt_bauhaus_combobox_from_params(self, "saturation_formula");
   gtk_widget_set_tooltip_text(g->saturation_formula, _("choose in which uniform color space the saturation is computed."));
 
-  gtk_box_pack_start(GTK_BOX(self->widget), dt_ui_section_label_new(_("luminance ranges")), FALSE, FALSE, 0);
+  gtk_box_pack_start(GTK_BOX(self->gui->widget), dt_ui_section_label_new(_("luminance ranges")), FALSE, FALSE, 0);
 
   g->area = GTK_DRAWING_AREA(gtk_drawing_area_new());
   gtk_widget_set_hexpand(GTK_WIDGET(g->area), TRUE);
   g_object_set_data(G_OBJECT(g->area), "iop-instance", self);
   g_signal_connect(G_OBJECT(g->area), "draw", G_CALLBACK(dt_iop_tonecurve_draw), self);
-  gtk_box_pack_start(GTK_BOX(self->widget),
+  gtk_box_pack_start(GTK_BOX(self->gui->widget),
                      dt_ui_resizable_drawing_area(GTK_WIDGET(g->area),
                                                   "plugins/darkroom/colorbalancergb/graphheight", 200, 100),
                      FALSE, FALSE, 0);
@@ -2010,7 +2010,7 @@ void gui_init(dt_iop_module_t *self)
   dt_bauhaus_widget_set_quad_toggle(g->highlights_weight, TRUE);
   g_signal_connect(G_OBJECT(g->highlights_weight), "quad-pressed", G_CALLBACK(mask_callback), self);
 
-  gtk_box_pack_start(GTK_BOX(self->widget), dt_ui_section_label_new(_("threshold")), FALSE, FALSE, 0);
+  gtk_box_pack_start(GTK_BOX(self->gui->widget), dt_ui_section_label_new(_("threshold")), FALSE, FALSE, 0);
 
   g->white_fulcrum = dt_color_picker_new(self, DT_COLOR_PICKER_AREA, dt_bauhaus_slider_from_params(self, "white_fulcrum"));
   dt_bauhaus_slider_set_soft_range(g->white_fulcrum, -2., +2.);
@@ -2074,7 +2074,7 @@ void gui_init(dt_iop_module_t *self)
   }
 
   // main widget is the notebook
-  self->widget = GTK_WIDGET(g->notebook);
+  self->gui->widget = GTK_WIDGET(g->notebook);
 }
 
 

--- a/src/iop/colorchecker.c
+++ b/src/iop/colorchecker.c
@@ -40,6 +40,7 @@
     You should have received a copy of the GNU General Public License
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
+#include "develop/imageop_gui.h"
 #include "system/macros.h"
 #include "common/colorspaces_inline_conversions.h"
 #include "system/openmp.h"
@@ -821,7 +822,7 @@ void gui_reset(struct dt_iop_module_t *self)
 
 void _colorchecker_rebuild_patch_list(struct dt_iop_module_t *self)
 {
-  dt_iop_colorchecker_gui_data_t *g = (dt_iop_colorchecker_gui_data_t *)self->gui_data;
+  dt_iop_colorchecker_gui_data_t *g = (dt_iop_colorchecker_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_colorchecker_params_t *p = (dt_iop_colorchecker_params_t *)self->params;
   if(g->patch >= p->num_patches || g->patch < 0) return;
 
@@ -845,7 +846,7 @@ void _colorchecker_rebuild_patch_list(struct dt_iop_module_t *self)
 
 void _colorchecker_update_sliders(struct dt_iop_module_t *self)
 {
-  dt_iop_colorchecker_gui_data_t *g = (dt_iop_colorchecker_gui_data_t *)self->gui_data;
+  dt_iop_colorchecker_gui_data_t *g = (dt_iop_colorchecker_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_colorchecker_params_t *p = (dt_iop_colorchecker_params_t *)self->params;
   if(g->patch >= p->num_patches || g->patch < 0) return;
 
@@ -876,7 +877,7 @@ void _colorchecker_update_sliders(struct dt_iop_module_t *self)
 
 void gui_update(struct dt_iop_module_t *self)
 {
-  dt_iop_colorchecker_gui_data_t *g = (dt_iop_colorchecker_gui_data_t *)self->gui_data;
+  dt_iop_colorchecker_gui_data_t *g = (dt_iop_colorchecker_gui_data_t *)dt_iop_gui_data(self);
 
   _colorchecker_rebuild_patch_list(self);
   _colorchecker_update_sliders(self);
@@ -890,7 +891,6 @@ void init(dt_iop_module_t *module)
   module->default_params = calloc(1, sizeof(dt_iop_colorchecker_params_t));
   module->default_enabled = 0;
   module->params_size = sizeof(dt_iop_colorchecker_params_t);
-  module->gui_data = NULL;
 
   dt_iop_colorchecker_params_t *d = module->default_params;
   d->num_patches = colorchecker_patches;
@@ -921,7 +921,7 @@ void cleanup_global(dt_iop_module_so_t *module)
 
 void color_picker_apply(dt_iop_module_t *self, GtkWidget *picker, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
 {
-  dt_iop_colorchecker_gui_data_t *g = (dt_iop_colorchecker_gui_data_t *)self->gui_data;
+  dt_iop_colorchecker_gui_data_t *g = (dt_iop_colorchecker_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_colorchecker_params_t *p = (dt_iop_colorchecker_params_t *)self->params;
   if(p->num_patches <= 0) return;
 
@@ -956,7 +956,7 @@ static void target_L_callback(GtkWidget *slider, gpointer user_data)
 {
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
   dt_iop_colorchecker_params_t *p = (dt_iop_colorchecker_params_t *)self->params;
-  dt_iop_colorchecker_gui_data_t *g = (dt_iop_colorchecker_gui_data_t *)self->gui_data;
+  dt_iop_colorchecker_gui_data_t *g = (dt_iop_colorchecker_gui_data_t *)dt_iop_gui_data(self);
   if(g->patch >= p->num_patches || g->patch < 0) return;
   if(g->absolute_target)
     p->target_L[g->patch] = dt_bauhaus_slider_get(slider);
@@ -969,7 +969,7 @@ static void target_a_callback(GtkWidget *slider, gpointer user_data)
 {
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
   dt_iop_colorchecker_params_t *p = (dt_iop_colorchecker_params_t *)self->params;
-  dt_iop_colorchecker_gui_data_t *g = (dt_iop_colorchecker_gui_data_t *)self->gui_data;
+  dt_iop_colorchecker_gui_data_t *g = (dt_iop_colorchecker_gui_data_t *)dt_iop_gui_data(self);
   if(g->patch >= p->num_patches || g->patch < 0) return;
   if(g->absolute_target)
   {
@@ -1001,7 +1001,7 @@ static void target_b_callback(GtkWidget *slider, gpointer user_data)
 {
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
   dt_iop_colorchecker_params_t *p = (dt_iop_colorchecker_params_t *)self->params;
-  dt_iop_colorchecker_gui_data_t *g = (dt_iop_colorchecker_gui_data_t *)self->gui_data;
+  dt_iop_colorchecker_gui_data_t *g = (dt_iop_colorchecker_gui_data_t *)dt_iop_gui_data(self);
   if(g->patch >= p->num_patches || g->patch < 0) return;
   if(g->absolute_target)
   {
@@ -1033,7 +1033,7 @@ static void target_C_callback(GtkWidget *slider, gpointer user_data)
 {
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
   dt_iop_colorchecker_params_t *p = (dt_iop_colorchecker_params_t *)self->params;
-  dt_iop_colorchecker_gui_data_t *g = (dt_iop_colorchecker_gui_data_t *)self->gui_data;
+  dt_iop_colorchecker_gui_data_t *g = (dt_iop_colorchecker_gui_data_t *)dt_iop_gui_data(self);
   if(g->patch >= p->num_patches || g->patch < 0) return;
   const float Cin = sqrtf(
       p->source_a[g->patch]*p->source_a[g->patch] +
@@ -1068,7 +1068,7 @@ static void target_C_callback(GtkWidget *slider, gpointer user_data)
 static void target_callback(GtkWidget *combo, gpointer user_data)
 {
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
-  dt_iop_colorchecker_gui_data_t *g = (dt_iop_colorchecker_gui_data_t *)self->gui_data;
+  dt_iop_colorchecker_gui_data_t *g = (dt_iop_colorchecker_gui_data_t *)dt_iop_gui_data(self);
   g->absolute_target = dt_bauhaus_combobox_get(combo);
   dt_gui_freeze_begin();
   _colorchecker_update_sliders(self);
@@ -1081,7 +1081,7 @@ static void target_callback(GtkWidget *combo, gpointer user_data)
 static void patch_callback(GtkWidget *combo, gpointer user_data)
 {
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
-  dt_iop_colorchecker_gui_data_t *g = (dt_iop_colorchecker_gui_data_t *)self->gui_data;
+  dt_iop_colorchecker_gui_data_t *g = (dt_iop_colorchecker_gui_data_t *)dt_iop_gui_data(self);
   g->drawn_patch = g->patch = dt_bauhaus_combobox_get(combo);
   dt_gui_freeze_begin();
   _colorchecker_update_sliders(self);
@@ -1094,7 +1094,7 @@ static void patch_callback(GtkWidget *combo, gpointer user_data)
 static gboolean checker_draw(GtkWidget *widget, cairo_t *crf, gpointer user_data)
 {
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
-  dt_iop_colorchecker_gui_data_t *g = (dt_iop_colorchecker_gui_data_t *)self->gui_data;
+  dt_iop_colorchecker_gui_data_t *g = (dt_iop_colorchecker_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_colorchecker_params_t *p = (dt_iop_colorchecker_params_t *)self->params;
 
   GtkAllocation allocation;
@@ -1175,7 +1175,7 @@ static gboolean checker_motion_notify(GtkWidget *widget, GdkEventMotion *event,
 {
   // highlight?
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
-  dt_iop_colorchecker_gui_data_t *g = (dt_iop_colorchecker_gui_data_t *)self->gui_data;
+  dt_iop_colorchecker_gui_data_t *g = (dt_iop_colorchecker_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_colorchecker_params_t *p = (dt_iop_colorchecker_params_t *)self->params;
   GtkAllocation allocation;
   gtk_widget_get_allocation(widget, &allocation);
@@ -1209,7 +1209,7 @@ static gboolean checker_button_press(GtkWidget *widget, GdkEventButton *event,
                                                     gpointer user_data)
 {
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
-  dt_iop_colorchecker_gui_data_t *g = (dt_iop_colorchecker_gui_data_t *)self->gui_data;
+  dt_iop_colorchecker_gui_data_t *g = (dt_iop_colorchecker_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_colorchecker_params_t *p = (dt_iop_colorchecker_params_t *)self->params;
   GtkAllocation allocation;
   gtk_widget_get_allocation(widget, &allocation);
@@ -1314,11 +1314,11 @@ void gui_init(struct dt_iop_module_t *self)
   dt_iop_colorchecker_gui_data_t *g = IOP_GUI_ALLOC(colorchecker);
   dt_iop_colorchecker_params_t *p = (dt_iop_colorchecker_params_t *)self->default_params;
 
-  self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_GUI_BOX_SPACING);
+  self->gui->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_GUI_BOX_SPACING);
 
   // custom 24-patch widget in addition to combo box
   g->area = dtgtk_drawing_area_new_with_aspect_ratio(4.0/6.0);
-  gtk_box_pack_start(GTK_BOX(self->widget), g->area, TRUE, TRUE, 0);
+  gtk_box_pack_start(GTK_BOX(self->gui->widget), g->area, TRUE, TRUE, 0);
 
   gtk_widget_add_events(GTK_WIDGET(g->area), GDK_POINTER_MOTION_MASK
                                              | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK
@@ -1371,12 +1371,12 @@ void gui_init(struct dt_iop_module_t *self)
   dt_bauhaus_combobox_add(g->combobox_target, _("relative"));
   dt_bauhaus_combobox_add(g->combobox_target, _("absolute"));
 
-  gtk_box_pack_start(GTK_BOX(self->widget), g->combobox_patch, TRUE, TRUE, 0);
-  gtk_box_pack_start(GTK_BOX(self->widget), g->scale_L, TRUE, TRUE, 0);
-  gtk_box_pack_start(GTK_BOX(self->widget), g->scale_a, TRUE, TRUE, 0);
-  gtk_box_pack_start(GTK_BOX(self->widget), g->scale_b, TRUE, TRUE, 0);
-  gtk_box_pack_start(GTK_BOX(self->widget), g->scale_C, TRUE, TRUE, 0);
-  gtk_box_pack_start(GTK_BOX(self->widget), g->combobox_target, TRUE, TRUE, 0);
+  gtk_box_pack_start(GTK_BOX(self->gui->widget), g->combobox_patch, TRUE, TRUE, 0);
+  gtk_box_pack_start(GTK_BOX(self->gui->widget), g->scale_L, TRUE, TRUE, 0);
+  gtk_box_pack_start(GTK_BOX(self->gui->widget), g->scale_a, TRUE, TRUE, 0);
+  gtk_box_pack_start(GTK_BOX(self->gui->widget), g->scale_b, TRUE, TRUE, 0);
+  gtk_box_pack_start(GTK_BOX(self->gui->widget), g->scale_C, TRUE, TRUE, 0);
+  gtk_box_pack_start(GTK_BOX(self->gui->widget), g->combobox_target, TRUE, TRUE, 0);
 
   g_signal_connect(G_OBJECT(g->combobox_patch), "value-changed", G_CALLBACK(patch_callback), self);
   g_signal_connect(G_OBJECT(g->scale_L), "value-changed", G_CALLBACK(target_L_callback), self);

--- a/src/iop/colorcontrast.c
+++ b/src/iop/colorcontrast.c
@@ -234,7 +234,7 @@ void cleanup_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev
 
 void gui_update(dt_iop_module_t *self)
 {
-  dt_iop_colorcontrast_gui_data_t *g = (dt_iop_colorcontrast_gui_data_t *)self->gui_data;
+  dt_iop_colorcontrast_gui_data_t *g = (dt_iop_colorcontrast_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_colorcontrast_params_t *p = (dt_iop_colorcontrast_params_t *)self->params;
   dt_bauhaus_slider_set(g->a_scale, p->a_steepness);
   dt_bauhaus_slider_set(g->b_scale, p->b_steepness);

--- a/src/iop/colorcorrection.c
+++ b/src/iop/colorcorrection.c
@@ -264,10 +264,10 @@ void cleanup_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev
 
 void gui_update(struct dt_iop_module_t *self)
 {
-  dt_iop_colorcorrection_gui_data_t *g = (dt_iop_colorcorrection_gui_data_t *)self->gui_data;
+  dt_iop_colorcorrection_gui_data_t *g = (dt_iop_colorcorrection_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_colorcorrection_params_t *p = (dt_iop_colorcorrection_params_t *)self->params;
   dt_bauhaus_slider_set(g->slider, p->saturation);
-  gtk_widget_queue_draw(self->widget);
+  gtk_widget_queue_draw(self->gui->widget);
 }
 
 static gboolean dt_iop_colorcorrection_draw(GtkWidget *widget, cairo_t *cr, gpointer user_data);
@@ -286,11 +286,11 @@ void gui_init(struct dt_iop_module_t *self)
 
   g->selected = 0;
 
-  self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_GUI_BOX_SPACING);
+  self->gui->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_GUI_BOX_SPACING);
 
   g->area = GTK_DRAWING_AREA(dtgtk_drawing_area_new_with_aspect_ratio(1.0));
   g_object_set_data(G_OBJECT(g->area), "iop-instance", self);
-  gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(g->area), TRUE, TRUE, 0);
+  gtk_box_pack_start(GTK_BOX(self->gui->widget), GTK_WIDGET(g->area), TRUE, TRUE, 0);
   gtk_widget_set_tooltip_text(GTK_WIDGET(g->area), _("drag the line for split-toning. "
                                                      "bright means highlights, dark means shadows. "
                                                      "use mouse wheel to change saturation."));
@@ -319,7 +319,7 @@ void gui_init(struct dt_iop_module_t *self)
 
 void gui_cleanup(struct dt_iop_module_t *self)
 {
-  dt_iop_colorcorrection_gui_data_t *g = (dt_iop_colorcorrection_gui_data_t *)self->gui_data;
+  dt_iop_colorcorrection_gui_data_t *g = (dt_iop_colorcorrection_gui_data_t *)dt_iop_gui_data(self);
   cmsDeleteTransform(g->xform);
 
   IOP_GUI_FREE;
@@ -328,7 +328,7 @@ void gui_cleanup(struct dt_iop_module_t *self)
 static gboolean dt_iop_colorcorrection_draw(GtkWidget *widget, cairo_t *crf, gpointer user_data)
 {
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
-  dt_iop_colorcorrection_gui_data_t *g = (dt_iop_colorcorrection_gui_data_t *)self->gui_data;
+  dt_iop_colorcorrection_gui_data_t *g = (dt_iop_colorcorrection_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_colorcorrection_params_t *p = (dt_iop_colorcorrection_params_t *)self->params;
 
   const int inset = DT_COLORCORRECTION_INSET;
@@ -405,7 +405,7 @@ static gboolean dt_iop_colorcorrection_motion_notify(GtkWidget *widget, GdkEvent
                                                      gpointer user_data)
 {
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
-  dt_iop_colorcorrection_gui_data_t *g = (dt_iop_colorcorrection_gui_data_t *)self->gui_data;
+  dt_iop_colorcorrection_gui_data_t *g = (dt_iop_colorcorrection_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_colorcorrection_params_t *p = (dt_iop_colorcorrection_params_t *)self->params;
   const int inset = DT_COLORCORRECTION_INSET;
   GtkAllocation allocation;
@@ -442,7 +442,7 @@ static gboolean dt_iop_colorcorrection_motion_notify(GtkWidget *widget, GdkEvent
       g->selected = 2;
   }
   if(g->selected > 0) gtk_widget_grab_focus(widget);
-  gtk_widget_queue_draw(self->widget);
+  gtk_widget_queue_draw(self->gui->widget);
   return TRUE;
 }
 
@@ -453,7 +453,7 @@ static gboolean dt_iop_colorcorrection_button_press(GtkWidget *widget, GdkEventB
   {
     // double click resets:
     dt_iop_module_t *self = (dt_iop_module_t *)user_data;
-    dt_iop_colorcorrection_gui_data_t *g = (dt_iop_colorcorrection_gui_data_t *)self->gui_data;
+    dt_iop_colorcorrection_gui_data_t *g = (dt_iop_colorcorrection_gui_data_t *)dt_iop_gui_data(self);
     dt_iop_colorcorrection_params_t *p = (dt_iop_colorcorrection_params_t *)self->params;
     switch(g->selected)
     {
@@ -481,14 +481,14 @@ static gboolean dt_iop_colorcorrection_leave_notify(GtkWidget *widget, GdkEventC
                                                     gpointer user_data)
 {
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
-  gtk_widget_queue_draw(self->widget);
+  gtk_widget_queue_draw(self->gui->widget);
   return TRUE;
 }
 
 static gboolean dt_iop_colorcorrection_scrolled(GtkWidget *widget, GdkEventScroll *event, gpointer user_data)
 {
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
-  dt_iop_colorcorrection_gui_data_t *g = (dt_iop_colorcorrection_gui_data_t *)self->gui_data;
+  dt_iop_colorcorrection_gui_data_t *g = (dt_iop_colorcorrection_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_colorcorrection_params_t *p = (dt_iop_colorcorrection_params_t *)self->params;
 
   int delta_y;
@@ -507,7 +507,7 @@ static gboolean dt_iop_colorcorrection_scrolled(GtkWidget *widget, GdkEventScrol
 static gboolean dt_iop_colorcorrection_key_press(GtkWidget *widget, GdkEventKey *event, gpointer user_data)
 {
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
-  dt_iop_colorcorrection_gui_data_t *g = (dt_iop_colorcorrection_gui_data_t *)self->gui_data;
+  dt_iop_colorcorrection_gui_data_t *g = (dt_iop_colorcorrection_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_colorcorrection_params_t *p = (dt_iop_colorcorrection_params_t *)self->params;
   if(g->selected < 1) return FALSE;
   guint key = dt_keys_mainpad_alternatives(event->keyval);

--- a/src/iop/colorequal.c
+++ b/src/iop/colorequal.c
@@ -341,6 +341,8 @@ static void _init_default_curves(dt_iop_colorequal_params_t *p)
 static inline gboolean _curve_fields_equal(const dt_iop_colorequal_params_t *const a,
                                            const dt_iop_colorequal_params_t *const b)
 {
+  if(IS_NULL_PTR(a) || IS_NULL_PTR(b)) return a == b;   // params can be NULL before first init
+
   return !memcmp(a->curve_num_nodes, b->curve_num_nodes, sizeof(a->curve_num_nodes))
          && !memcmp(a->curve, b->curve, sizeof(a->curve));
 }
@@ -348,6 +350,8 @@ static inline gboolean _curve_fields_equal(const dt_iop_colorequal_params_t *con
 static inline gboolean _lut_fields_equal(const dt_iop_colorequal_params_t *const a,
                                          const dt_iop_colorequal_params_t *const b)
 {
+  if(IS_NULL_PTR(a) || IS_NULL_PTR(b)) return a == b;   // params can be NULL before first init
+
   return _curve_fields_equal(a, b) && a->sigma_L == b->sigma_L && a->sigma_rho == b->sigma_rho
          && a->sigma_theta == b->sigma_theta && a->neutral_protection == b->neutral_protection;
 }
@@ -956,7 +960,7 @@ int process(struct dt_iop_module_t *self, const dt_dev_pixelpipe_t *pipe, const 
 static void _update_gui_lut_cache(dt_iop_module_t *self)
 {
   if(!self->enabled) return;
-  dt_iop_colorequal_gui_data_t *g = (dt_iop_colorequal_gui_data_t *)self->gui_data;
+  dt_iop_colorequal_gui_data_t *g = (dt_iop_colorequal_gui_data_t *)dt_iop_gui_data(self);
   const dt_iop_colorequal_params_t *p = g ? &g->gui_params : (const dt_iop_colorequal_params_t *)self->params;
   const gboolean log_perf = (dt_get_debug_flags() & DT_DEBUG_PERF) != 0;
   const double start = log_perf ? dt_get_wtime() : 0.0;
@@ -1121,7 +1125,7 @@ static void _draw_graph_background(cairo_t *cr, const dt_iop_colorequal_channel_
 static gboolean _draw_curve(GtkWidget *widget, cairo_t *crf, gpointer user_data)
 {
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
-  dt_iop_colorequal_gui_data_t *g = (dt_iop_colorequal_gui_data_t *)self->gui_data;
+  dt_iop_colorequal_gui_data_t *g = (dt_iop_colorequal_gui_data_t *)dt_iop_gui_data(self);
   const dt_iop_colorequal_params_t *p = &g->gui_params;
   const dt_iop_colorequal_ring_t ring
       = (dt_iop_colorequal_ring_t)GPOINTER_TO_INT(g_object_get_data(G_OBJECT(widget), "colorequal-ring"));
@@ -1344,7 +1348,7 @@ static void _cacheline_ready_callback(gpointer instance, const guint64 hash,
   (void)instance;
   (void)producer_node_key;
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
-  dt_iop_colorequal_gui_data_t *g = (dt_iop_colorequal_gui_data_t *)self->gui_data;
+  dt_iop_colorequal_gui_data_t *g = (dt_iop_colorequal_gui_data_t *)dt_iop_gui_data(self);
   if(g->pending_preview_hash != hash || !_refresh_preview_cursor_sample(self)) return;
 
   const dt_iop_colorequal_ring_t ring = _active_ring_from_gui(g);
@@ -1356,9 +1360,9 @@ static void _cacheline_ready_callback(gpointer instance, const guint64 hash,
 static void _preview_cache_wait_restart(gpointer user_data)
 {
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
-  if(IS_NULL_PTR(self) || IS_NULL_PTR(self->gui_data)) return;
+  if(IS_NULL_PTR(self) || IS_NULL_PTR(dt_iop_gui_data(self))) return;
 
-  dt_iop_colorequal_gui_data_t *g = (dt_iop_colorequal_gui_data_t *)self->gui_data;
+  dt_iop_colorequal_gui_data_t *g = (dt_iop_colorequal_gui_data_t *)dt_iop_gui_data(self);
   if(IS_NULL_PTR(g) || !g->has_focus || !_refresh_preview_cursor_sample(self)) return;
 
   const dt_iop_colorequal_ring_t ring = _active_ring_from_gui(g);
@@ -1371,7 +1375,7 @@ static int _find_selected_node(const dt_iop_module_t *self, const dt_iop_coloreq
                                const dt_iop_colorequal_channel_t channel, const float mouse_x, const float mouse_y,
                                const float graph_width, const float graph_height)
 {
-  const dt_iop_colorequal_gui_data_t *g = (const dt_iop_colorequal_gui_data_t *)self->gui_data;
+  const dt_iop_colorequal_gui_data_t *g = (const dt_iop_colorequal_gui_data_t *)dt_iop_gui_data(self);
   const dt_iop_colorequal_params_t *p = &g->gui_params;
   int selected = -1;
   float best = DT_PIXEL_APPLY_DPI(10.f) * DT_PIXEL_APPLY_DPI(10.f);
@@ -1434,7 +1438,7 @@ static gboolean _move_selected_node(dt_iop_module_t *self, const dt_iop_colorequ
                                     const dt_iop_colorequal_channel_t channel, const int node, const float x,
                                     const float y)
 {
-  dt_iop_colorequal_gui_data_t *g = (dt_iop_colorequal_gui_data_t *)self->gui_data;
+  dt_iop_colorequal_gui_data_t *g = (dt_iop_colorequal_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_colorequal_params_t *p = &g->gui_params;
   dt_iop_colorequal_node_t *curve = _curve_nodes(p, ring, channel);
   const int nodes = _curve_nodes_count_const(p, ring, channel);
@@ -1466,7 +1470,7 @@ static gboolean _move_selected_node(dt_iop_module_t *self, const dt_iop_colorequ
 static gboolean _area_motion_notify_callback(GtkWidget *widget, GdkEventMotion *event, gpointer user_data)
 {
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
-  dt_iop_colorequal_gui_data_t *g = (dt_iop_colorequal_gui_data_t *)self->gui_data;
+  dt_iop_colorequal_gui_data_t *g = (dt_iop_colorequal_gui_data_t *)dt_iop_gui_data(self);
   const dt_iop_colorequal_ring_t ring
       = (dt_iop_colorequal_ring_t)GPOINTER_TO_INT(g_object_get_data(G_OBJECT(widget), "colorequal-ring"));
   const dt_iop_colorequal_channel_t channel
@@ -1510,7 +1514,7 @@ static gboolean _area_motion_notify_callback(GtkWidget *widget, GdkEventMotion *
 static gboolean _area_button_press_callback(GtkWidget *widget, GdkEventButton *event, gpointer user_data)
 {
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
-  dt_iop_colorequal_gui_data_t *g = (dt_iop_colorequal_gui_data_t *)self->gui_data;
+  dt_iop_colorequal_gui_data_t *g = (dt_iop_colorequal_gui_data_t *)dt_iop_gui_data(self);
   const dt_iop_colorequal_ring_t ring
       = (dt_iop_colorequal_ring_t)GPOINTER_TO_INT(g_object_get_data(G_OBJECT(widget), "colorequal-ring"));
   const dt_iop_colorequal_channel_t channel
@@ -1615,7 +1619,7 @@ static gboolean _area_button_release_callback(GtkWidget *widget, GdkEventButton 
     const dt_iop_colorequal_channel_t channel
         = (dt_iop_colorequal_channel_t)GPOINTER_TO_INT(g_object_get_data(G_OBJECT(widget), "colorequal-channel"));
     dt_iop_module_t *self = (dt_iop_module_t *)user_data;
-    dt_iop_colorequal_gui_data_t *g = (dt_iop_colorequal_gui_data_t *)self->gui_data;
+    dt_iop_colorequal_gui_data_t *g = (dt_iop_colorequal_gui_data_t *)dt_iop_gui_data(self);
     const gboolean was_dragging = g->dragging[ring][channel];
     g->dragging[ring][channel] = FALSE;
 
@@ -1643,7 +1647,7 @@ static void _channel_tabs_switch_callback(GtkNotebook *notebook, GtkWidget *page
   if(dt_gui_widgets_suppressed()) return;
 
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
-  dt_iop_colorequal_gui_data_t *g = (dt_iop_colorequal_gui_data_t *)self->gui_data;
+  dt_iop_colorequal_gui_data_t *g = (dt_iop_colorequal_gui_data_t *)dt_iop_gui_data(self);
   const int source_ring = GPOINTER_TO_INT(g_object_get_data(G_OBJECT(notebook), "colorequal-ring"));
   const dt_iop_colorequal_channel_t channel
       = (dt_iop_colorequal_channel_t)GPOINTER_TO_INT(g_object_get_data(G_OBJECT(page), "colorequal-channel"));
@@ -1668,7 +1672,7 @@ static void _ring_tabs_switch_callback(GtkNotebook *notebook, GtkWidget *page, g
   if(dt_gui_widgets_suppressed()) return;
 
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
-  dt_iop_colorequal_gui_data_t *g = (dt_iop_colorequal_gui_data_t *)self->gui_data;
+  dt_iop_colorequal_gui_data_t *g = (dt_iop_colorequal_gui_data_t *)dt_iop_gui_data(self);
 
   if(page_num < DT_IOP_COLOREQUAL_NUM_RINGS)
   {
@@ -1694,7 +1698,7 @@ static void _ring_tabs_switch_callback(GtkNotebook *notebook, GtkWidget *page, g
 
 int mouse_moved(struct dt_iop_module_t *self, double x, double y, double pressure, int which)
 {
-  dt_iop_colorequal_gui_data_t *g = (dt_iop_colorequal_gui_data_t *)self->gui_data;
+  dt_iop_colorequal_gui_data_t *g = (dt_iop_colorequal_gui_data_t *)dt_iop_gui_data(self);
   dt_develop_t *dev = self ? self->dev : NULL;
   if(!g->has_focus) return 0;
 
@@ -1742,7 +1746,7 @@ int mouse_moved(struct dt_iop_module_t *self, double x, double y, double pressur
 
 int mouse_leave(struct dt_iop_module_t *self)
 {
-  dt_iop_colorequal_gui_data_t *g = (dt_iop_colorequal_gui_data_t *)self->gui_data;
+  dt_iop_colorequal_gui_data_t *g = (dt_iop_colorequal_gui_data_t *)dt_iop_gui_data(self);
   g->cursor_valid = FALSE;
   _invalidate_preview_cursor(g);
   _switch_preview_cursor(self);
@@ -1762,14 +1766,14 @@ int mouse_leave(struct dt_iop_module_t *self)
 int button_pressed(struct dt_iop_module_t *self, double x, double y, double pressure, int which, int type,
                    uint32_t state)
 {
-  dt_iop_colorequal_gui_data_t *g = (dt_iop_colorequal_gui_data_t *)self->gui_data;
+  dt_iop_colorequal_gui_data_t *g = (dt_iop_colorequal_gui_data_t *)dt_iop_gui_data(self);
   if(!g->has_focus || which != 3 || !g->cursor_valid || !g->cursor_sample_valid
      || dt_iop_color_picker_is_visible(self->dev))
     return 0;
 
   if(!self->enabled)
   {
-    if(self->off) gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(self->off), 1);
+    if(self->gui->off) gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(self->gui->off), 1);
     return 1;
   }
 
@@ -1799,7 +1803,7 @@ int button_pressed(struct dt_iop_module_t *self, double x, double y, double pres
 
 int scrolled(struct dt_iop_module_t *self, double x, double y, int up, uint32_t state)
 {
-  dt_iop_colorequal_gui_data_t *g = (dt_iop_colorequal_gui_data_t *)self->gui_data;
+  dt_iop_colorequal_gui_data_t *g = (dt_iop_colorequal_gui_data_t *)dt_iop_gui_data(self);
   // A drawn mask being edited (anywhere on canvas, not just hovered directly -- that case
   // already wins via dt_masks_events_mouse_scrolled in views/darkroom.c) must not leak scroll
   // input into this module's own hue/chroma curve adjustment.
@@ -1809,7 +1813,7 @@ int scrolled(struct dt_iop_module_t *self, double x, double y, int up, uint32_t 
 
   if(!self->enabled)
   {
-    if(self->off) gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(self->off), 1);
+    if(self->gui->off) gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(self->gui->off), 1);
     return 1;
   }
 
@@ -1867,7 +1871,7 @@ int scrolled(struct dt_iop_module_t *self, double x, double y, int up, uint32_t 
 void gui_post_expose(struct dt_iop_module_t *self, cairo_t *cr, int32_t width, int32_t height,
                      int32_t pointerx, int32_t pointery)
 {
-  dt_iop_colorequal_gui_data_t *g = (dt_iop_colorequal_gui_data_t *)self->gui_data;
+  dt_iop_colorequal_gui_data_t *g = (dt_iop_colorequal_gui_data_t *)dt_iop_gui_data(self);
   dt_develop_t *dev = self ? self->dev : NULL;
   if(IS_NULL_PTR(g) || IS_NULL_PTR(dev)) return;
   if(!g->has_focus || !self->enabled || !g->cursor_valid || dt_iop_color_picker_is_visible(dev))
@@ -1960,7 +1964,7 @@ static void _pipe_rgb_to_dt_ucs_hsb(dt_iop_module_t *self, dt_dev_pixelpipe_t *p
 
 static void _switch_preview_cursor(dt_iop_module_t *self)
 {
-  dt_iop_colorequal_gui_data_t *g = (dt_iop_colorequal_gui_data_t *)self->gui_data;
+  dt_iop_colorequal_gui_data_t *g = (dt_iop_colorequal_gui_data_t *)dt_iop_gui_data(self);
   GtkWidget *widget = dt_gui_main_window();
 
   if(!widget || !gtk_widget_get_window(widget)) return;
@@ -1991,7 +1995,7 @@ static void _switch_preview_cursor(dt_iop_module_t *self)
 
 static gboolean _refresh_preview_cursor_sample(dt_iop_module_t *self)
 {
-  dt_iop_colorequal_gui_data_t *g = (dt_iop_colorequal_gui_data_t *)self->gui_data;
+  dt_iop_colorequal_gui_data_t *g = (dt_iop_colorequal_gui_data_t *)dt_iop_gui_data(self);
   dt_develop_t *dev = self ? self->dev : NULL;
   if(!self->enabled || !g->cursor_valid)
   {
@@ -2121,7 +2125,7 @@ static void _format_picker_brightness_position(const float brightness, char *tex
 void color_picker_apply(dt_iop_module_t *self, GtkWidget *picker, dt_dev_pixelpipe_t *pipe,
                         dt_dev_pixelpipe_iop_t *piece)
 {
-  dt_iop_colorequal_gui_data_t *g = (dt_iop_colorequal_gui_data_t *)self->gui_data;
+  dt_iop_colorequal_gui_data_t *g = (dt_iop_colorequal_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_colorequal_params_t *p = (dt_iop_colorequal_params_t *)self->params;
   const dt_iop_module_t *sampled_module = piece && piece->module ? piece->module : self;
 
@@ -2193,7 +2197,7 @@ void autoset(struct dt_iop_module_t *self, const struct dt_dev_pixelpipe_t *pipe
   if(IS_NULL_PTR(work_profile) || piece->dsc_in.channels != 4) return;
 
   dt_iop_colorequal_params_t *p = (dt_iop_colorequal_params_t *)self->params;
-  dt_iop_colorequal_gui_data_t *g = (dt_iop_colorequal_gui_data_t *)self->gui_data;
+  dt_iop_colorequal_gui_data_t *g = (dt_iop_colorequal_gui_data_t *)dt_iop_gui_data(self);
   const dt_iop_roi_t *const roi_out = &piece->roi_out;
   const float *const restrict in = (const float *)i;
   float max_Y = 0.0f;
@@ -2214,7 +2218,7 @@ void autoset(struct dt_iop_module_t *self, const struct dt_dev_pixelpipe_t *pipe
 
 void gui_changed(dt_iop_module_t *self, GtkWidget *w, void *previous)
 {
-  dt_iop_colorequal_gui_data_t *g = (dt_iop_colorequal_gui_data_t *)self->gui_data;
+  dt_iop_colorequal_gui_data_t *g = (dt_iop_colorequal_gui_data_t *)dt_iop_gui_data(self);
   const dt_iop_colorequal_params_t *p = (const dt_iop_colorequal_params_t *)self->params;
   const gboolean curves_changed = !_curve_fields_equal(&g->gui_params, p);
   memcpy(&g->gui_params, self->params, sizeof(dt_iop_colorequal_params_t));
@@ -2233,7 +2237,7 @@ void gui_changed(dt_iop_module_t *self, GtkWidget *w, void *previous)
 void gui_update(dt_iop_module_t *self)
 {
   const dt_iop_colorequal_params_t *p = (const dt_iop_colorequal_params_t *)self->params;
-  dt_iop_colorequal_gui_data_t *g = (dt_iop_colorequal_gui_data_t *)self->gui_data;
+  dt_iop_colorequal_gui_data_t *g = (dt_iop_colorequal_gui_data_t *)dt_iop_gui_data(self);
   memcpy(&g->gui_params, p, sizeof(dt_iop_colorequal_params_t));
   dt_bauhaus_slider_set(g->white_level, p->white_level);
   dt_bauhaus_slider_set(g->sigma_L, p->sigma_L);
@@ -2246,7 +2250,7 @@ void gui_update(dt_iop_module_t *self)
 
 void gui_focus(struct dt_iop_module_t *self, gboolean in)
 {
-  dt_iop_colorequal_gui_data_t *g = (dt_iop_colorequal_gui_data_t *)self->gui_data;
+  dt_iop_colorequal_gui_data_t *g = (dt_iop_colorequal_gui_data_t *)dt_iop_gui_data(self);
   g->has_focus = in;
 
   if(in)
@@ -2275,7 +2279,7 @@ void gui_focus(struct dt_iop_module_t *self, gboolean in)
 
 void gui_cleanup(dt_iop_module_t *self)
 {
-  dt_iop_colorequal_gui_data_t *g = (dt_iop_colorequal_gui_data_t *)self->gui_data;
+  dt_iop_colorequal_gui_data_t *g = (dt_iop_colorequal_gui_data_t *)dt_iop_gui_data(self);
   self->request_color_pick = DT_REQUEST_COLORPICK_OFF;
   // The LUT viewer's task holds `self` and reads g->..., both invalid past this point.
   // (It was never cancelled here: only the history task, which no longer exists, was.)
@@ -2319,10 +2323,10 @@ void gui_init(dt_iop_module_t *self)
   g->pending_preview_hash = DT_PIXELPIPE_CACHE_HASH_INVALID;
   g->has_focus = FALSE;
 
-  self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_GUI_BOX_SPACING);
+  self->gui->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_GUI_BOX_SPACING);
 
   GtkWidget *ring_tabs_box = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_GUI_BOX_SPACING);
-  gtk_box_pack_start(GTK_BOX(self->widget), ring_tabs_box, TRUE, TRUE, 0);
+  gtk_box_pack_start(GTK_BOX(self->gui->widget), ring_tabs_box, TRUE, TRUE, 0);
 
   g->ring_notebook = GTK_NOTEBOOK(gtk_notebook_new());
   gtk_widget_set_name(GTK_WIDGET(g->ring_notebook), "colorequal-ring-tabs");
@@ -2383,8 +2387,8 @@ void gui_init(dt_iop_module_t *self)
   gtk_notebook_append_page(g->ring_notebook, options_page, options_label);
   gtk_container_child_set(GTK_CONTAINER(g->ring_notebook), options_page, "tab-expand", TRUE, "tab-fill", TRUE, NULL);
 
-  GtkWidget *const module_root = self->widget;
-  self->widget = options_page;
+  GtkWidget *const module_root = self->gui->widget;
+  self->gui->widget = options_page;
 
   g->white_level
       = dt_color_picker_new(self, DT_COLOR_PICKER_AREA, dt_bauhaus_slider_from_params(self, "white_level"));
@@ -2407,7 +2411,7 @@ void gui_init(dt_iop_module_t *self)
   g->interpolation = dt_bauhaus_combobox_from_params(self, "interpolation");
   gtk_widget_set_tooltip_text(g->interpolation, _("select the interpolation method"));
 
-  self->widget = module_root;
+  self->gui->widget = module_root;
 
   GtkWidget *picker_box = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, DT_GUI_BOX_SPACING);
   gtk_box_pack_start(GTK_BOX(ring_tabs_box), picker_box, FALSE, FALSE, 0);
@@ -2443,9 +2447,9 @@ void gui_init(dt_iop_module_t *self)
   g->viewer_control_node_count = 0;
   g->viewer = dt_lut_viewer_new(DT_GUI_MODULE(self));
   if(g->viewer)
-    gtk_box_pack_start(GTK_BOX(GTK_BOX(self->widget)), dt_lut_viewer_get_widget(g->viewer), TRUE, TRUE, 0);
+    gtk_box_pack_start(GTK_BOX(GTK_BOX(self->gui->widget)), dt_lut_viewer_get_widget(g->viewer), TRUE, TRUE, 0);
 
-  gtk_widget_show_all(self->widget);
+  gtk_widget_show_all(self->gui->widget);
 }
 
 void init_global(dt_iop_module_so_t *module)

--- a/src/iop/colorin.c
+++ b/src/iop/colorin.c
@@ -507,7 +507,7 @@ static void profile_changed(GtkWidget *widget, gpointer user_data)
   if(dt_gui_widgets_suppressed()) return;
   dt_iop_request_focus(self);
   dt_iop_colorin_params_t *p = (dt_iop_colorin_params_t *)self->params;
-  dt_iop_colorin_gui_data_t *g = (dt_iop_colorin_gui_data_t *)self->gui_data;
+  dt_iop_colorin_gui_data_t *g = (dt_iop_colorin_gui_data_t *)dt_iop_gui_data(self);
   int pos = dt_bauhaus_combobox_get(widget);
 
   /* The combo lists this image's own derived profiles first (g->image_profiles, which
@@ -910,7 +910,7 @@ void cleanup_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev
 
 void gui_update(struct dt_iop_module_t *self)
 {
-  dt_iop_colorin_gui_data_t *g = (dt_iop_colorin_gui_data_t *)self->gui_data;
+  dt_iop_colorin_gui_data_t *g = (dt_iop_colorin_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_colorin_params_t *p = (dt_iop_colorin_params_t *)self->params;
 
   dt_bauhaus_combobox_set(g->clipping_combobox, p->normalize);
@@ -976,7 +976,7 @@ void reload_defaults(dt_iop_module_t *module)
 
 static void update_profile_list(dt_iop_module_t *self)
 {
-  dt_iop_colorin_gui_data_t *g = (dt_iop_colorin_gui_data_t *)self->gui_data;
+  dt_iop_colorin_gui_data_t *g = (dt_iop_colorin_gui_data_t *)dt_iop_gui_data(self);
 
   if(IS_NULL_PTR(g)) return;
 
@@ -1129,15 +1129,15 @@ void gui_init(struct dt_iop_module_t *self)
   dt_loc_get_datadir(datadir, sizeof(datadir));
   dt_loc_get_user_config_dir(confdir, sizeof(confdir));
 
-  self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_GUI_BOX_SPACING);
+  self->gui->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_GUI_BOX_SPACING);
 
   g->profile_combobox = dt_bauhaus_combobox_new(dt_bauhaus_get_global(), DT_GUI_MODULE(self));
   dt_bauhaus_widget_set_label(g->profile_combobox, N_("input profile"));
-  gtk_box_pack_start(GTK_BOX(self->widget), g->profile_combobox, TRUE, TRUE, 0);
+  gtk_box_pack_start(GTK_BOX(self->gui->widget), g->profile_combobox, TRUE, TRUE, 0);
 
   g->work_combobox = dt_bauhaus_combobox_new(dt_bauhaus_get_global(), DT_GUI_MODULE(self));
   dt_bauhaus_widget_set_label(g->work_combobox, N_("working profile"));
-  gtk_box_pack_start(GTK_BOX(self->widget), g->work_combobox, TRUE, TRUE, 0);
+  gtk_box_pack_start(GTK_BOX(self->gui->widget), g->work_combobox, TRUE, TRUE, 0);
 
   dt_bauhaus_combobox_set(g->profile_combobox, 0);
   {
@@ -1170,7 +1170,7 @@ void gui_init(struct dt_iop_module_t *self)
 
 void gui_cleanup(struct dt_iop_module_t *self)
 {
-  dt_iop_colorin_gui_data_t *g = (dt_iop_colorin_gui_data_t *)self->gui_data;
+  dt_iop_colorin_gui_data_t *g = (dt_iop_colorin_gui_data_t *)dt_iop_gui_data(self);
   while(g->image_profiles)
   {
     dt_free(g->image_profiles->data);

--- a/src/iop/colorize.c
+++ b/src/iop/colorize.c
@@ -202,7 +202,7 @@ static inline void update_saturation_slider_end_color(GtkWidget *slider, float h
 void gui_changed(dt_iop_module_t *self, GtkWidget *w, void *previous)
 {
   dt_iop_colorize_params_t *p = (dt_iop_colorize_params_t *)self->params;
-  dt_iop_colorize_gui_data_t *g = (dt_iop_colorize_gui_data_t *)self->gui_data;
+  dt_iop_colorize_gui_data_t *g = (dt_iop_colorize_gui_data_t *)dt_iop_gui_data(self);
 
   if(w == g->hue)
   {
@@ -213,7 +213,7 @@ void gui_changed(dt_iop_module_t *self, GtkWidget *w, void *previous)
 
 void color_picker_apply(dt_iop_module_t *self, GtkWidget *picker, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
 {
-  dt_iop_colorize_gui_data_t *g = (dt_iop_colorize_gui_data_t *)self->gui_data;
+  dt_iop_colorize_gui_data_t *g = (dt_iop_colorize_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_colorize_params_t *p = (dt_iop_colorize_params_t *)self->params;
 
   // convert picker RGB 2 HSL
@@ -298,7 +298,7 @@ void cleanup_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev
 
 void gui_update(struct dt_iop_module_t *self)
 {
-  dt_iop_colorize_gui_data_t *g = (dt_iop_colorize_gui_data_t *)self->gui_data;
+  dt_iop_colorize_gui_data_t *g = (dt_iop_colorize_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_colorize_params_t *p = (dt_iop_colorize_params_t *)self->params;
 
   dt_iop_color_picker_reset(self, TRUE);

--- a/src/iop/colormapping.c
+++ b/src/iop/colormapping.c
@@ -457,7 +457,7 @@ int process(struct dt_iop_module_t *self, const dt_dev_pixelpipe_t *pipe, const 
   const dt_iop_roi_t *const roi_in = &piece->roi_in;
   const dt_iop_roi_t *const roi_out = &piece->roi_out;
   dt_iop_colormapping_data_t *const restrict data = (dt_iop_colormapping_data_t *)piece->data;
-  dt_iop_colormapping_gui_data_t *const restrict g = (dt_iop_colormapping_gui_data_t *)self->gui_data;
+  dt_iop_colormapping_gui_data_t *const restrict g = (dt_iop_colormapping_gui_data_t *)dt_iop_gui_data(self);
   float *const restrict in = (float *)ivoid;
   float *const restrict out = (float *)ovoid;
 
@@ -636,7 +636,7 @@ void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pix
 void gui_changed(dt_iop_module_t *self, GtkWidget *w, void *previous)
 {
   dt_iop_colormapping_params_t *p = (dt_iop_colormapping_params_t *)self->params;
-  dt_iop_colormapping_gui_data_t *g = (dt_iop_colormapping_gui_data_t *)self->gui_data;
+  dt_iop_colormapping_gui_data_t *g = (dt_iop_colormapping_gui_data_t *)dt_iop_gui_data(self);
 
   if(w == g->clusters)
   {
@@ -693,7 +693,7 @@ void reload_defaults(dt_iop_module_t *module)
 {
   dt_iop_colormapping_params_t *d = module->default_params;
 
-  dt_iop_colormapping_gui_data_t *g = (dt_iop_colormapping_gui_data_t *)module->gui_data;
+  dt_iop_colormapping_gui_data_t *g = (dt_iop_colormapping_gui_data_t *)dt_iop_gui_data(module);
   if(module->dev->gui_attached && !IS_NULL_PTR(g) && g->flowback_set)
   {
     memcpy(d->source_ihist, g->flowback.hist, sizeof(float) * HISTN);
@@ -709,7 +709,7 @@ void reload_defaults(dt_iop_module_t *module)
 static gboolean cluster_preview_draw(GtkWidget *widget, cairo_t *crf, dt_iop_module_t *self)
 {
   dt_iop_colormapping_params_t *p = (dt_iop_colormapping_params_t *)self->params;
-  dt_iop_colormapping_gui_data_t *g = (dt_iop_colormapping_gui_data_t *)self->gui_data;
+  dt_iop_colormapping_gui_data_t *g = (dt_iop_colormapping_gui_data_t *)dt_iop_gui_data(self);
 
   float2 *mean;
   float2 *var;
@@ -775,7 +775,7 @@ static void process_clusters(gpointer instance, gpointer user_data)
 {
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
   dt_iop_colormapping_params_t *p = (dt_iop_colormapping_params_t *)self->params;
-  dt_iop_colormapping_gui_data_t *g = (dt_iop_colormapping_gui_data_t *)self->gui_data;
+  dt_iop_colormapping_gui_data_t *g = (dt_iop_colormapping_gui_data_t *)dt_iop_gui_data(self);
   int new_source_clusters = 0;
 
   if(IS_NULL_PTR(g) || IS_NULL_PTR(g->buffer)) return;
@@ -870,22 +870,22 @@ void gui_init(struct dt_iop_module_t *self)
   g->xform = cmsCreateTransform(hLab, TYPE_Lab_DBL, hsRGB, TYPE_RGB_DBL, INTENT_PERCEPTUAL, 0);
   g->buffer = NULL;
 
-  self->widget = GTK_WIDGET(gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_GUI_BOX_SPACING));
+  self->gui->widget = GTK_WIDGET(gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_GUI_BOX_SPACING));
 
-  gtk_box_pack_start(GTK_BOX(self->widget), dt_ui_label_new(_("source clusters:")), TRUE, TRUE, 0);
+  gtk_box_pack_start(GTK_BOX(self->gui->widget), dt_ui_label_new(_("source clusters:")), TRUE, TRUE, 0);
 
   g->source_area = dtgtk_drawing_area_new_with_aspect_ratio(1.0 / 3.0);
-  gtk_box_pack_start(GTK_BOX(self->widget), g->source_area, TRUE, TRUE, 0);
+  gtk_box_pack_start(GTK_BOX(self->gui->widget), g->source_area, TRUE, TRUE, 0);
   g_signal_connect(G_OBJECT(g->source_area), "draw", G_CALLBACK(cluster_preview_draw), self);
 
-  gtk_box_pack_start(GTK_BOX(self->widget), dt_ui_label_new(_("target clusters:")), TRUE, TRUE, 0);
+  gtk_box_pack_start(GTK_BOX(self->gui->widget), dt_ui_label_new(_("target clusters:")), TRUE, TRUE, 0);
 
   g->target_area = dtgtk_drawing_area_new_with_aspect_ratio(1.0 / 3.0);
-  gtk_box_pack_start(GTK_BOX(self->widget), g->target_area, TRUE, TRUE, 0);
+  gtk_box_pack_start(GTK_BOX(self->gui->widget), g->target_area, TRUE, TRUE, 0);
   g_signal_connect(G_OBJECT(g->target_area), "draw", G_CALLBACK(cluster_preview_draw), self);
 
   GtkWidget *box = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, DT_GUI_BOX_SPACING);
-  gtk_box_pack_start(GTK_BOX(self->widget), box, TRUE, TRUE, 0);
+  gtk_box_pack_start(GTK_BOX(self->gui->widget), box, TRUE, TRUE, 0);
 
   g->acquire_source_button = dt_iop_button_new(self, N_("acquire as source"),
                                                G_CALLBACK(acquire_source_button_pressed), FALSE, 0, 0,
@@ -925,7 +925,7 @@ void gui_init(struct dt_iop_module_t *self)
 
 void gui_cleanup(struct dt_iop_module_t *self)
 {
-  dt_iop_colormapping_gui_data_t *g = (dt_iop_colormapping_gui_data_t *)self->gui_data;
+  dt_iop_colormapping_gui_data_t *g = (dt_iop_colormapping_gui_data_t *)dt_iop_gui_data(self);
 
   DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(dt_control_signal_get_global(), G_CALLBACK(process_clusters), self);
 

--- a/src/iop/colorout.c
+++ b/src/iop/colorout.c
@@ -57,6 +57,7 @@
 #include "config.h"
 #include "system/simd.h"
 #endif
+#include "develop/imageop_gui.h"
 #include "system/macros.h"
 #include "system/openmp.h"
 #include "system/target_clones.h"
@@ -626,12 +627,12 @@ dt_iop_colorout_gui_data_t dummy;
 void gui_init(dt_iop_module_t *self)
 {
   IOP_GUI_ALLOC(colorout);
-  self->widget = gtk_label_new(NULL);
-  gtk_label_set_markup(GTK_LABEL(self->widget),_("Convert images to the display or export RGB color space. "
+  self->gui->widget = gtk_label_new(NULL);
+  gtk_label_set_markup(GTK_LABEL(self->gui->widget),_("Convert images to the display or export RGB color space. "
                                                  "The color profile is set in the export module or in the display preferences. "));
-  gtk_widget_set_halign(self->widget, GTK_ALIGN_START);
-  gtk_label_set_xalign (GTK_LABEL(self->widget), 0.0f);
-  gtk_label_set_line_wrap(GTK_LABEL(self->widget), TRUE);
+  gtk_widget_set_halign(self->gui->widget, GTK_ALIGN_START);
+  gtk_label_set_xalign (GTK_LABEL(self->gui->widget), 0.0f);
+  gtk_label_set_line_wrap(GTK_LABEL(self->gui->widget), TRUE);
 }
 
 

--- a/src/iop/colorprimaries.c
+++ b/src/iop/colorprimaries.c
@@ -1003,7 +1003,7 @@ static void _set_slider_stop_from_profile_rgb(GtkWidget *slider, const float sto
 
 static void _refresh_slider_gradients(dt_iop_module_t *self)
 {
-  dt_iop_colorprimaries_gui_data_t *g = (dt_iop_colorprimaries_gui_data_t *)self->gui_data;
+  dt_iop_colorprimaries_gui_data_t *g = (dt_iop_colorprimaries_gui_data_t *)dt_iop_gui_data(self);
   const dt_iop_colorprimaries_params_t *p = (const dt_iop_colorprimaries_params_t *)self->params;
   const dt_iop_order_iccprofile_info_t *lut_profile
       = self->dev ? dt_colorspaces_add_profile(DT_COLORSPACE_HLG_REC2020, "", DT_INTENT_PERCEPTUAL)
@@ -1086,7 +1086,7 @@ static void _update_gui_lut_cache(dt_iop_module_t *self)
   // state and must never be read from a pipeline thread (see commit_params(), which uses
   // the historical params it is passed instead). g->viewer_lut is this instance's own gui_data,
   // never shared with any other instance's viewer or with the pipeline's piece->data clut.
-  dt_iop_colorprimaries_gui_data_t *g = (dt_iop_colorprimaries_gui_data_t *)self->gui_data;
+  dt_iop_colorprimaries_gui_data_t *g = (dt_iop_colorprimaries_gui_data_t *)dt_iop_gui_data(self);
   const dt_iop_colorprimaries_params_t *p = (const dt_iop_colorprimaries_params_t *)self->params;
   const dt_iop_order_iccprofile_info_t *lut_profile
       = self->dev ? dt_colorspaces_add_profile(DT_COLORSPACE_HLG_REC2020, "", DT_INTENT_PERCEPTUAL)
@@ -1130,7 +1130,7 @@ static void _update_gui_lut_cache(dt_iop_module_t *self)
 
 void gui_changed(dt_iop_module_t *self, GtkWidget *w, void *previous)
 {
-  dt_iop_colorprimaries_gui_data_t *g = (dt_iop_colorprimaries_gui_data_t *)self->gui_data;
+  dt_iop_colorprimaries_gui_data_t *g = (dt_iop_colorprimaries_gui_data_t *)dt_iop_gui_data(self);
   if(IS_NULL_PTR(g)) return;
   _refresh_slider_gradients(self);
   _update_gui_lut_cache(self);
@@ -1139,7 +1139,7 @@ void gui_changed(dt_iop_module_t *self, GtkWidget *w, void *previous)
 void gui_update(dt_iop_module_t *self)
 {
   const dt_iop_colorprimaries_params_t *p = (const dt_iop_colorprimaries_params_t *)self->params;
-  dt_iop_colorprimaries_gui_data_t *g = (dt_iop_colorprimaries_gui_data_t *)self->gui_data;
+  dt_iop_colorprimaries_gui_data_t *g = (dt_iop_colorprimaries_gui_data_t *)dt_iop_gui_data(self);
 
   dt_gui_freeze_begin();
   dt_bauhaus_slider_set(g->white_level, p->white_level);
@@ -1163,7 +1163,7 @@ void gui_update(dt_iop_module_t *self)
 
 void gui_cleanup(dt_iop_module_t *self)
 {
-  dt_iop_colorprimaries_gui_data_t *g = (dt_iop_colorprimaries_gui_data_t *)self->gui_data;
+  dt_iop_colorprimaries_gui_data_t *g = (dt_iop_colorprimaries_gui_data_t *)dt_iop_gui_data(self);
   dt_free_align(g->viewer_lut.clut);
   g->viewer_lut.clut = NULL;
   dt_lut_viewer_destroy(&g->viewer);
@@ -1181,7 +1181,7 @@ static GtkWidget *_new_section_label(GtkWidget *box, const char *label)
 void color_picker_apply(dt_iop_module_t *self, GtkWidget *picker, dt_dev_pixelpipe_t *pipe,
                         dt_dev_pixelpipe_iop_t *piece)
 {
-  dt_iop_colorprimaries_gui_data_t *g = (dt_iop_colorprimaries_gui_data_t *)self->gui_data;
+  dt_iop_colorprimaries_gui_data_t *g = (dt_iop_colorprimaries_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_colorprimaries_params_t *p = (dt_iop_colorprimaries_params_t *)self->params;
   const dt_iop_module_t *sampled_module = piece && piece->module ? piece->module : self;
 
@@ -1235,11 +1235,11 @@ void gui_init(dt_iop_module_t *self)
   g->preview_signal_connected = FALSE;
   g->viewer_display_profile = NULL;
 
-  self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_GUI_BOX_SPACING);
+  self->gui->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_GUI_BOX_SPACING);
 
   g->tabs = GTK_NOTEBOOK(gtk_notebook_new());
   gtk_notebook_set_show_border(g->tabs, FALSE);
-  gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(g->tabs), TRUE, TRUE, 0);
+  gtk_box_pack_start(GTK_BOX(self->gui->widget), GTK_WIDGET(g->tabs), TRUE, TRUE, 0);
   // white_level lives on the "options" tab; reset it if still active once the
   // user switches away from that tab.
   dt_ui_notebook_set_picker_owner(g->tabs, self);
@@ -1250,8 +1250,8 @@ void gui_init(dt_iop_module_t *self)
   gtk_notebook_append_page(g->tabs, colors_page, colors_tab);
   gtk_container_child_set(GTK_CONTAINER(g->tabs), colors_page, "tab-expand", TRUE, "tab-fill", TRUE, NULL);
 
-  GtkWidget *const module_root = self->widget;
-  self->widget = colors_page;
+  GtkWidget *const module_root = self->gui->widget;
+  self->gui->widget = colors_page;
   for(int node = 0; node < DT_IOP_COLORPRIMARIES_NODE_COUNT; node++)
   {
     char hue_name[16] = { 0 };
@@ -1278,7 +1278,7 @@ void gui_init(dt_iop_module_t *self)
     dt_bauhaus_slider_set_soft_range(g->node_brightness[node], -0.25f, 0.25f);
     dt_bauhaus_slider_set_default(g->node_brightness[node], defaults->brightness[node]);
   }
-  self->widget = module_root;
+  self->gui->widget = module_root;
 
   GtkWidget *options_page = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_GUI_BOX_SPACING);
   GtkWidget *options_tab = gtk_label_new(_("options"));
@@ -1286,7 +1286,7 @@ void gui_init(dt_iop_module_t *self)
   gtk_notebook_append_page(g->tabs, options_page, options_tab);
   gtk_container_child_set(GTK_CONTAINER(g->tabs), options_page, "tab-expand", TRUE, "tab-fill", TRUE, NULL);
 
-  self->widget = options_page;
+  self->gui->widget = options_page;
   g->white_level = dt_color_picker_new(self, DT_COLOR_PICKER_AREA, dt_bauhaus_slider_from_params(self, "white_level"));
   dt_bauhaus_slider_set_default(g->white_level, defaults->white_level);
   dt_bauhaus_slider_set_format(g->white_level, _(" EV"));
@@ -1316,13 +1316,13 @@ void gui_init(dt_iop_module_t *self)
 
   g->interpolation = dt_bauhaus_combobox_from_params(self, "interpolation");
   dt_bauhaus_combobox_set_default(g->interpolation, defaults->interpolation);
-  self->widget = module_root;
+  self->gui->widget = module_root;
 
   g->viewer = dt_lut_viewer_new(DT_GUI_MODULE(self));
   if(g->viewer)
     gtk_box_pack_start(GTK_BOX(options_page), dt_lut_viewer_get_widget(g->viewer), TRUE, TRUE, 0);
 
-  gtk_widget_show_all(self->widget);
+  gtk_widget_show_all(self->gui->widget);
   gui_update(self);
 }
 

--- a/src/iop/colorreconstruction.c
+++ b/src/iop/colorreconstruction.c
@@ -583,7 +583,7 @@ int process(struct dt_iop_module_t *self, const dt_dev_pixelpipe_t *pipe, const 
   const dt_iop_roi_t *const roi_in = &piece->roi_in;
   const dt_iop_roi_t *const roi_out = &piece->roi_out;
   dt_iop_colorreconstruct_data_t *data = (dt_iop_colorreconstruct_data_t *)piece->data;
-  dt_iop_colorreconstruct_gui_data_t *g = (dt_iop_colorreconstruct_gui_data_t *)self->gui_data;
+  dt_iop_colorreconstruct_gui_data_t *g = (dt_iop_colorreconstruct_gui_data_t *)dt_iop_gui_data(self);
   float *in = (float *)ivoid;
   float *out = (float *)ovoid;
 
@@ -922,7 +922,7 @@ int process_cl(struct dt_iop_module_t *self, const dt_dev_pixelpipe_t *pipe, con
   const dt_iop_roi_t *const roi_out = &piece->roi_out;
   dt_iop_colorreconstruct_data_t *d = (dt_iop_colorreconstruct_data_t *)piece->data;
   dt_iop_colorreconstruct_global_data_t *gd = (dt_iop_colorreconstruct_global_data_t *)self->global_data;
-  dt_iop_colorreconstruct_gui_data_t *g = (dt_iop_colorreconstruct_gui_data_t *)self->gui_data;
+  dt_iop_colorreconstruct_gui_data_t *g = (dt_iop_colorreconstruct_gui_data_t *)dt_iop_gui_data(self);
 
   const float scale = dt_dev_get_module_scale(pipe, roi_in);
   const float sigma_r = fmax(d->range, 0.1f); // does not depend on scale
@@ -1030,7 +1030,7 @@ void tiling_callback(struct dt_iop_module_t *self, const struct dt_dev_pixelpipe
 void gui_changed(dt_iop_module_t *self, GtkWidget *w, void *previous)
 {
   dt_iop_colorreconstruct_params_t *p = (dt_iop_colorreconstruct_params_t *)self->params;
-  dt_iop_colorreconstruct_gui_data_t *g = (dt_iop_colorreconstruct_gui_data_t *)self->gui_data;
+  dt_iop_colorreconstruct_gui_data_t *g = (dt_iop_colorreconstruct_gui_data_t *)dt_iop_gui_data(self);
   if(w == g->precedence)
   {
     gtk_widget_set_visible(g->hue, p->precedence == COLORRECONSTRUCT_PRECEDENCE_HUE);
@@ -1070,11 +1070,11 @@ void cleanup_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev
 void gui_update(struct dt_iop_module_t *self)
 {
   const gboolean monochrome = dt_image_is_monochrome(&self->dev->image_storage);
-  dt_iop_colorreconstruct_gui_data_t *g = (dt_iop_colorreconstruct_gui_data_t *)self->gui_data;
+  dt_iop_colorreconstruct_gui_data_t *g = (dt_iop_colorreconstruct_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_colorreconstruct_params_t *p = (dt_iop_colorreconstruct_params_t *)self->params;
 
   self->hide_enable_button = monochrome;
-  gtk_stack_set_visible_child_name(GTK_STACK(self->widget), !monochrome ? "default" : "monochrome");
+  gtk_stack_set_visible_child_name(GTK_STACK(self->gui->widget), !monochrome ? "default" : "monochrome");
 
   gtk_widget_set_visible(g->hue, p->precedence == COLORRECONSTRUCT_PRECEDENCE_HUE);
 
@@ -1115,7 +1115,7 @@ void gui_init(struct dt_iop_module_t *self)
   g->can = NULL;
   g->hash = 0;
 
-  GtkWidget *box_enabled = self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_GUI_BOX_SPACING);
+  GtkWidget *box_enabled = self->gui->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_GUI_BOX_SPACING);
 
   g->threshold = dt_bauhaus_slider_from_params(self, N_("threshold"));
   g->spatial = dt_bauhaus_slider_from_params(self, N_("spatial"));
@@ -1145,15 +1145,15 @@ void gui_init(struct dt_iop_module_t *self)
   GtkWidget *monochromes = dt_ui_label_new(_("not applicable"));
   gtk_widget_set_tooltip_text(monochromes, _("no highlights reconstruction for monochrome images"));
 
-  self->widget = gtk_stack_new();
-  gtk_stack_set_homogeneous(GTK_STACK(self->widget), FALSE);
-  gtk_stack_add_named(GTK_STACK(self->widget), monochromes, "monochrome");
-  gtk_stack_add_named(GTK_STACK(self->widget), box_enabled, "default");
+  self->gui->widget = gtk_stack_new();
+  gtk_stack_set_homogeneous(GTK_STACK(self->gui->widget), FALSE);
+  gtk_stack_add_named(GTK_STACK(self->gui->widget), monochromes, "monochrome");
+  gtk_stack_add_named(GTK_STACK(self->gui->widget), box_enabled, "default");
 }
 
 void gui_cleanup(struct dt_iop_module_t *self)
 {
-  dt_iop_colorreconstruct_gui_data_t *g = (dt_iop_colorreconstruct_gui_data_t *)self->gui_data;
+  dt_iop_colorreconstruct_gui_data_t *g = (dt_iop_colorreconstruct_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_colorreconstruct_bilateral_dump(g->can);
 
   IOP_GUI_FREE;

--- a/src/iop/colorzones.c
+++ b/src/iop/colorzones.c
@@ -438,7 +438,7 @@ void process_display(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, con
                      const dt_iop_roi_t *const roi_out)
 {
   dt_iop_colorzones_data_t *d = (dt_iop_colorzones_data_t *)(piece->data);
-  dt_iop_colorzones_gui_data_t *g = (dt_iop_colorzones_gui_data_t *)self->gui_data;
+  dt_iop_colorzones_gui_data_t *g = (dt_iop_colorzones_gui_data_t *)dt_iop_gui_data(self);
 
   const int ch = piece->dsc_in.channels;
   const float normalize_C = 1.f / (128.0f * sqrtf(2.f));
@@ -573,7 +573,7 @@ int process(struct dt_iop_module_t *self, const dt_dev_pixelpipe_t *pipe, const 
   const dt_iop_roi_t *const roi_in = &piece->roi_in;
   const dt_iop_roi_t *const roi_out = &piece->roi_out;
   dt_iop_colorzones_data_t *d = (dt_iop_colorzones_data_t *)(piece->data);
-  dt_iop_colorzones_gui_data_t *g = (dt_iop_colorzones_gui_data_t *)self->gui_data;
+  dt_iop_colorzones_gui_data_t *g = (dt_iop_colorzones_gui_data_t *)dt_iop_gui_data(self);
 
   // display selection if requested
   if(pipe->type == DT_DEV_PIXELPIPE_FULL && !IS_NULL_PTR(g) && g->display_mask && self->dev->gui_attached
@@ -790,7 +790,7 @@ void init_presets(dt_iop_module_so_t *self)
 
 static void _reset_display_selection(dt_iop_module_t *self)
 {
-  dt_iop_colorzones_gui_data_t *c = (dt_iop_colorzones_gui_data_t *)self->gui_data;
+  dt_iop_colorzones_gui_data_t *c = (dt_iop_colorzones_gui_data_t *)dt_iop_gui_data(self);
   if(c)
   {
     if(c->display_mask)
@@ -1104,7 +1104,7 @@ static void _draw_background(cairo_t *cr, dt_iop_colorzones_params_t *p, dt_iop_
 
 static gboolean _area_draw_callback(GtkWidget *widget, cairo_t *crf, dt_iop_module_t *self)
 {
-  dt_iop_colorzones_gui_data_t *c = (dt_iop_colorzones_gui_data_t *)self->gui_data;
+  dt_iop_colorzones_gui_data_t *c = (dt_iop_colorzones_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_colorzones_params_t p = *(dt_iop_colorzones_params_t *)self->params;
 
   if(p.splines_version == DT_IOP_COLORZONES_SPLINES_V1)
@@ -1438,7 +1438,7 @@ static gboolean _area_draw_callback(GtkWidget *widget, cairo_t *crf, dt_iop_modu
 
 static gboolean _bottom_area_draw_callback(GtkWidget *widget, cairo_t *crf, dt_iop_module_t *self)
 {
-  dt_iop_colorzones_gui_data_t *c = (dt_iop_colorzones_gui_data_t *)self->gui_data;
+  dt_iop_colorzones_gui_data_t *c = (dt_iop_colorzones_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_colorzones_params_t p = *(dt_iop_colorzones_params_t *)self->params;
 
   GtkAllocation allocation;
@@ -1540,7 +1540,7 @@ static gboolean _bottom_area_draw_callback(GtkWidget *widget, cairo_t *crf, dt_i
 
 static gboolean _bottom_area_button_press_callback(GtkWidget *widget, GdkEventButton *event, dt_iop_module_t *self)
 {
-  dt_iop_colorzones_gui_data_t *c = (dt_iop_colorzones_gui_data_t *)self->gui_data;
+  dt_iop_colorzones_gui_data_t *c = (dt_iop_colorzones_gui_data_t *)dt_iop_gui_data(self);
 
   if(event->button == 1 && event->type == GDK_2BUTTON_PRESS)
   {
@@ -1548,7 +1548,7 @@ static gboolean _bottom_area_button_press_callback(GtkWidget *widget, GdkEventBu
     c->zoom_factor = 1.f;
     c->offset_x = c->offset_y = 0.f;
 
-    gtk_widget_queue_draw(self->widget);
+    gtk_widget_queue_draw(self->gui->widget);
 
     return TRUE;
   }
@@ -1580,7 +1580,7 @@ static gboolean _sanity_check(const float x, const int selected, const int nodes
 static gboolean _move_point_internal(dt_iop_module_t *self, GtkWidget *widget, int node, float dx, float dy, guint state)
 {
   dt_iop_colorzones_params_t *p = (dt_iop_colorzones_params_t *)self->params;
-  dt_iop_colorzones_gui_data_t *c = (dt_iop_colorzones_gui_data_t *)self->gui_data;
+  dt_iop_colorzones_gui_data_t *c = (dt_iop_colorzones_gui_data_t *)dt_iop_gui_data(self);
 
   int ch = c->channel;
   dt_iop_colorzones_node_t *curve = p->curve[ch];
@@ -1667,7 +1667,7 @@ static void _delete_node(dt_iop_module_t *self, dt_iop_colorzones_node_t *curve,
   }
 
   dt_iop_color_picker_reset(self, TRUE);
-  gtk_widget_queue_draw(self->widget);
+  gtk_widget_queue_draw(self->gui->widget);
   dt_dev_add_history_item(self->dev, self, TRUE, TRUE);
 }
 
@@ -1712,7 +1712,7 @@ static inline int _add_node(dt_iop_colorzones_node_t *curve, int *nodes, float x
 
 static gboolean _area_scrolled_callback(GtkWidget *widget, GdkEventScroll *event, dt_iop_module_t *self)
 {
-  dt_iop_colorzones_gui_data_t *c = (dt_iop_colorzones_gui_data_t *)self->gui_data;
+  dt_iop_colorzones_gui_data_t *c = (dt_iop_colorzones_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_colorzones_params_t *p = (dt_iop_colorzones_params_t *)self->params;
 
   int delta_y;
@@ -1743,7 +1743,7 @@ static gboolean _area_scrolled_callback(GtkWidget *widget, GdkEventScroll *event
 
 static gboolean _area_motion_notify_callback(GtkWidget *widget, GdkEventMotion *event, dt_iop_module_t *self)
 {
-  dt_iop_colorzones_gui_data_t *c = (dt_iop_colorzones_gui_data_t *)self->gui_data;
+  dt_iop_colorzones_gui_data_t *c = (dt_iop_colorzones_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_colorzones_params_t *p = (dt_iop_colorzones_params_t *)self->params;
 
   const int inset = DT_IOP_COLORZONES_INSET;
@@ -1871,7 +1871,7 @@ static gboolean _area_motion_notify_callback(GtkWidget *widget, GdkEventMotion *
 
 static gboolean _area_button_press_callback(GtkWidget *widget, GdkEventButton *event, dt_iop_module_t *self)
 {
-  dt_iop_colorzones_gui_data_t *c = (dt_iop_colorzones_gui_data_t *)self->gui_data;
+  dt_iop_colorzones_gui_data_t *c = (dt_iop_colorzones_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_colorzones_params_t *p = (dt_iop_colorzones_params_t *)self->params;
   dt_iop_colorzones_params_t *d = (dt_iop_colorzones_params_t *)self->default_params;
 
@@ -1938,7 +1938,7 @@ static gboolean _area_button_press_callback(GtkWidget *widget, GdkEventButton *e
 
         dt_iop_color_picker_reset(self, TRUE);
         dt_dev_add_history_item(self->dev, self, TRUE, TRUE);
-        gtk_widget_queue_draw(self->widget);
+        gtk_widget_queue_draw(self->gui->widget);
       }
 
       return TRUE;
@@ -1956,7 +1956,7 @@ static gboolean _area_button_press_callback(GtkWidget *widget, GdkEventButton *e
 
       dt_iop_color_picker_reset(self, TRUE);
       dt_dev_add_history_item(self->dev, self, TRUE, TRUE);
-      gtk_widget_queue_draw(self->widget);
+      gtk_widget_queue_draw(self->gui->widget);
 
       return TRUE;
     }
@@ -1980,7 +1980,7 @@ static gboolean _area_button_press_callback(GtkWidget *widget, GdkEventButton *e
       }
 
       dt_iop_color_picker_reset(self, TRUE);
-      gtk_widget_queue_draw(self->widget);
+      gtk_widget_queue_draw(self->gui->widget);
       dt_dev_add_history_item(self->dev, self, TRUE, TRUE);
       return TRUE;
     }
@@ -2000,7 +2000,7 @@ static gboolean _area_button_release_callback(GtkWidget *widget, GdkEventButton 
   if(event->button == 1)
   {
     dt_iop_module_t *self = (dt_iop_module_t *)user_data;
-    dt_iop_colorzones_gui_data_t *c = (dt_iop_colorzones_gui_data_t *)self->gui_data;
+    dt_iop_colorzones_gui_data_t *c = (dt_iop_colorzones_gui_data_t *)dt_iop_gui_data(self);
     c->dragging = 0;
     return TRUE;
   }
@@ -2009,7 +2009,7 @@ static gboolean _area_button_release_callback(GtkWidget *widget, GdkEventButton 
 
 static gboolean _area_enter_notify_callback(GtkWidget *widget, GdkEventCrossing *event, dt_iop_module_t *self)
 {
-  dt_iop_colorzones_gui_data_t *c = (dt_iop_colorzones_gui_data_t *)self->gui_data;
+  dt_iop_colorzones_gui_data_t *c = (dt_iop_colorzones_gui_data_t *)dt_iop_gui_data(self);
   c->mouse_y = fabs(c->mouse_y);
   gtk_widget_queue_draw(widget);
   return TRUE;
@@ -2017,7 +2017,7 @@ static gboolean _area_enter_notify_callback(GtkWidget *widget, GdkEventCrossing 
 
 static gboolean _area_leave_notify_callback(GtkWidget *widget, GdkEventCrossing *event, dt_iop_module_t *self)
 {
-  dt_iop_colorzones_gui_data_t *c = (dt_iop_colorzones_gui_data_t *)self->gui_data;
+  dt_iop_colorzones_gui_data_t *c = (dt_iop_colorzones_gui_data_t *)dt_iop_gui_data(self);
   // for fluxbox
   c->mouse_y = -fabs(c->mouse_y);
   gtk_widget_queue_draw(widget);
@@ -2037,7 +2037,7 @@ static gboolean _area_resized_callback(GtkWidget *widget, GdkEvent *event, gpoin
 
 static gboolean _area_key_press_callback(GtkWidget *widget, GdkEventKey *event, dt_iop_module_t *self)
 {
-  dt_iop_colorzones_gui_data_t *c = (dt_iop_colorzones_gui_data_t *)self->gui_data;
+  dt_iop_colorzones_gui_data_t *c = (dt_iop_colorzones_gui_data_t *)dt_iop_gui_data(self);
 
   if(c->selected < 0) return FALSE;
 
@@ -2075,7 +2075,7 @@ static void _channel_tabs_switch_callback(GtkNotebook *notebook, GtkWidget *page
                                           dt_iop_module_t *self)
 {
   if(dt_gui_widgets_suppressed()) return;
-  dt_iop_colorzones_gui_data_t *c = (dt_iop_colorzones_gui_data_t *)self->gui_data;
+  dt_iop_colorzones_gui_data_t *c = (dt_iop_colorzones_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_colorzones_params_t *p = (dt_iop_colorzones_params_t *)self->params;
 
   c->channel = (dt_iop_colorzones_channel_t)page_num;
@@ -2088,14 +2088,14 @@ static void _channel_tabs_switch_callback(GtkNotebook *notebook, GtkWidget *page
 
   if(c->display_mask)
     dt_dev_pixelpipe_update_history_main(self->dev);
-  gtk_widget_queue_draw(self->widget);
+  gtk_widget_queue_draw(self->gui->widget);
 }
 
 
 void gui_changed(dt_iop_module_t *self, GtkWidget *w, void *previous)
 {
   dt_iop_colorzones_params_t *p = (dt_iop_colorzones_params_t *)self->params;
-  dt_iop_colorzones_gui_data_t *g = (dt_iop_colorzones_gui_data_t *)self->gui_data;
+  dt_iop_colorzones_gui_data_t *g = (dt_iop_colorzones_gui_data_t *)dt_iop_gui_data(self);
 
   if(w == g->select_by)
   {
@@ -2110,7 +2110,7 @@ static void _interpolator_callback(GtkWidget *widget, dt_iop_module_t *self)
 {
   if(dt_gui_widgets_suppressed()) return;
   dt_iop_colorzones_params_t *p = (dt_iop_colorzones_params_t *)self->params;
-  dt_iop_colorzones_gui_data_t *g = (dt_iop_colorzones_gui_data_t *)self->gui_data;
+  dt_iop_colorzones_gui_data_t *g = (dt_iop_colorzones_gui_data_t *)dt_iop_gui_data(self);
 
   const int combo = dt_bauhaus_combobox_get(widget);
 
@@ -2129,7 +2129,7 @@ static void _interpolator_callback(GtkWidget *widget, dt_iop_module_t *self)
 static void _edit_by_area_callback(GtkWidget *widget, dt_iop_module_t *self)
 {
   if(dt_gui_widgets_suppressed()) return;
-  dt_iop_colorzones_gui_data_t *g = (dt_iop_colorzones_gui_data_t *)self->gui_data;
+  dt_iop_colorzones_gui_data_t *g = (dt_iop_colorzones_gui_data_t *)dt_iop_gui_data(self);
 
   g->edit_by_area = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(widget));
 
@@ -2140,7 +2140,7 @@ static void _display_mask_callback(GtkToggleButton *togglebutton, dt_iop_module_
 {
   if(dt_gui_widgets_suppressed()) return;
 
-  dt_iop_colorzones_gui_data_t *g = (dt_iop_colorzones_gui_data_t *)module->gui_data;
+  dt_iop_colorzones_gui_data_t *g = (dt_iop_colorzones_gui_data_t *)dt_iop_gui_data(module);
 
   // if blend module is displaying mask do not display it here
   if(module->request_mask_display && !g->display_mask)
@@ -2155,14 +2155,14 @@ static void _display_mask_callback(GtkToggleButton *togglebutton, dt_iop_module_
 
   g->display_mask = gtk_toggle_button_get_active(togglebutton);
 
-  if(module->off) gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(module->off), 1);
+  if(module->gui->off) gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(module->gui->off), 1);
   dt_iop_request_focus(module);
   dt_dev_pixelpipe_update_history_main(module->dev);
 }
 
 void color_picker_apply(dt_iop_module_t *self, GtkWidget *picker, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
 {
-  dt_iop_colorzones_gui_data_t *g = (dt_iop_colorzones_gui_data_t *)self->gui_data;
+  dt_iop_colorzones_gui_data_t *g = (dt_iop_colorzones_gui_data_t *)dt_iop_gui_data(self);
   if(picker == g->colorpicker_set_values)
   {
     dt_iop_colorzones_params_t *p = (dt_iop_colorzones_params_t *)self->params;
@@ -2240,12 +2240,12 @@ void color_picker_apply(dt_iop_module_t *self, GtkWidget *picker, dt_dev_pixelpi
     dt_dev_add_history_item(self->dev, self, TRUE, TRUE);
   }
 
-  dt_control_queue_redraw_widget(self->widget);
+  dt_control_queue_redraw_widget(self->gui->widget);
 }
 
 void gui_reset(struct dt_iop_module_t *self)
 {
-  dt_iop_colorzones_gui_data_t *c = (dt_iop_colorzones_gui_data_t *)self->gui_data;
+  dt_iop_colorzones_gui_data_t *c = (dt_iop_colorzones_gui_data_t *)dt_iop_gui_data(self);
 
   dt_iop_color_picker_reset(self, TRUE);
 
@@ -2288,9 +2288,9 @@ void gui_init(struct dt_iop_module_t *self)
   c->dragging = 0;
   c->edit_by_area = 0;
   c->display_mask = FALSE;
-  self->timeout_handle = 0;
+  self->gui->timeout_handle = 0;
 
-  self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_GUI_BOX_SPACING);
+  self->gui->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_GUI_BOX_SPACING);
 
   // tabs
   GtkWidget *hbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, DT_GUI_BOX_SPACING);
@@ -2340,7 +2340,7 @@ void gui_init(struct dt_iop_module_t *self)
   c->bottom_area = gtk_drawing_area_new();
   gtk_box_pack_start(GTK_BOX(dabox), GTK_WIDGET(c->bottom_area), TRUE, TRUE, 0);
   gtk_box_pack_start(GTK_BOX(vbox), GTK_WIDGET(dabox), TRUE, TRUE, 0);
-  gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(vbox), TRUE, TRUE, 0);
+  gtk_box_pack_start(GTK_BOX(self->gui->widget), GTK_WIDGET(vbox), TRUE, TRUE, 0);
 
   GtkWidget *hbox_select_by = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, DT_GUI_BOX_SPACING);
 
@@ -2361,7 +2361,7 @@ void gui_init(struct dt_iop_module_t *self)
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(c->bt_showmask), FALSE);
   gtk_box_pack_end(GTK_BOX(hbox_select_by), c->bt_showmask, FALSE, FALSE, 0);
 
-  gtk_box_pack_start(GTK_BOX(self->widget), hbox_select_by, TRUE, TRUE, 0);
+  gtk_box_pack_start(GTK_BOX(self->gui->widget), hbox_select_by, TRUE, TRUE, 0);
 
   // select by which dimension
   c->select_by = dt_bauhaus_combobox_from_params(self, "channel");
@@ -2406,7 +2406,7 @@ void gui_init(struct dt_iop_module_t *self)
   dt_bauhaus_combobox_add(c->interpolator, _("cubic spline"));
   dt_bauhaus_combobox_add(c->interpolator, _("centripetal spline"));
   dt_bauhaus_combobox_add(c->interpolator, _("monotonic spline"));
-  gtk_box_pack_start(GTK_BOX(self->widget), c->interpolator, TRUE, TRUE, 0);
+  gtk_box_pack_start(GTK_BOX(self->gui->widget), c->interpolator, TRUE, TRUE, 0);
   gtk_widget_set_tooltip_text(c->interpolator,
       _("change this method if you see oscillations or cusps in the curve\n"
         "- cubic spline is better to produce smooth curves but oscillates when nodes are too close\n"
@@ -2417,18 +2417,18 @@ void gui_init(struct dt_iop_module_t *self)
 
 void gui_update(struct dt_iop_module_t *self)
 {
-  dt_iop_colorzones_gui_data_t *g = (dt_iop_colorzones_gui_data_t *)self->gui_data;
+  dt_iop_colorzones_gui_data_t *g = (dt_iop_colorzones_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_colorzones_params_t *p = (dt_iop_colorzones_params_t *)self->params;
 
   dt_bauhaus_combobox_set(g->interpolator, p->curve_type[g->channel]);
 
 
-  gtk_widget_queue_draw(self->widget);
+  gtk_widget_queue_draw(self->gui->widget);
 }
 
 void gui_cleanup(struct dt_iop_module_t *self)
 {
-  dt_iop_colorzones_gui_data_t *c = (dt_iop_colorzones_gui_data_t *)self->gui_data;
+  dt_iop_colorzones_gui_data_t *c = (dt_iop_colorzones_gui_data_t *)dt_iop_gui_data(self);
   dt_conf_set_int("plugins/darkroom/colorzones/gui_channel", c->channel);
 
   for(int ch = 0; ch < DT_IOP_COLORZONES_MAX_CHANNELS; ch++) dt_draw_curve_destroy(c->minmax_curve[ch]);
@@ -2462,7 +2462,7 @@ void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pix
   // pull in new params to pipe
   dt_iop_colorzones_data_t *d = (dt_iop_colorzones_data_t *)(piece->data);
   dt_iop_colorzones_params_t *p = (dt_iop_colorzones_params_t *)p1;
-  dt_iop_colorzones_gui_data_t *g = (dt_iop_colorzones_gui_data_t *)self->gui_data;
+  dt_iop_colorzones_gui_data_t *g = (dt_iop_colorzones_gui_data_t *)dt_iop_gui_data(self);
 
   if(dt_dev_pixelpipe_has_preview_output(self->dev, pipe, NULL))
     piece->request_histogram |= (DT_REQUEST_ON);
@@ -2591,7 +2591,6 @@ void init(dt_iop_module_t *module)
   module->default_params = calloc(1, sizeof(dt_iop_colorzones_params_t));
   module->default_enabled = 0; // we're a rather slow and rare op.
   module->params_size = sizeof(dt_iop_colorzones_params_t);
-  module->gui_data = NULL;
   module->request_histogram |= (DT_REQUEST_ON);
 
   _reset_parameters(module->default_params, DT_IOP_COLORZONES_h, DT_IOP_COLORZONES_SPLINES_V2);

--- a/src/iop/crop.c
+++ b/src/iop/crop.c
@@ -263,7 +263,7 @@ static void _commit_box(dt_iop_module_t *self, dt_iop_crop_gui_data_t *g, dt_iop
  */
 static gboolean _set_max_clip(dt_dev_pixelpipe_t *pipe, struct dt_iop_module_t *self)
 {
-  dt_iop_crop_gui_data_t *g = (dt_iop_crop_gui_data_t *)self->gui_data;
+  dt_iop_crop_gui_data_t *g = (dt_iop_crop_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_crop_params_t *p = (dt_iop_crop_params_t *)self->params;
 
   // we want to know the size of the actual buffer
@@ -413,7 +413,7 @@ void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pix
 {
   dt_iop_crop_params_t *p = (dt_iop_crop_params_t *)p1;
   dt_iop_crop_data_t *d = (dt_iop_crop_data_t *)piece->data;
-  dt_iop_crop_gui_data_t *g = (dt_iop_crop_gui_data_t *)self->gui_data;
+  dt_iop_crop_gui_data_t *g = (dt_iop_crop_gui_data_t *)dt_iop_gui_data(self);
 
   if(!IS_NULL_PTR(g) && g->editing)
   {
@@ -590,7 +590,7 @@ static void _aspect_apply(dt_iop_module_t *self, _grab_region_t grab)
 {
   if(grab == GRAB_NONE) return;
 
-  dt_iop_crop_gui_data_t *g = (dt_iop_crop_gui_data_t *)self->gui_data;
+  dt_iop_crop_gui_data_t *g = (dt_iop_crop_gui_data_t *)dt_iop_gui_data(self);
 
   // enforce aspect ratio.
   float aspect = _aspect_ratio_get(self, g->aspect_presets);
@@ -781,7 +781,7 @@ static void _float_to_fract(const char *num, int *n, int *d)
 
 static void _event_aspect_presets_changed(GtkWidget *combo, dt_iop_module_t *self)
 {
-  dt_iop_crop_gui_data_t *g = (dt_iop_crop_gui_data_t *)self->gui_data;
+  dt_iop_crop_gui_data_t *g = (dt_iop_crop_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_crop_params_t *p = (dt_iop_crop_params_t *)self->params;
   const int which = dt_bauhaus_combobox_get(combo);
   int d = abs(p->ratio_d), n = p->ratio_n;
@@ -922,7 +922,7 @@ static void _event_aspect_presets_changed(GtkWidget *combo, dt_iop_module_t *sel
 
 void gui_changed(dt_iop_module_t *self, GtkWidget *w, void *previous)
 {
-  dt_iop_crop_gui_data_t *g = (dt_iop_crop_gui_data_t *)self->gui_data;
+  dt_iop_crop_gui_data_t *g = (dt_iop_crop_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_crop_params_t *p = (dt_iop_crop_params_t *)self->params;
 
   dt_gui_freeze_begin();
@@ -980,7 +980,7 @@ void gui_reset(struct dt_iop_module_t *self)
 
 void gui_update(struct dt_iop_module_t *self)
 {
-  dt_iop_crop_gui_data_t *g = (dt_iop_crop_gui_data_t *)self->gui_data;
+  dt_iop_crop_gui_data_t *g = (dt_iop_crop_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_crop_params_t *p = (dt_iop_crop_params_t *)self->params;
 
   //  set aspect ratio based on the current image, if not found let's default
@@ -1041,7 +1041,7 @@ static void _event_key_swap(dt_iop_module_t *self)
 
 static void _enter_edit_mode(GtkToggleButton *button, struct dt_iop_module_t *self)
 {
-  dt_iop_crop_gui_data_t *g = (dt_iop_crop_gui_data_t *)self->gui_data;
+  dt_iop_crop_gui_data_t *g = (dt_iop_crop_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_crop_params_t *p = (dt_iop_crop_params_t *)self->params;
   if(!self->enabled) dt_dev_add_history_item(self->dev, self, TRUE, TRUE);
 
@@ -1086,7 +1086,7 @@ static void _enter_edit_mode(GtkToggleButton *button, struct dt_iop_module_t *se
 
 static void _event_commit_clicked(GtkButton *button, dt_iop_module_t *self)
 {
-  dt_iop_crop_gui_data_t *g = (dt_iop_crop_gui_data_t *)self->gui_data;
+  dt_iop_crop_gui_data_t *g = (dt_iop_crop_gui_data_t *)dt_iop_gui_data(self);
 
   // Close edit mode on commit
   g->editing = FALSE;
@@ -1300,7 +1300,7 @@ void gui_init(struct dt_iop_module_t *self)
      _("margins"),
      GTK_BOX(box_enabled), GTK_PACK_END);
 
-  self->widget = GTK_WIDGET(g->cs.container);
+  self->gui->widget = GTK_WIDGET(g->cs.container);
 
   g->cx = dt_bauhaus_slider_from_params(self, "cx");
   dt_bauhaus_slider_set_digits(g->cx, 4);
@@ -1326,7 +1326,7 @@ void gui_init(struct dt_iop_module_t *self)
   dt_bauhaus_slider_set_format(g->ch, "%");
   gtk_widget_set_tooltip_text(g->ch, _("the bottom margin cannot overlap with the top margin"));
 
-  self->widget = box_enabled;
+  self->gui->widget = box_enabled;
 }
 
 static void _aspect_free(gpointer data)
@@ -1338,7 +1338,7 @@ static void _aspect_free(gpointer data)
 
 void gui_cleanup(struct dt_iop_module_t *self)
 {
-  dt_iop_crop_gui_data_t *g = (dt_iop_crop_gui_data_t *)self->gui_data;
+  dt_iop_crop_gui_data_t *g = (dt_iop_crop_gui_data_t *)dt_iop_gui_data(self);
   g_list_free_full(g->aspect_list, _aspect_free);
   g->aspect_list = NULL;
 
@@ -1380,7 +1380,7 @@ void gui_post_expose(struct dt_iop_module_t *self, cairo_t *cr, int32_t width, i
                      int32_t pointery)
 {
   dt_develop_t *dev = self->dev;
-  dt_iop_crop_gui_data_t *g = (dt_iop_crop_gui_data_t *)self->gui_data;
+  dt_iop_crop_gui_data_t *g = (dt_iop_crop_gui_data_t *)dt_iop_gui_data(self);
   if(IS_NULL_PTR(g)) return;
 
   _aspect_apply(self, GRAB_HORIZONTAL);
@@ -1514,7 +1514,7 @@ void gui_post_expose(struct dt_iop_module_t *self, cairo_t *cr, int32_t width, i
 int mouse_moved(struct dt_iop_module_t *self, double x, double y, double pressure, int which)
 {
   dt_develop_t *dev = self->dev;
-  dt_iop_crop_gui_data_t *g = (dt_iop_crop_gui_data_t *)self->gui_data;
+  dt_iop_crop_gui_data_t *g = (dt_iop_crop_gui_data_t *)dt_iop_gui_data(self);
   if(!g->editing) return 0;
 
   float pzxpy[2] = { (float)x, (float)y };
@@ -1665,7 +1665,7 @@ int mouse_moved(struct dt_iop_module_t *self, double x, double y, double pressur
 
 int button_released(struct dt_iop_module_t *self, double x, double y, int which, uint32_t state)
 {
-  dt_iop_crop_gui_data_t *g = (dt_iop_crop_gui_data_t *)self->gui_data;
+  dt_iop_crop_gui_data_t *g = (dt_iop_crop_gui_data_t *)dt_iop_gui_data(self);
   if(!g->editing) return 0;
 
   /* reset internal ui states*/
@@ -1685,7 +1685,7 @@ int button_released(struct dt_iop_module_t *self, double x, double y, int which,
 int button_pressed(struct dt_iop_module_t *self, double x, double y, double pressure, int which, int type,
                    uint32_t state)
 {
-  dt_iop_crop_gui_data_t *g = (dt_iop_crop_gui_data_t *)self->gui_data;
+  dt_iop_crop_gui_data_t *g = (dt_iop_crop_gui_data_t *)dt_iop_gui_data(self);
   if(!g->editing) return 0;
 
   // avoid unexpected back to lt mode:
@@ -1759,7 +1759,7 @@ int button_pressed(struct dt_iop_module_t *self, double x, double y, double pres
 
 int mouse_leave(struct dt_iop_module_t *self)
 {
-  dt_iop_crop_gui_data_t *g = (dt_iop_crop_gui_data_t *)self->gui_data;
+  dt_iop_crop_gui_data_t *g = (dt_iop_crop_gui_data_t *)dt_iop_gui_data(self);
   if(!g->editing) return 0;
 
   g->shift_hold = FALSE;

--- a/src/iop/crystgrain.c
+++ b/src/iop/crystgrain.c
@@ -1441,7 +1441,7 @@ int process(struct dt_iop_module_t *self, const dt_dev_pixelpipe_t *pipe, const 
 
 void gui_update(struct dt_iop_module_t *self)
 {
-  dt_iop_crystgrain_gui_data_t *g = (dt_iop_crystgrain_gui_data_t *)self->gui_data;
+  dt_iop_crystgrain_gui_data_t *g = (dt_iop_crystgrain_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_crystgrain_params_t *p = (dt_iop_crystgrain_params_t *)self->params;
   const gboolean is_color = (p->mode == DT_CRYSTGRAIN_COLOR);
 

--- a/src/iop/defringe.c
+++ b/src/iop/defringe.c
@@ -460,7 +460,7 @@ void gui_init(dt_iop_module_t *self)
 
 void gui_update(dt_iop_module_t *module)
 {
-  dt_iop_defringe_gui_data_t *g = (dt_iop_defringe_gui_data_t *)module->gui_data;
+  dt_iop_defringe_gui_data_t *g = (dt_iop_defringe_gui_data_t *)dt_iop_gui_data(module);
   dt_iop_defringe_params_t *p = (dt_iop_defringe_params_t *)module->params;
   dt_bauhaus_combobox_set(g->mode_select, p->op_mode);
   dt_bauhaus_slider_set(g->radius_scale, p->radius);

--- a/src/iop/demosaic.c
+++ b/src/iop/demosaic.c
@@ -1030,7 +1030,7 @@ int process(struct dt_iop_module_t *self, const dt_dev_pixelpipe_t *pipe, const 
   gboolean showmask = FALSE;
   if(self->dev->gui_attached && pipe->type == DT_DEV_PIXELPIPE_FULL)
   {
-    dt_iop_demosaic_gui_data_t *g = (dt_iop_demosaic_gui_data_t *)self->gui_data;
+    dt_iop_demosaic_gui_data_t *g = (dt_iop_demosaic_gui_data_t *)dt_iop_gui_data(self);
     if(g) showmask = (g->visual_mask);
     // take care of passthru modes
     if(pipe->mask_display == DT_DEV_PIXELPIPE_DISPLAY_PASSTHRU)
@@ -1663,7 +1663,7 @@ int process_cl(struct dt_iop_module_t *self, const dt_dev_pixelpipe_t *pipe, con
   gboolean showmask = FALSE;
   if(self->dev->gui_attached && pipe->type == DT_DEV_PIXELPIPE_FULL)
   {
-    dt_iop_demosaic_gui_data_t *g = (dt_iop_demosaic_gui_data_t *)self->gui_data;
+    dt_iop_demosaic_gui_data_t *g = (dt_iop_demosaic_gui_data_t *)dt_iop_gui_data(self);
     if(g) showmask = (g->visual_mask);
     // take care of passthru modes
     if(pipe->mask_display == DT_DEV_PIXELPIPE_DISPLAY_PASSTHRU)
@@ -2296,7 +2296,7 @@ void reload_defaults(dt_iop_module_t *module)
 
 void gui_changed(dt_iop_module_t *self, GtkWidget *w, void *previous)
 {
-  dt_iop_demosaic_gui_data_t *g = (dt_iop_demosaic_gui_data_t *)self->gui_data;
+  dt_iop_demosaic_gui_data_t *g = (dt_iop_demosaic_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_demosaic_params_t *p = (dt_iop_demosaic_params_t *)self->params;
 
   const gboolean bayer = (self->dev->image_storage.dsc.filters != 9u);
@@ -2342,20 +2342,20 @@ void gui_changed(dt_iop_module_t *self, GtkWidget *w, void *previous)
 }
 void gui_update(struct dt_iop_module_t *self)
 {
-  dt_iop_demosaic_gui_data_t *g = (dt_iop_demosaic_gui_data_t *)self->gui_data;
+  dt_iop_demosaic_gui_data_t *g = (dt_iop_demosaic_gui_data_t *)dt_iop_gui_data(self);
   dt_bauhaus_widget_set_quad_active(g->dual_thrs, FALSE);
 
   g->visual_mask = FALSE;
   gui_changed(self, NULL, NULL);
 
-  gtk_stack_set_visible_child_name(GTK_STACK(self->widget), self->default_enabled ? "raw" : "non_raw");
+  gtk_stack_set_visible_child_name(GTK_STACK(self->gui->widget), self->default_enabled ? "raw" : "non_raw");
 }
 
 static void _visualize_callback(GtkWidget *quad, gpointer user_data)
 {
   if(dt_gui_widgets_suppressed()) return;
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
-  dt_iop_demosaic_gui_data_t *g = (dt_iop_demosaic_gui_data_t *)self->gui_data;
+  dt_iop_demosaic_gui_data_t *g = (dt_iop_demosaic_gui_data_t *)dt_iop_gui_data(self);
 
   g->visual_mask = dt_bauhaus_widget_get_quad_active(quad);
   dt_dev_pixelpipe_update_history_main(self->dev);
@@ -2363,7 +2363,7 @@ static void _visualize_callback(GtkWidget *quad, gpointer user_data)
 
 void gui_focus(struct dt_iop_module_t *self, gboolean in)
 {
-  dt_iop_demosaic_gui_data_t *g = (dt_iop_demosaic_gui_data_t *)self->gui_data;
+  dt_iop_demosaic_gui_data_t *g = (dt_iop_demosaic_gui_data_t *)dt_iop_gui_data(self);
   if(!in)
   {
     const gboolean was_dualmask = g->visual_mask;
@@ -2377,7 +2377,7 @@ void gui_init(struct dt_iop_module_t *self)
 {
   dt_iop_demosaic_gui_data_t *g = IOP_GUI_ALLOC(demosaic);
 
-  GtkWidget *box_raw = self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_GUI_BOX_SPACING);
+  GtkWidget *box_raw = self->gui->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_GUI_BOX_SPACING);
 
   g->demosaic_method_bayer = dt_bauhaus_combobox_from_params(self, "demosaicing_method");
   for(int i=0;i<7;i++) dt_bauhaus_combobox_remove_at(g->demosaic_method_bayer, 9);
@@ -2411,14 +2411,14 @@ void gui_init(struct dt_iop_module_t *self)
   gtk_widget_set_tooltip_text(g->greeneq, _("green channels matching method"));
 
   // start building top level widget
-  self->widget = gtk_stack_new();
-  gtk_stack_set_homogeneous(GTK_STACK(self->widget), FALSE);
+  self->gui->widget = gtk_stack_new();
+  gtk_stack_set_homogeneous(GTK_STACK(self->gui->widget), FALSE);
 
   GtkWidget *label_non_raw = dt_ui_label_new(_("not applicable"));
   gtk_widget_set_tooltip_text(label_non_raw, _("demosaicing is only used for color raw images"));
 
-  gtk_stack_add_named(GTK_STACK(self->widget), label_non_raw, "non_raw");
-  gtk_stack_add_named(GTK_STACK(self->widget), box_raw, "raw");
+  gtk_stack_add_named(GTK_STACK(self->gui->widget), label_non_raw, "non_raw");
+  gtk_stack_add_named(GTK_STACK(self->gui->widget), box_raw, "raw");
 }
 
 // clang-format off

--- a/src/iop/denoiseprofile.c
+++ b/src/iop/denoiseprofile.c
@@ -1720,7 +1720,7 @@ static inline __attribute__((always_inline)) int process_variance(struct dt_iop_
                             const dt_iop_roi_t *const roi_out)
 {
   const dt_iop_denoiseprofile_data_t *const d = piece->data;
-  dt_iop_denoiseprofile_gui_data_t *g = (dt_iop_denoiseprofile_gui_data_t*)self->gui_data;
+  dt_iop_denoiseprofile_gui_data_t *g = (dt_iop_denoiseprofile_gui_data_t *)dt_iop_gui_data(self);
 
   const int width = roi_in->width, height = roi_in->height;
   size_t npixels = (size_t)width * height;
@@ -2904,7 +2904,7 @@ static void profile_callback(GtkWidget *w, dt_iop_module_t *self)
 {
   int i = dt_bauhaus_combobox_get(w);
   dt_iop_denoiseprofile_params_t *p = (dt_iop_denoiseprofile_params_t *)self->params;
-  dt_iop_denoiseprofile_gui_data_t *g = (dt_iop_denoiseprofile_gui_data_t *)self->gui_data;
+  dt_iop_denoiseprofile_gui_data_t *g = (dt_iop_denoiseprofile_gui_data_t *)dt_iop_gui_data(self);
   const dt_noiseprofile_t *profile = &(g->interpolated);
   if(i > 0) profile = (dt_noiseprofile_t *)g_list_nth_data(g->profiles, i - 1);
   for(int k = 0; k < 3; k++)
@@ -2918,7 +2918,7 @@ static void profile_callback(GtkWidget *w, dt_iop_module_t *self)
 static void mode_callback(GtkWidget *w, dt_iop_module_t *self)
 {
   dt_iop_denoiseprofile_params_t *p = (dt_iop_denoiseprofile_params_t *)self->params;
-  dt_iop_denoiseprofile_gui_data_t *g = (dt_iop_denoiseprofile_gui_data_t *)self->gui_data;
+  dt_iop_denoiseprofile_gui_data_t *g = (dt_iop_denoiseprofile_gui_data_t *)dt_iop_gui_data(self);
   const unsigned mode = dt_bauhaus_combobox_get(w);
   switch(mode)
   {
@@ -2972,7 +2972,7 @@ static void mode_callback(GtkWidget *w, dt_iop_module_t *self)
 void gui_changed(dt_iop_module_t *self, GtkWidget *w, void *previous)
 {
   dt_iop_denoiseprofile_params_t *p = (dt_iop_denoiseprofile_params_t *)self->params;
-  dt_iop_denoiseprofile_gui_data_t *g = (dt_iop_denoiseprofile_gui_data_t *)self->gui_data;
+  dt_iop_denoiseprofile_gui_data_t *g = (dt_iop_denoiseprofile_gui_data_t *)dt_iop_gui_data(self);
 
   if(w == g->wavelet_color_mode)
   {
@@ -3032,7 +3032,7 @@ void gui_changed(dt_iop_module_t *self, GtkWidget *w, void *previous)
 
 void gui_update(dt_iop_module_t *self)
 {
-  dt_iop_denoiseprofile_gui_data_t *g = (dt_iop_denoiseprofile_gui_data_t *)self->gui_data;
+  dt_iop_denoiseprofile_gui_data_t *g = (dt_iop_denoiseprofile_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_denoiseprofile_params_t *p = (dt_iop_denoiseprofile_params_t *)self->params;
 
   // Matching noise profiles + the interpolated default profile and the profile combobox, formerly
@@ -3187,7 +3187,7 @@ void gui_update(dt_iop_module_t *self)
 
 void gui_reset(dt_iop_module_t *self)
 {
-  dt_iop_denoiseprofile_gui_data_t *g = (dt_iop_denoiseprofile_gui_data_t *)self->gui_data;
+  dt_iop_denoiseprofile_gui_data_t *g = (dt_iop_denoiseprofile_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_denoiseprofile_params_t *p = (dt_iop_denoiseprofile_params_t *)self->params;
   if(p->wavelet_color_mode == MODE_Y0U0V0)
   {
@@ -3218,7 +3218,7 @@ static gboolean denoiseprofile_draw_variance(GtkWidget *widget, cairo_t *crf, gp
   if(dt_gui_widgets_suppressed()) return FALSE;
 
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
-  dt_iop_denoiseprofile_gui_data_t *c = (dt_iop_denoiseprofile_gui_data_t *)self->gui_data;
+  dt_iop_denoiseprofile_gui_data_t *c = (dt_iop_denoiseprofile_gui_data_t *)dt_iop_gui_data(self);
 
   if(!isnan(c->variance_R))
   {
@@ -3250,7 +3250,7 @@ static gboolean denoiseprofile_draw_variance(GtkWidget *widget, cairo_t *crf, gp
 static gboolean denoiseprofile_draw(GtkWidget *widget, cairo_t *crf, gpointer user_data)
 {
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
-  dt_iop_denoiseprofile_gui_data_t *c = (dt_iop_denoiseprofile_gui_data_t *)self->gui_data;
+  dt_iop_denoiseprofile_gui_data_t *c = (dt_iop_denoiseprofile_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_denoiseprofile_params_t p = *(dt_iop_denoiseprofile_params_t *)self->params;
 
   int ch = (int)c->channel;
@@ -3463,7 +3463,7 @@ static gboolean denoiseprofile_draw(GtkWidget *widget, cairo_t *crf, gpointer us
 static gboolean denoiseprofile_motion_notify(GtkWidget *widget, GdkEventMotion *event, gpointer user_data)
 {
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
-  dt_iop_denoiseprofile_gui_data_t *c = (dt_iop_denoiseprofile_gui_data_t *)self->gui_data;
+  dt_iop_denoiseprofile_gui_data_t *c = (dt_iop_denoiseprofile_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_denoiseprofile_params_t *p = (dt_iop_denoiseprofile_params_t *)self->params;
   const int inset = DT_IOP_DENOISE_PROFILE_INSET;
   GtkAllocation allocation;
@@ -3491,7 +3491,7 @@ static gboolean denoiseprofile_motion_notify(GtkWidget *widget, GdkEventMotion *
 static gboolean denoiseprofile_button_press(GtkWidget *widget, GdkEventButton *event, gpointer user_data)
 {
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
-  dt_iop_denoiseprofile_gui_data_t *c = (dt_iop_denoiseprofile_gui_data_t *)self->gui_data;
+  dt_iop_denoiseprofile_gui_data_t *c = (dt_iop_denoiseprofile_gui_data_t *)dt_iop_gui_data(self);
   const int ch = c->channel;
   if(event->button == 1 && event->type == GDK_2BUTTON_PRESS)
   {
@@ -3505,7 +3505,7 @@ static gboolean denoiseprofile_button_press(GtkWidget *widget, GdkEventButton *e
       p->y[ch][k] = d->y[ch][k];
     }
     dt_dev_add_history_item(self->dev, self, TRUE, TRUE);
-    gtk_widget_queue_draw(self->widget);
+    gtk_widget_queue_draw(self->gui->widget);
   }
   else if(event->button == 1)
   {
@@ -3528,7 +3528,7 @@ static gboolean denoiseprofile_button_release(GtkWidget *widget, GdkEventButton 
   if(event->button == 1)
   {
     dt_iop_module_t *self = (dt_iop_module_t *)user_data;
-    dt_iop_denoiseprofile_gui_data_t *c = (dt_iop_denoiseprofile_gui_data_t *)self->gui_data;
+    dt_iop_denoiseprofile_gui_data_t *c = (dt_iop_denoiseprofile_gui_data_t *)dt_iop_gui_data(self);
     c->dragging = 0;
     return TRUE;
   }
@@ -3538,7 +3538,7 @@ static gboolean denoiseprofile_button_release(GtkWidget *widget, GdkEventButton 
 static gboolean denoiseprofile_leave_notify(GtkWidget *widget, GdkEventCrossing *event, gpointer user_data)
 {
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
-  dt_iop_denoiseprofile_gui_data_t *c = (dt_iop_denoiseprofile_gui_data_t *)self->gui_data;
+  dt_iop_denoiseprofile_gui_data_t *c = (dt_iop_denoiseprofile_gui_data_t *)dt_iop_gui_data(self);
   if(!c->dragging) c->mouse_y = -1.0;
   gtk_widget_queue_draw(widget);
   return TRUE;
@@ -3547,7 +3547,7 @@ static gboolean denoiseprofile_leave_notify(GtkWidget *widget, GdkEventCrossing 
 static gboolean denoiseprofile_scrolled(GtkWidget *widget, GdkEventScroll *event, gpointer user_data)
 {
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
-  dt_iop_denoiseprofile_gui_data_t *c = (dt_iop_denoiseprofile_gui_data_t *)self->gui_data;
+  dt_iop_denoiseprofile_gui_data_t *c = (dt_iop_denoiseprofile_gui_data_t *)dt_iop_gui_data(self);
 
   int delta_y;
   if(dt_gui_get_scroll_unit_deltas(event, NULL, &delta_y))
@@ -3564,12 +3564,12 @@ static void denoiseprofile_tab_switch(GtkNotebook *notebook, GtkWidget *page, gu
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
   dt_iop_denoiseprofile_params_t *p = (dt_iop_denoiseprofile_params_t *)self->params;
   if(dt_gui_widgets_suppressed()) return;
-  dt_iop_denoiseprofile_gui_data_t *c = (dt_iop_denoiseprofile_gui_data_t *)self->gui_data;
+  dt_iop_denoiseprofile_gui_data_t *c = (dt_iop_denoiseprofile_gui_data_t *)dt_iop_gui_data(self);
   if(p->wavelet_color_mode == MODE_Y0U0V0)
     c->channel = (dt_iop_denoiseprofile_channel_t)page_num + DT_DENOISE_PROFILE_Y0;
   else
     c->channel = (dt_iop_denoiseprofile_channel_t)page_num;
-  gtk_widget_queue_draw(self->widget);
+  gtk_widget_queue_draw(self->gui->widget);
 }
 
 void gui_init(dt_iop_module_t *self)
@@ -3582,7 +3582,7 @@ void gui_init(dt_iop_module_t *self)
   g->channel = 0;
 
   // First build sub-level boxes
-  g->box_nlm = self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_GUI_BOX_SPACING);
+  g->box_nlm = self->gui->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_GUI_BOX_SPACING);
 
   g->radius = dt_bauhaus_slider_from_params(self, "radius");
   dt_bauhaus_slider_set_soft_range(g->radius, 0.0, 8.0);
@@ -3594,7 +3594,7 @@ void gui_init(dt_iop_module_t *self)
   g->central_pixel_weight = dt_bauhaus_slider_from_params(self, "central_pixel_weight");
   dt_bauhaus_slider_set_soft_max(g->central_pixel_weight, 1.0f);
 
-  g->box_wavelets = self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_GUI_BOX_SPACING);
+  g->box_wavelets = self->gui->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_GUI_BOX_SPACING);
 
   g->wavelet_color_mode = dt_bauhaus_combobox_from_params(self, "wavelet_color_mode");
 
@@ -3676,12 +3676,12 @@ void gui_init(dt_iop_module_t *self)
   g_signal_connect(G_OBJECT(g->box_variance), "draw", G_CALLBACK(denoiseprofile_draw_variance), self);
 
   // start building top level widget
-  self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_GUI_BOX_SPACING);
+  self->gui->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_GUI_BOX_SPACING);
 
   g->profile = dt_bauhaus_combobox_new(dt_bauhaus_get_global(), DT_GUI_MODULE(self));
   dt_bauhaus_widget_set_label(g->profile, N_("profile"));
   g_signal_connect(G_OBJECT(g->profile), "value-changed", G_CALLBACK(profile_callback), self);
-  gtk_box_pack_start(GTK_BOX(self->widget), g->profile, TRUE, TRUE, 0);
+  gtk_box_pack_start(GTK_BOX(self->gui->widget), g->profile, TRUE, TRUE, 0);
 
   g->wb_adaptive_anscombe = dt_bauhaus_toggle_from_params(self, "wb_adaptive_anscombe");
 
@@ -3694,10 +3694,10 @@ void gui_init(dt_iop_module_t *self)
   const gboolean compute_variance = dt_conf_get_bool("plugins/darkroom/denoiseprofile/show_compute_variance_mode");
   if(compute_variance) dt_bauhaus_combobox_add(g->mode, _("compute variance"));
   g_signal_connect(G_OBJECT(g->mode), "value-changed", G_CALLBACK(mode_callback), self);
-  gtk_box_pack_start(GTK_BOX(self->widget), g->mode, TRUE, TRUE, 0);
+  gtk_box_pack_start(GTK_BOX(self->gui->widget), g->mode, TRUE, TRUE, 0);
 
-  gtk_box_pack_start(GTK_BOX(self->widget), g->box_nlm, TRUE, TRUE, 0);
-  gtk_box_pack_start(GTK_BOX(self->widget), g->box_wavelets, TRUE, TRUE, 0);
+  gtk_box_pack_start(GTK_BOX(self->gui->widget), g->box_nlm, TRUE, TRUE, 0);
+  gtk_box_pack_start(GTK_BOX(self->gui->widget), g->box_wavelets, TRUE, TRUE, 0);
 
   g->overshooting = dt_bauhaus_slider_from_params(self, "overshooting");
   g->strength = dt_bauhaus_slider_from_params(self, N_("strength"));
@@ -3714,7 +3714,7 @@ void gui_init(dt_iop_module_t *self)
   // Those are created just above, so doing this earlier dereferenced NULL.
   dt_bauhaus_slider_set_soft_max(g->overshooting, 4.0f);
 
-  gtk_box_pack_start(GTK_BOX(self->widget), g->box_variance, TRUE, TRUE, 0);
+  gtk_box_pack_start(GTK_BOX(self->gui->widget), g->box_variance, TRUE, TRUE, 0);
 
   g->fix_anscombe_and_nlmeans_norm = dt_bauhaus_toggle_from_params(self, "fix_anscombe_and_nlmeans_norm");
 
@@ -3776,7 +3776,7 @@ void gui_init(dt_iop_module_t *self)
 
 void gui_cleanup(dt_iop_module_t *self)
 {
-  dt_iop_denoiseprofile_gui_data_t *g = (dt_iop_denoiseprofile_gui_data_t *)self->gui_data;
+  dt_iop_denoiseprofile_gui_data_t *g = (dt_iop_denoiseprofile_gui_data_t *)dt_iop_gui_data(self);
   g_list_free_full(g->profiles, dt_noiseprofile_free);
   g->profiles = NULL;
   dt_draw_curve_destroy(g->transition_curve);

--- a/src/iop/diffuse.c
+++ b/src/iop/diffuse.c
@@ -1647,9 +1647,9 @@ void cleanup_global(dt_iop_module_so_t *module)
 void gui_init(struct dt_iop_module_t *self)
 {
   dt_iop_diffuse_gui_data_t *g = IOP_GUI_ALLOC(diffuse);
-  self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_GUI_BOX_SPACING);
+  self->gui->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_GUI_BOX_SPACING);
 
-  gtk_box_pack_start(GTK_BOX(self->widget), dt_ui_section_label_new(_("properties")), FALSE, FALSE, 0);
+  gtk_box_pack_start(GTK_BOX(self->gui->widget), dt_ui_section_label_new(_("properties")), FALSE, FALSE, 0);
 
   g->iterations = dt_bauhaus_slider_from_params(self, "iterations");
   dt_bauhaus_slider_set_soft_range(g->iterations, 1., 128);
@@ -1680,7 +1680,7 @@ void gui_init(struct dt_iop_module_t *self)
                    "the radius should be around the width of your lens blur."));
 
   GtkWidget *label_speed = dt_ui_section_label_new(_("speed (sharpen \342\206\224 diffuse)"));
-  gtk_box_pack_start(GTK_BOX(self->widget), label_speed, FALSE, FALSE, 0);
+  gtk_box_pack_start(GTK_BOX(self->gui->widget), label_speed, FALSE, FALSE, 0);
 
   g->first = dt_bauhaus_slider_from_params(self, "first");
   dt_bauhaus_slider_set_digits(g->first, 4);
@@ -1719,7 +1719,7 @@ void gui_init(struct dt_iop_module_t *self)
                   "zero does nothing."));
 
   GtkWidget *label_direction = dt_ui_section_label_new(_("direction"));
-  gtk_box_pack_start(GTK_BOX(self->widget), label_direction, FALSE, FALSE, 0);
+  gtk_box_pack_start(GTK_BOX(self->gui->widget), label_direction, FALSE, FALSE, 0);
 
   g->anisotropy_first = dt_bauhaus_slider_from_params(self, "anisotropy_first");
   dt_bauhaus_slider_set_digits(g->anisotropy_first, 4);
@@ -1753,7 +1753,7 @@ void gui_init(struct dt_iop_module_t *self)
                   "positive values rather avoid edges (isophotes), \n"
                   "zero affects both equally (isotropic)."));
 
-  gtk_box_pack_start(GTK_BOX(self->widget), dt_ui_section_label_new(_("edge management")), FALSE, FALSE, 0);
+  gtk_box_pack_start(GTK_BOX(self->gui->widget), dt_ui_section_label_new(_("edge management")), FALSE, FALSE, 0);
 
   g->sharpness = dt_bauhaus_slider_from_params(self, "sharpness");
   dt_bauhaus_slider_set_format(g->sharpness, "%");
@@ -1776,7 +1776,7 @@ void gui_init(struct dt_iop_module_t *self)
                                 "if dark areas seem oversharpened compared to bright areas."));
 
 
-  gtk_box_pack_start(GTK_BOX(self->widget), dt_ui_section_label_new(_("diffusion spatiality")), FALSE, FALSE, 0);
+  gtk_box_pack_start(GTK_BOX(self->gui->widget), dt_ui_section_label_new(_("diffusion spatiality")), FALSE, FALSE, 0);
 
   g->threshold = dt_bauhaus_slider_from_params(self, "threshold");
   dt_bauhaus_slider_set_format(g->threshold, "%");

--- a/src/iop/dither.c
+++ b/src/iop/dither.c
@@ -550,7 +550,7 @@ error:
 void gui_changed(dt_iop_module_t *self, GtkWidget *w, void *previous)
 {
   dt_iop_dither_params_t *p = (dt_iop_dither_params_t *)self->params;
-  dt_iop_dither_gui_data_t *g = (dt_iop_dither_gui_data_t *)self->gui_data;
+  dt_iop_dither_gui_data_t *g = (dt_iop_dither_gui_data_t *)dt_iop_gui_data(self);
 
   if(w == g->dither_type)
   {
@@ -644,7 +644,7 @@ void cleanup_global(dt_iop_module_so_t *module)
 
 void gui_update(struct dt_iop_module_t *self)
 {
-  dt_iop_dither_gui_data_t *g = (dt_iop_dither_gui_data_t *)self->gui_data;
+  dt_iop_dither_gui_data_t *g = (dt_iop_dither_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_dither_params_t *p = (dt_iop_dither_params_t *)self->params;
 #if 0
   dt_bauhaus_slider_set(g->radius, p->random.radius);
@@ -662,7 +662,7 @@ void gui_init(struct dt_iop_module_t *self)
 {
   dt_iop_dither_gui_data_t *g = IOP_GUI_ALLOC(dither);
 
-  g->random = self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_GUI_BOX_SPACING);
+  g->random = self->gui->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_GUI_BOX_SPACING);
 
 #if 0
   g->radius = dt_bauhaus_slider_new_with_range(dt_bauhaus_get_global(), DT_GUI_MODULE(self), 0.0, 200.0, 0.1, p->random.radius, 2);
@@ -697,11 +697,11 @@ void gui_init(struct dt_iop_module_t *self)
   gtk_box_pack_start(GTK_BOX(g->random), g->range, TRUE, TRUE, 0);
 #endif
 
-  self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_GUI_BOX_SPACING);
+  self->gui->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_GUI_BOX_SPACING);
 
   g->dither_type = dt_bauhaus_combobox_from_params(self, "dither_type");
 
-  gtk_box_pack_start(GTK_BOX(self->widget), g->random, TRUE, TRUE, 0);
+  gtk_box_pack_start(GTK_BOX(self->gui->widget), g->random, TRUE, TRUE, 0);
 
 #if 0
   g_signal_connect (G_OBJECT (g->radius), "value-changed",

--- a/src/iop/drawlayer.c
+++ b/src/iop/drawlayer.c
@@ -197,7 +197,7 @@ static void _brush_pipeline_color_from_display(dt_iop_module_t *self, const floa
 /** @brief Cache brush colors in GUI state so stroke input snapshots don't re-transform per event. */
 static void _sync_cached_brush_colors(dt_iop_module_t *self, const float display_rgb[3])
 {
-  dt_iop_drawlayer_gui_data_t *g = self ? (dt_iop_drawlayer_gui_data_t *)self->gui_data : NULL;
+  dt_iop_drawlayer_gui_data_t *g = self ? (dt_iop_drawlayer_gui_data_t *)dt_iop_gui_data(self) : NULL;
   if(IS_NULL_PTR(g) || !display_rgb) return;
 
   g->ui.brush_display_color[0] = _clamp01(display_rgb[0]);
@@ -210,7 +210,7 @@ static void _sync_cached_brush_colors(dt_iop_module_t *self, const float display
 static void _fill_input_brush_settings(dt_iop_module_t *self, dt_drawlayer_paint_raw_input_t *input)
 {
   if(IS_NULL_PTR(self) || IS_NULL_PTR(input)) return;
-  dt_iop_drawlayer_gui_data_t *g = (dt_iop_drawlayer_gui_data_t *)self->gui_data;
+  dt_iop_drawlayer_gui_data_t *g = (dt_iop_drawlayer_gui_data_t *)dt_iop_gui_data(self);
 
   uint32_t map_flags = 0u;
   if(dt_conf_get_bool(DRAWLAYER_CONF_MAP_PRESSURE_SIZE)) map_flags |= DRAWLAYER_INPUT_MAP_PRESSURE_SIZE;
@@ -1156,7 +1156,7 @@ static int64_t _sidecar_timestamp_from_path(const char *path)
 static void _ensure_cursor_stamp_surface(dt_iop_module_t *self, const float widget_radius, const float opacity,
                                          const float hardness)
 {
-  dt_iop_drawlayer_gui_data_t *g = self ? (dt_iop_drawlayer_gui_data_t *)self->gui_data : NULL;
+  dt_iop_drawlayer_gui_data_t *g = self ? (dt_iop_drawlayer_gui_data_t *)dt_iop_gui_data(self) : NULL;
   if(IS_NULL_PTR(g) || widget_radius <= 0.0f) return;
 
   const double ppd = (dt_gui_get_global() && dt_gui_get_global()->ppd > 0.0) ? dt_gui_get_global()->ppd : 1.0;
@@ -1346,7 +1346,7 @@ static gboolean _prompt_layer_name_dialog(const char *title, const char *message
 
 static gboolean _color_picker_set_from_position(dt_iop_module_t *self, const float x, const float y)
 {
-  dt_iop_drawlayer_gui_data_t *g = self ? (dt_iop_drawlayer_gui_data_t *)self->gui_data : NULL;
+  dt_iop_drawlayer_gui_data_t *g = self ? (dt_iop_drawlayer_gui_data_t *)dt_iop_gui_data(self) : NULL;
   if(IS_NULL_PTR(g) || !g->ui.widgets || IS_NULL_PTR(g->controls.color)) return FALSE;
 
   float display_rgb[3] = { 0.0f };
@@ -1358,7 +1358,7 @@ static gboolean _color_picker_set_from_position(dt_iop_module_t *self, const flo
 static gboolean _color_picker_draw(GtkWidget *widget, cairo_t *cr, gpointer user_data)
 {
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
-  dt_iop_drawlayer_gui_data_t *g = self ? (dt_iop_drawlayer_gui_data_t *)self->gui_data : NULL;
+  dt_iop_drawlayer_gui_data_t *g = self ? (dt_iop_drawlayer_gui_data_t *)dt_iop_gui_data(self) : NULL;
   if(IS_NULL_PTR(g) || !g->ui.widgets) return FALSE;
   const double ppd = (dt_gui_get_global() && dt_gui_get_global()->ppd > 0.0) ? dt_gui_get_global()->ppd : 1.0;
   return dt_drawlayer_widgets_draw_picker(g->ui.widgets, widget, cr, ppd);
@@ -1367,7 +1367,7 @@ static gboolean _color_picker_draw(GtkWidget *widget, cairo_t *cr, gpointer user
 static gboolean _color_swatch_draw(GtkWidget *widget, cairo_t *cr, gpointer user_data)
 {
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
-  dt_iop_drawlayer_gui_data_t *g = self ? (dt_iop_drawlayer_gui_data_t *)self->gui_data : NULL;
+  dt_iop_drawlayer_gui_data_t *g = self ? (dt_iop_drawlayer_gui_data_t *)dt_iop_gui_data(self) : NULL;
   if(IS_NULL_PTR(g) || !g->ui.widgets) return FALSE;
   return dt_drawlayer_widgets_draw_swatch(g->ui.widgets, widget, cr);
 }
@@ -1375,7 +1375,7 @@ static gboolean _color_swatch_draw(GtkWidget *widget, cairo_t *cr, gpointer user
 static gboolean _color_swatch_button_press(GtkWidget *widget, GdkEventButton *event, gpointer user_data)
 {
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
-  dt_iop_drawlayer_gui_data_t *g = self ? (dt_iop_drawlayer_gui_data_t *)self->gui_data : NULL;
+  dt_iop_drawlayer_gui_data_t *g = self ? (dt_iop_drawlayer_gui_data_t *)dt_iop_gui_data(self) : NULL;
   if(IS_NULL_PTR(g) || !g->ui.widgets || !widget || IS_NULL_PTR(event) || event->button != 1) return FALSE;
 
   float display_rgb[3] = { 0.0f };
@@ -1386,7 +1386,7 @@ static gboolean _color_swatch_button_press(GtkWidget *widget, GdkEventButton *ev
 
 static void _sync_brush_profile_preview_widget(dt_iop_module_t *self)
 {
-  dt_iop_drawlayer_gui_data_t *g = self ? (dt_iop_drawlayer_gui_data_t *)self->gui_data : NULL;
+  dt_iop_drawlayer_gui_data_t *g = self ? (dt_iop_drawlayer_gui_data_t *)dt_iop_gui_data(self) : NULL;
   if(IS_NULL_PTR(g) || !g->ui.widgets || IS_NULL_PTR(g->controls.brush_shape)) return;
 
   dt_drawlayer_widgets_set_brush_profile_preview(g->ui.widgets, _conf_opacity() / 100.0f, _conf_hardness(),
@@ -1398,7 +1398,7 @@ static void _sync_brush_profile_preview_widget(dt_iop_module_t *self)
 static gboolean _brush_profile_draw(GtkWidget *widget, cairo_t *cr, gpointer user_data)
 {
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
-  dt_iop_drawlayer_gui_data_t *g = self ? (dt_iop_drawlayer_gui_data_t *)self->gui_data : NULL;
+  dt_iop_drawlayer_gui_data_t *g = self ? (dt_iop_drawlayer_gui_data_t *)dt_iop_gui_data(self) : NULL;
   if(IS_NULL_PTR(g) || !g->ui.widgets) return FALSE;
   const double ppd = (dt_gui_get_global() && dt_gui_get_global()->ppd > 0.0) ? dt_gui_get_global()->ppd : 1.0;
   return dt_drawlayer_widgets_draw_brush_profiles(g->ui.widgets, widget, cr, ppd);
@@ -1407,7 +1407,7 @@ static gboolean _brush_profile_draw(GtkWidget *widget, cairo_t *cr, gpointer use
 static gboolean _brush_profile_button_press(GtkWidget *widget, GdkEventButton *event, gpointer user_data)
 {
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
-  dt_iop_drawlayer_gui_data_t *g = self ? (dt_iop_drawlayer_gui_data_t *)self->gui_data : NULL;
+  dt_iop_drawlayer_gui_data_t *g = self ? (dt_iop_drawlayer_gui_data_t *)dt_iop_gui_data(self) : NULL;
   if(IS_NULL_PTR(g) || !g->ui.widgets || !widget || IS_NULL_PTR(event) || event->button != 1) return FALSE;
 
   int shape = DT_DRAWLAYER_BRUSH_SHAPE_LINEAR;
@@ -1484,7 +1484,7 @@ static gboolean _color_picker_button_press(GtkWidget *widget, GdkEventButton *ev
 static gboolean _color_picker_button_release(GtkWidget *widget, GdkEventButton *event, gpointer user_data)
 {
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
-  dt_iop_drawlayer_gui_data_t *g = self ? (dt_iop_drawlayer_gui_data_t *)self->gui_data : NULL;
+  dt_iop_drawlayer_gui_data_t *g = self ? (dt_iop_drawlayer_gui_data_t *)dt_iop_gui_data(self) : NULL;
   (void)widget;
   (void)event;
   if(!IS_NULL_PTR(g) && g->ui.widgets)
@@ -1499,7 +1499,7 @@ static gboolean _color_picker_button_release(GtkWidget *widget, GdkEventButton *
 static gboolean _color_picker_motion(GtkWidget *widget, GdkEventMotion *event, gpointer user_data)
 {
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
-  dt_iop_drawlayer_gui_data_t *g = self ? (dt_iop_drawlayer_gui_data_t *)self->gui_data : NULL;
+  dt_iop_drawlayer_gui_data_t *g = self ? (dt_iop_drawlayer_gui_data_t *)dt_iop_gui_data(self) : NULL;
   (void)widget;
   if(IS_NULL_PTR(g) || !g->ui.widgets || IS_NULL_PTR(event) || !dt_drawlayer_widgets_is_picker_dragging(g->ui.widgets)) return FALSE;
   return _color_picker_set_from_position(self, event->x, event->y);
@@ -1670,7 +1670,7 @@ void dt_drawlayer_touch_stroke_commit_hash(dt_iop_drawlayer_params_t *params, co
 
 static void _refresh_layer_widgets(dt_iop_module_t *self)
 {
-  dt_iop_drawlayer_gui_data_t *g = self ? (dt_iop_drawlayer_gui_data_t *)self->gui_data : NULL;
+  dt_iop_drawlayer_gui_data_t *g = self ? (dt_iop_drawlayer_gui_data_t *)dt_iop_gui_data(self) : NULL;
   dt_iop_drawlayer_params_t *params = self ? (dt_iop_drawlayer_params_t *)self->params : NULL;
   GMainContext *const ui_ctx = g_main_context_default();
   if(IS_NULL_PTR(g) || IS_NULL_PTR(params) || !(ui_ctx && g_main_context_is_owner(ui_ctx))) return;
@@ -1683,7 +1683,7 @@ static void _refresh_layer_widgets(dt_iop_module_t *self)
 
 static void _sync_layer_controls(dt_iop_module_t *self)
 {
-  dt_iop_drawlayer_gui_data_t *g = self ? (dt_iop_drawlayer_gui_data_t *)self->gui_data : NULL;
+  dt_iop_drawlayer_gui_data_t *g = self ? (dt_iop_drawlayer_gui_data_t *)dt_iop_gui_data(self) : NULL;
   dt_iop_drawlayer_params_t *params = self ? (dt_iop_drawlayer_params_t *)self->params : NULL;
   if(IS_NULL_PTR(g) || IS_NULL_PTR(params)) return;
 
@@ -1730,7 +1730,7 @@ static void _sync_layer_controls(dt_iop_module_t *self)
 
 static void _sync_preview_bg_buttons(dt_iop_module_t *self)
 {
-  dt_iop_drawlayer_gui_data_t *g = self ? (dt_iop_drawlayer_gui_data_t *)self->gui_data : NULL;
+  dt_iop_drawlayer_gui_data_t *g = self ? (dt_iop_drawlayer_gui_data_t *)dt_iop_gui_data(self) : NULL;
   if(IS_NULL_PTR(g)) return;
 
   if(GTK_IS_TOGGLE_BUTTON(g->controls.preview_bg_image))
@@ -1749,7 +1749,7 @@ static void _sync_preview_bg_buttons(dt_iop_module_t *self)
 
 gboolean dt_drawlayer_commit_dabs(dt_iop_module_t *self, const gboolean record_history)
 {
-  dt_iop_drawlayer_gui_data_t *g = (dt_iop_drawlayer_gui_data_t *)self->gui_data;
+  dt_iop_drawlayer_gui_data_t *g = (dt_iop_drawlayer_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_drawlayer_params_t *params = (dt_iop_drawlayer_params_t *)self->params;
   if(IS_NULL_PTR(g) || IS_NULL_PTR(self->dev)) return TRUE;
   /* A stroke is still physically in progress (button held down). Never finalize or
@@ -1849,7 +1849,7 @@ static void _develop_ui_pipe_finished_callback(gpointer instance, gpointer user_
 {
   (void)instance;
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
-  dt_iop_drawlayer_gui_data_t *g = self ? (dt_iop_drawlayer_gui_data_t *)self->gui_data : NULL;
+  dt_iop_drawlayer_gui_data_t *g = self ? (dt_iop_drawlayer_gui_data_t *)dt_iop_gui_data(self) : NULL;
   if(IS_NULL_PTR(g) || IS_NULL_PTR(self->dev)) return;
   drawlayer_runtime_host_context_t runtime_host = {
     .runtime = {
@@ -1876,7 +1876,7 @@ static void _develop_ui_pipe_finished_callback(gpointer instance, gpointer user_
 
 static void _sync_mode_sensitive_widgets(dt_iop_module_t *self)
 {
-  dt_iop_drawlayer_gui_data_t *g = self ? (dt_iop_drawlayer_gui_data_t *)self->gui_data : NULL;
+  dt_iop_drawlayer_gui_data_t *g = self ? (dt_iop_drawlayer_gui_data_t *)dt_iop_gui_data(self) : NULL;
   if(IS_NULL_PTR(g) || IS_NULL_PTR(g->controls.color) || IS_NULL_PTR(g->controls.softness)) return;
 
   const gboolean paint_mode = (_conf_brush_mode() == DT_DRAWLAYER_BRUSH_MODE_PAINT);
@@ -1893,7 +1893,7 @@ static gboolean _delete_current_layer(dt_iop_module_t *self)
 {
   if(IS_NULL_PTR(self->dev)) return FALSE;
 
-  dt_iop_drawlayer_gui_data_t *g = (dt_iop_drawlayer_gui_data_t *)self->gui_data;
+  dt_iop_drawlayer_gui_data_t *g = (dt_iop_drawlayer_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_drawlayer_params_t *params = (dt_iop_drawlayer_params_t *)self->params;
   if(!_layer_name_non_empty(params->layer_name)) return FALSE;
 
@@ -1989,7 +1989,7 @@ static gboolean _confirm_delete_layer(dt_iop_module_t *self, const gboolean remo
 
 static gboolean _rename_current_layer_from_gui(dt_iop_module_t *self, const char *requested_name)
 {
-  dt_iop_drawlayer_gui_data_t *g = self ? (dt_iop_drawlayer_gui_data_t *)self->gui_data : NULL;
+  dt_iop_drawlayer_gui_data_t *g = self ? (dt_iop_drawlayer_gui_data_t *)dt_iop_gui_data(self) : NULL;
   dt_iop_drawlayer_params_t *params = self ? (dt_iop_drawlayer_params_t *)self->params : NULL;
   if(IS_NULL_PTR(self) || IS_NULL_PTR(self->dev) || IS_NULL_PTR(g) || IS_NULL_PTR(params)) return FALSE;
   if(!_layer_name_non_empty(params->layer_name)) return FALSE;
@@ -2061,7 +2061,7 @@ static gboolean _rename_current_layer_from_gui(dt_iop_module_t *self, const char
 
 static gboolean _create_new_layer(dt_iop_module_t *self, const char *requested_name)
 {
-  dt_iop_drawlayer_gui_data_t *g = self ? (dt_iop_drawlayer_gui_data_t *)self->gui_data : NULL;
+  dt_iop_drawlayer_gui_data_t *g = self ? (dt_iop_drawlayer_gui_data_t *)dt_iop_gui_data(self) : NULL;
   dt_iop_drawlayer_params_t *params = self ? (dt_iop_drawlayer_params_t *)self->params : NULL;
   if(IS_NULL_PTR(self) || IS_NULL_PTR(self->dev) || IS_NULL_PTR(g) || IS_NULL_PTR(params)) return FALSE;
 
@@ -2166,7 +2166,7 @@ static gboolean _background_layer_job_done_idle(gpointer user_data)
       dt_iop_module_t *module = (dt_iop_module_t *)modules->data;
       if(!module || g_strcmp0(module->op, "drawlayer")) continue;
 
-      dt_iop_drawlayer_gui_data_t *g = (dt_iop_drawlayer_gui_data_t *)module->gui_data;
+      dt_iop_drawlayer_gui_data_t *g = (dt_iop_drawlayer_gui_data_t *)dt_iop_gui_data(module);
       dt_iop_drawlayer_params_t *params = (dt_iop_drawlayer_params_t *)module->params;
       if(g && params && !g_strcmp0(params->layer_name, result->initiator_layer_name)
          && params->layer_order == result->initiator_layer_order)
@@ -2190,7 +2190,7 @@ static gboolean _background_layer_job_done_idle(gpointer user_data)
     {
       dt_iop_module_t *module = (dt_iop_module_t *)modules->data;
       if(!module || g_strcmp0(module->op, "drawlayer")) continue;
-      dt_iop_drawlayer_gui_data_t *g = (dt_iop_drawlayer_gui_data_t *)module->gui_data;
+      dt_iop_drawlayer_gui_data_t *g = (dt_iop_drawlayer_gui_data_t *)dt_iop_gui_data(module);
       if(IS_NULL_PTR(g) || !g->session.background_job_running) continue;
       g->session.background_job_running = FALSE;
       if(g->controls.create_background) gtk_widget_set_sensitive(g->controls.create_background, TRUE);
@@ -2203,7 +2203,7 @@ static gboolean _background_layer_job_done_idle(gpointer user_data)
 
 static gboolean _create_background_layer_from_input(dt_iop_module_t *self)
 {
-  dt_iop_drawlayer_gui_data_t *g = self ? (dt_iop_drawlayer_gui_data_t *)self->gui_data : NULL;
+  dt_iop_drawlayer_gui_data_t *g = self ? (dt_iop_drawlayer_gui_data_t *)dt_iop_gui_data(self) : NULL;
   dt_iop_drawlayer_params_t *params = self ? (dt_iop_drawlayer_params_t *)self->params : NULL;
   if(IS_NULL_PTR(self) || IS_NULL_PTR(self->dev) || IS_NULL_PTR(g) || IS_NULL_PTR(params)) return FALSE;
   if(g->session.background_job_running) return FALSE;
@@ -2271,7 +2271,7 @@ static gboolean _create_background_layer_from_input(dt_iop_module_t *self)
 static void _widget_changed(GtkWidget *widget, gpointer user_data)
 {
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
-  dt_iop_drawlayer_gui_data_t *g = (dt_iop_drawlayer_gui_data_t *)self->gui_data;
+  dt_iop_drawlayer_gui_data_t *g = (dt_iop_drawlayer_gui_data_t *)dt_iop_gui_data(self);
   if(IS_NULL_PTR(g) || (dt_gui_get_global() && dt_gui_widgets_suppressed())) return;
 
   _sync_params_from_gui(self, FALSE);
@@ -2328,7 +2328,7 @@ static gboolean _apply_selected_layer_attachment(dt_iop_module_t *self, dt_iop_d
 static void _layer_selected(GtkWidget *widget, gpointer user_data)
 {
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
-  dt_iop_drawlayer_gui_data_t *g = (dt_iop_drawlayer_gui_data_t *)self->gui_data;
+  dt_iop_drawlayer_gui_data_t *g = (dt_iop_drawlayer_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_drawlayer_params_t *params = (dt_iop_drawlayer_params_t *)self->params;
   if(IS_NULL_PTR(g) || (dt_gui_get_global() && dt_gui_widgets_suppressed())) return;
 
@@ -2350,7 +2350,7 @@ static void _attach_selected_layer_clicked(GtkButton *button, gpointer user_data
 {
   (void)button;
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
-  dt_iop_drawlayer_gui_data_t *g = self ? (dt_iop_drawlayer_gui_data_t *)self->gui_data : NULL;
+  dt_iop_drawlayer_gui_data_t *g = self ? (dt_iop_drawlayer_gui_data_t *)dt_iop_gui_data(self) : NULL;
   dt_iop_drawlayer_params_t *params = self ? (dt_iop_drawlayer_params_t *)self->params : NULL;
   if(IS_NULL_PTR(self) || IS_NULL_PTR(self->dev) || IS_NULL_PTR(g) || IS_NULL_PTR(params)) return;
   if(_layer_name_non_empty(params->layer_name)) return;
@@ -2367,7 +2367,7 @@ static void _rename_layer_clicked(GtkButton *button, gpointer user_data)
 {
   (void)button;
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
-  dt_iop_drawlayer_gui_data_t *g = self ? (dt_iop_drawlayer_gui_data_t *)self->gui_data : NULL;
+  dt_iop_drawlayer_gui_data_t *g = self ? (dt_iop_drawlayer_gui_data_t *)dt_iop_gui_data(self) : NULL;
   dt_iop_drawlayer_params_t *params = self ? (dt_iop_drawlayer_params_t *)self->params : NULL;
   if(IS_NULL_PTR(self) || IS_NULL_PTR(self->dev) || IS_NULL_PTR(g) || IS_NULL_PTR(params)) return;
   if(!_layer_name_non_empty(params->layer_name)) return;
@@ -2399,7 +2399,7 @@ static void _delete_layer_clicked(GtkButton *button, gpointer user_data)
 
 static gboolean _fill_current_layer(dt_iop_module_t *self, const float value)
 {
-  dt_iop_drawlayer_gui_data_t *g = self ? (dt_iop_drawlayer_gui_data_t *)self->gui_data : NULL;
+  dt_iop_drawlayer_gui_data_t *g = self ? (dt_iop_drawlayer_gui_data_t *)dt_iop_gui_data(self) : NULL;
   dt_iop_drawlayer_params_t *params = self ? (dt_iop_drawlayer_params_t *)self->params : NULL;
   if(IS_NULL_PTR(self) || IS_NULL_PTR(self->dev) || IS_NULL_PTR(g) || IS_NULL_PTR(params)) return FALSE;
 
@@ -2437,7 +2437,7 @@ static gboolean _fill_current_layer(dt_iop_module_t *self, const float value)
 
 static gboolean _clear_current_layer(dt_iop_module_t *self)
 {
-  dt_iop_drawlayer_gui_data_t *g = self ? (dt_iop_drawlayer_gui_data_t *)self->gui_data : NULL;
+  dt_iop_drawlayer_gui_data_t *g = self ? (dt_iop_drawlayer_gui_data_t *)dt_iop_gui_data(self) : NULL;
   dt_iop_drawlayer_params_t *params = self ? (dt_iop_drawlayer_params_t *)self->params : NULL;
   if(IS_NULL_PTR(self) || IS_NULL_PTR(self->dev) || IS_NULL_PTR(g) || IS_NULL_PTR(params)) return FALSE;
 
@@ -2488,7 +2488,7 @@ static void _save_layer_clicked(GtkButton *button, gpointer user_data)
 {
   (void)button;
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
-  dt_iop_drawlayer_gui_data_t *g = self ? (dt_iop_drawlayer_gui_data_t *)self->gui_data : NULL;
+  dt_iop_drawlayer_gui_data_t *g = self ? (dt_iop_drawlayer_gui_data_t *)dt_iop_gui_data(self) : NULL;
   if(IS_NULL_PTR(self) || IS_NULL_PTR(self->dev) || IS_NULL_PTR(g)) return;
 
   if(!g->process.cache_valid || IS_NULL_PTR(g->process.base_patch.pixels))
@@ -2582,7 +2582,7 @@ static void _create_background_clicked(GtkButton *button, gpointer user_data)
 static void _preview_bg_toggled(GtkToggleButton *button, gpointer user_data)
 {
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
-  dt_iop_drawlayer_gui_data_t *g = self ? (dt_iop_drawlayer_gui_data_t *)self->gui_data : NULL;
+  dt_iop_drawlayer_gui_data_t *g = self ? (dt_iop_drawlayer_gui_data_t *)dt_iop_gui_data(self) : NULL;
   dt_iop_drawlayer_params_t *params = self ? (dt_iop_drawlayer_params_t *)self->params : NULL;
   if(IS_NULL_PTR(self) || IS_NULL_PTR(self->dev) || IS_NULL_PTR(g) || (dt_gui_get_global() && dt_gui_widgets_suppressed()) || !gtk_toggle_button_get_active(button))
     return;
@@ -2606,7 +2606,7 @@ static gboolean _build_raw_input_event(dt_iop_module_t *self, const double wx, c
                                        const dt_drawlayer_paint_stroke_pos_t stroke_pos,
                                        dt_drawlayer_paint_raw_input_t *input)
 {
-  dt_iop_drawlayer_gui_data_t *g = self ? (dt_iop_drawlayer_gui_data_t *)self->gui_data : NULL;
+  dt_iop_drawlayer_gui_data_t *g = self ? (dt_iop_drawlayer_gui_data_t *)dt_iop_gui_data(self) : NULL;
   if(IS_NULL_PTR(g) || IS_NULL_PTR(input)) return FALSE;
 
   dt_control_pointer_input_t pointer_input = { 0 };
@@ -2632,7 +2632,7 @@ static gboolean _build_raw_input_event(dt_iop_module_t *self, const double wx, c
 
 void dt_drawlayer_begin_gui_stroke_capture(dt_iop_module_t *self, const dt_drawlayer_paint_raw_input_t *first_input)
 {
-  dt_iop_drawlayer_gui_data_t *g = self ? (dt_iop_drawlayer_gui_data_t *)self->gui_data : NULL;
+  dt_iop_drawlayer_gui_data_t *g = self ? (dt_iop_drawlayer_gui_data_t *)dt_iop_gui_data(self) : NULL;
   if(IS_NULL_PTR(self) || IS_NULL_PTR(g)) return;
 
   uint32_t stroke_batch = g->stroke.current_stroke_batch + 1u;
@@ -2655,7 +2655,7 @@ void dt_drawlayer_begin_gui_stroke_capture(dt_iop_module_t *self, const dt_drawl
 
 void dt_drawlayer_end_gui_stroke_capture(dt_iop_module_t *self)
 {
-  dt_iop_drawlayer_gui_data_t *g = self ? (dt_iop_drawlayer_gui_data_t *)self->gui_data : NULL;
+  dt_iop_drawlayer_gui_data_t *g = self ? (dt_iop_drawlayer_gui_data_t *)dt_iop_gui_data(self) : NULL;
   if(IS_NULL_PTR(g)) return;
 }
 
@@ -2782,7 +2782,6 @@ void init(dt_iop_module_t *module)
   module->params = calloc(1, sizeof(dt_iop_drawlayer_params_t));
   module->default_params = calloc(1, sizeof(dt_iop_drawlayer_params_t));
   module->params_size = sizeof(dt_iop_drawlayer_params_t);
-  module->gui_data = NULL;
 
   if(module->params) ((dt_iop_drawlayer_params_t *)module->params)->layer_order = -1;
   if(module->default_params) ((dt_iop_drawlayer_params_t *)module->default_params)->layer_order = -1;
@@ -2820,9 +2819,9 @@ void commit_params(dt_iop_module_t *self, dt_iop_params_t *params, dt_dev_pixelp
                    dt_dev_pixelpipe_iop_t *piece)
 {
   dt_iop_drawlayer_data_t *data = (dt_iop_drawlayer_data_t *)piece->data;
-  const gboolean display_pipe = self && self->dev && self->gui_data && pipe
+  const gboolean display_pipe = self && self->dev && dt_iop_gui_data(self) && pipe
                                 && (pipe == self->dev->pipe || pipe == self->dev->preview_pipe);
-  dt_iop_drawlayer_gui_data_t *g = self ? (dt_iop_drawlayer_gui_data_t *)self->gui_data : NULL;
+  dt_iop_drawlayer_gui_data_t *g = self ? (dt_iop_drawlayer_gui_data_t *)dt_iop_gui_data(self) : NULL;
   dt_drawlayer_runtime_manager_bind_piece(&data->headless_manager, &data->process, g ? &g->manager : NULL,
                                           g ? &g->process : NULL, display_pipe, &data->runtime_manager,
                                           &data->runtime_process, &data->runtime_display_pipe);
@@ -2849,7 +2848,7 @@ void gui_reset(dt_iop_module_t *self)
   params->sidecar_timestamp = 0;
   memset(params->work_profile, 0, sizeof(params->work_profile));
   _touch_stroke_commit_hash(params, 0, FALSE, 0.0f, 0.0f, 0u);
-  dt_iop_drawlayer_gui_data_t *g = (dt_iop_drawlayer_gui_data_t *)self->gui_data;
+  dt_iop_drawlayer_gui_data_t *g = (dt_iop_drawlayer_gui_data_t *)dt_iop_gui_data(self);
   if(!IS_NULL_PTR(g))
   {
     g->session.missing_layer_error[0] = '\0';
@@ -2893,7 +2892,7 @@ gboolean module_will_remove(dt_iop_module_t *self)
 void gui_init(dt_iop_module_t *self)
 {
   IOP_GUI_ALLOC(drawlayer);
-  dt_iop_drawlayer_gui_data_t *g = (dt_iop_drawlayer_gui_data_t *)self->gui_data;
+  dt_iop_drawlayer_gui_data_t *g = (dt_iop_drawlayer_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_drawlayer_params_t *params = (dt_iop_drawlayer_params_t *)self->params;
   _ensure_gui_conf_defaults();
   g->ui.widgets = dt_drawlayer_widgets_init();
@@ -2916,18 +2915,18 @@ void gui_init(dt_iop_module_t *self)
     g->session.last_view_scale = self->dev->roi.scaling;
   }
 
-  self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_GUI_BOX_SPACING);
-  if(self->reset_button) gtk_widget_hide(self->reset_button);
+  self->gui->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_GUI_BOX_SPACING);
+  if(self->gui->reset_button) gtk_widget_hide(self->gui->reset_button);
 
   GtkWidget *history_box = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, DT_GUI_BOX_SPACING);
   g->controls.save_layer = gtk_button_new_with_label(_("save sidecar"));
   gtk_box_pack_start(GTK_BOX(history_box), g->controls.save_layer, TRUE, TRUE, 0);
-  gtk_box_pack_start(GTK_BOX(self->widget), history_box, FALSE, FALSE, 0);
+  gtk_box_pack_start(GTK_BOX(self->gui->widget), history_box, FALSE, FALSE, 0);
 
   GtkWidget *notebook = gtk_notebook_new();
   g->controls.notebook = notebook;
   gtk_widget_set_hexpand(notebook, TRUE);
-  gtk_box_pack_start(GTK_BOX(self->widget), notebook, FALSE, FALSE, 0);
+  gtk_box_pack_start(GTK_BOX(self->gui->widget), notebook, FALSE, FALSE, 0);
   // image_colorpicker lives on the "Brush" tab; reset it if still active once the
   // user switches away from that tab.
   dt_ui_notebook_set_picker_owner(GTK_NOTEBOOK(notebook), self);
@@ -3228,7 +3227,7 @@ void gui_init(dt_iop_module_t *self)
 /** @brief Refresh GUI controls from current params and configuration. */
 void gui_update(dt_iop_module_t *self)
 {
-  dt_iop_drawlayer_gui_data_t *g = (dt_iop_drawlayer_gui_data_t *)self->gui_data;
+  dt_iop_drawlayer_gui_data_t *g = (dt_iop_drawlayer_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_drawlayer_params_t *params = (dt_iop_drawlayer_params_t *)self->params;
   if(IS_NULL_PTR(g)) return;
 
@@ -3330,9 +3329,9 @@ void gui_update(dt_iop_module_t *self)
 /** @brief Invalidate module state when active image changes. */
 void change_image(dt_iop_module_t *self)
 {
-  if(self->gui_data)
+  if(dt_iop_gui_data(self))
   {
-    dt_iop_drawlayer_gui_data_t *g = (dt_iop_drawlayer_gui_data_t *)self->gui_data;
+    dt_iop_drawlayer_gui_data_t *g = (dt_iop_drawlayer_gui_data_t *)dt_iop_gui_data(self);
     g->session.missing_layer_error[0] = '\0';
     drawlayer_runtime_host_context_t runtime_host = {
       .runtime = {
@@ -3361,7 +3360,7 @@ void gui_focus(dt_iop_module_t *self, gboolean in)
 {
   if(!in)
   {
-    dt_iop_drawlayer_gui_data_t *g = (dt_iop_drawlayer_gui_data_t *)self->gui_data;
+    dt_iop_drawlayer_gui_data_t *g = (dt_iop_drawlayer_gui_data_t *)dt_iop_gui_data(self);
     dt_iop_drawlayer_params_t *params = (dt_iop_drawlayer_params_t *)self->params;
     const int pending_samples = g ? (int)g->stroke.stroke_sample_count : 0;
     const gboolean had_pending_edits
@@ -3402,9 +3401,9 @@ void gui_focus(dt_iop_module_t *self, gboolean in)
       dt_dev_history_notify_change(self->dev, self->dev->image_storage.id);
     }
   }
-  else if(self->gui_data)
+  else if(dt_iop_gui_data(self))
   {
-    dt_iop_drawlayer_gui_data_t *g = (dt_iop_drawlayer_gui_data_t *)self->gui_data;
+    dt_iop_drawlayer_gui_data_t *g = (dt_iop_drawlayer_gui_data_t *)dt_iop_gui_data(self);
     drawlayer_runtime_host_context_t runtime_host = {
       .runtime = {
         .self = self,
@@ -3436,14 +3435,14 @@ void quiesce(dt_iop_module_t *self)
    * leave() frees the nodes, it faults on freed piece->data. Stop and join the worker now, while the
    * pipe is still alive, so any in-flight commit completes against valid nodes and no further commit
    * can start during teardown. */
-  dt_iop_drawlayer_gui_data_t *g = self ? (dt_iop_drawlayer_gui_data_t *)self->gui_data : NULL;
+  dt_iop_drawlayer_gui_data_t *g = self ? (dt_iop_drawlayer_gui_data_t *)dt_iop_gui_data(self) : NULL;
   if(IS_NULL_PTR(g)) return;
   dt_drawlayer_worker_stop(self, g->stroke.worker);
 }
 
 void gui_cleanup(dt_iop_module_t *self)
 {
-  dt_iop_drawlayer_gui_data_t *g = (dt_iop_drawlayer_gui_data_t *)self->gui_data;
+  dt_iop_drawlayer_gui_data_t *g = (dt_iop_drawlayer_gui_data_t *)dt_iop_gui_data(self);
   if(IS_NULL_PTR(g)) return;
 
   dt_control_set_cursor_visible(TRUE);
@@ -3567,7 +3566,7 @@ static void _draw_brush_hud(cairo_t *cr, const drawlayer_hud_brush_state_t *stat
 void gui_post_expose(dt_iop_module_t *self, cairo_t *cr, int32_t width, int32_t height, int32_t pointerx,
                      int32_t pointery)
 {
-  dt_iop_drawlayer_gui_data_t *g = (dt_iop_drawlayer_gui_data_t *)self->gui_data;
+  dt_iop_drawlayer_gui_data_t *g = (dt_iop_drawlayer_gui_data_t *)dt_iop_gui_data(self);
   if(IS_NULL_PTR(g) || IS_NULL_PTR(self->dev)) return;
 
   cairo_save(cr);
@@ -3652,7 +3651,7 @@ void gui_post_expose(dt_iop_module_t *self, cairo_t *cr, int32_t width, int32_t 
 /** @brief Mouse leave handler. */
 int mouse_leave(dt_iop_module_t *self)
 {
-  dt_iop_drawlayer_gui_data_t *g = (dt_iop_drawlayer_gui_data_t *)self->gui_data;
+  dt_iop_drawlayer_gui_data_t *g = (dt_iop_drawlayer_gui_data_t *)dt_iop_gui_data(self);
   if(IS_NULL_PTR(g)) return 0;
   drawlayer_runtime_host_context_t runtime_host = {
     .runtime = {
@@ -3679,7 +3678,7 @@ int mouse_leave(dt_iop_module_t *self)
 /** @brief Mouse motion handler. */
 int mouse_moved(dt_iop_module_t *self, double x, double y, double pressure, int which)
 {
-  dt_iop_drawlayer_gui_data_t *g = (dt_iop_drawlayer_gui_data_t *)self->gui_data;
+  dt_iop_drawlayer_gui_data_t *g = (dt_iop_drawlayer_gui_data_t *)dt_iop_gui_data(self);
   if(IS_NULL_PTR(g) || IS_NULL_PTR(self->dev)) return 0;
 
   if(self->request_color_pick != DT_REQUEST_COLORPICK_OFF)
@@ -3810,7 +3809,7 @@ int mouse_moved(dt_iop_module_t *self, double x, double y, double pressure, int 
 /** @brief Button press handler (starts stroke capture on left button). */
 int button_pressed(dt_iop_module_t *self, double x, double y, double pressure, int which, int type, uint32_t state)
 {
-  dt_iop_drawlayer_gui_data_t *g = (dt_iop_drawlayer_gui_data_t *)self->gui_data;
+  dt_iop_drawlayer_gui_data_t *g = (dt_iop_drawlayer_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_drawlayer_params_t *params = (dt_iop_drawlayer_params_t *)self->params;
   if(IS_NULL_PTR(g) || IS_NULL_PTR(self->dev) || which != 1) return 0;
   if(!_layer_name_non_empty(params ? params->layer_name : NULL)) return 0;
@@ -3874,7 +3873,7 @@ int button_pressed(dt_iop_module_t *self, double x, double y, double pressure, i
 /** @brief Button release handler (ends current stroke). */
 int button_released(dt_iop_module_t *self, double x, double y, int which, uint32_t state)
 {
-  dt_iop_drawlayer_gui_data_t *g = (dt_iop_drawlayer_gui_data_t *)self->gui_data;
+  dt_iop_drawlayer_gui_data_t *g = (dt_iop_drawlayer_gui_data_t *)dt_iop_gui_data(self);
   if(IS_NULL_PTR(g) || IS_NULL_PTR(self->dev) || which != 1) return 0;
 
   if(g->manager.painting_active)
@@ -3941,9 +3940,9 @@ int scrolled(dt_iop_module_t *self, double x, double y, int up, uint32_t state)
   const float new_size = CLAMP(_conf_size() * factor, 1.0f, 2048.0f);
   dt_conf_set_float(DRAWLAYER_CONF_SIZE, new_size);
 
-  if(self->gui_data)
+  if(dt_iop_gui_data(self))
   {
-    dt_iop_drawlayer_gui_data_t *g = (dt_iop_drawlayer_gui_data_t *)self->gui_data;
+    dt_iop_drawlayer_gui_data_t *g = (dt_iop_drawlayer_gui_data_t *)dt_iop_gui_data(self);
     dt_bauhaus_slider_set(g->controls.size, new_size);
     drawlayer_runtime_host_context_t runtime_host = {
       .runtime = {
@@ -3976,7 +3975,7 @@ int process_cl(struct dt_iop_module_t *self, const dt_dev_pixelpipe_t *pipe, con
   const dt_iop_roi_t *const roi_out = &piece->roi_out;
   const gint64 process_t0 = g_get_monotonic_time();
   const dt_iop_drawlayer_global_data_t *global = (const dt_iop_drawlayer_global_data_t *)self->global_data;
-  dt_iop_drawlayer_gui_data_t *gui = (dt_iop_drawlayer_gui_data_t *)self->gui_data;
+  dt_iop_drawlayer_gui_data_t *gui = (dt_iop_drawlayer_gui_data_t *)dt_iop_gui_data(self);
   const gboolean have_gui = (!IS_NULL_PTR(gui));
   {
     const gboolean display_pipe = have_gui && (pipe == self->dev->pipe || pipe == self->dev->preview_pipe);
@@ -4126,7 +4125,7 @@ int process(dt_iop_module_t *self, const dt_dev_pixelpipe_t *pipe, const dt_dev_
 {
   const dt_iop_roi_t *const roi_in = &piece->roi_in;
   const dt_iop_roi_t *const roi_out = &piece->roi_out;
-  dt_iop_drawlayer_gui_data_t *gui = (dt_iop_drawlayer_gui_data_t *)self->gui_data;
+  dt_iop_drawlayer_gui_data_t *gui = (dt_iop_drawlayer_gui_data_t *)dt_iop_gui_data(self);
   const gboolean have_gui = (!IS_NULL_PTR(gui));
   {
     const gboolean display_pipe = have_gui && (pipe == self->dev->pipe || pipe == self->dev->preview_pipe);

--- a/src/iop/drawlayer/conf.c
+++ b/src/iop/drawlayer/conf.c
@@ -284,7 +284,7 @@ static void _store_color_history(const dt_iop_drawlayer_gui_data_t *g)
 /** @brief Push current display color to history and trigger swatch redraw. */
 static void _remember_display_color(dt_iop_module_t *self, const float display_rgb[3])
 {
-  dt_iop_drawlayer_gui_data_t *g = self ? (dt_iop_drawlayer_gui_data_t *)self->gui_data : NULL;
+  dt_iop_drawlayer_gui_data_t *g = self ? (dt_iop_drawlayer_gui_data_t *)dt_iop_gui_data(self) : NULL;
   if(IS_NULL_PTR(g) || !g->ui.widgets || !display_rgb) return;
 
   if(!dt_drawlayer_widgets_push_color_history(g->ui.widgets, display_rgb)) return;
@@ -295,7 +295,7 @@ static void _remember_display_color(dt_iop_module_t *self, const float display_r
 /** @brief Apply display-space brush color to conf, widgets and redraw. */
 static void _apply_display_brush_color(dt_iop_module_t *self, const float display_rgb[3], const gboolean remember)
 {
-  dt_iop_drawlayer_gui_data_t *g = self ? (dt_iop_drawlayer_gui_data_t *)self->gui_data : NULL;
+  dt_iop_drawlayer_gui_data_t *g = self ? (dt_iop_drawlayer_gui_data_t *)dt_iop_gui_data(self) : NULL;
   if(IS_NULL_PTR(self) || IS_NULL_PTR(g) || !g->ui.widgets || !display_rgb) return;
 
   dt_conf_set_float(DRAWLAYER_CONF_COLOR_R, _clamp01(display_rgb[0]));
@@ -316,7 +316,7 @@ static void _apply_display_brush_color(dt_iop_module_t *self, const float displa
 /** @brief Refresh picker widgets from persisted config color. */
 static void _sync_color_picker_from_conf(dt_iop_module_t *self)
 {
-  dt_iop_drawlayer_gui_data_t *g = self ? (dt_iop_drawlayer_gui_data_t *)self->gui_data : NULL;
+  dt_iop_drawlayer_gui_data_t *g = self ? (dt_iop_drawlayer_gui_data_t *)dt_iop_gui_data(self) : NULL;
   if(IS_NULL_PTR(g) || !g->ui.widgets) return;
 
   float display_rgb[3] = { 0.0f };
@@ -330,7 +330,7 @@ static void _sync_color_picker_from_conf(dt_iop_module_t *self)
 /** @brief Sync active GUI widget values back into persistent config keys. */
 static void _sync_params_from_gui(dt_iop_module_t *self, const gboolean record_history)
 {
-  dt_iop_drawlayer_gui_data_t *g = (dt_iop_drawlayer_gui_data_t *)self->gui_data;
+  dt_iop_drawlayer_gui_data_t *g = (dt_iop_drawlayer_gui_data_t *)dt_iop_gui_data(self);
   (void)record_history;
   if(IS_NULL_PTR(g) || (dt_gui_get_global() && dt_gui_widgets_suppressed())) return;
 

--- a/src/iop/drawlayer/layers.c
+++ b/src/iop/drawlayer/layers.c
@@ -42,7 +42,7 @@ static void _layerio_log_errors(GString *errors)
 
 static void _populate_layer_list(dt_iop_module_t *self)
 {
-  dt_iop_drawlayer_gui_data_t *g = (dt_iop_drawlayer_gui_data_t *)self->gui_data;
+  dt_iop_drawlayer_gui_data_t *g = (dt_iop_drawlayer_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_drawlayer_params_t *params = (dt_iop_drawlayer_params_t *)self->params;
   if(IS_NULL_PTR(g)) return;
   // Scope guard: the freeze spans the rest of the function, which has an early return; the
@@ -129,7 +129,7 @@ gboolean dt_drawlayer_ensure_layer_cache(dt_iop_module_t *self)
    * The low-level TIFF read/write primitives live in drawlayer/io.c, while this
    * function stays here because it orchestrates cache lifetime, widget state,
    * prompting, and history/UI side effects around those I/O operations. */
-  dt_iop_drawlayer_gui_data_t *g = (dt_iop_drawlayer_gui_data_t *)self->gui_data;
+  dt_iop_drawlayer_gui_data_t *g = (dt_iop_drawlayer_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_drawlayer_params_t *params = (dt_iop_drawlayer_params_t *)self->params;
   if(IS_NULL_PTR(g) || IS_NULL_PTR(self->dev)) return FALSE;
 
@@ -357,7 +357,7 @@ gboolean dt_drawlayer_ensure_layer_cache(dt_iop_module_t *self)
 
 gboolean dt_drawlayer_flush_layer_cache(dt_iop_module_t *self)
 {
-  dt_iop_drawlayer_gui_data_t *g = (dt_iop_drawlayer_gui_data_t *)self->gui_data;
+  dt_iop_drawlayer_gui_data_t *g = (dt_iop_drawlayer_gui_data_t *)dt_iop_gui_data(self);
   const dt_iop_drawlayer_params_t *params = (const dt_iop_drawlayer_params_t *)self->params;
   if(IS_NULL_PTR(g) || IS_NULL_PTR(self->dev) || !g->process.cache_valid || !g->process.cache_dirty || IS_NULL_PTR(g->process.base_patch.pixels)) return TRUE;
   if(!_layer_name_non_empty(params ? params->layer_name : NULL)) return TRUE;
@@ -402,7 +402,7 @@ gboolean dt_drawlayer_flush_layer_cache(dt_iop_module_t *self)
 
 static gboolean _ensure_widget_cache(dt_iop_module_t *self)
 {
-  dt_iop_drawlayer_gui_data_t *g = (dt_iop_drawlayer_gui_data_t *)self->gui_data;
+  dt_iop_drawlayer_gui_data_t *g = (dt_iop_drawlayer_gui_data_t *)dt_iop_gui_data(self);
   if(IS_NULL_PTR(g) || IS_NULL_PTR(self->dev)) return FALSE;
 
   drawlayer_view_patch_info_t view = { 0 };
@@ -467,7 +467,7 @@ void dt_drawlayer_set_pipeline_realtime_mode(dt_iop_module_t *self, const gboole
 
 gboolean dt_drawlayer_sync_widget_cache(dt_iop_module_t *self)
 {
-  dt_iop_drawlayer_gui_data_t *g = (dt_iop_drawlayer_gui_data_t *)self->gui_data;
+  dt_iop_drawlayer_gui_data_t *g = (dt_iop_drawlayer_gui_data_t *)dt_iop_gui_data(self);
   if(IS_NULL_PTR(g) || IS_NULL_PTR(self->dev)) return FALSE;
 
   _pause_worker(self, g->stroke.worker);

--- a/src/iop/drawlayer/worker.c
+++ b/src/iop/drawlayer/worker.c
@@ -298,7 +298,7 @@ static void _publish_backend_progress(drawlayer_paint_backend_ctx_t *ctx, gboole
   if(IS_NULL_PTR(ctx) || IS_NULL_PTR(ctx->self) || !flush_pending) return;
 
   dt_iop_module_t *self = ctx->self;
-  dt_iop_drawlayer_gui_data_t *g = (dt_iop_drawlayer_gui_data_t *)ctx->self->gui_data;
+  dt_iop_drawlayer_gui_data_t *g = (dt_iop_drawlayer_gui_data_t *)dt_iop_gui_data(ctx->self);
   dt_iop_drawlayer_params_t *params = (dt_iop_drawlayer_params_t *)self->params;
   dt_develop_t *dev = self->dev;
   if(IS_NULL_PTR(ctx->worker) || IS_NULL_PTR(g) || IS_NULL_PTR(params) || IS_NULL_PTR(dev) || !ctx->worker->live_publish_damage.valid) return;
@@ -325,7 +325,7 @@ static void _publish_backend_progress(drawlayer_paint_backend_ctx_t *ctx, gboole
 static void _process_backend_input(dt_iop_module_t *self, const dt_drawlayer_paint_raw_input_t *input,
                                    dt_drawlayer_paint_stroke_t *stroke)
 {
-  dt_iop_drawlayer_gui_data_t *g = self ? (dt_iop_drawlayer_gui_data_t *)self->gui_data : NULL;
+  dt_iop_drawlayer_gui_data_t *g = self ? (dt_iop_drawlayer_gui_data_t *)dt_iop_gui_data(self) : NULL;
   if(IS_NULL_PTR(g) || IS_NULL_PTR(input) || IS_NULL_PTR(stroke)) return;
 
   drawlayer_paint_backend_ctx_t ctx = _make_backend_ctx(self, g->stroke.worker, stroke);
@@ -354,7 +354,7 @@ static void _process_backend_input(dt_iop_module_t *self, const dt_drawlayer_pai
 
 void dt_drawlayer_worker_publish_backend_stroke_damage(dt_iop_module_t *self)
 {
-  dt_iop_drawlayer_gui_data_t *g = self ? (dt_iop_drawlayer_gui_data_t *)self->gui_data : NULL;
+  dt_iop_drawlayer_gui_data_t *g = self ? (dt_iop_drawlayer_gui_data_t *)dt_iop_gui_data(self) : NULL;
   if(IS_NULL_PTR(g)) return;
 
   dt_drawlayer_damaged_rect_t backend_damage = { 0 };
@@ -885,7 +885,7 @@ static guint _rasterize_dab_batch_outer_loop(const GArray *dabs, const guint max
 
 static guint _rasterize_pending_dab_batch(drawlayer_paint_backend_ctx_t *ctx, gint64 budget_us)
 {
-  dt_iop_drawlayer_gui_data_t *g = (ctx && ctx->self) ? (dt_iop_drawlayer_gui_data_t *)ctx->self->gui_data : NULL;
+  dt_iop_drawlayer_gui_data_t *g = (ctx && ctx->self) ? (dt_iop_drawlayer_gui_data_t *)dt_iop_gui_data(ctx->self) : NULL;
   dt_drawlayer_paint_stroke_t *stroke = ctx ? ctx->stroke : NULL;
   dt_drawlayer_worker_t *worker = ctx ? ctx->worker : NULL;
   if(IS_NULL_PTR(g) || IS_NULL_PTR(stroke) || IS_NULL_PTR(worker) || !stroke->pending_dabs || stroke->pending_dabs->len == 0) return 0;
@@ -1125,7 +1125,7 @@ static gboolean _rt_workers_any_active(dt_drawlayer_worker_t *rt)
 /** @brief Backend-worker idle hook. */
 static void _backend_worker_on_idle(dt_iop_module_t *self, dt_drawlayer_worker_t *rt)
 {
-  dt_iop_drawlayer_gui_data_t *g = self ? (dt_iop_drawlayer_gui_data_t *)self->gui_data : NULL;
+  dt_iop_drawlayer_gui_data_t *g = self ? (dt_iop_drawlayer_gui_data_t *)dt_iop_gui_data(self) : NULL;
   drawlayer_paint_backend_ctx_t ctx = _make_backend_ctx(self, rt, rt ? rt->stroke : NULL);
   if(!IS_NULL_PTR(self) && g && !IS_NULL_PTR(rt) && rt->stroke && rt->stroke->pending_dabs && rt->stroke->pending_dabs->len > 0)
   {

--- a/src/iop/exposure.c
+++ b/src/iop/exposure.c
@@ -433,7 +433,7 @@ static void _compute_correction(dt_iop_module_t *self, dt_iop_params_t *p1,
 static void _process_common_setup(dt_iop_module_t *self, const dt_dev_pixelpipe_t *pipe,
                                   const dt_dev_pixelpipe_iop_t *piece)
 {
-  dt_iop_exposure_gui_data_t *g = (dt_iop_exposure_gui_data_t*)self->gui_data;
+  dt_iop_exposure_gui_data_t *g = (dt_iop_exposure_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_exposure_data_t *d = piece->data;
 
   d->black = d->params.black;
@@ -651,7 +651,7 @@ static void _autoexp_disable(dt_iop_module_t *self)
 
 void gui_update(struct dt_iop_module_t *self)
 {
-  dt_iop_exposure_gui_data_t *g = (dt_iop_exposure_gui_data_t *)self->gui_data;
+  dt_iop_exposure_gui_data_t *g = (dt_iop_exposure_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_exposure_params_t *p = (dt_iop_exposure_params_t *)self->params;
 
   if(!dt_image_needs_rawprepare(&self->dev->image_storage)
@@ -736,7 +736,7 @@ static void _exposure_set_white(struct dt_iop_module_t *self, const float white)
   p->exposure = exposure;
   if(p->black >= white) _exposure_set_black(self, white - 0.01);
 
-  dt_iop_exposure_gui_data_t *g = (dt_iop_exposure_gui_data_t *)self->gui_data;
+  dt_iop_exposure_gui_data_t *g = (dt_iop_exposure_gui_data_t *)dt_iop_gui_data(self);
 
   dt_gui_freeze_begin();
   dt_bauhaus_slider_set(g->exposure, p->exposure);
@@ -756,7 +756,7 @@ static void _exposure_set_black(struct dt_iop_module_t *self, const float black)
     _exposure_set_white(self, p->black + 0.01);
   }
 
-  dt_iop_exposure_gui_data_t *g = (dt_iop_exposure_gui_data_t *)self->gui_data;
+  dt_iop_exposure_gui_data_t *g = (dt_iop_exposure_gui_data_t *)dt_iop_gui_data(self);
   dt_gui_freeze_begin();
   dt_bauhaus_slider_set(g->black, p->black);
   dt_gui_freeze_end();
@@ -765,7 +765,7 @@ static void _exposure_set_black(struct dt_iop_module_t *self, const float black)
 
 static void _auto_set_exposure(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe)
 {
-  dt_iop_exposure_gui_data_t *g = (dt_iop_exposure_gui_data_t *)self->gui_data;
+  dt_iop_exposure_gui_data_t *g = (dt_iop_exposure_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_exposure_params_t *p = (dt_iop_exposure_params_t *)self->params;
 
   // capture gui color picked event.
@@ -886,7 +886,7 @@ void color_picker_apply(dt_iop_module_t *self, GtkWidget *picker, dt_dev_pixelpi
 
 void gui_changed(dt_iop_module_t *self, GtkWidget *w, void *previous)
 {
-  dt_iop_exposure_gui_data_t *g = (dt_iop_exposure_gui_data_t *)self->gui_data;
+  dt_iop_exposure_gui_data_t *g = (dt_iop_exposure_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_exposure_params_t *p = (dt_iop_exposure_params_t *)self->params;
 
   if(w == g->mode)
@@ -939,7 +939,7 @@ static gboolean _draw(GtkWidget *widget, cairo_t *cr, dt_iop_module_t *self)
 {
   if(dt_gui_widgets_suppressed()) return FALSE;
 
-  dt_iop_exposure_gui_data_t *g = (dt_iop_exposure_gui_data_t *)self->gui_data;
+  dt_iop_exposure_gui_data_t *g = (dt_iop_exposure_gui_data_t *)dt_iop_gui_data(self);
 
   dt_iop_gui_enter_critical_section(self);
   if(!isnan(g->deflicker_computed_exposure))
@@ -960,7 +960,7 @@ static gboolean _draw(GtkWidget *widget, cairo_t *cr, dt_iop_module_t *self)
 static gboolean _target_color_draw(GtkWidget *widget, cairo_t *crf, gpointer user_data)
 {
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
-  dt_iop_exposure_gui_data_t *g = (dt_iop_exposure_gui_data_t *)self->gui_data;
+  dt_iop_exposure_gui_data_t *g = (dt_iop_exposure_gui_data_t *)dt_iop_gui_data(self);
 
   // Init
   GtkAllocation allocation;
@@ -1003,7 +1003,7 @@ static gboolean _target_color_draw(GtkWidget *widget, cairo_t *crf, gpointer use
 static gboolean _origin_color_draw(GtkWidget *widget, cairo_t *crf, gpointer user_data)
 {
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
-  dt_iop_exposure_gui_data_t *g = (dt_iop_exposure_gui_data_t *)self->gui_data;
+  dt_iop_exposure_gui_data_t *g = (dt_iop_exposure_gui_data_t *)dt_iop_gui_data(self);
 
   // Init
   GtkAllocation allocation;
@@ -1034,7 +1034,7 @@ static gboolean _origin_color_draw(GtkWidget *widget, cairo_t *crf, gpointer use
 static void _paint_hue(dt_iop_module_t *self)
 {
   // update the fill background color of LCh sliders
-  dt_iop_exposure_gui_data_t *g = (dt_iop_exposure_gui_data_t *)self->gui_data;
+  dt_iop_exposure_gui_data_t *g = (dt_iop_exposure_gui_data_t *)dt_iop_gui_data(self);
 
   const float lightness_min = dt_bauhaus_slider_get_hard_min(g->lightness_spot);
   const float lightness_max = dt_bauhaus_slider_get_hard_max(g->lightness_spot);
@@ -1066,7 +1066,7 @@ static void _spot_settings_changed_callback(GtkWidget *slider, dt_iop_module_t *
 {
   if(dt_gui_widgets_suppressed()) return;
 
-  dt_iop_exposure_gui_data_t *g = (dt_iop_exposure_gui_data_t *)self->gui_data;
+  dt_iop_exposure_gui_data_t *g = (dt_iop_exposure_gui_data_t *)dt_iop_gui_data(self);
 
   dt_aligned_pixel_t Lch_target = { 0.f };
 
@@ -1104,15 +1104,15 @@ void gui_init(struct dt_iop_module_t *self)
   // So we need to store the main widget first, stupidly update the ref to self->widget,
   // as we add boxes and restore it last to the main widget.
   // The guy who thought of that should really burn his computer and do everyone a favour.
-  GtkWidget *main_widget = self->widget = GTK_WIDGET(gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_GUI_BOX_SPACING));
+  GtkWidget *main_widget = self->gui->widget = GTK_WIDGET(gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_GUI_BOX_SPACING));
 
   g->mode = dt_bauhaus_combobox_from_params(self, N_("mode"));
 
   g->mode_stack = GTK_STACK(gtk_stack_new());
   gtk_stack_set_homogeneous(GTK_STACK(g->mode_stack),FALSE);
-  gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(g->mode_stack), TRUE, TRUE, 0);
+  gtk_box_pack_start(GTK_BOX(self->gui->widget), GTK_WIDGET(g->mode_stack), TRUE, TRUE, 0);
 
-  GtkWidget *vbox_manual = self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_GUI_BOX_SPACING);
+  GtkWidget *vbox_manual = self->gui->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_GUI_BOX_SPACING);
   gtk_stack_add_named(GTK_STACK(g->mode_stack), vbox_manual, "manual");
 
   g->compensate_exposure_bias = dt_bauhaus_toggle_from_params(self, "compensate_exposure_bias");
@@ -1134,7 +1134,7 @@ void gui_init(struct dt_iop_module_t *self)
   dt_bauhaus_slider_set_digits(g->black, 4);
   dt_bauhaus_slider_set_soft_range(g->black, -0.1, 0.1);
 
-  GtkWidget *vbox_deflicker = self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_GUI_BOX_SPACING);
+  GtkWidget *vbox_deflicker = self->gui->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_GUI_BOX_SPACING);
   gtk_stack_add_named(GTK_STACK(g->mode_stack), vbox_deflicker, "deflicker");
 
   g->deflicker_percentile = dt_bauhaus_slider_from_params(self, "deflicker_percentile");
@@ -1158,13 +1158,13 @@ void gui_init(struct dt_iop_module_t *self)
   g->deflicker_computed_exposure = NAN;
   dt_iop_gui_leave_critical_section(self);
 
-  self->widget = main_widget;
+  self->gui->widget = main_widget;
 
   dt_gui_new_collapsible_section
     (&g->cs,
      "plugins/darkroom/exposure/mapping",
      _("spot exposure mapping"),
-     GTK_BOX(self->widget), GTK_PACK_END);
+     GTK_BOX(self->gui->widget), GTK_PACK_END);
 
   DT_BAUHAUS_COMBOBOX_NEW_FULL(dt_bauhaus_get_global(), g->spot_mode, DT_GUI_MODULE(self), N_("spot mode"),
                                 _("\"correction\" automatically adjust exposure\n"
@@ -1222,12 +1222,12 @@ void gui_init(struct dt_iop_module_t *self)
 
   gtk_box_pack_start(GTK_BOX(g->cs.container), GTK_WIDGET(hhbox), FALSE, FALSE, 0);
 
-  g_signal_connect(G_OBJECT(self->widget), "draw", G_CALLBACK(_draw), self);
+  g_signal_connect(G_OBJECT(self->gui->widget), "draw", G_CALLBACK(_draw), self);
 }
 
 void gui_cleanup(struct dt_iop_module_t *self)
 {
-  dt_iop_exposure_gui_data_t *g = (dt_iop_exposure_gui_data_t *)self->gui_data;
+  dt_iop_exposure_gui_data_t *g = (dt_iop_exposure_gui_data_t *)dt_iop_gui_data(self);
 
   dt_free(g->deflicker_histogram);
 

--- a/src/iop/filmic.c
+++ b/src/iop/filmic.c
@@ -38,6 +38,7 @@
 #include "config.h"
 #include "common/colorspaces_inline_conversions.h"
 #endif
+#include "develop/imageop_gui.h"
 #include "widgets/bauhaus.h"
 #include "system/macros.h"
 #include "system/openmp.h"
@@ -599,7 +600,7 @@ static void apply_auto_grey(dt_iop_module_t *self)
 {
   if(dt_gui_widgets_suppressed()) return;
   dt_iop_filmic_params_t *p = (dt_iop_filmic_params_t *)self->params;
-  dt_iop_filmic_gui_data_t *g = (dt_iop_filmic_gui_data_t *)self->gui_data;
+  dt_iop_filmic_gui_data_t *g = (dt_iop_filmic_gui_data_t *)dt_iop_gui_data(self);
 
   dt_aligned_pixel_t XYZ = { 0.0f };
   dt_Lab_to_XYZ(self->picked_color, XYZ);
@@ -618,14 +619,14 @@ static void apply_auto_grey(dt_iop_module_t *self)
   dt_gui_freeze_end();
 
   dt_dev_add_history_item(self->dev, self, TRUE, TRUE);
-  gtk_widget_queue_draw(self->widget);
+  gtk_widget_queue_draw(self->gui->widget);
 }
 
 static void apply_auto_black(dt_iop_module_t *self)
 {
   if(dt_gui_widgets_suppressed()) return;
   dt_iop_filmic_params_t *p = (dt_iop_filmic_params_t *)self->params;
-  dt_iop_filmic_gui_data_t *g = (dt_iop_filmic_gui_data_t *)self->gui_data;
+  dt_iop_filmic_gui_data_t *g = (dt_iop_filmic_gui_data_t *)dt_iop_gui_data(self);
 
   const float noise = powf(2.0f, -16.0f);
   dt_aligned_pixel_t XYZ = { 0.0f };
@@ -645,7 +646,7 @@ static void apply_auto_black(dt_iop_module_t *self)
   sanitize_latitude(p, g);
 
   dt_dev_add_history_item(self->dev, self, TRUE, TRUE);
-  gtk_widget_queue_draw(self->widget);
+  gtk_widget_queue_draw(self->gui->widget);
 }
 
 
@@ -653,7 +654,7 @@ static void apply_auto_white_point_source(dt_iop_module_t *self)
 {
   if(dt_gui_widgets_suppressed()) return;
   dt_iop_filmic_params_t *p = (dt_iop_filmic_params_t *)self->params;
-  dt_iop_filmic_gui_data_t *g = (dt_iop_filmic_gui_data_t *)self->gui_data;
+  dt_iop_filmic_gui_data_t *g = (dt_iop_filmic_gui_data_t *)dt_iop_gui_data(self);
 
   const float noise = powf(2.0f, -16.0f);
   dt_aligned_pixel_t XYZ = { 0.0f };
@@ -673,7 +674,7 @@ static void apply_auto_white_point_source(dt_iop_module_t *self)
   sanitize_latitude(p, g);
 
   dt_dev_add_history_item(self->dev, self, TRUE, TRUE);
-  gtk_widget_queue_draw(self->widget);
+  gtk_widget_queue_draw(self->gui->widget);
 }
 
 static void security_threshold_callback(GtkWidget *slider, gpointer user_data)
@@ -681,7 +682,7 @@ static void security_threshold_callback(GtkWidget *slider, gpointer user_data)
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
   if(dt_gui_widgets_suppressed()) return;
   dt_iop_filmic_params_t *p = (dt_iop_filmic_params_t *)self->params;
-  dt_iop_filmic_gui_data_t *g = (dt_iop_filmic_gui_data_t *)self->gui_data;
+  dt_iop_filmic_gui_data_t *g = (dt_iop_filmic_gui_data_t *)dt_iop_gui_data(self);
 
   float previous = p->security_factor;
   p->security_factor = dt_bauhaus_slider_get(slider);
@@ -706,12 +707,12 @@ static void security_threshold_callback(GtkWidget *slider, gpointer user_data)
   dt_iop_color_picker_reset(self, TRUE);
 
   dt_dev_add_history_item(self->dev, self, TRUE, TRUE);
-  gtk_widget_queue_draw(self->widget);
+  gtk_widget_queue_draw(self->gui->widget);
 }
 
 static void apply_autotune(dt_iop_module_t *self)
 {
-  dt_iop_filmic_gui_data_t *g = (dt_iop_filmic_gui_data_t *)self->gui_data;
+  dt_iop_filmic_gui_data_t *g = (dt_iop_filmic_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_filmic_params_t *p = (dt_iop_filmic_params_t *)self->params;
 
   const float noise = powf(2.0f, -16.0f);
@@ -746,12 +747,12 @@ static void apply_autotune(dt_iop_module_t *self)
   sanitize_latitude(p, g);
 
   dt_dev_add_history_item(self->dev, self, TRUE, TRUE);
-  gtk_widget_queue_draw(self->widget);
+  gtk_widget_queue_draw(self->gui->widget);
 }
 
 void color_picker_apply(dt_iop_module_t *self, GtkWidget *picker, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
 {
-  dt_iop_filmic_gui_data_t *g = (dt_iop_filmic_gui_data_t *)self->gui_data;
+  dt_iop_filmic_gui_data_t *g = (dt_iop_filmic_gui_data_t *)dt_iop_gui_data(self);
   if     (picker == g->grey_point_source)
     apply_auto_grey(self);
   else if(picker == g->black_point_source)
@@ -768,7 +769,7 @@ static void grey_point_source_callback(GtkWidget *slider, gpointer user_data)
 {
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
   if(dt_gui_widgets_suppressed()) return;
-  dt_iop_filmic_gui_data_t *g = (dt_iop_filmic_gui_data_t *)self->gui_data;
+  dt_iop_filmic_gui_data_t *g = (dt_iop_filmic_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_filmic_params_t *p = (dt_iop_filmic_params_t *)self->params;
   float prev_grey = p->grey_point_source;
   p->grey_point_source = dt_bauhaus_slider_get(slider);
@@ -785,7 +786,7 @@ static void grey_point_source_callback(GtkWidget *slider, gpointer user_data)
   dt_iop_color_picker_reset(self, TRUE);
 
   dt_dev_add_history_item(self->dev, self, TRUE, TRUE);
-  gtk_widget_queue_draw(self->widget);
+  gtk_widget_queue_draw(self->gui->widget);
 }
 
 static void white_point_source_callback(GtkWidget *slider, gpointer user_data)
@@ -793,7 +794,7 @@ static void white_point_source_callback(GtkWidget *slider, gpointer user_data)
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
   if(dt_gui_widgets_suppressed()) return;
   dt_iop_filmic_params_t *p = (dt_iop_filmic_params_t *)self->params;
-  dt_iop_filmic_gui_data_t *g = (dt_iop_filmic_gui_data_t *)self->gui_data;
+  dt_iop_filmic_gui_data_t *g = (dt_iop_filmic_gui_data_t *)dt_iop_gui_data(self);
   p->white_point_source = dt_bauhaus_slider_get(slider);
 
   sanitize_latitude(p, g);
@@ -801,7 +802,7 @@ static void white_point_source_callback(GtkWidget *slider, gpointer user_data)
   dt_iop_color_picker_reset(self, TRUE);
 
   dt_dev_add_history_item(self->dev, self, TRUE, TRUE);
-  gtk_widget_queue_draw(self->widget);
+  gtk_widget_queue_draw(self->gui->widget);
 }
 
 static void black_point_source_callback(GtkWidget *slider, gpointer user_data)
@@ -809,7 +810,7 @@ static void black_point_source_callback(GtkWidget *slider, gpointer user_data)
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
   if(dt_gui_widgets_suppressed()) return;
   dt_iop_filmic_params_t *p = (dt_iop_filmic_params_t *)self->params;
-  dt_iop_filmic_gui_data_t *g = (dt_iop_filmic_gui_data_t *)self->gui_data;
+  dt_iop_filmic_gui_data_t *g = (dt_iop_filmic_gui_data_t *)dt_iop_gui_data(self);
   p->black_point_source = dt_bauhaus_slider_get(slider);
 
   sanitize_latitude(p, g);
@@ -817,7 +818,7 @@ static void black_point_source_callback(GtkWidget *slider, gpointer user_data)
   dt_iop_color_picker_reset(self, TRUE);
 
   dt_dev_add_history_item(self->dev, self, TRUE, TRUE);
-  gtk_widget_queue_draw(self->widget);
+  gtk_widget_queue_draw(self->gui->widget);
 }
 
 static void grey_point_target_callback(GtkWidget *slider, gpointer user_data)
@@ -828,7 +829,7 @@ static void grey_point_target_callback(GtkWidget *slider, gpointer user_data)
   p->grey_point_target = dt_bauhaus_slider_get(slider);
   dt_iop_color_picker_reset(self, TRUE);
   dt_dev_add_history_item(self->dev, self, TRUE, TRUE);
-  gtk_widget_queue_draw(self->widget);
+  gtk_widget_queue_draw(self->gui->widget);
 }
 
 static void latitude_stops_callback(GtkWidget *slider, gpointer user_data)
@@ -836,7 +837,7 @@ static void latitude_stops_callback(GtkWidget *slider, gpointer user_data)
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
   if(dt_gui_widgets_suppressed()) return;
   dt_iop_filmic_params_t *p = (dt_iop_filmic_params_t *)self->params;
-  dt_iop_filmic_gui_data_t *g = (dt_iop_filmic_gui_data_t *)self->gui_data;
+  dt_iop_filmic_gui_data_t *g = (dt_iop_filmic_gui_data_t *)dt_iop_gui_data(self);
 
   p->latitude_stops = dt_bauhaus_slider_get(slider);
 
@@ -844,7 +845,7 @@ static void latitude_stops_callback(GtkWidget *slider, gpointer user_data)
 
   dt_iop_color_picker_reset(self, TRUE);
   dt_dev_add_history_item(self->dev, self, TRUE, TRUE);
-  gtk_widget_queue_draw(self->widget);
+  gtk_widget_queue_draw(self->gui->widget);
 }
 
 static void contrast_callback(GtkWidget *slider, gpointer user_data)
@@ -855,7 +856,7 @@ static void contrast_callback(GtkWidget *slider, gpointer user_data)
   p->contrast = dt_bauhaus_slider_get(slider);
   dt_iop_color_picker_reset(self, TRUE);
   dt_dev_add_history_item(self->dev, self, TRUE, TRUE);
-  gtk_widget_queue_draw(self->widget);
+  gtk_widget_queue_draw(self->gui->widget);
 }
 
 static void saturation_callback(GtkWidget *slider, gpointer user_data)
@@ -886,7 +887,7 @@ static void white_point_target_callback(GtkWidget *slider, gpointer user_data)
   p->white_point_target = dt_bauhaus_slider_get(slider);
   dt_iop_color_picker_reset(self, TRUE);
   dt_dev_add_history_item(self->dev, self, TRUE, TRUE);
-  gtk_widget_queue_draw(self->widget);
+  gtk_widget_queue_draw(self->gui->widget);
 }
 
 static void black_point_target_callback(GtkWidget *slider, gpointer user_data)
@@ -897,7 +898,7 @@ static void black_point_target_callback(GtkWidget *slider, gpointer user_data)
   p->black_point_target = dt_bauhaus_slider_get(slider);
   dt_iop_color_picker_reset(self, TRUE);
   dt_dev_add_history_item(self->dev, self, TRUE, TRUE);
-  gtk_widget_queue_draw(self->widget);
+  gtk_widget_queue_draw(self->gui->widget);
 }
 
 static void output_power_callback(GtkWidget *slider, gpointer user_data)
@@ -908,7 +909,7 @@ static void output_power_callback(GtkWidget *slider, gpointer user_data)
   p->output_power = dt_bauhaus_slider_get(slider);
   dt_iop_color_picker_reset(self, TRUE);
   dt_dev_add_history_item(self->dev, self, TRUE, TRUE);
-  gtk_widget_queue_draw(self->widget);
+  gtk_widget_queue_draw(self->gui->widget);
 }
 
 static void balance_callback(GtkWidget *slider, gpointer user_data)
@@ -919,7 +920,7 @@ static void balance_callback(GtkWidget *slider, gpointer user_data)
   p->balance = dt_bauhaus_slider_get(slider);
   dt_iop_color_picker_reset(self, TRUE);
   dt_dev_add_history_item(self->dev, self, TRUE, TRUE);
-  gtk_widget_queue_draw(self->widget);
+  gtk_widget_queue_draw(self->gui->widget);
 }
 
 static void interpolator_callback(GtkWidget *widget, dt_iop_module_t *self)
@@ -959,7 +960,7 @@ static void interpolator_callback(GtkWidget *widget, dt_iop_module_t *self)
   }
 
   dt_dev_add_history_item(self->dev, self, TRUE, TRUE);
-  gtk_widget_queue_draw(self->widget);
+  gtk_widget_queue_draw(self->gui->widget);
 }
 
 static void preserve_color_callback(GtkWidget *widget, dt_iop_module_t *self)
@@ -1261,7 +1262,7 @@ void cleanup_pipe(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelp
 void gui_update(dt_iop_module_t *self)
 {
   dt_iop_module_t *module = (dt_iop_module_t *)self;
-  dt_iop_filmic_gui_data_t *g = (dt_iop_filmic_gui_data_t *)self->gui_data;
+  dt_iop_filmic_gui_data_t *g = (dt_iop_filmic_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_filmic_params_t *p = (dt_iop_filmic_params_t *)module->params;
 
   dt_iop_color_picker_reset(self, TRUE);
@@ -1286,7 +1287,7 @@ void gui_update(dt_iop_module_t *self)
   dtgtk_expander_set_expanded(DTGTK_EXPANDER(g->extra_expander),
                               gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(g->extra_toggle)));
 
-  gtk_widget_queue_draw(self->widget);
+  gtk_widget_queue_draw(self->gui->widget);
 
 }
 
@@ -1296,7 +1297,6 @@ void init(dt_iop_module_t *module)
   module->default_params = calloc(1, sizeof(dt_iop_filmic_params_t));
   module->default_enabled = 0;
   module->params_size = sizeof(dt_iop_filmic_params_t);
-  module->gui_data = NULL;
 
   *(dt_iop_filmic_params_t *)module->default_params
     = (dt_iop_filmic_params_t){
@@ -1343,7 +1343,7 @@ void cleanup_global(dt_iop_module_so_t *module)
 
 void gui_reset(dt_iop_module_t *self)
 {
-  dt_iop_filmic_gui_data_t *g = (dt_iop_filmic_gui_data_t *)self->gui_data;
+  dt_iop_filmic_gui_data_t *g = (dt_iop_filmic_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_color_picker_reset(self, TRUE);
   dtgtk_expander_set_expanded(DTGTK_EXPANDER(g->extra_expander), FALSE);
   dtgtk_togglebutton_set_paint(DTGTK_TOGGLEBUTTON(g->extra_toggle), dtgtk_cairo_paint_solid_arrow,
@@ -1354,7 +1354,7 @@ void gui_reset(dt_iop_module_t *self)
 static gboolean dt_iop_tonecurve_draw(GtkWidget *widget, cairo_t *crf, gpointer user_data)
 {
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
-  dt_iop_filmic_gui_data_t *c = (dt_iop_filmic_gui_data_t *)self->gui_data;
+  dt_iop_filmic_gui_data_t *c = (dt_iop_filmic_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_filmic_params_t *p = (dt_iop_filmic_params_t *)self->params;
   dt_iop_filmic_nodes_t *nodes_data = (dt_iop_filmic_nodes_t *)malloc(sizeof(dt_iop_filmic_nodes_t));
   compute_curve_lut(p, c->table, c->table_temp, 256, NULL, nodes_data);
@@ -1455,7 +1455,7 @@ static gboolean dt_iop_tonecurve_draw(GtkWidget *widget, cairo_t *crf, gpointer 
 static void _extra_options_button_changed(GtkDarktableToggleButton *widget, gpointer user_data)
 {
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
-  dt_iop_filmic_gui_data_t *g = (dt_iop_filmic_gui_data_t *)self->gui_data;
+  dt_iop_filmic_gui_data_t *g = (dt_iop_filmic_gui_data_t *)dt_iop_gui_data(self);
   const gboolean active = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(g->extra_toggle));
   dtgtk_expander_set_expanded(DTGTK_EXPANDER(g->extra_expander), active);
   dtgtk_togglebutton_set_paint(DTGTK_TOGGLEBUTTON(g->extra_toggle), dtgtk_cairo_paint_solid_arrow,
@@ -1467,25 +1467,25 @@ void gui_init(dt_iop_module_t *self)
   dt_iop_filmic_gui_data_t *g = IOP_GUI_ALLOC(filmic);
   dt_iop_filmic_params_t *p = (dt_iop_filmic_params_t *)self->default_params;
 
-  self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_GUI_BOX_SPACING);
+  self->gui->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_GUI_BOX_SPACING);
 
   // read-only graph; modest default height, user-resizable via its grip
   g->area = GTK_DRAWING_AREA(gtk_drawing_area_new());
   gtk_widget_set_hexpand(GTK_WIDGET(g->area), TRUE);
   gtk_widget_set_tooltip_text(GTK_WIDGET(g->area), _("read-only graph, use the parameters below to set the nodes"));
-  gtk_box_pack_start(GTK_BOX(self->widget),
+  gtk_box_pack_start(GTK_BOX(self->gui->widget),
                      dt_ui_resizable_drawing_area(GTK_WIDGET(g->area),
                                                   "plugins/darkroom/filmic/graphheight", 200, 100),
                      FALSE, FALSE, 0);
   g_signal_connect(G_OBJECT(g->area), "draw", G_CALLBACK(dt_iop_tonecurve_draw), self);
 
-  gtk_box_pack_start(GTK_BOX(self->widget), dt_ui_section_label_new(_("logarithmic shaper")), FALSE, FALSE, 0);
+  gtk_box_pack_start(GTK_BOX(self->gui->widget), dt_ui_section_label_new(_("logarithmic shaper")), FALSE, FALSE, 0);
 
   // grey_point_source slider
   g->grey_point_source = dt_bauhaus_slider_new_with_range(dt_bauhaus_get_global(), DT_GUI_MODULE(self), 0.0, 100., 0, p->grey_point_source, 2);
   dt_bauhaus_slider_set_soft_range(g->grey_point_source, 0.1, 36.0);
   dt_bauhaus_widget_set_label(g->grey_point_source, N_("middle gray luminance"));
-  gtk_box_pack_start(GTK_BOX(self->widget), g->grey_point_source, TRUE, TRUE, 0);
+  gtk_box_pack_start(GTK_BOX(self->gui->widget), g->grey_point_source, TRUE, TRUE, 0);
   dt_bauhaus_slider_set_format(g->grey_point_source, "%");
   gtk_widget_set_tooltip_text(g->grey_point_source, _("adjust to match the average luminance of the subject.\n"
                                                       "except in back-lighting situations, this should be around 18%."));
@@ -1496,7 +1496,7 @@ void gui_init(dt_iop_module_t *self)
   g->white_point_source = dt_bauhaus_slider_new_with_range(dt_bauhaus_get_global(), DT_GUI_MODULE(self), 0.0, 16.0, 0, p->white_point_source, 2);
   dt_bauhaus_slider_set_soft_range(g->white_point_source, 2.0, 8.0);
   dt_bauhaus_widget_set_label(g->white_point_source, N_("white relative exposure"));
-  gtk_box_pack_start(GTK_BOX(self->widget), g->white_point_source, TRUE, TRUE, 0);
+  gtk_box_pack_start(GTK_BOX(self->gui->widget), g->white_point_source, TRUE, TRUE, 0);
   dt_bauhaus_slider_set_format(g->white_point_source, _(" EV"));
   gtk_widget_set_tooltip_text(g->white_point_source, _("number of stops between middle gray and pure white.\n"
                                                        "this is a reading a lightmeter would give you on the scene.\n"
@@ -1508,7 +1508,7 @@ void gui_init(dt_iop_module_t *self)
   g->black_point_source = dt_bauhaus_slider_new_with_range(dt_bauhaus_get_global(), DT_GUI_MODULE(self), -16.0, -0.1, 0, p->black_point_source, 2);
   dt_bauhaus_slider_set_soft_range(g->black_point_source, -14.0, -3.0);
   dt_bauhaus_widget_set_label(g->black_point_source, N_("black relative exposure"));
-  gtk_box_pack_start(GTK_BOX(self->widget), g->black_point_source, TRUE, TRUE, 0);
+  gtk_box_pack_start(GTK_BOX(self->gui->widget), g->black_point_source, TRUE, TRUE, 0);
   dt_bauhaus_slider_set_format(g->black_point_source, _(" EV"));
   gtk_widget_set_tooltip_text(g->black_point_source, _("number of stops between middle gray and pure black.\n"
                                                        "this is a reading a lightmeter would give you on the scene.\n"
@@ -1519,7 +1519,7 @@ void gui_init(dt_iop_module_t *self)
   // Security factor
   g->security_factor = dt_bauhaus_slider_new_with_range(dt_bauhaus_get_global(), DT_GUI_MODULE(self), -50., 50., 0, p->security_factor, 2);
   dt_bauhaus_widget_set_label(g->security_factor, N_("safety factor"));
-  gtk_box_pack_start(GTK_BOX(self->widget), g->security_factor, TRUE, TRUE, 0);
+  gtk_box_pack_start(GTK_BOX(self->gui->widget), g->security_factor, TRUE, TRUE, 0);
   dt_bauhaus_slider_set_format(g->security_factor, "%");
   gtk_widget_set_tooltip_text(g->security_factor, _("enlarge or shrink the computed dynamic range.\n"
                                                     "useful in conjunction with \"auto tune levels\"."));
@@ -1532,15 +1532,15 @@ void gui_init(dt_iop_module_t *self)
   gtk_widget_set_tooltip_text(g->auto_button, _("try to optimize the settings with some guessing.\n"
                                                 "this will fit the luminance range inside the histogram bounds.\n"
                                                 "works better for landscapes and evenly-lit pictures\nbut fails for high-keys and low-keys." ));
-  gtk_box_pack_start(GTK_BOX(self->widget), g->auto_button, TRUE, TRUE, 0);
+  gtk_box_pack_start(GTK_BOX(self->gui->widget), g->auto_button, TRUE, TRUE, 0);
 
-  gtk_box_pack_start(GTK_BOX(self->widget), dt_ui_section_label_new(_("filmic S curve")), FALSE, FALSE, 0);
+  gtk_box_pack_start(GTK_BOX(self->gui->widget), dt_ui_section_label_new(_("filmic S curve")), FALSE, FALSE, 0);
 
   // contrast slider
   g->contrast = dt_bauhaus_slider_new_with_range(dt_bauhaus_get_global(), DT_GUI_MODULE(self), 0., 5., 0, p->contrast, 3);
   dt_bauhaus_slider_set_soft_range(g->contrast, 1.0, 2.0);
   dt_bauhaus_widget_set_label(g->contrast, N_("contrast"));
-  gtk_box_pack_start(GTK_BOX(self->widget), g->contrast, TRUE, TRUE, 0);
+  gtk_box_pack_start(GTK_BOX(self->gui->widget), g->contrast, TRUE, TRUE, 0);
   gtk_widget_set_tooltip_text(g->contrast, _("slope of the linear part of the curve\n"
                                              "affects mostly the mid-tones"));
   g_signal_connect(G_OBJECT(g->contrast), "value-changed", G_CALLBACK(contrast_callback), self);
@@ -1550,7 +1550,7 @@ void gui_init(dt_iop_module_t *self)
   dt_bauhaus_slider_set_soft_range(g->latitude_stops, 2, 8.0);
   dt_bauhaus_widget_set_label(g->latitude_stops, N_("latitude"));
   dt_bauhaus_slider_set_format(g->latitude_stops, _(" EV"));
-  gtk_box_pack_start(GTK_BOX(self->widget), g->latitude_stops, TRUE, TRUE, 0);
+  gtk_box_pack_start(GTK_BOX(self->gui->widget), g->latitude_stops, TRUE, TRUE, 0);
   gtk_widget_set_tooltip_text(g->latitude_stops, _("width of the linear domain in the middle of the curve.\n"
                                                    "increase to get more contrast at the extreme luminances.\n"
                                                    "this has no effect on mid-tones."));
@@ -1559,7 +1559,7 @@ void gui_init(dt_iop_module_t *self)
   // balance slider
   g->balance = dt_bauhaus_slider_new_with_range(dt_bauhaus_get_global(), DT_GUI_MODULE(self), -50., 50., 0, p->balance, 2);
   dt_bauhaus_widget_set_label(g->balance, N_("shadows/highlights balance"));
-  gtk_box_pack_start(GTK_BOX(self->widget), g->balance, TRUE, TRUE, 0);
+  gtk_box_pack_start(GTK_BOX(self->gui->widget), g->balance, TRUE, TRUE, 0);
   dt_bauhaus_slider_set_format(g->balance, "%");
   gtk_widget_set_tooltip_text(g->balance, _("slides the latitude along the slope\nto give more room to shadows or highlights.\n"
                                             "use it if you need to protect the details\nat one extremity of the histogram."));
@@ -1570,7 +1570,7 @@ void gui_init(dt_iop_module_t *self)
   dt_bauhaus_widget_set_label(g->global_saturation, N_("global saturation"));
   dt_bauhaus_slider_set_soft_range(g->global_saturation, 0.0, 200.0);
   dt_bauhaus_slider_set_format(g->global_saturation, "%");
-  gtk_box_pack_start(GTK_BOX(self->widget), g->global_saturation, TRUE, TRUE, 0);
+  gtk_box_pack_start(GTK_BOX(self->gui->widget), g->global_saturation, TRUE, TRUE, 0);
   gtk_widget_set_tooltip_text(g->global_saturation, _("desaturates the input of the module globally.\n"
                                                       "you need to set this value below 100%\nif the chrominance preservation is enabled."));
   g_signal_connect(G_OBJECT(g->global_saturation), "value-changed", G_CALLBACK(global_saturation_callback), self);
@@ -1580,7 +1580,7 @@ void gui_init(dt_iop_module_t *self)
   dt_bauhaus_widget_set_label(g->saturation, N_("extreme luminance saturation"));
   dt_bauhaus_slider_set_soft_range(g->saturation, 0.0, 200.0);
   dt_bauhaus_slider_set_format(g->saturation, "%");
-  gtk_box_pack_start(GTK_BOX(self->widget), g->saturation, TRUE, TRUE, 0);
+  gtk_box_pack_start(GTK_BOX(self->gui->widget), g->saturation, TRUE, TRUE, 0);
   gtk_widget_set_tooltip_text(g->saturation, _("desaturates the output of the module\nspecifically at extreme luminances.\n"
                                                "decrease if shadows and/or highlights are over-saturated."));
   g_signal_connect(G_OBJECT(g->saturation), "value-changed", G_CALLBACK(saturation_callback), self);
@@ -1596,7 +1596,7 @@ void gui_init(dt_iop_module_t *self)
   dt_bauhaus_combobox_add(g->interpolator, _("faded")); // centripetal spline
   dt_bauhaus_combobox_add(g->interpolator, _("linear")); // monotonic spline
   dt_bauhaus_combobox_add(g->interpolator, _("optimized")); // monotonic spline
-  gtk_box_pack_start(GTK_BOX(self->widget), g->interpolator , TRUE, TRUE, 0);
+  gtk_box_pack_start(GTK_BOX(self->gui->widget), g->interpolator , TRUE, TRUE, 0);
   gtk_widget_set_tooltip_text(g->interpolator, _("change this method if you see reversed contrast or faded blacks"));
   g_signal_connect(G_OBJECT(g->interpolator), "value-changed", G_CALLBACK(interpolator_callback), self);
 
@@ -1606,7 +1606,7 @@ void gui_init(dt_iop_module_t *self)
   gtk_widget_set_tooltip_text(g->preserve_color, _("ensure the original color are preserved.\n"
                                                    "may reinforce chromatic aberrations.\n"
                                                    "you need to manually tune the saturation when using this mode."));
-  gtk_box_pack_start(GTK_BOX(self->widget), g->preserve_color , TRUE, TRUE, 0);
+  gtk_box_pack_start(GTK_BOX(self->gui->widget), g->preserve_color , TRUE, TRUE, 0);
   g_signal_connect(G_OBJECT(g->preserve_color), "toggled", G_CALLBACK(preserve_color_callback), self);
 
 
@@ -1621,7 +1621,7 @@ void gui_init(dt_iop_module_t *self)
   gtk_widget_set_visible(extra_options, FALSE);
   g->extra_expander = dtgtk_expander_new(destdisp_head, extra_options);
   dtgtk_expander_set_expanded(DTGTK_EXPANDER(g->extra_expander), TRUE);
-  gtk_box_pack_start(GTK_BOX(self->widget), g->extra_expander, FALSE, FALSE, 0);
+  gtk_box_pack_start(GTK_BOX(self->gui->widget), g->extra_expander, FALSE, FALSE, 0);
 
 
   g_signal_connect(G_OBJECT(g->extra_toggle), "toggled", G_CALLBACK(_extra_options_button_changed),  (gpointer)self);

--- a/src/iop/filmicrgb.c
+++ b/src/iop/filmicrgb.c
@@ -2701,7 +2701,7 @@ int process(dt_iop_module_t *self, const dt_dev_pixelpipe_t *pipe, const dt_dev_
   // display mask and exit
   if(self->dev->gui_attached && pipe->type == DT_DEV_PIXELPIPE_FULL && !IS_NULL_PTR(mask))
   {
-    dt_iop_filmicrgb_gui_data_t *g = (dt_iop_filmicrgb_gui_data_t *)self->gui_data;
+    dt_iop_filmicrgb_gui_data_t *g = (dt_iop_filmicrgb_gui_data_t *)dt_iop_gui_data(self);
 
     if(!IS_NULL_PTR(g) && g->show_mask)
     {
@@ -3180,7 +3180,7 @@ int process_cl(struct dt_iop_module_t *self, const dt_dev_pixelpipe_t *pipe, con
   // display mask and exit
   if(self->dev->gui_attached && pipe->type == DT_DEV_PIXELPIPE_FULL)
   {
-    dt_iop_filmicrgb_gui_data_t *g = (dt_iop_filmicrgb_gui_data_t *)self->gui_data;
+    dt_iop_filmicrgb_gui_data_t *g = (dt_iop_filmicrgb_gui_data_t *)dt_iop_gui_data(self);
 
     if(!IS_NULL_PTR(g) && g->show_mask)
     {
@@ -3397,7 +3397,7 @@ static void apply_auto_grey(dt_iop_module_t *self,
 {
   if(dt_gui_widgets_suppressed()) return;
   dt_iop_filmicrgb_params_t *p = (dt_iop_filmicrgb_params_t *)self->params;
-  dt_iop_filmicrgb_gui_data_t *g = (dt_iop_filmicrgb_gui_data_t *)self->gui_data;
+  dt_iop_filmicrgb_gui_data_t *g = (dt_iop_filmicrgb_gui_data_t *)dt_iop_gui_data(self);
 
   const float grey = get_pixel_norm(self->picked_color, p->preserve_color, work_profile) / 2.0f;
 
@@ -3416,7 +3416,7 @@ static void apply_auto_grey(dt_iop_module_t *self,
   dt_bauhaus_slider_set(g->output_power, p->output_power);
   dt_gui_freeze_end();
 
-  gtk_widget_queue_draw(self->widget);
+  gtk_widget_queue_draw(self->gui->widget);
   dt_dev_add_history_item(self->dev, self, TRUE, TRUE);
 }
 
@@ -3425,7 +3425,7 @@ static void apply_auto_black(dt_iop_module_t *self,
 {
   if(dt_gui_widgets_suppressed()) return;
   dt_iop_filmicrgb_params_t *p = (dt_iop_filmicrgb_params_t *)self->params;
-  dt_iop_filmicrgb_gui_data_t *g = (dt_iop_filmicrgb_gui_data_t *)self->gui_data;
+  dt_iop_filmicrgb_gui_data_t *g = (dt_iop_filmicrgb_gui_data_t *)dt_iop_gui_data(self);
 
   // Black
   const float black = get_pixel_norm(self->picked_color_min, DT_FILMIC_METHOD_MAX_RGB, work_profile);
@@ -3442,7 +3442,7 @@ static void apply_auto_black(dt_iop_module_t *self,
   dt_bauhaus_slider_set(g->output_power, p->output_power);
   dt_gui_freeze_end();
 
-  gtk_widget_queue_draw(self->widget);
+  gtk_widget_queue_draw(self->gui->widget);
   dt_dev_add_history_item(self->dev, self, TRUE, TRUE);
 }
 
@@ -3452,7 +3452,7 @@ static void apply_auto_white_point_source(dt_iop_module_t *self,
 {
   if(dt_gui_widgets_suppressed()) return;
   dt_iop_filmicrgb_params_t *p = (dt_iop_filmicrgb_params_t *)self->params;
-  dt_iop_filmicrgb_gui_data_t *g = (dt_iop_filmicrgb_gui_data_t *)self->gui_data;
+  dt_iop_filmicrgb_gui_data_t *g = (dt_iop_filmicrgb_gui_data_t *)dt_iop_gui_data(self);
 
   // White
   const float white = get_pixel_norm(self->picked_color_max, DT_FILMIC_METHOD_MAX_RGB, work_profile);
@@ -3469,14 +3469,14 @@ static void apply_auto_white_point_source(dt_iop_module_t *self,
   dt_bauhaus_slider_set(g->output_power, p->output_power);
   dt_gui_freeze_end();
 
-  gtk_widget_queue_draw(self->widget);
+  gtk_widget_queue_draw(self->gui->widget);
   dt_dev_add_history_item(self->dev, self, TRUE, TRUE);
 }
 
 static void apply_autotune(dt_iop_module_t *self,
                            const dt_iop_order_iccprofile_info_t *const work_profile)
 {
-  dt_iop_filmicrgb_gui_data_t *g = (dt_iop_filmicrgb_gui_data_t *)self->gui_data;
+  dt_iop_filmicrgb_gui_data_t *g = (dt_iop_filmicrgb_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_filmicrgb_params_t *p = (dt_iop_filmicrgb_params_t *)self->params;
 
   // Grey
@@ -3508,7 +3508,7 @@ static void apply_autotune(dt_iop_module_t *self,
   dt_bauhaus_slider_set(g->output_power, p->output_power);
   dt_gui_freeze_end();
 
-  gtk_widget_queue_draw(self->widget);
+  gtk_widget_queue_draw(self->gui->widget);
   dt_dev_add_history_item(self->dev, self, TRUE, TRUE);
 }
 
@@ -3567,7 +3567,7 @@ void color_picker_apply(dt_iop_module_t *self, GtkWidget *picker, dt_dev_pixelpi
   dt_print(DT_DEBUG_DEV, "[picker/filmicrgb] apply picker=%p pipe=%p min=%g max=%g avg=%g\n",
            (void *)picker, (void *)pipe,
            self->picked_color_min[0], self->picked_color_max[0], self->picked_color[0]);
-  dt_iop_filmicrgb_gui_data_t *g = (dt_iop_filmicrgb_gui_data_t *)self->gui_data;
+  dt_iop_filmicrgb_gui_data_t *g = (dt_iop_filmicrgb_gui_data_t *)dt_iop_gui_data(self);
   const dt_iop_order_iccprofile_info_t *const work_profile
       = pipe ? dt_ioppr_get_pipe_current_profile_info(self, pipe)
              : dt_ioppr_get_iop_work_profile_info(self, self->dev->iop);
@@ -3586,8 +3586,8 @@ static void show_mask_callback(GtkToggleButton *button, GdkEventButton *event, g
 {
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
   if(dt_gui_widgets_suppressed()) return;
-  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(self->off), TRUE);
-  dt_iop_filmicrgb_gui_data_t *g = (dt_iop_filmicrgb_gui_data_t *)self->gui_data;
+  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(self->gui->off), TRUE);
+  dt_iop_filmicrgb_gui_data_t *g = (dt_iop_filmicrgb_gui_data_t *)dt_iop_gui_data(self);
 
   // if blend module is displaying mask do not display it here
   if(self->request_mask_display != DT_DEV_PIXELPIPE_DISPLAY_NONE)
@@ -4054,7 +4054,7 @@ void commit_params(dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pixelpipe_
 
 void gui_focus(struct dt_iop_module_t *self, gboolean in)
 {
-  dt_iop_filmicrgb_gui_data_t *g = (dt_iop_filmicrgb_gui_data_t *)self->gui_data;
+  dt_iop_filmicrgb_gui_data_t *g = (dt_iop_filmicrgb_gui_data_t *)dt_iop_gui_data(self);
 
   if(!in)
   {
@@ -4090,7 +4090,7 @@ void cleanup_pipe(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelp
 
 static void filmic_gui_sync_toe_shoulder(dt_iop_module_t *self)
 {
-  dt_iop_filmicrgb_gui_data_t *g = (dt_iop_filmicrgb_gui_data_t *)self->gui_data;
+  dt_iop_filmicrgb_gui_data_t *g = (dt_iop_filmicrgb_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_filmicrgb_params_t *p = (dt_iop_filmicrgb_params_t *)self->params;
   float toe = 0.0f;
   float shoulder = 0.0f;
@@ -4107,7 +4107,7 @@ static void toe_shoulder_callback(GtkWidget *slider, gpointer user_data)
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
   if(dt_gui_widgets_suppressed()) return;
 
-  dt_iop_filmicrgb_gui_data_t *g = (dt_iop_filmicrgb_gui_data_t *)self->gui_data;
+  dt_iop_filmicrgb_gui_data_t *g = (dt_iop_filmicrgb_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_filmicrgb_params_t *p = (dt_iop_filmicrgb_params_t *)self->params;
   filmic_v3_direct_to_legacy(p, dt_bauhaus_slider_get(g->toe), dt_bauhaus_slider_get(g->shoulder),
                              &p->latitude, &p->balance);
@@ -4117,7 +4117,7 @@ static void toe_shoulder_callback(GtkWidget *slider, gpointer user_data)
 
 void gui_update(dt_iop_module_t *self)
 {
-  dt_iop_filmicrgb_gui_data_t *g = (dt_iop_filmicrgb_gui_data_t *)self->gui_data;
+  dt_iop_filmicrgb_gui_data_t *g = (dt_iop_filmicrgb_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_filmicrgb_params_t *p = (dt_iop_filmicrgb_params_t *)self->params;
 
   dt_iop_color_picker_reset(self, TRUE);
@@ -4296,7 +4296,7 @@ static gboolean dt_iop_tonecurve_draw(GtkWidget *widget, cairo_t *crf, gpointer 
 {
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
   dt_iop_filmicrgb_params_t *p = (dt_iop_filmicrgb_params_t *)self->params;
-  dt_iop_filmicrgb_gui_data_t *g = (dt_iop_filmicrgb_gui_data_t *)self->gui_data;
+  dt_iop_filmicrgb_gui_data_t *g = (dt_iop_filmicrgb_gui_data_t *)dt_iop_gui_data(self);
   gboolean contrast_clamped = dt_iop_filmic_rgb_compute_spline(p, &g->spline);
 
   // Cache the graph objects to avoid recomputing all the view at each redraw
@@ -5145,7 +5145,7 @@ static gboolean area_button_press(GtkWidget *widget, GdkEventButton *event, gpoi
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
   if(dt_gui_widgets_suppressed()) return TRUE;
 
-  dt_iop_filmicrgb_gui_data_t *g = (dt_iop_filmicrgb_gui_data_t *)self->gui_data;
+  dt_iop_filmicrgb_gui_data_t *g = (dt_iop_filmicrgb_gui_data_t *)dt_iop_gui_data(self);
 
   dt_iop_request_focus(self);
 
@@ -5233,7 +5233,7 @@ static gboolean area_enter_notify(GtkWidget *widget, GdkEventCrossing *event, gp
   if(dt_gui_widgets_suppressed()) return 1;
   if(!self->enabled) return 0;
 
-  dt_iop_filmicrgb_gui_data_t *g = (dt_iop_filmicrgb_gui_data_t *)self->gui_data;
+  dt_iop_filmicrgb_gui_data_t *g = (dt_iop_filmicrgb_gui_data_t *)dt_iop_gui_data(self);
   g->gui_hover = TRUE;
   gtk_widget_queue_draw(GTK_WIDGET(g->area));
   return TRUE;
@@ -5246,7 +5246,7 @@ static gboolean area_leave_notify(GtkWidget *widget, GdkEventCrossing *event, gp
   if(dt_gui_widgets_suppressed()) return 1;
   if(!self->enabled) return 0;
 
-  dt_iop_filmicrgb_gui_data_t *g = (dt_iop_filmicrgb_gui_data_t *)self->gui_data;
+  dt_iop_filmicrgb_gui_data_t *g = (dt_iop_filmicrgb_gui_data_t *)dt_iop_gui_data(self);
   g->gui_hover = FALSE;
   gtk_widget_queue_draw(GTK_WIDGET(g->area));
   return TRUE;
@@ -5257,7 +5257,7 @@ static gboolean area_motion_notify(GtkWidget *widget, GdkEventMotion *event, gpo
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
   if(dt_gui_widgets_suppressed()) return 1;
 
-  dt_iop_filmicrgb_gui_data_t *g = (dt_iop_filmicrgb_gui_data_t *)self->gui_data;
+  dt_iop_filmicrgb_gui_data_t *g = (dt_iop_filmicrgb_gui_data_t *)dt_iop_gui_data(self);
   if(!g->gui_sizes_inited) return FALSE;
 
   // get in-widget coordinates
@@ -5365,7 +5365,7 @@ void gui_init(dt_iop_module_t *self)
   dt_ui_notebook_set_picker_owner(g->notebook, self);
 
   // Page SCENE
-  self->widget = dt_ui_notebook_page(g->notebook, N_("scene"), NULL);
+  self->gui->widget = dt_ui_notebook_page(g->notebook, N_("scene"), NULL);
 
   g->grey_point_source
       = dt_color_picker_new(self, DT_COLOR_PICKER_AREA, dt_bauhaus_slider_from_params(self, "grey_point_source"));
@@ -5415,10 +5415,10 @@ void gui_init(dt_iop_module_t *self)
                                                 "but fails for high-keys, low-keys and high-ISO pictures.\n"
                                                 "this is not an artificial intelligence, but a simple guess.\n"
                                                 "ensure you understand its assumptions before using it."));
-  gtk_box_pack_start(GTK_BOX(self->widget), hbox, FALSE, FALSE, 0);
+  gtk_box_pack_start(GTK_BOX(self->gui->widget), hbox, FALSE, FALSE, 0);
 
   GtkWidget *label = dt_ui_section_label_new(_("advanced"));
-  gtk_box_pack_start(GTK_BOX(self->widget), label, FALSE, FALSE, 0);
+  gtk_box_pack_start(GTK_BOX(self->gui->widget), label, FALSE, FALSE, 0);
 
   g->custom_grey = dt_bauhaus_toggle_from_params(self, "custom_grey");
   gtk_widget_set_tooltip_text(g->custom_grey, _("enable to input custom middle-gray values.\n"
@@ -5427,10 +5427,10 @@ void gui_init(dt_iop_module_t *self)
                                                 "disable to use standard 18.45 %% middle gray."));
 
   // Page RECONSTRUCT
-  self->widget = dt_ui_notebook_page(g->notebook, N_("reconstruct"), NULL);
+  self->gui->widget = dt_ui_notebook_page(g->notebook, N_("reconstruct"), NULL);
 
   label = dt_ui_section_label_new(_("highlights clipping"));
-  gtk_box_pack_start(GTK_BOX(self->widget), label, FALSE, FALSE, 0);
+  gtk_box_pack_start(GTK_BOX(self->gui->widget), label, FALSE, FALSE, 0);
 
   g->reconstruct_threshold = dt_bauhaus_slider_from_params(self, "reconstruct_threshold");
   dt_bauhaus_slider_set_format(g->reconstruct_threshold, _(" EV"));
@@ -5457,10 +5457,10 @@ void gui_init(dt_iop_module_t *self)
   dtgtk_togglebutton_set_paint(DTGTK_TOGGLEBUTTON(g->show_highlight_mask), dtgtk_cairo_paint_showmask, 0, NULL);
   dt_gui_add_class(g->show_highlight_mask, "dt_bauhaus_alignment");
 
-  gtk_box_pack_start(GTK_BOX(self->widget), hbox, FALSE, FALSE, 0);
+  gtk_box_pack_start(GTK_BOX(self->gui->widget), hbox, FALSE, FALSE, 0);
 
   label = dt_ui_section_label_new(_("balance"));
-  gtk_box_pack_start(GTK_BOX(self->widget), label, FALSE, FALSE, 0);
+  gtk_box_pack_start(GTK_BOX(self->gui->widget), label, FALSE, FALSE, 0);
 
   g->reconstruct_structure_vs_texture = dt_bauhaus_slider_from_params(self, "reconstruct_structure_vs_texture");
   dt_bauhaus_slider_set_format(g->reconstruct_structure_vs_texture, "%");
@@ -5497,7 +5497,7 @@ void gui_init(dt_iop_module_t *self)
                                 "decrease if you see magenta or out-of-gamut highlights."));
 
   label = dt_ui_section_label_new(_("advanced"));
-  gtk_box_pack_start(GTK_BOX(self->widget), label, FALSE, FALSE, 0);
+  gtk_box_pack_start(GTK_BOX(self->gui->widget), label, FALSE, FALSE, 0);
 
   // Color inpainting
   g->high_quality_reconstruction = dt_bauhaus_slider_from_params(self, "high_quality_reconstruction");
@@ -5520,10 +5520,10 @@ void gui_init(dt_iop_module_t *self)
                                                        "this is useful to match natural sensor noise pattern.\n"));
 
   // Page LOOK
-  self->widget = dt_ui_notebook_page(g->notebook, N_("look"), NULL);
+  self->gui->widget = dt_ui_notebook_page(g->notebook, N_("look"), NULL);
 
   label = dt_ui_section_label_new(_("tone mapping"));
-  gtk_box_pack_start(GTK_BOX(self->widget), label, FALSE, FALSE, 0);
+  gtk_box_pack_start(GTK_BOX(self->gui->widget), label, FALSE, FALSE, 0);
 
   g->contrast = dt_bauhaus_slider_from_params(self, N_("contrast"));
   dt_bauhaus_slider_set_soft_range(g->contrast, 0.5, 3.0);
@@ -5542,7 +5542,7 @@ void gui_init(dt_iop_module_t *self)
   // with the params defaults (which keep latitude/balance for compatibility)
 
   g->shoulder = dt_bauhaus_slider_new_with_range(dt_bauhaus_get_global(), DT_GUI_MODULE(self), 0.0f, 100.0f, 0.0f, 10.0f, 2);
-  gtk_box_pack_start(GTK_BOX(self->widget), g->shoulder, FALSE, FALSE, 0);
+  gtk_box_pack_start(GTK_BOX(self->gui->widget), g->shoulder, FALSE, FALSE, 0);
   dt_bauhaus_widget_set_label(g->shoulder, N_("highlights"));
   dt_bauhaus_slider_set_soft_range(g->shoulder, 0.1f, 90.0f);
   dt_bauhaus_slider_set_format(g->shoulder, "%");
@@ -5553,7 +5553,7 @@ void gui_init(dt_iop_module_t *self)
   g_signal_connect(G_OBJECT(g->shoulder), "value-changed", G_CALLBACK(toe_shoulder_callback), self);
 
   g->toe = dt_bauhaus_slider_new_with_range(dt_bauhaus_get_global(), DT_GUI_MODULE(self), 0.0f, 100.0f, 0.0f, 10.0f, 2);
-  gtk_box_pack_start(GTK_BOX(self->widget), g->toe, FALSE, FALSE, 0);
+  gtk_box_pack_start(GTK_BOX(self->gui->widget), g->toe, FALSE, FALSE, 0);
   dt_bauhaus_widget_set_label(g->toe, N_("shadows"));
   dt_bauhaus_slider_set_soft_range(g->toe, 0.1f, 90.0f);
   dt_bauhaus_slider_set_format(g->toe, "%");
@@ -5579,7 +5579,7 @@ void gui_init(dt_iop_module_t *self)
                                             "hard compresses shadows more, soft less."));
 
   label = dt_ui_section_label_new(_("color mapping"));
-  gtk_box_pack_start(GTK_BOX(self->widget), label, FALSE, FALSE, 0);
+  gtk_box_pack_start(GTK_BOX(self->gui->widget), label, FALSE, FALSE, 0);
 
   g->saturation = dt_bauhaus_slider_from_params(self, "saturation");
   dt_bauhaus_slider_set_soft_range(g->saturation, -100.0, 100.0);
@@ -5594,7 +5594,7 @@ void gui_init(dt_iop_module_t *self)
                                                    "so ensure they are properly corrected elsewhere.\n"));
 
   label = dt_ui_section_label_new(_("advanced"));
-  gtk_box_pack_start(GTK_BOX(self->widget), label, FALSE, FALSE, 0);
+  gtk_box_pack_start(GTK_BOX(self->gui->widget), label, FALSE, FALSE, 0);
 
   // Color science
   g->version = dt_bauhaus_combobox_from_params(self, "version");
@@ -5622,7 +5622,7 @@ void gui_init(dt_iop_module_t *self)
                           "disable if you want a manual control."));
 
   // Page DISPLAY
-  self->widget = dt_ui_notebook_page(g->notebook, N_("display"), NULL);
+  self->gui->widget = dt_ui_notebook_page(g->notebook, N_("display"), NULL);
 
   // Black slider
   g->black_point_target = dt_bauhaus_slider_from_params(self, "black_point_target");
@@ -5646,19 +5646,19 @@ void gui_init(dt_iop_module_t *self)
                                                        "this should be 100%\nexcept if you want a faded look"));
 
   // start building top level widget
-  self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_GUI_BOX_SPACING);
+  self->gui->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_GUI_BOX_SPACING);
 
-  gtk_box_pack_start(GTK_BOX(self->widget),
+  gtk_box_pack_start(GTK_BOX(self->gui->widget),
                      dt_ui_resizable_drawing_area(GTK_WIDGET(g->area),
                                                   "plugins/darkroom/filmicrgb/graphheight", 230, 100),
                      FALSE, FALSE, 0);
-  gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(g->notebook), FALSE, FALSE, 0);
+  gtk_box_pack_start(GTK_BOX(self->gui->widget), GTK_WIDGET(g->notebook), FALSE, FALSE, 0);
 }
 
 void gui_changed(dt_iop_module_t *self, GtkWidget *w, void *previous)
 {
   dt_iop_filmicrgb_params_t *p = (dt_iop_filmicrgb_params_t *)self->params;
-  dt_iop_filmicrgb_gui_data_t *g = (dt_iop_filmicrgb_gui_data_t *)self->gui_data;
+  dt_iop_filmicrgb_gui_data_t *g = (dt_iop_filmicrgb_gui_data_t *)dt_iop_gui_data(self);
 
   if(IS_NULL_PTR(w) || w == g->auto_hardness || w == g->security_factor || w == g->grey_point_source
      || w == g->black_point_source || w == g->white_point_source)

--- a/src/iop/finalscale.c
+++ b/src/iop/finalscale.c
@@ -33,6 +33,7 @@
 #include "common/logging.h"
 #include "config.h"
 #endif
+#include "develop/imageop_gui.h"
 #include "widgets/bauhaus.h"
 #include "pixel/interpolation.h"
 #include "develop/imageop.h"
@@ -186,7 +187,6 @@ void init(dt_iop_module_t *self)
   self->default_enabled = 1;
   self->hide_enable_button = 1;
   self->params_size = sizeof(dt_iop_finalscale_params_t);
-  self->gui_data = NULL;
 }
 
 void cleanup(dt_iop_module_t *self)
@@ -203,13 +203,13 @@ dt_iop_finalscale_gui_data_t dummy;
 void gui_init(dt_iop_module_t *self)
 {
   IOP_GUI_ALLOC(finalscale);
-  self->widget = gtk_label_new(NULL);
-  gtk_label_set_markup(GTK_LABEL(self->widget),_("This module is used to downscale images at export time. "
+  self->gui->widget = gtk_label_new(NULL);
+  gtk_label_set_markup(GTK_LABEL(self->gui->widget),_("This module is used to downscale images at export time. "
                                                  "Moving it along the pipeline will have diffent effects on exported images. "
                                                  "<a href='https://ansel.photos/en/doc/modules/processing-modules/finalscale/'>Learn more</a>"));
-  gtk_widget_set_halign(self->widget, GTK_ALIGN_START);
-  gtk_label_set_xalign (GTK_LABEL(self->widget), 0.0f);
-  gtk_label_set_line_wrap(GTK_LABEL(self->widget), TRUE);
+  gtk_widget_set_halign(self->gui->widget, GTK_ALIGN_START);
+  gtk_label_set_xalign (GTK_LABEL(self->gui->widget), 0.0f);
+  gtk_label_set_line_wrap(GTK_LABEL(self->gui->widget), TRUE);
 }
 
 // clang-format off

--- a/src/iop/flip.c
+++ b/src/iop/flip.c
@@ -567,32 +567,32 @@ static void _flip_v(GtkWidget *widget, dt_iop_module_t *self)
 
 void gui_init(struct dt_iop_module_t *self)
 {
-  self->gui_data = NULL;
+  self->gui->gui_data = NULL;
   dt_iop_flip_params_t *p = (dt_iop_flip_params_t *)self->params;
 
-  self->widget = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, DT_GUI_BOX_SPACING);
+  self->gui->widget = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, DT_GUI_BOX_SPACING);
 
   GtkWidget *label = dt_iop_gui_reset_label_new(_("transform"), self, &p->orientation, sizeof(int32_t));
-  gtk_box_pack_start(GTK_BOX(self->widget), label, TRUE, TRUE, 0);
+  gtk_box_pack_start(GTK_BOX(self->gui->widget), label, TRUE, TRUE, 0);
 
   dt_iop_button_new(self, N_("rotate 90 degrees CCW."),
                     G_CALLBACK(rotate_ccw), FALSE, GDK_KEY_bracketleft, 0,
-                    dtgtk_cairo_paint_refresh, 0, self->widget);
+                    dtgtk_cairo_paint_refresh, 0, self->gui->widget);
 
   dt_iop_button_new(self, N_("rotate 90 degrees CW."),
                     G_CALLBACK(rotate_cw), FALSE, GDK_KEY_bracketright, 0,
-                    dtgtk_cairo_paint_refresh, 1, self->widget);
+                    dtgtk_cairo_paint_refresh, 1, self->gui->widget);
 
   dt_iop_button_new(self, N_("flip horizontally."), G_CALLBACK(_flip_h), FALSE, 0, 0, dtgtk_cairo_paint_flip, 1,
-                    self->widget);
+                    self->gui->widget);
 
   dt_iop_button_new(self, N_("flip vertically."), G_CALLBACK(_flip_v), FALSE, 0, 0, dtgtk_cairo_paint_flip, 0,
-                    self->widget);
+                    self->gui->widget);
 }
 
 void gui_cleanup(struct dt_iop_module_t *self)
 {
-  self->gui_data = NULL;
+  self->gui->gui_data = NULL;
 }
 
 // clang-format off

--- a/src/iop/gamma.c
+++ b/src/iop/gamma.c
@@ -45,6 +45,7 @@
 #include "system/target_clones.h"
 #include "config.h"
 #endif
+#include "develop/imageop_gui.h"
 #include <assert.h>
 #include <math.h>
 #include <stdlib.h>
@@ -553,7 +554,6 @@ void init(dt_iop_module_t *module)
   module->params = calloc(1, sizeof(dt_iop_gamma_params_t));
   module->default_params = calloc(1, sizeof(dt_iop_gamma_params_t));
   module->params_size = sizeof(dt_iop_gamma_params_t);
-  module->gui_data = NULL;
   module->hide_enable_button = 1;
   module->default_enabled = 1;
 }

--- a/src/iop/globaltonemap.c
+++ b/src/iop/globaltonemap.c
@@ -182,7 +182,7 @@ static inline void process_drago(struct dt_iop_module_t *self, const dt_dev_pixe
                                  const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out,
                                  dt_iop_global_tonemap_data_t *data)
 {
-  dt_iop_global_tonemap_gui_data_t *g = (dt_iop_global_tonemap_gui_data_t *)self->gui_data;
+  dt_iop_global_tonemap_gui_data_t *g = (dt_iop_global_tonemap_gui_data_t *)dt_iop_gui_data(self);
   float *in = (float *)ivoid;
   float *out = (float *)ovoid;
   const int ch = 4;
@@ -378,7 +378,7 @@ void cleanup_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev
 
 void gui_changed(dt_iop_module_t *self, GtkWidget *w, void *previous)
 {
-  dt_iop_global_tonemap_gui_data_t *g = (dt_iop_global_tonemap_gui_data_t *)self->gui_data;
+  dt_iop_global_tonemap_gui_data_t *g = (dt_iop_global_tonemap_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_global_tonemap_params_t *p = (dt_iop_global_tonemap_params_t *)self->params;
 
   if(IS_NULL_PTR(w) || w == g->operator)
@@ -390,7 +390,7 @@ void gui_changed(dt_iop_module_t *self, GtkWidget *w, void *previous)
 
 void gui_update(struct dt_iop_module_t *self)
 {
-  dt_iop_global_tonemap_gui_data_t *g = (dt_iop_global_tonemap_gui_data_t *)self->gui_data;
+  dt_iop_global_tonemap_gui_data_t *g = (dt_iop_global_tonemap_gui_data_t *)dt_iop_gui_data(self);
 
   gui_changed(self, NULL, 0);
 

--- a/src/iop/graduatednd.c
+++ b/src/iop/graduatednd.c
@@ -408,7 +408,7 @@ static inline void update_saturation_slider_end_color(GtkWidget *slider, float h
 
 void color_picker_apply(dt_iop_module_t *self, GtkWidget *picker, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
 {
-  dt_iop_graduatednd_gui_data_t *g = (dt_iop_graduatednd_gui_data_t *)self->gui_data;
+  dt_iop_graduatednd_gui_data_t *g = (dt_iop_graduatednd_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_graduatednd_params_t *p = (dt_iop_graduatednd_params_t *)self->params;
 
   // convert picker RGB 2 HSL
@@ -442,7 +442,7 @@ void gui_post_expose(struct dt_iop_module_t *self, cairo_t *cr, int32_t width, i
                      int32_t pointerx, int32_t pointery)
 {
   dt_develop_t *dev = self->dev;
-  dt_iop_graduatednd_gui_data_t *g = (dt_iop_graduatednd_gui_data_t *)self->gui_data;
+  dt_iop_graduatednd_gui_data_t *g = (dt_iop_graduatednd_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_graduatednd_params_t *p = (dt_iop_graduatednd_params_t *)self->params;
   if(IS_NULL_PTR(g) || IS_NULL_PTR(p)) return;
 
@@ -490,7 +490,7 @@ void gui_post_expose(struct dt_iop_module_t *self, cairo_t *cr, int32_t width, i
 
 int mouse_moved(struct dt_iop_module_t *self, double x, double y, double pressure, int which)
 {
-  dt_iop_graduatednd_gui_data_t *g = (dt_iop_graduatednd_gui_data_t *)self->gui_data;
+  dt_iop_graduatednd_gui_data_t *g = (dt_iop_graduatednd_gui_data_t *)dt_iop_gui_data(self);
   float pzxpy[2] = { (float)x, (float)y };
   dt_dev_coordinates_widget_to_image_norm(self->dev, pzxpy, 1);
   float pzx = pzxpy[0];
@@ -558,7 +558,7 @@ int mouse_moved(struct dt_iop_module_t *self, double x, double y, double pressur
 int button_pressed(struct dt_iop_module_t *self, double x, double y, double pressure, int which, int type,
                    uint32_t state)
 {
-  dt_iop_graduatednd_gui_data_t *g = (dt_iop_graduatednd_gui_data_t *)self->gui_data;
+  dt_iop_graduatednd_gui_data_t *g = (dt_iop_graduatednd_gui_data_t *)dt_iop_gui_data(self);
   float pzxpy[2] = { (float)x, (float)y };
   dt_dev_coordinates_widget_to_image_norm(self->dev, pzxpy, 1);
   float pzx = pzxpy[0];
@@ -589,7 +589,7 @@ int button_pressed(struct dt_iop_module_t *self, double x, double y, double pres
 
 int button_released(struct dt_iop_module_t *self, double x, double y, int which, uint32_t state)
 {
-  dt_iop_graduatednd_gui_data_t *g = (dt_iop_graduatednd_gui_data_t *)self->gui_data;
+  dt_iop_graduatednd_gui_data_t *g = (dt_iop_graduatednd_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_graduatednd_params_t *p = (dt_iop_graduatednd_params_t *)self->params;
   if(g->dragging > 0)
   {
@@ -621,7 +621,7 @@ int button_released(struct dt_iop_module_t *self, double x, double y, int which,
 
 int scrolled(dt_iop_module_t *self, double x, double y, int up, uint32_t state)
 {
-  dt_iop_graduatednd_gui_data_t *g = (dt_iop_graduatednd_gui_data_t *)self->gui_data;
+  dt_iop_graduatednd_gui_data_t *g = (dt_iop_graduatednd_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_graduatednd_params_t *p = (dt_iop_graduatednd_params_t *)self->params;
 
   // A drawn mask being edited (anywhere on canvas, not just hovered directly -- that case
@@ -858,7 +858,7 @@ void cleanup_global(dt_iop_module_so_t *module)
 void gui_changed(dt_iop_module_t *self, GtkWidget *w, void *previous)
 {
   dt_iop_graduatednd_params_t *p = (dt_iop_graduatednd_params_t *)self->params;
-  dt_iop_graduatednd_gui_data_t *g = (dt_iop_graduatednd_gui_data_t *)self->gui_data;
+  dt_iop_graduatednd_gui_data_t *g = (dt_iop_graduatednd_gui_data_t *)dt_iop_gui_data(self);
   if(w == g->rotation)
   {
     set_points_from_grad(self, &g->a, &g->b, p->rotation, p->offset);
@@ -904,7 +904,7 @@ void cleanup_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev
 
 void gui_update(struct dt_iop_module_t *self)
 {
-  dt_iop_graduatednd_gui_data_t *g = (dt_iop_graduatednd_gui_data_t *)self->gui_data;
+  dt_iop_graduatednd_gui_data_t *g = (dt_iop_graduatednd_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_graduatednd_params_t *p = (dt_iop_graduatednd_params_t *)self->params;
 
   dt_iop_color_picker_reset(self, TRUE);

--- a/src/iop/hazeremoval.c
+++ b/src/iop/hazeremoval.c
@@ -207,7 +207,7 @@ void cleanup_global(dt_iop_module_so_t *self)
 
 void gui_update(struct dt_iop_module_t *self)
 {
-  dt_iop_hazeremoval_gui_data_t *g = (dt_iop_hazeremoval_gui_data_t *)self->gui_data;
+  dt_iop_hazeremoval_gui_data_t *g = (dt_iop_hazeremoval_gui_data_t *)dt_iop_gui_data(self);
 
   dt_iop_gui_enter_critical_section(self);
   g->distance_max = NAN;
@@ -234,7 +234,7 @@ static void _history_resync_callback(gpointer instance, gpointer user_data)
 {
   (void)instance;
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
-  dt_iop_hazeremoval_gui_data_t *g = (dt_iop_hazeremoval_gui_data_t *)self->gui_data;
+  dt_iop_hazeremoval_gui_data_t *g = (dt_iop_hazeremoval_gui_data_t *)dt_iop_gui_data(self);
   if(IS_NULL_PTR(g)) return;
 
   const uint64_t preview_hash = _current_preview_hash(self);
@@ -494,7 +494,7 @@ int process(struct dt_iop_module_t *self, const dt_dev_pixelpipe_t *pipe, const 
 {
   const dt_iop_roi_t *const roi_in = &piece->roi_in;
   const dt_iop_roi_t *const roi_out = &piece->roi_out;
-  dt_iop_hazeremoval_gui_data_t *const g = (dt_iop_hazeremoval_gui_data_t*)self->gui_data;
+  dt_iop_hazeremoval_gui_data_t *const g = (dt_iop_hazeremoval_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_hazeremoval_params_t *d = piece->data;
   int err = 0;
   gray_image trans_map = (gray_image){ 0 };
@@ -803,7 +803,7 @@ int process_cl(struct dt_iop_module_t *self, const dt_dev_pixelpipe_t *pipe, con
 {
   const dt_iop_roi_t *const roi_in = &piece->roi_in;
   const dt_iop_roi_t *const roi_out = &piece->roi_out;
-  dt_iop_hazeremoval_gui_data_t *const g = (dt_iop_hazeremoval_gui_data_t*)self->gui_data;
+  dt_iop_hazeremoval_gui_data_t *const g = (dt_iop_hazeremoval_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_hazeremoval_params_t *d = piece->data;
 
   const int ch = piece->dsc_in.channels;

--- a/src/iop/highlights.c
+++ b/src/iop/highlights.c
@@ -345,7 +345,7 @@ int process_cl(struct dt_iop_module_t *self, const dt_dev_pixelpipe_t *pipe, con
   const dt_iop_roi_t *const roi_in = &piece->roi_in;
   const dt_iop_roi_t *const roi_out = &piece->roi_out;
   dt_iop_highlights_data_t *d = (dt_iop_highlights_data_t *)piece->data;
-  dt_iop_highlights_gui_data_t *g = (dt_iop_highlights_gui_data_t *)self->gui_data;
+  dt_iop_highlights_gui_data_t *g = (dt_iop_highlights_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_highlights_global_data_t *gd = (dt_iop_highlights_global_data_t *)self->global_data;
 
   const uint32_t filters = piece->dsc_in.filters;
@@ -548,7 +548,7 @@ int process(struct dt_iop_module_t *self, const dt_dev_pixelpipe_t *pipe, const 
   // filters==9u / !filters checks are shift-invariant.
   const uint32_t filters = dt_dev_get_roi_filters(piece, roi_in);
   dt_iop_highlights_data_t *data = (dt_iop_highlights_data_t *)piece->data;
-  dt_iop_highlights_gui_data_t *g = (dt_iop_highlights_gui_data_t *)self->gui_data;
+  dt_iop_highlights_gui_data_t *g = (dt_iop_highlights_gui_data_t *)dt_iop_gui_data(self);
 
   /* This transient preview belongs to the central darkroom view. Do not infer
    * its owner from ROI geometry: at zoom-to-fit the main and navigation pipes
@@ -1034,7 +1034,7 @@ void cleanup_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev
 
 void gui_changed(dt_iop_module_t *self, GtkWidget *w, void *previous)
 {
-  dt_iop_highlights_gui_data_t *g = (dt_iop_highlights_gui_data_t *)self->gui_data;
+  dt_iop_highlights_gui_data_t *g = (dt_iop_highlights_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_highlights_params_t *p = (dt_iop_highlights_params_t *)self->params;
 
   const gboolean raw = (self->dev->image_storage.dsc.filters != 0);
@@ -1055,7 +1055,7 @@ void gui_changed(dt_iop_module_t *self, GtkWidget *w, void *previous)
 
 void gui_update(struct dt_iop_module_t *self)
 {
-  dt_iop_highlights_gui_data_t *g = (dt_iop_highlights_gui_data_t *)self->gui_data;
+  dt_iop_highlights_gui_data_t *g = (dt_iop_highlights_gui_data_t *)dt_iop_gui_data(self);
   const dt_image_t *const image = &self->dev->image_storage;
   const gboolean supported = _highlights_image_supported(image);
   // Auto-enable only on raw colorimetry (raw / sRAW, not monochrome); on rendered RGB it is opt-in.
@@ -1065,7 +1065,7 @@ void gui_update(struct dt_iop_module_t *self)
   // the module self-disables (mono-raw / greyscale), and even then keep it if already enabled (history
   // copy & paste from a RAW image) so the user can turn it back off.
   self->hide_enable_button = !supported && !self->enabled;
-  gtk_stack_set_visible_child_name(GTK_STACK(self->widget), supported ? "default" : "monochrome");
+  gtk_stack_set_visible_child_name(GTK_STACK(self->gui->widget), supported ? "default" : "monochrome");
 
   // capability entries, added once (moved here from reload_defaults so it never touches widgets off
   // the GUI thread / on a widget-less export dev)
@@ -1102,7 +1102,7 @@ static void _visualize_callback(GtkWidget *quad, gpointer user_data)
 {
   if(dt_gui_widgets_suppressed()) return;
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
-  dt_iop_highlights_gui_data_t *g = (dt_iop_highlights_gui_data_t *)self->gui_data;
+  dt_iop_highlights_gui_data_t *g = (dt_iop_highlights_gui_data_t *)dt_iop_gui_data(self);
 
   // if blend module is displaying mask do not display it here
   if(self->request_mask_display != DT_DEV_PIXELPIPE_DISPLAY_NONE)
@@ -1118,7 +1118,7 @@ static void _visualize_callback(GtkWidget *quad, gpointer user_data)
 
 void gui_focus(struct dt_iop_module_t *self, gboolean in)
 {
-  dt_iop_highlights_gui_data_t *g = (dt_iop_highlights_gui_data_t *)self->gui_data;
+  dt_iop_highlights_gui_data_t *g = (dt_iop_highlights_gui_data_t *)dt_iop_gui_data(self);
   if(!in)
   {
     const gboolean was_visualize = g->show_visualize;
@@ -1131,7 +1131,7 @@ void gui_focus(struct dt_iop_module_t *self, gboolean in)
 void gui_init(struct dt_iop_module_t *self)
 {
   dt_iop_highlights_gui_data_t *g = IOP_GUI_ALLOC(highlights);
-  GtkWidget *box_raw = self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_GUI_BOX_SPACING);
+  GtkWidget *box_raw = self->gui->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_GUI_BOX_SPACING);
 
   g->mode = dt_bauhaus_combobox_from_params(self, "mode");
   gtk_widget_set_tooltip_text(g->mode, _("highlight reconstruction method"));
@@ -1169,10 +1169,10 @@ void gui_init(struct dt_iop_module_t *self)
   gtk_widget_set_tooltip_text(monochromes, _("no highlights reconstruction for monochrome images"));
 
   // start building top level widget
-  self->widget = gtk_stack_new();
-  gtk_stack_set_homogeneous(GTK_STACK(self->widget), FALSE);
-  gtk_stack_add_named(GTK_STACK(self->widget), monochromes, "monochrome");
-  gtk_stack_add_named(GTK_STACK(self->widget), box_raw, "default");
+  self->gui->widget = gtk_stack_new();
+  gtk_stack_set_homogeneous(GTK_STACK(self->gui->widget), FALSE);
+  gtk_stack_add_named(GTK_STACK(self->gui->widget), monochromes, "monochrome");
+  gtk_stack_add_named(GTK_STACK(self->gui->widget), box_raw, "default");
 }
 
 // clang-format off

--- a/src/iop/hotpixels.c
+++ b/src/iop/hotpixels.c
@@ -415,7 +415,7 @@ void cleanup_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev
 
 void gui_update(dt_iop_module_t *self)
 {
-  dt_iop_hotpixels_gui_data_t *g = (dt_iop_hotpixels_gui_data_t *)self->gui_data;
+  dt_iop_hotpixels_gui_data_t *g = (dt_iop_hotpixels_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_hotpixels_params_t *p = (dt_iop_hotpixels_params_t *)self->params;
   gtk_toggle_button_set_active(g->permissive, p->permissive);
 
@@ -424,14 +424,14 @@ void gui_update(dt_iop_module_t *self)
   // can't be switched on for non-mosaiced images:
   self->hide_enable_button = !enabled;
 
-  gtk_stack_set_visible_child_name(GTK_STACK(self->widget), self->hide_enable_button ? "non_raw" : "raw");
+  gtk_stack_set_visible_child_name(GTK_STACK(self->gui->widget), self->hide_enable_button ? "non_raw" : "raw");
 }
 
 void gui_init(dt_iop_module_t *self)
 {
   dt_iop_hotpixels_gui_data_t *g = IOP_GUI_ALLOC(hotpixels);
 
-  GtkWidget *box_raw = self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_GUI_BOX_SPACING);
+  GtkWidget *box_raw = self->gui->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_GUI_BOX_SPACING);
 
   g->threshold = dt_bauhaus_slider_from_params(self, N_("threshold"));
   dt_bauhaus_slider_set_digits(g->threshold, 4);
@@ -445,13 +445,13 @@ void gui_init(dt_iop_module_t *self)
   g->permissive = GTK_TOGGLE_BUTTON(dt_bauhaus_toggle_from_params(self, "permissive"));
 
   // start building top level widget
-  self->widget = gtk_stack_new();
-  gtk_stack_set_homogeneous(GTK_STACK(self->widget), FALSE);
+  self->gui->widget = gtk_stack_new();
+  gtk_stack_set_homogeneous(GTK_STACK(self->gui->widget), FALSE);
 
   GtkWidget *label_non_raw = dt_ui_label_new(_("hot pixel correction\nonly works for raw images."));
 
-  gtk_stack_add_named(GTK_STACK(self->widget), label_non_raw, "non_raw");
-  gtk_stack_add_named(GTK_STACK(self->widget), box_raw, "raw");
+  gtk_stack_add_named(GTK_STACK(self->gui->widget), label_non_raw, "non_raw");
+  gtk_stack_add_named(GTK_STACK(self->gui->widget), box_raw, "raw");
 }
 
 // clang-format off

--- a/src/iop/initialscale.c
+++ b/src/iop/initialscale.c
@@ -32,6 +32,7 @@
 #include "common/logging.h"
 #include "config.h"
 #endif
+#include "develop/imageop_gui.h"
 #include "pixel/interpolation.h"
 #include "develop/imageop.h"
 #include "develop/imageop_math.h"
@@ -149,7 +150,6 @@ void init(dt_iop_module_t *self)
   self->default_enabled = 1;
   self->hide_enable_button = 1;
   self->params_size = sizeof(dt_iop_initialscale_params_t);
-  self->gui_data = NULL;
 }
 
 void cleanup(dt_iop_module_t *self)
@@ -166,13 +166,13 @@ dt_iop_initialscale_gui_data_t dummy;
 void gui_init(dt_iop_module_t *self)
 {
   IOP_GUI_ALLOC(initialscale);
-  self->widget = gtk_label_new(NULL);
-  gtk_label_set_markup(GTK_LABEL(self->widget),_("This module is used to downscale images at export time. "
+  self->gui->widget = gtk_label_new(NULL);
+  gtk_label_set_markup(GTK_LABEL(self->gui->widget),_("This module is used to downscale images at export time. "
                                                  "Moving it along the pipeline will have diffent effects on exported images. "
                                                  "<a href='https://ansel.photos/en/doc/modules/processing-modules/initialscale/'>Learn more</a>"));
-  gtk_widget_set_halign(self->widget, GTK_ALIGN_START);
-  gtk_label_set_xalign (GTK_LABEL(self->widget), 0.0f);
-  gtk_label_set_line_wrap(GTK_LABEL(self->widget), TRUE);
+  gtk_widget_set_halign(self->gui->widget, GTK_ALIGN_START);
+  gtk_label_set_xalign (GTK_LABEL(self->gui->widget), 0.0f);
+  gtk_label_set_line_wrap(GTK_LABEL(self->gui->widget), TRUE);
 }
 
 // clang-format off

--- a/src/iop/invert.c
+++ b/src/iop/invert.c
@@ -171,7 +171,7 @@ void output_format(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixel
 
 static void gui_update_from_coeffs(dt_iop_module_t *self)
 {
-  dt_iop_invert_gui_data_t *g = (dt_iop_invert_gui_data_t *)self->gui_data;
+  dt_iop_invert_gui_data_t *g = (dt_iop_invert_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_invert_params_t *p = (dt_iop_invert_params_t *)self->params;
 
   GdkRGBA color = (GdkRGBA){.red = p->color[0], .green = p->color[1], .blue = p->color[2], .alpha = 1.0 };
@@ -210,13 +210,13 @@ void color_picker_apply(dt_iop_module_t *self, GtkWidget *picker, dt_dev_pixelpi
   dt_gui_freeze_end();
 
   dt_dev_add_history_item(self->dev, self, TRUE, TRUE);
-  dt_control_queue_redraw_widget(self->widget);
+  dt_control_queue_redraw_widget(self->gui->widget);
 }
 
 static void colorpicker_callback(GtkColorButton *widget, dt_iop_module_t *self)
 {
   if(dt_gui_widgets_suppressed()) return;
-  dt_iop_invert_gui_data_t *g = (dt_iop_invert_gui_data_t *)self->gui_data;
+  dt_iop_invert_gui_data_t *g = (dt_iop_invert_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_invert_params_t *p = (dt_iop_invert_params_t *)self->params;
 
   dt_iop_color_picker_reset(self, TRUE);
@@ -342,7 +342,7 @@ void cleanup_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev
 
 void gui_update(dt_iop_module_t *self)
 {
-  dt_iop_invert_gui_data_t *const g = (dt_iop_invert_gui_data_t *)self->gui_data;
+  dt_iop_invert_gui_data_t *const g = (dt_iop_invert_gui_data_t *)dt_iop_gui_data(self);
   const dt_image_t *const img = &self->dev->image_storage;
 
   // Per-image GUI state (moved here from reload_defaults so it only runs on the GUI thread with
@@ -377,12 +377,12 @@ void gui_init(dt_iop_module_t *self)
   dt_iop_invert_gui_data_t *g = IOP_GUI_ALLOC(invert);
   dt_iop_invert_params_t *p = (dt_iop_invert_params_t *)self->params;
 
-  self->widget = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, DT_GUI_BOX_SPACING);
+  self->gui->widget = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, DT_GUI_BOX_SPACING);
   g->label = DTGTK_RESET_LABEL(dt_iop_gui_reset_label_new("", self, &p->color, sizeof(float) * 4));
-  gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(g->label), TRUE, TRUE, 0);
+  gtk_box_pack_start(GTK_BOX(self->gui->widget), GTK_WIDGET(g->label), TRUE, TRUE, 0);
 
   g->pickerbuttons = GTK_BOX(gtk_box_new(GTK_ORIENTATION_HORIZONTAL, DT_GUI_BOX_SPACING));
-  gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(g->pickerbuttons), TRUE, TRUE, 0);
+  gtk_box_pack_start(GTK_BOX(self->gui->widget), GTK_WIDGET(g->pickerbuttons), TRUE, TRUE, 0);
 
   GdkRGBA color = (GdkRGBA){.red = p->color[0], .green = p->color[1], .blue = p->color[2], .alpha = 1.0 };
   g->colorpicker = gtk_color_button_new_with_rgba(&color);

--- a/src/iop/lens.cc
+++ b/src/iop/lens.cc
@@ -453,7 +453,7 @@ int process(dt_iop_module_t *self, const dt_dev_pixelpipe_t *pipe, const dt_dev_
   const dt_iop_roi_t *const roi_in = &piece->roi_in;
   const dt_iop_roi_t *const roi_out = &piece->roi_out;
   const dt_iop_lensfun_data_t *const d = (dt_iop_lensfun_data_t *)piece->data;
-  dt_iop_lensfun_gui_data_t *g = (dt_iop_lensfun_gui_data_t *)self->gui_data;
+  dt_iop_lensfun_gui_data_t *g = (dt_iop_lensfun_gui_data_t *)dt_iop_gui_data(self);
 
   const int ch = piece->dsc_in.channels;
   const int ch_width = ch * roi_in->width;
@@ -691,7 +691,7 @@ int process_cl(struct dt_iop_module_t *self, const dt_dev_pixelpipe_t *pipe, con
   const dt_iop_roi_t *const roi_out = &piece->roi_out;
   dt_iop_lensfun_data_t *d = (dt_iop_lensfun_data_t *)piece->data;
   dt_iop_lensfun_global_data_t *gd = (dt_iop_lensfun_global_data_t *)self->global_data;
-  dt_iop_lensfun_gui_data_t *g = (dt_iop_lensfun_gui_data_t *)self->gui_data;
+  dt_iop_lensfun_gui_data_t *g = (dt_iop_lensfun_gui_data_t *)dt_iop_gui_data(self);
 
   const gboolean raw_monochrome = dt_image_is_monochrome(&self->dev->image_storage);
   const int used_lf_mask = (raw_monochrome) ? LF_MODIFY_ALL & ~LF_MODIFY_TCA : LF_MODIFY_ALL;
@@ -1604,7 +1604,7 @@ static void ptr_array_insert_index(GPtrArray *array, const void *item, int index
 
 static void camera_set(dt_iop_module_t *self, const lfCamera *cam)
 {
-  dt_iop_lensfun_gui_data_t *g = (dt_iop_lensfun_gui_data_t *)self->gui_data;
+  dt_iop_lensfun_gui_data_t *g = (dt_iop_lensfun_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_lensfun_params_t *p = (dt_iop_lensfun_params_t *)self->params;
   gchar *fm;
   const char *maker, *model, *variant;
@@ -1661,7 +1661,7 @@ static void camera_menu_select(GtkMenuItem *menuitem, gpointer user_data)
 
 static void camera_menu_fill(dt_iop_module_t *self, const lfCamera *const *camlist)
 {
-  dt_iop_lensfun_gui_data_t *g = (dt_iop_lensfun_gui_data_t *)self->gui_data;
+  dt_iop_lensfun_gui_data_t *g = (dt_iop_lensfun_gui_data_t *)dt_iop_gui_data(self);
   unsigned i;
   GPtrArray *makers, *submenus;
 
@@ -1732,7 +1732,7 @@ static void camera_menusearch_clicked(GtkWidget *button, gpointer user_data)
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
   dt_iop_lensfun_global_data_t *gd = (dt_iop_lensfun_global_data_t *)self->global_data;
   lfDatabase *dt_iop_lensfun_db = (lfDatabase *)gd->db;
-  dt_iop_lensfun_gui_data_t *g = (dt_iop_lensfun_gui_data_t *)self->gui_data;
+  dt_iop_lensfun_gui_data_t *g = (dt_iop_lensfun_gui_data_t *)dt_iop_gui_data(self);
 
   (void)button;
 
@@ -1751,7 +1751,7 @@ static void camera_autosearch_clicked(GtkWidget *button, gpointer user_data)
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
   dt_iop_lensfun_global_data_t *gd = (dt_iop_lensfun_global_data_t *)self->global_data;
   lfDatabase *dt_iop_lensfun_db = (lfDatabase *)gd->db;
-  dt_iop_lensfun_gui_data_t *g = (dt_iop_lensfun_gui_data_t *)self->gui_data;
+  dt_iop_lensfun_gui_data_t *g = (dt_iop_lensfun_gui_data_t *)dt_iop_gui_data(self);
   char make[200], model[200];
   const gchar *txt = (const gchar *)((dt_iop_lensfun_params_t *)self->default_params)->camera;
 
@@ -1818,7 +1818,7 @@ static void delete_children(GtkWidget *widget, gpointer data)
 
 static void lens_set(dt_iop_module_t *self, const lfLens *lens)
 {
-  dt_iop_lensfun_gui_data_t *g = (dt_iop_lensfun_gui_data_t *)self->gui_data;
+  dt_iop_lensfun_gui_data_t *g = (dt_iop_lensfun_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_lensfun_params_t *p = (dt_iop_lensfun_params_t *)self->params;
 
   gchar *fm;
@@ -2012,7 +2012,7 @@ static void lens_set(dt_iop_module_t *self, const lfLens *lens)
 static void lens_menu_select(GtkMenuItem *menuitem, gpointer user_data)
 {
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
-  dt_iop_lensfun_gui_data_t *g = (dt_iop_lensfun_gui_data_t *)self->gui_data;
+  dt_iop_lensfun_gui_data_t *g = (dt_iop_lensfun_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_lensfun_params_t *p = (dt_iop_lensfun_params_t *)self->params;
   lens_set(self, (lfLens *)g_object_get_data(G_OBJECT(menuitem), "lfLens"));
   if(dt_gui_widgets_suppressed()) return;
@@ -2024,7 +2024,7 @@ static void lens_menu_select(GtkMenuItem *menuitem, gpointer user_data)
 
 static void lens_menu_fill(dt_iop_module_t *self, const lfLens *const *lenslist)
 {
-  dt_iop_lensfun_gui_data_t *g = (dt_iop_lensfun_gui_data_t *)self->gui_data;
+  dt_iop_lensfun_gui_data_t *g = (dt_iop_lensfun_gui_data_t *)dt_iop_gui_data(self);
   unsigned i;
   GPtrArray *makers, *submenus;
 
@@ -2078,7 +2078,7 @@ static void lens_menusearch_clicked(GtkWidget *button, gpointer user_data)
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
   dt_iop_lensfun_global_data_t *gd = (dt_iop_lensfun_global_data_t *)self->global_data;
   lfDatabase *dt_iop_lensfun_db = (lfDatabase *)gd->db;
-  dt_iop_lensfun_gui_data_t *g = (dt_iop_lensfun_gui_data_t *)self->gui_data;
+  dt_iop_lensfun_gui_data_t *g = (dt_iop_lensfun_gui_data_t *)dt_iop_gui_data(self);
   const lfLens **lenslist;
 
   (void)button;
@@ -2098,7 +2098,7 @@ static void lens_autosearch_clicked(GtkWidget *button, gpointer user_data)
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
   dt_iop_lensfun_global_data_t *gd = (dt_iop_lensfun_global_data_t *)self->global_data;
   lfDatabase *dt_iop_lensfun_db = (lfDatabase *)gd->db;
-  dt_iop_lensfun_gui_data_t *g = (dt_iop_lensfun_gui_data_t *)self->gui_data;
+  dt_iop_lensfun_gui_data_t *g = (dt_iop_lensfun_gui_data_t *)dt_iop_gui_data(self);
   const lfLens **lenslist;
   char model[200];
   const gchar *txt = ((dt_iop_lensfun_params_t *)self->default_params)->lens;
@@ -2135,7 +2135,7 @@ static void modflags_changed(GtkWidget *widget, gpointer user_data)
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
   if(dt_gui_widgets_suppressed()) return;
   dt_iop_lensfun_params_t *p = (dt_iop_lensfun_params_t *)self->params;
-  dt_iop_lensfun_gui_data_t *g = (dt_iop_lensfun_gui_data_t *)self->gui_data;
+  dt_iop_lensfun_gui_data_t *g = (dt_iop_lensfun_gui_data_t *)dt_iop_gui_data(self);
   int pos = dt_bauhaus_combobox_get(widget);
   for(GList *modifiers = g->modifiers;  modifiers; modifiers = g_list_next(modifiers))
   {
@@ -2153,7 +2153,7 @@ static void modflags_changed(GtkWidget *widget, gpointer user_data)
 void gui_changed(dt_iop_module_t *self, GtkWidget *w, void *previous)
 {
   dt_iop_lensfun_params_t *p = (dt_iop_lensfun_params_t *)self->params;
-  dt_iop_lensfun_gui_data_t *g = (dt_iop_lensfun_gui_data_t *)self->gui_data;
+  dt_iop_lensfun_gui_data_t *g = (dt_iop_lensfun_gui_data_t *)dt_iop_gui_data(self);
   const gboolean raw_monochrome = dt_image_is_monochrome(&self->dev->image_storage);
   gtk_widget_set_visible(g->tca_override, !raw_monochrome);
   // update gui to show/hide tca sliders if tca_override was changed
@@ -2237,7 +2237,7 @@ static float get_autoscale(dt_iop_module_t *self, dt_iop_lensfun_params_t *p, co
 static void autoscale_pressed(GtkWidget *button, gpointer user_data)
 {
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
-  dt_iop_lensfun_gui_data_t *g = (dt_iop_lensfun_gui_data_t *)self->gui_data;
+  dt_iop_lensfun_gui_data_t *g = (dt_iop_lensfun_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_lensfun_params_t *p = (dt_iop_lensfun_params_t *)self->params;
   const float scale = get_autoscale(self, p, g->camera);
   p->modified = 1;
@@ -2248,7 +2248,7 @@ static void autoscale_pressed(GtkWidget *button, gpointer user_data)
 static void corrections_done(gpointer instance, gpointer user_data)
 {
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
-  dt_iop_lensfun_gui_data_t *g = (dt_iop_lensfun_gui_data_t *)self->gui_data;
+  dt_iop_lensfun_gui_data_t *g = (dt_iop_lensfun_gui_data_t *)dt_iop_gui_data(self);
   if(dt_gui_widgets_suppressed()) return;
 
   dt_iop_gui_enter_critical_section(self);
@@ -2337,8 +2337,8 @@ void gui_init(struct dt_iop_module_t *self)
   modifier->modflag = LENSFUN_MODFLAG_VIGN;
   modifier->pos = ++pos;
 
-  self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_GUI_BOX_SPACING);
-    gtk_widget_set_name(self->widget, "lens-module");
+  self->gui->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_GUI_BOX_SPACING);
+    gtk_widget_set_name(self->gui->widget, "lens-module");
 
   // camera selector
   GtkWidget *hbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, DT_GUI_BOX_SPACING);
@@ -2350,7 +2350,7 @@ void gui_init(struct dt_iop_module_t *self)
                                             dtgtk_cairo_paint_solid_arrow, CPF_DIRECTION_DOWN, NULL);
   dt_gui_add_class(g->find_camera_button, "dt_big_btn_canvas");
   gtk_box_pack_start(GTK_BOX(hbox), g->find_camera_button, FALSE, FALSE, 0);
-  gtk_box_pack_start(GTK_BOX(self->widget), hbox, TRUE, TRUE, 0);
+  gtk_box_pack_start(GTK_BOX(self->gui->widget), hbox, TRUE, TRUE, 0);
 
   // lens selector
   hbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, DT_GUI_BOX_SPACING);
@@ -2362,11 +2362,11 @@ void gui_init(struct dt_iop_module_t *self)
                                           dtgtk_cairo_paint_solid_arrow, CPF_DIRECTION_DOWN, NULL);
   dt_gui_add_class(g->find_lens_button, "dt_big_btn_canvas");
   gtk_box_pack_start(GTK_BOX(hbox), g->find_lens_button, FALSE, FALSE, 0);
-  gtk_box_pack_start(GTK_BOX(self->widget), hbox, TRUE, TRUE, 0);
+  gtk_box_pack_start(GTK_BOX(self->gui->widget), hbox, TRUE, TRUE, 0);
 
   // lens properties
   g->lens_param_box = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, DT_GUI_BOX_SPACING);
-  gtk_box_pack_start(GTK_BOX(self->widget), g->lens_param_box, TRUE, TRUE, 0);
+  gtk_box_pack_start(GTK_BOX(self->gui->widget), g->lens_param_box, TRUE, TRUE, 0);
 
 #if 0
   // if unambiguous info is there, use it.
@@ -2388,7 +2388,7 @@ void gui_init(struct dt_iop_module_t *self)
   // selector for correction type (modflags): one or more out of distortion, TCA, vignetting
   g->modflags = dt_bauhaus_combobox_new(dt_bauhaus_get_global(), DT_GUI_MODULE(self));
   dt_bauhaus_widget_set_label(g->modflags, N_("corrections"));
-  gtk_box_pack_start(GTK_BOX(self->widget), g->modflags, TRUE, TRUE, 0);
+  gtk_box_pack_start(GTK_BOX(self->gui->widget), g->modflags, TRUE, TRUE, 0);
   gtk_widget_set_tooltip_text(g->modflags, _("which corrections to apply"));
   GList *l = g->modifiers;
   while(l)
@@ -2403,7 +2403,7 @@ void gui_init(struct dt_iop_module_t *self)
   // target geometry
   g->target_geom = dt_bauhaus_combobox_new(dt_bauhaus_get_global(), DT_GUI_MODULE(self));
   dt_bauhaus_widget_set_label(g->target_geom, N_("geometry"));
-  gtk_box_pack_start(GTK_BOX(self->widget), g->target_geom, TRUE, TRUE, 0);
+  gtk_box_pack_start(GTK_BOX(self->gui->widget), g->target_geom, TRUE, TRUE, 0);
   gtk_widget_set_tooltip_text(g->target_geom, _("target geometry"));
   dt_bauhaus_combobox_add(g->target_geom, _("rectilinear"));
   dt_bauhaus_combobox_add(g->target_geom, _("fish-eye"));
@@ -2452,7 +2452,7 @@ void gui_init(struct dt_iop_module_t *self)
   g->message = GTK_LABEL(gtk_label_new("")); // This gets filled in by process
   gtk_label_set_ellipsize(GTK_LABEL(g->message), PANGO_ELLIPSIZE_MIDDLE);
   gtk_box_pack_start(GTK_BOX(hbox1), GTK_WIDGET(g->message), FALSE, FALSE, 0);
-  gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(hbox1), TRUE, TRUE, 0);
+  gtk_box_pack_start(GTK_BOX(self->gui->widget), GTK_WIDGET(hbox1), TRUE, TRUE, 0);
 
   /* add signal handler for preview pipe finish to update message on corrections done */
   DT_DEBUG_CONTROL_SIGNAL_CONNECT(dt_control_signal_get_global(), DT_SIGNAL_DEVELOP_PREVIEW_PIPE_FINISHED,
@@ -2462,7 +2462,7 @@ void gui_init(struct dt_iop_module_t *self)
 void gui_update(struct dt_iop_module_t *self)
 {
   // let gui elements reflect params
-  dt_iop_lensfun_gui_data_t *g = (dt_iop_lensfun_gui_data_t *)self->gui_data;
+  dt_iop_lensfun_gui_data_t *g = (dt_iop_lensfun_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_lensfun_params_t *p = (dt_iop_lensfun_params_t *)self->params;
 
   if(p->modified == 0)
@@ -2578,7 +2578,7 @@ void gui_update(struct dt_iop_module_t *self)
 
 void gui_cleanup(struct dt_iop_module_t *self)
 {
-  dt_iop_lensfun_gui_data_t *g = (dt_iop_lensfun_gui_data_t *)self->gui_data;
+  dt_iop_lensfun_gui_data_t *g = (dt_iop_lensfun_gui_data_t *)dt_iop_gui_data(self);
 
   DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(dt_control_signal_get_global(), G_CALLBACK(corrections_done), self);
 

--- a/src/iop/levels.c
+++ b/src/iop/levels.c
@@ -305,7 +305,7 @@ void color_picker_apply(dt_iop_module_t *self, GtkWidget *picker, dt_dev_pixelpi
 {
   (void)pipe;
   (void)piece;
-  dt_iop_levels_gui_data_t *c = (dt_iop_levels_gui_data_t *)self->gui_data;
+  dt_iop_levels_gui_data_t *c = (dt_iop_levels_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_levels_params_t *p = (dt_iop_levels_params_t *)self->params;
 
   /* we need to save the last picked color to prevent flickering when
@@ -374,7 +374,7 @@ static inline __attribute__((always_inline)) void commit_params_late(dt_iop_modu
                                const dt_dev_pixelpipe_iop_t *piece)
 {
   dt_iop_levels_data_t *d = (dt_iop_levels_data_t *)piece->data;
-  dt_iop_levels_gui_data_t *g = (dt_iop_levels_gui_data_t *)self->gui_data;
+  dt_iop_levels_gui_data_t *g = (dt_iop_levels_gui_data_t *)dt_iop_gui_data(self);
 
   if(d->mode == LEVELS_MODE_AUTOMATIC)
   {
@@ -551,7 +551,7 @@ void cleanup_pipe(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelp
 
 void gui_changed(dt_iop_module_t *self, GtkWidget *w, void *previous)
 {
-  dt_iop_levels_gui_data_t *g = (dt_iop_levels_gui_data_t *)self->gui_data;
+  dt_iop_levels_gui_data_t *g = (dt_iop_levels_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_levels_params_t *p = (dt_iop_levels_params_t *)self->params;
 
   if(w == g->mode)
@@ -570,7 +570,7 @@ void gui_changed(dt_iop_module_t *self, GtkWidget *w, void *previous)
 
 void gui_update(dt_iop_module_t *self)
 {
-  dt_iop_levels_gui_data_t *g = (dt_iop_levels_gui_data_t *)self->gui_data;
+  dt_iop_levels_gui_data_t *g = (dt_iop_levels_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_levels_params_t *p = (dt_iop_levels_params_t *)self->params;
 
   dt_bauhaus_combobox_set(g->mode, p->mode);
@@ -584,7 +584,7 @@ void gui_update(dt_iop_module_t *self)
   g->hash = 0;
   dt_iop_gui_leave_critical_section(self);
 
-  gtk_widget_queue_draw(self->widget);
+  gtk_widget_queue_draw(self->gui->widget);
 }
 
 void init(dt_iop_module_t *module)
@@ -668,7 +668,7 @@ void gui_init(dt_iop_module_t *self)
 
   gtk_stack_add_named(GTK_STACK(c->mode_stack), vbox_manual, "manual");
 
-  GtkWidget *vbox_automatic = self->widget = GTK_WIDGET(gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_GUI_BOX_SPACING));
+  GtkWidget *vbox_automatic = self->gui->widget = GTK_WIDGET(gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_GUI_BOX_SPACING));
 
   c->percentile_black = dt_bauhaus_slider_from_params(self, N_("black"));
   gtk_widget_set_tooltip_text(c->percentile_black, _("black percentile"));
@@ -685,16 +685,16 @@ void gui_init(dt_iop_module_t *self)
   gtk_stack_add_named(GTK_STACK(c->mode_stack), vbox_automatic, "automatic");
 
   // start building top level widget
-  self->widget = GTK_WIDGET(gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_GUI_BOX_SPACING));
+  self->gui->widget = GTK_WIDGET(gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_GUI_BOX_SPACING));
 
   c->mode = dt_bauhaus_combobox_from_params(self, N_("mode"));
 
-  gtk_box_pack_start(GTK_BOX(self->widget), c->mode_stack, TRUE, TRUE, 0);
+  gtk_box_pack_start(GTK_BOX(self->gui->widget), c->mode_stack, TRUE, TRUE, 0);
 }
 
 void gui_cleanup(dt_iop_module_t *self)
 {
-  dt_iop_levels_gui_data_t *g = (dt_iop_levels_gui_data_t *)self->gui_data;
+  dt_iop_levels_gui_data_t *g = (dt_iop_levels_gui_data_t *)dt_iop_gui_data(self);
   g_list_free(g->modes);
   g->modes = NULL;
 
@@ -704,7 +704,7 @@ void gui_cleanup(dt_iop_module_t *self)
 static gboolean dt_iop_levels_leave_notify(GtkWidget *widget, GdkEventCrossing *event, gpointer user_data)
 {
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
-  dt_iop_levels_gui_data_t *c = (dt_iop_levels_gui_data_t *)self->gui_data;
+  dt_iop_levels_gui_data_t *c = (dt_iop_levels_gui_data_t *)dt_iop_gui_data(self);
   c->mouse_x = c->mouse_y = -1.0;
   gtk_widget_queue_draw(widget);
   return TRUE;
@@ -713,7 +713,7 @@ static gboolean dt_iop_levels_leave_notify(GtkWidget *widget, GdkEventCrossing *
 static gboolean dt_iop_levels_area_draw(GtkWidget *widget, cairo_t *crf, gpointer user_data)
 {
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
-  dt_iop_levels_gui_data_t *c = (dt_iop_levels_gui_data_t *)self->gui_data;
+  dt_iop_levels_gui_data_t *c = (dt_iop_levels_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_levels_params_t *p = (dt_iop_levels_params_t *)self->params;
 
   const int inset = DT_GUI_CURVE_EDITOR_INSET;
@@ -834,7 +834,7 @@ static gboolean dt_iop_levels_area_draw(GtkWidget *widget, cairo_t *crf, gpointe
 static void dt_iop_levels_move_handle(dt_iop_module_t *self, int handle_move, float new_pos, float *levels,
                                       float drag_start_percentage)
 {
-  dt_iop_levels_gui_data_t *c = (dt_iop_levels_gui_data_t *)self->gui_data;
+  dt_iop_levels_gui_data_t *c = (dt_iop_levels_gui_data_t *)dt_iop_gui_data(self);
   float min_x = 0;
   float max_x = 1;
 
@@ -872,7 +872,7 @@ static void dt_iop_levels_move_handle(dt_iop_module_t *self, int handle_move, fl
 static gboolean dt_iop_levels_motion_notify(GtkWidget *widget, GdkEventMotion *event, gpointer user_data)
 {
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
-  dt_iop_levels_gui_data_t *c = (dt_iop_levels_gui_data_t *)self->gui_data;
+  dt_iop_levels_gui_data_t *c = (dt_iop_levels_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_levels_params_t *p = (dt_iop_levels_params_t *)self->params;
   const int inset = DT_GUI_CURVE_EDITOR_INSET;
   GtkAllocation allocation;
@@ -927,18 +927,18 @@ static gboolean dt_iop_levels_button_press(GtkWidget *widget, GdkEventButton *ev
     if(event->type == GDK_2BUTTON_PRESS)
     {
       // Reset
-      dt_iop_levels_gui_data_t *c = (dt_iop_levels_gui_data_t *)self->gui_data;
+      dt_iop_levels_gui_data_t *c = (dt_iop_levels_gui_data_t *)dt_iop_gui_data(self);
       memcpy(self->params, self->default_params, self->params_size);
 
       // Needed in case the user scrolls or drags immediately after a reset,
       // as drag_start_percentage is only updated when the mouse is moved.
       c->drag_start_percentage = 0.5;
       dt_dev_add_history_item(self->dev, self, TRUE, TRUE);
-      gtk_widget_queue_draw(self->widget);
+      gtk_widget_queue_draw(self->gui->widget);
     }
     else
     {
-      dt_iop_levels_gui_data_t *c = (dt_iop_levels_gui_data_t *)self->gui_data;
+      dt_iop_levels_gui_data_t *c = (dt_iop_levels_gui_data_t *)dt_iop_gui_data(self);
       c->dragging = 1;
     }
     return TRUE;
@@ -951,7 +951,7 @@ static gboolean dt_iop_levels_button_release(GtkWidget *widget, GdkEventButton *
   if(event->button == 1)
   {
     dt_iop_module_t *self = (dt_iop_module_t *)user_data;
-    dt_iop_levels_gui_data_t *c = (dt_iop_levels_gui_data_t *)self->gui_data;
+    dt_iop_levels_gui_data_t *c = (dt_iop_levels_gui_data_t *)dt_iop_gui_data(self);
     c->dragging = 0;
     return TRUE;
   }
@@ -961,7 +961,7 @@ static gboolean dt_iop_levels_button_release(GtkWidget *widget, GdkEventButton *
 static gboolean dt_iop_levels_scroll(GtkWidget *widget, GdkEventScroll *event, gpointer user_data)
 {
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
-  dt_iop_levels_gui_data_t *c = (dt_iop_levels_gui_data_t *)self->gui_data;
+  dt_iop_levels_gui_data_t *c = (dt_iop_levels_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_levels_params_t *p = (dt_iop_levels_params_t *)self->params;
 
   int delta_y;
@@ -991,7 +991,7 @@ static void dt_iop_levels_autoadjust_callback(GtkRange *range, dt_iop_module_t *
 {
   if(dt_gui_widgets_suppressed()) return;
   dt_iop_levels_params_t *p = (dt_iop_levels_params_t *)self->params;
-  dt_iop_levels_gui_data_t *c = (dt_iop_levels_gui_data_t *)self->gui_data;
+  dt_iop_levels_gui_data_t *c = (dt_iop_levels_gui_data_t *)dt_iop_gui_data(self);
 
   dt_iop_color_picker_reset(self, TRUE);
 

--- a/src/iop/liquify.c
+++ b/src/iop/liquify.c
@@ -1746,7 +1746,6 @@ void init(dt_iop_module_t *module)
   // module is disabled by default
   module->default_enabled = 0;
   module->params_size = sizeof(dt_iop_liquify_params_t);
-  module->gui_data = NULL;
 
   // all allocated to 0, which is the default
   module->params = calloc(1, module->params_size);
@@ -1948,7 +1947,7 @@ static void _draw_paths(dt_iop_module_t *module,
                         dt_iop_liquify_params_t *p,
                         GList *layers)
 {
-  const dt_iop_liquify_gui_data_t *g = (dt_iop_liquify_gui_data_t *) module->gui_data;
+  const dt_iop_liquify_gui_data_t *g = (dt_iop_liquify_gui_data_t *)dt_iop_gui_data(module);
 
   cairo_set_line_cap(cr, CAIRO_LINE_CAP_ROUND);
 
@@ -2472,7 +2471,7 @@ static dt_liquify_hit_t _hit_paths(dt_iop_module_t *module,
 
 static void draw_paths(struct dt_iop_module_t *module, cairo_t *cr, const float scale, dt_iop_liquify_params_t *params)
 {
-  const dt_iop_liquify_gui_data_t *g = (dt_iop_liquify_gui_data_t *) module->gui_data;
+  const dt_iop_liquify_gui_data_t *g = (dt_iop_liquify_gui_data_t *)dt_iop_gui_data(module);
   GList *layers = NULL;
 
   for(dt_liquify_layer_enum_t layer = 0; layer < DT_LIQUIFY_LAYER_LAST; ++layer)
@@ -2778,7 +2777,7 @@ static void init_warp(dt_liquify_warp_t *warp, float complex point)
 
 static dt_liquify_path_data_t *alloc_move_to(dt_iop_module_t *module, float complex start_point)
 {
-  dt_iop_liquify_gui_data_t *g = (dt_iop_liquify_gui_data_t *) module->gui_data;
+  dt_iop_liquify_gui_data_t *g = (dt_iop_liquify_gui_data_t *)dt_iop_gui_data(module);
   dt_liquify_path_data_t* m = (dt_liquify_path_data_t*)node_alloc(&g->params, &g->node_index);
   if(m)
   {
@@ -2791,7 +2790,7 @@ static dt_liquify_path_data_t *alloc_move_to(dt_iop_module_t *module, float comp
 
 static dt_liquify_path_data_t *alloc_line_to(dt_iop_module_t *module, float complex end_point)
 {
-  dt_iop_liquify_gui_data_t *g = (dt_iop_liquify_gui_data_t *) module->gui_data;
+  dt_iop_liquify_gui_data_t *g = (dt_iop_liquify_gui_data_t *)dt_iop_gui_data(module);
   dt_liquify_path_data_t* l = (dt_liquify_path_data_t*)node_alloc(&g->params, &g->node_index);
   if(!IS_NULL_PTR(l))
   {
@@ -2804,7 +2803,7 @@ static dt_liquify_path_data_t *alloc_line_to(dt_iop_module_t *module, float comp
 
 static dt_liquify_path_data_t *alloc_curve_to(dt_iop_module_t *module, float complex end_point)
 {
-  dt_iop_liquify_gui_data_t *g = (dt_iop_liquify_gui_data_t *) module->gui_data;
+  dt_iop_liquify_gui_data_t *g = (dt_iop_liquify_gui_data_t *)dt_iop_gui_data(module);
   dt_liquify_path_data_t* c = (dt_liquify_path_data_t*)node_alloc(&g->params, &g->node_index);
   if(!IS_NULL_PTR(c))
   {
@@ -2842,7 +2841,7 @@ void gui_post_expose(struct dt_iop_module_t *module,
   dt_develop_t *develop = module->dev;
   if(IS_NULL_PTR(develop))
     return;
-  dt_iop_liquify_gui_data_t *g = (dt_iop_liquify_gui_data_t *) module->gui_data;
+  dt_iop_liquify_gui_data_t *g = (dt_iop_liquify_gui_data_t *)dt_iop_gui_data(module);
   if(IS_NULL_PTR(g))
     return;
 
@@ -2889,7 +2888,7 @@ static void sync_pipe(struct dt_iop_module_t *module, gboolean history)
 {
   if(history)
   {
-    const dt_iop_liquify_gui_data_t *g = (dt_iop_liquify_gui_data_t *) module->gui_data;
+    const dt_iop_liquify_gui_data_t *g = (dt_iop_liquify_gui_data_t *)dt_iop_gui_data(module);
     // something definitive has happened like button release ... so
     // redraw pipe
     memcpy(module->params, &g->params, sizeof(dt_iop_liquify_params_t));
@@ -2952,7 +2951,7 @@ int mouse_moved(struct dt_iop_module_t *module,
                  double pressure,
                  int which)
 {
-  dt_iop_liquify_gui_data_t *g = (dt_iop_liquify_gui_data_t *) module->gui_data;
+  dt_iop_liquify_gui_data_t *g = (dt_iop_liquify_gui_data_t *)dt_iop_gui_data(module);
   gboolean handled = FALSE;
   float complex pt = 0.0f;
   float scale = 0.0f;
@@ -3195,7 +3194,7 @@ static void get_stamp_params(dt_iop_module_t *module, float *radius, float *r_st
  */
 int scrolled(struct dt_iop_module_t *module, double x, double y, int up, uint32_t state)
 {
-  const dt_iop_liquify_gui_data_t *g = (dt_iop_liquify_gui_data_t *) module->gui_data;
+  const dt_iop_liquify_gui_data_t *g = (dt_iop_liquify_gui_data_t *)dt_iop_gui_data(module);
 
   // add an option to allow skip mouse events while editing masks
   const gboolean incr = dt_mask_scroll_increases(up);
@@ -3271,7 +3270,7 @@ int button_pressed(struct dt_iop_module_t *module,
                     int type,
                     uint32_t state)
 {
-  dt_iop_liquify_gui_data_t *g = (dt_iop_liquify_gui_data_t *) module->gui_data;
+  dt_iop_liquify_gui_data_t *g = (dt_iop_liquify_gui_data_t *)dt_iop_gui_data(module);
   int handled = 0;
   float complex pt = 0.0f;
   float scale = 0.0f;
@@ -3382,7 +3381,7 @@ done:
 
 static void _start_new_shape(dt_iop_module_t *module)
 {
-  dt_iop_liquify_gui_data_t *g = (dt_iop_liquify_gui_data_t *) module->gui_data;
+  dt_iop_liquify_gui_data_t *g = (dt_iop_liquify_gui_data_t *)dt_iop_gui_data(module);
 
   //  create initial shape at the center
   float complex pt = 0.0f;
@@ -3410,7 +3409,7 @@ int button_released(struct dt_iop_module_t *module,
                      int which,
                      uint32_t state)
 {
-  dt_iop_liquify_gui_data_t *g = (dt_iop_liquify_gui_data_t *) module->gui_data;
+  dt_iop_liquify_gui_data_t *g = (dt_iop_liquify_gui_data_t *)dt_iop_gui_data(module);
   int handled = 0;
   float complex pt = 0.0f;
   float scale = 0.0f;
@@ -3664,7 +3663,7 @@ int key_pressed(struct dt_iop_module_t *self, GdkEventKey *event)
 {
   if(IS_NULL_PTR(event)) return 0;
 
-  dt_iop_liquify_gui_data_t *g = (dt_iop_liquify_gui_data_t *)self->gui_data;
+  dt_iop_liquify_gui_data_t *g = (dt_iop_liquify_gui_data_t *)dt_iop_gui_data(self);
   if(IS_NULL_PTR(g)) return 0;
   guint key = dt_keys_mainpad_alternatives(event->keyval);
 
@@ -3835,7 +3834,7 @@ int key_pressed(struct dt_iop_module_t *self, GdkEventKey *event)
 
 static gboolean btn_make_radio_callback(GtkToggleButton *btn, GdkEventButton *event, dt_iop_module_t *module)
 {
-  dt_iop_liquify_gui_data_t *g = (dt_iop_liquify_gui_data_t *) module->gui_data;
+  dt_iop_liquify_gui_data_t *g = (dt_iop_liquify_gui_data_t *)dt_iop_gui_data(module);
 
   // if currently dragging and a form (line or node) has been started, does nothing (expect resetting the toggle button status).
   if(is_dragging(g) && g->temp && node_prev(&g->params, g->temp))
@@ -3898,7 +3897,7 @@ static gboolean btn_make_radio_callback(GtkToggleButton *btn, GdkEventButton *ev
 
 void gui_update(dt_iop_module_t *module)
 {
-  dt_iop_liquify_gui_data_t *g = (dt_iop_liquify_gui_data_t *) module->gui_data;
+  dt_iop_liquify_gui_data_t *g = (dt_iop_liquify_gui_data_t *)dt_iop_gui_data(module);
   memcpy(&g->params, module->params, sizeof(dt_iop_liquify_params_t));
   update_warp_count(g);
 }
@@ -3919,11 +3918,11 @@ void gui_init(dt_iop_module_t *self)
   g->last_hit = NOWHERE;
   g->node_index = 0;
 
-  self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_GUI_BOX_SPACING);
+  self->gui->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_GUI_BOX_SPACING);
 
   GtkWidget *hbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, DT_GUI_BOX_SPACING);
   gtk_widget_set_tooltip_text(hbox, _("use a tool to add warps.\nright-click to remove a warp."));
-  gtk_box_pack_start(GTK_BOX(self->widget), hbox, TRUE, TRUE, 0);
+  gtk_box_pack_start(GTK_BOX(self->gui->widget), hbox, TRUE, TRUE, 0);
 
 
   GtkWidget *lbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, DT_GUI_BOX_SPACING);
@@ -3944,7 +3943,7 @@ void gui_init(dt_iop_module_t *self)
   gtk_box_pack_start(GTK_BOX(lbox), labelbox2, FALSE, TRUE, 0);
 
   hbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, DT_GUI_BOX_SPACING);
-  gtk_box_pack_start(GTK_BOX(self->widget), hbox, TRUE, TRUE, 0);
+  gtk_box_pack_start(GTK_BOX(self->gui->widget), hbox, TRUE, TRUE, 0);
 
   g->btn_node_tool = GTK_TOGGLE_BUTTON(dt_iop_togglebutton_new(self, NULL, N_("edit, add and delete nodes"), NULL,
                                        G_CALLBACK(btn_make_radio_callback), TRUE, 0, 0,
@@ -3978,7 +3977,7 @@ void gui_init(dt_iop_module_t *self)
 
 void gui_reset(dt_iop_module_t *self)
 {
-  dt_iop_liquify_gui_data_t *g = (dt_iop_liquify_gui_data_t *)self->gui_data;
+  dt_iop_liquify_gui_data_t *g = (dt_iop_liquify_gui_data_t *)dt_iop_gui_data(self);
   g->dragging = NOWHERE;
   g->temp = NULL;
   g->status = 0;

--- a/src/iop/lowlight.c
+++ b/src/iop/lowlight.c
@@ -251,10 +251,10 @@ void cleanup_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev
 
 void gui_update(struct dt_iop_module_t *self)
 {
-  dt_iop_lowlight_gui_data_t *g = (dt_iop_lowlight_gui_data_t *)self->gui_data;
+  dt_iop_lowlight_gui_data_t *g = (dt_iop_lowlight_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_lowlight_params_t *p = (dt_iop_lowlight_params_t *)self->params;
   dt_bauhaus_slider_set(g->scale_blueness, p->blueness);
-  gtk_widget_queue_draw(self->widget);
+  gtk_widget_queue_draw(self->gui->widget);
 }
 
 void init(dt_iop_module_t *module)
@@ -452,7 +452,7 @@ static void dt_iop_lowlight_get_params(dt_iop_lowlight_params_t *p, const double
 static gboolean lowlight_draw(GtkWidget *widget, cairo_t *crf, gpointer user_data)
 {
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
-  dt_iop_lowlight_gui_data_t *c = (dt_iop_lowlight_gui_data_t *)self->gui_data;
+  dt_iop_lowlight_gui_data_t *c = (dt_iop_lowlight_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_lowlight_params_t p = *(dt_iop_lowlight_params_t *)self->params;
 
   dt_draw_curve_set_point(c->transition_curve, 0, p.transition_x[DT_IOP_LOWLIGHT_BANDS - 2] - 1.0,
@@ -644,7 +644,7 @@ static gboolean lowlight_draw(GtkWidget *widget, cairo_t *crf, gpointer user_dat
 static gboolean lowlight_motion_notify(GtkWidget *widget, GdkEventMotion *event, gpointer user_data)
 {
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
-  dt_iop_lowlight_gui_data_t *c = (dt_iop_lowlight_gui_data_t *)self->gui_data;
+  dt_iop_lowlight_gui_data_t *c = (dt_iop_lowlight_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_lowlight_params_t *p = (dt_iop_lowlight_params_t *)self->params;
   const int inset = DT_IOP_LOWLIGHT_INSET;
   GtkAllocation allocation;
@@ -709,11 +709,11 @@ static gboolean lowlight_button_press(GtkWidget *widget, GdkEventButton *event, 
       p->transition_y[k] = d->transition_y[k];
     }
     dt_dev_add_history_item(self->dev, self, TRUE, TRUE);
-    gtk_widget_queue_draw(self->widget);
+    gtk_widget_queue_draw(self->gui->widget);
   }
   else if(event->button == 1)
   {
-    dt_iop_lowlight_gui_data_t *c = (dt_iop_lowlight_gui_data_t *)self->gui_data;
+    dt_iop_lowlight_gui_data_t *c = (dt_iop_lowlight_gui_data_t *)dt_iop_gui_data(self);
     c->drag_params = *(dt_iop_lowlight_params_t *)self->params;
     const int inset = DT_IOP_LOWLIGHT_INSET;
     GtkAllocation allocation;
@@ -733,7 +733,7 @@ static gboolean lowlight_button_release(GtkWidget *widget, GdkEventButton *event
   if(event->button == 1)
   {
     dt_iop_module_t *self = (dt_iop_module_t *)user_data;
-    dt_iop_lowlight_gui_data_t *c = (dt_iop_lowlight_gui_data_t *)self->gui_data;
+    dt_iop_lowlight_gui_data_t *c = (dt_iop_lowlight_gui_data_t *)dt_iop_gui_data(self);
     c->dragging = 0;
     return TRUE;
   }
@@ -743,7 +743,7 @@ static gboolean lowlight_button_release(GtkWidget *widget, GdkEventButton *event
 static gboolean lowlight_leave_notify(GtkWidget *widget, GdkEventCrossing *event, gpointer user_data)
 {
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
-  dt_iop_lowlight_gui_data_t *c = (dt_iop_lowlight_gui_data_t *)self->gui_data;
+  dt_iop_lowlight_gui_data_t *c = (dt_iop_lowlight_gui_data_t *)dt_iop_gui_data(self);
   if(!c->dragging) c->mouse_y = -1.0;
   gtk_widget_queue_draw(widget);
   return TRUE;
@@ -752,7 +752,7 @@ static gboolean lowlight_leave_notify(GtkWidget *widget, GdkEventCrossing *event
 static gboolean lowlight_scrolled(GtkWidget *widget, GdkEventScroll *event, gpointer user_data)
 {
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
-  dt_iop_lowlight_gui_data_t *c = (dt_iop_lowlight_gui_data_t *)self->gui_data;
+  dt_iop_lowlight_gui_data_t *c = (dt_iop_lowlight_gui_data_t *)dt_iop_gui_data(self);
 
   int delta_y;
   if(dt_gui_get_scroll_unit_deltas(event, NULL, &delta_y))
@@ -779,15 +779,15 @@ void gui_init(struct dt_iop_module_t *self)
   c->mouse_x = c->mouse_y = c->mouse_pick = -1.0;
   c->dragging = 0;
   c->x_move = -1;
-  self->timeout_handle = 0;
+  self->gui->timeout_handle = 0;
   c->mouse_radius = 1.0 / DT_IOP_LOWLIGHT_BANDS;
 
-  self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_GUI_BOX_SPACING);
+  self->gui->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_GUI_BOX_SPACING);
 
   c->area = GTK_DRAWING_AREA(gtk_drawing_area_new());
   gtk_widget_set_hexpand(GTK_WIDGET(c->area), TRUE);
   g_object_set_data(G_OBJECT(c->area), "iop-instance", self);
-  gtk_box_pack_start(GTK_BOX(self->widget),
+  gtk_box_pack_start(GTK_BOX(self->gui->widget),
                      dt_ui_resizable_drawing_area(GTK_WIDGET(c->area),
                                                   "plugins/darkroom/lowlight/graphheight", 280, 100),
                      FALSE, FALSE, 0);
@@ -809,7 +809,7 @@ void gui_init(struct dt_iop_module_t *self)
 
 void gui_cleanup(struct dt_iop_module_t *self)
 {
-  dt_iop_lowlight_gui_data_t *c = (dt_iop_lowlight_gui_data_t *)self->gui_data;
+  dt_iop_lowlight_gui_data_t *c = (dt_iop_lowlight_gui_data_t *)dt_iop_gui_data(self);
   dt_draw_curve_destroy(c->transition_curve);
 
   IOP_GUI_FREE;

--- a/src/iop/lut3d.c
+++ b/src/iop/lut3d.c
@@ -1067,7 +1067,7 @@ static void get_selected_lutname(dt_iop_lut3d_gui_data_t *g, char *const lutname
 
 static void get_compressed_clut(dt_iop_module_t *self, gboolean newlutname)
 {
-  dt_iop_lut3d_gui_data_t *g = (dt_iop_lut3d_gui_data_t *)self->gui_data;
+  dt_iop_lut3d_gui_data_t *g = (dt_iop_lut3d_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_lut3d_params_t *p = (dt_iop_lut3d_params_t *)self->params;
   int nb_lut = 0;
   char *lutfolder = dt_conf_get_string("plugins/darkroom/lut3d/def_path");
@@ -1105,7 +1105,7 @@ static void get_compressed_clut(dt_iop_module_t *self, gboolean newlutname)
 
 static void show_hide_controls(dt_iop_module_t *self)
 {
-  dt_iop_lut3d_gui_data_t *g = (dt_iop_lut3d_gui_data_t *)self->gui_data;
+  dt_iop_lut3d_gui_data_t *g = (dt_iop_lut3d_gui_data_t *)dt_iop_gui_data(self);
   GtkTreeModel *model = gtk_tree_view_get_model((GtkTreeView *)g->lutname);
   const int nb_luts = gtk_tree_model_iter_n_children(model, NULL);
   if ((nb_luts > 1) || ((nb_luts > 0) &&
@@ -1179,7 +1179,7 @@ static void filepath_callback(GtkWidget *widget, dt_iop_module_t *self)
   {
     filepath_set_unix_separator(filepath);
 #ifdef HAVE_GMIC
-    dt_iop_lut3d_gui_data_t *g = (dt_iop_lut3d_gui_data_t *)self->gui_data;
+    dt_iop_lut3d_gui_data_t *g = (dt_iop_lut3d_gui_data_t *)dt_iop_gui_data(self);
     if (strcmp(filepath, p->filepath) != 0 && !(g_str_has_suffix(filepath, ".gmz") || g_str_has_suffix(filepath, ".GMZ")))
     {
       // if new file is gmz we try to keep the same lut
@@ -1201,7 +1201,7 @@ static void filepath_callback(GtkWidget *widget, dt_iop_module_t *self)
 #ifdef HAVE_GMIC
 static void entry_callback(GtkEntry *entry, dt_iop_module_t *self)
 {
-  dt_iop_lut3d_gui_data_t *g = (dt_iop_lut3d_gui_data_t *)self->gui_data;
+  dt_iop_lut3d_gui_data_t *g = (dt_iop_lut3d_gui_data_t *)dt_iop_gui_data(self);
   apply_filter_lutname_list(g);
 }
 
@@ -1330,7 +1330,7 @@ static void update_filepath_combobox(dt_iop_lut3d_gui_data_t *g, char *filepath,
 
 static void button_clicked(GtkWidget *widget, dt_iop_module_t *self)
 {
-  dt_iop_lut3d_gui_data_t *g = (dt_iop_lut3d_gui_data_t *)self->gui_data;
+  dt_iop_lut3d_gui_data_t *g = (dt_iop_lut3d_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_lut3d_params_t *p = (dt_iop_lut3d_params_t *)self->params;
   gchar* lutfolder = dt_conf_get_string("plugins/darkroom/lut3d/def_path");
   if (strlen(lutfolder) == 0)
@@ -1403,7 +1403,7 @@ static void button_clicked(GtkWidget *widget, dt_iop_module_t *self)
 static void _show_hide_colorspace(dt_iop_module_t *self)
 {
   if(IS_NULL_PTR(self)) return;
-  dt_iop_lut3d_gui_data_t *g = (dt_iop_lut3d_gui_data_t *)self->gui_data;
+  dt_iop_lut3d_gui_data_t *g = (dt_iop_lut3d_gui_data_t *)dt_iop_gui_data(self);
   if(IS_NULL_PTR(g) || IS_NULL_PTR(g->colorspace)) return;
   GList *iop_order_list = self->dev->iop_order_list;
   const int order_lut3d = dt_ioppr_get_iop_order(iop_order_list, self->op, self->multi_priority);
@@ -1422,7 +1422,7 @@ static void _show_hide_colorspace(dt_iop_module_t *self)
 void gui_update(dt_iop_module_t *self)
 {
   if(IS_NULL_PTR(self)) return;
-  dt_iop_lut3d_gui_data_t *g = (dt_iop_lut3d_gui_data_t *)self->gui_data;
+  dt_iop_lut3d_gui_data_t *g = (dt_iop_lut3d_gui_data_t *)dt_iop_gui_data(self);
     if(IS_NULL_PTR(g)) return;
   dt_iop_lut3d_params_t *p = (dt_iop_lut3d_params_t *)self->params;
     if(IS_NULL_PTR(p)) return;
@@ -1461,7 +1461,7 @@ void gui_init(dt_iop_module_t *self)
 {
   dt_iop_lut3d_gui_data_t *g = IOP_GUI_ALLOC(lut3d);
 
-  self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_GUI_BOX_SPACING);
+  self->gui->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_GUI_BOX_SPACING);
 
   g->hbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, DT_GUI_BOX_SPACING);
   GtkWidget *button = dtgtk_button_new(dtgtk_cairo_paint_directory, CPF_NONE, NULL);
@@ -1489,14 +1489,14 @@ void gui_init(dt_iop_module_t *self)
 #endif // HAVE_GMIC
   g_signal_connect(G_OBJECT(g->filepath), "value-changed", G_CALLBACK(filepath_callback), self);
 
-  gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(g->hbox), TRUE, TRUE, 0);
+  gtk_box_pack_start(GTK_BOX(self->gui->widget), GTK_WIDGET(g->hbox), TRUE, TRUE, 0);
 
 #ifdef HAVE_GMIC
   // text entry
   GtkWidget *entry = gtk_entry_new();
   dt_accels_disconnect_on_text_input(entry);
   gtk_widget_set_tooltip_text(entry, _("enter lut name"));
-  gtk_box_pack_start((GtkBox *)self->widget,entry, TRUE, TRUE, 0);
+  gtk_box_pack_start((GtkBox *)self->gui->widget,entry, TRUE, TRUE, 0);
   gtk_widget_add_events(entry, GDK_KEY_RELEASE_MASK);
   g_signal_connect(G_OBJECT(entry), "changed", G_CALLBACK(entry_callback), self);
   g->lutentry = entry;
@@ -1526,7 +1526,7 @@ void gui_init(dt_iop_module_t *self)
   gtk_tree_selection_set_mode(selection, GTK_SELECTION_SINGLE);
   g->lutname_handler_id = g_signal_connect(G_OBJECT(selection), "changed", G_CALLBACK(lutname_callback), self);
   g_signal_connect(G_OBJECT(view), "scroll-event", G_CALLBACK(mouse_scroll), (gpointer)self);
-  gtk_box_pack_start((GtkBox *)self->widget, sw , TRUE, TRUE, 0);
+  gtk_box_pack_start((GtkBox *)self->gui->widget, sw , TRUE, TRUE, 0);
 #endif // HAVE_GMIC
 
   g->colorspace = dt_bauhaus_combobox_from_params(self, "colorspace");

--- a/src/iop/monochrome.c
+++ b/src/iop/monochrome.c
@@ -293,7 +293,7 @@ void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pix
 
 void gui_update(struct dt_iop_module_t *self)
 {
-  dt_iop_monochrome_gui_data_t *g = (dt_iop_monochrome_gui_data_t *)self->gui_data;
+  dt_iop_monochrome_gui_data_t *g = (dt_iop_monochrome_gui_data_t *)dt_iop_gui_data(self);
   g->dragging = FALSE;
 }
 
@@ -313,7 +313,7 @@ static gboolean dt_iop_monochrome_draw(GtkWidget *widget, cairo_t *crf, gpointer
 {
   if(dt_gui_widgets_suppressed()) return FALSE;
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
-  dt_iop_monochrome_gui_data_t *g = (dt_iop_monochrome_gui_data_t *)self->gui_data;
+  dt_iop_monochrome_gui_data_t *g = (dt_iop_monochrome_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_monochrome_params_t *p = (dt_iop_monochrome_params_t *)self->params;
 
   const int inset = DT_COLORCORRECTION_INSET;
@@ -388,13 +388,13 @@ void color_picker_apply(dt_iop_module_t *self, GtkWidget *picker, dt_dev_pixelpi
   p->size = CLAMP((da + db)/128.0, .5, 3.0);
 
   dt_dev_add_history_item(self->dev, self, TRUE, TRUE);
-  dt_control_queue_redraw_widget(self->widget);
+  dt_control_queue_redraw_widget(self->gui->widget);
 }
 
 static gboolean dt_iop_monochrome_motion_notify(GtkWidget *widget, GdkEventMotion *event, gpointer user_data)
 {
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
-  dt_iop_monochrome_gui_data_t *g = (dt_iop_monochrome_gui_data_t *)self->gui_data;
+  dt_iop_monochrome_gui_data_t *g = (dt_iop_monochrome_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_monochrome_params_t *p = (dt_iop_monochrome_params_t *)self->params;
   if(g->dragging)
   {
@@ -409,7 +409,7 @@ static gboolean dt_iop_monochrome_motion_notify(GtkWidget *widget, GdkEventMotio
     p->b = PANEL_WIDTH * (mouse_y - height * 0.5f) / (float)height;
 
     if(old_a != p->a || old_b != p->b) dt_dev_add_history_item(self->dev, self, TRUE, TRUE);
-    gtk_widget_queue_draw(self->widget);
+    gtk_widget_queue_draw(self->gui->widget);
   }
   return TRUE;
 }
@@ -419,7 +419,7 @@ static gboolean dt_iop_monochrome_button_press(GtkWidget *widget, GdkEventButton
   if(event->button == 1)
   {
     dt_iop_module_t *self = (dt_iop_module_t *)user_data;
-    dt_iop_monochrome_gui_data_t *g = (dt_iop_monochrome_gui_data_t *)self->gui_data;
+    dt_iop_monochrome_gui_data_t *g = (dt_iop_monochrome_gui_data_t *)dt_iop_gui_data(self);
     dt_iop_monochrome_params_t *p = (dt_iop_monochrome_params_t *)self->params;
     dt_iop_color_picker_reset(self, TRUE);
     if(event->type == GDK_2BUTTON_PRESS)
@@ -443,7 +443,7 @@ static gboolean dt_iop_monochrome_button_press(GtkWidget *widget, GdkEventButton
       g->dragging = 1;
       g_object_set(G_OBJECT(widget), "has-tooltip", FALSE, (gchar *)0);
     }
-    gtk_widget_queue_draw(self->widget);
+    gtk_widget_queue_draw(self->gui->widget);
     return TRUE;
   }
   return FALSE;
@@ -454,7 +454,7 @@ static gboolean dt_iop_monochrome_button_release(GtkWidget *widget, GdkEventButt
   if(event->button == 1)
   {
     dt_iop_module_t *self = (dt_iop_module_t *)user_data;
-    dt_iop_monochrome_gui_data_t *g = (dt_iop_monochrome_gui_data_t *)self->gui_data;
+    dt_iop_monochrome_gui_data_t *g = (dt_iop_monochrome_gui_data_t *)dt_iop_gui_data(self);
     dt_iop_color_picker_reset(self, TRUE);
     g->dragging = 0;
     dt_dev_add_history_item(self->dev, self, TRUE, TRUE);
@@ -467,9 +467,9 @@ static gboolean dt_iop_monochrome_button_release(GtkWidget *widget, GdkEventButt
 static gboolean dt_iop_monochrome_leave_notify(GtkWidget *widget, GdkEventCrossing *event, gpointer user_data)
 {
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
-  dt_iop_monochrome_gui_data_t *g = (dt_iop_monochrome_gui_data_t *)self->gui_data;
+  dt_iop_monochrome_gui_data_t *g = (dt_iop_monochrome_gui_data_t *)dt_iop_gui_data(self);
   g->dragging = 0;
-  gtk_widget_queue_draw(self->widget);
+  gtk_widget_queue_draw(self->gui->widget);
   return TRUE;
 }
 
@@ -498,10 +498,10 @@ void gui_init(struct dt_iop_module_t *self)
 
   g->dragging = 0;
 
-  self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_GUI_BOX_SPACING);
+  self->gui->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_GUI_BOX_SPACING);
 
   g->area = GTK_DRAWING_AREA(dtgtk_drawing_area_new_with_aspect_ratio(1.0));
-  gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(g->area), TRUE, TRUE, 0);
+  gtk_box_pack_start(GTK_BOX(self->gui->widget), GTK_WIDGET(g->area), TRUE, TRUE, 0);
   gtk_widget_set_tooltip_text(GTK_WIDGET(g->area), _("drag and scroll mouse wheel to adjust the virtual color filter"));
 
   gtk_widget_add_events(GTK_WIDGET(g->area), GDK_POINTER_MOTION_MASK
@@ -528,7 +528,7 @@ void gui_init(struct dt_iop_module_t *self)
 
 void gui_cleanup(struct dt_iop_module_t *self)
 {
-  dt_iop_monochrome_gui_data_t *g = (dt_iop_monochrome_gui_data_t *)self->gui_data;
+  dt_iop_monochrome_gui_data_t *g = (dt_iop_monochrome_gui_data_t *)dt_iop_gui_data(self);
   cmsDeleteTransform(g->xform);
 
   IOP_GUI_FREE;

--- a/src/iop/negadoctor.c
+++ b/src/iop/negadoctor.c
@@ -437,7 +437,7 @@ static void setup_color_variables(dt_iop_negadoctor_gui_data_t *const g, const g
 
 static void toggle_stock_controls(dt_iop_module_t *const self)
 {
-  dt_iop_negadoctor_gui_data_t *const g = (dt_iop_negadoctor_gui_data_t *)self->gui_data;
+  dt_iop_negadoctor_gui_data_t *const g = (dt_iop_negadoctor_gui_data_t *)dt_iop_gui_data(self);
   const dt_iop_negadoctor_params_t *const p = (dt_iop_negadoctor_params_t *)self->params;
 
   if(p->film_stock == DT_FILMSTOCK_NB)
@@ -462,7 +462,7 @@ static void toggle_stock_controls(dt_iop_module_t *const self)
 
 static void Dmin_picker_update(dt_iop_module_t *self)
 {
-  dt_iop_negadoctor_gui_data_t *const g = (dt_iop_negadoctor_gui_data_t *)self->gui_data;
+  dt_iop_negadoctor_gui_data_t *const g = (dt_iop_negadoctor_gui_data_t *)dt_iop_gui_data(self);
   const dt_iop_negadoctor_params_t *const p = (dt_iop_negadoctor_params_t *)self->params;
 
   GdkRGBA color;
@@ -485,7 +485,7 @@ static void Dmin_picker_update(dt_iop_module_t *self)
 static void Dmin_picker_callback(GtkColorButton *widget, dt_iop_module_t *self)
 {
   if(dt_gui_widgets_suppressed()) return;
-  dt_iop_negadoctor_gui_data_t *g = (dt_iop_negadoctor_gui_data_t *)self->gui_data;
+  dt_iop_negadoctor_gui_data_t *g = (dt_iop_negadoctor_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_negadoctor_params_t *p = (dt_iop_negadoctor_params_t *)self->params;
 
   dt_iop_color_picker_reset(self, TRUE);
@@ -509,7 +509,7 @@ static void Dmin_picker_callback(GtkColorButton *widget, dt_iop_module_t *self)
 
 static void WB_low_picker_update(dt_iop_module_t *self)
 {
-  dt_iop_negadoctor_gui_data_t *const g = (dt_iop_negadoctor_gui_data_t *)self->gui_data;
+  dt_iop_negadoctor_gui_data_t *const g = (dt_iop_negadoctor_gui_data_t *)dt_iop_gui_data(self);
   const dt_iop_negadoctor_params_t *const p = (dt_iop_negadoctor_params_t *)self->params;
 
   GdkRGBA color;
@@ -530,7 +530,7 @@ static void WB_low_picker_update(dt_iop_module_t *self)
 static void WB_low_picker_callback(GtkColorButton *widget, dt_iop_module_t *self)
 {
   if(dt_gui_widgets_suppressed()) return;
-  dt_iop_negadoctor_gui_data_t *g = (dt_iop_negadoctor_gui_data_t *)self->gui_data;
+  dt_iop_negadoctor_gui_data_t *g = (dt_iop_negadoctor_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_negadoctor_params_t *p = (dt_iop_negadoctor_params_t *)self->params;
 
   dt_iop_color_picker_reset(self, TRUE);
@@ -557,7 +557,7 @@ static void WB_low_picker_callback(GtkColorButton *widget, dt_iop_module_t *self
 
 static void WB_high_picker_update(dt_iop_module_t *self)
 {
-  dt_iop_negadoctor_gui_data_t *const g = (dt_iop_negadoctor_gui_data_t *)self->gui_data;
+  dt_iop_negadoctor_gui_data_t *const g = (dt_iop_negadoctor_gui_data_t *)dt_iop_gui_data(self);
   const dt_iop_negadoctor_params_t *const p = (dt_iop_negadoctor_params_t *)self->params;
 
   GdkRGBA color;
@@ -578,7 +578,7 @@ static void WB_high_picker_update(dt_iop_module_t *self)
 static void WB_high_picker_callback(GtkColorButton *widget, dt_iop_module_t *self)
 {
   if(dt_gui_widgets_suppressed()) return;
-  dt_iop_negadoctor_gui_data_t *g = (dt_iop_negadoctor_gui_data_t *)self->gui_data;
+  dt_iop_negadoctor_gui_data_t *g = (dt_iop_negadoctor_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_negadoctor_params_t *p = (dt_iop_negadoctor_params_t *)self->params;
 
   dt_iop_color_picker_reset(self, TRUE);
@@ -605,7 +605,7 @@ static void Wb_low_norm_callback(GtkColorButton *widget, dt_iop_module_t *self)
 {
   if(dt_gui_widgets_suppressed()) return;
 
-  dt_iop_negadoctor_gui_data_t *const g = (dt_iop_negadoctor_gui_data_t *)self->gui_data;
+  dt_iop_negadoctor_gui_data_t *const g = (dt_iop_negadoctor_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_negadoctor_params_t *p = (dt_iop_negadoctor_params_t *)self->params;
 
 
@@ -621,7 +621,7 @@ static void Wb_low_norm_callback(GtkColorButton *widget, dt_iop_module_t *self)
   dt_gui_freeze_end();
 
   WB_low_picker_update(self);
-  dt_control_queue_redraw_widget(self->widget);
+  dt_control_queue_redraw_widget(self->gui->widget);
   dt_dev_add_history_item(self->dev, self, TRUE, TRUE);
 }
 
@@ -629,7 +629,7 @@ static void Wb_high_norm_callback(GtkColorButton *widget, dt_iop_module_t *self)
 {
   if(dt_gui_widgets_suppressed()) return;
 
-  dt_iop_negadoctor_gui_data_t *const g = (dt_iop_negadoctor_gui_data_t *)self->gui_data;
+  dt_iop_negadoctor_gui_data_t *const g = (dt_iop_negadoctor_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_negadoctor_params_t *p = (dt_iop_negadoctor_params_t *)self->params;
 
   const float WB_high_min = v_minf(p->wb_high);
@@ -644,7 +644,7 @@ static void Wb_high_norm_callback(GtkColorButton *widget, dt_iop_module_t *self)
   dt_gui_freeze_end();
 
   WB_low_picker_update(self);
-  dt_control_queue_redraw_widget(self->widget);
+  dt_control_queue_redraw_widget(self->gui->widget);
   dt_dev_add_history_item(self->dev, self, TRUE, TRUE);
 }
 
@@ -654,7 +654,7 @@ static void Wb_high_norm_callback(GtkColorButton *widget, dt_iop_module_t *self)
 static void apply_auto_Dmin(dt_iop_module_t *self)
 {
   if(dt_gui_widgets_suppressed()) return;
-  dt_iop_negadoctor_gui_data_t *g = (dt_iop_negadoctor_gui_data_t *)self->gui_data;
+  dt_iop_negadoctor_gui_data_t *g = (dt_iop_negadoctor_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_negadoctor_params_t *p = (dt_iop_negadoctor_params_t *)self->params;
 
   for(int k = 0; k < 4; k++) p->Dmin[k] = self->picked_color[k];
@@ -666,7 +666,7 @@ static void apply_auto_Dmin(dt_iop_module_t *self)
   dt_gui_freeze_end();
 
   Dmin_picker_update(self);
-  dt_control_queue_redraw_widget(self->widget);
+  dt_control_queue_redraw_widget(self->gui->widget);
   dt_dev_add_history_item(self->dev, self, TRUE, TRUE);
 }
 
@@ -674,7 +674,7 @@ static void apply_auto_Dmin(dt_iop_module_t *self)
 static void apply_auto_Dmax(dt_iop_module_t *self)
 {
   if(dt_gui_widgets_suppressed()) return;
-  dt_iop_negadoctor_gui_data_t *g = (dt_iop_negadoctor_gui_data_t *)self->gui_data;
+  dt_iop_negadoctor_gui_data_t *g = (dt_iop_negadoctor_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_negadoctor_params_t *p = (dt_iop_negadoctor_params_t *)self->params;
 
   dt_aligned_pixel_t RGB;
@@ -690,7 +690,7 @@ static void apply_auto_Dmax(dt_iop_module_t *self)
   dt_bauhaus_slider_set(g->D_max, p->D_max);
   dt_gui_freeze_end();
 
-  dt_control_queue_redraw_widget(self->widget);
+  dt_control_queue_redraw_widget(self->gui->widget);
   dt_dev_add_history_item(self->dev, self, TRUE, TRUE);
 }
 
@@ -698,7 +698,7 @@ static void apply_auto_Dmax(dt_iop_module_t *self)
 static void apply_auto_offset(dt_iop_module_t *self)
 {
   if(dt_gui_widgets_suppressed()) return;
-  dt_iop_negadoctor_gui_data_t *g = (dt_iop_negadoctor_gui_data_t *)self->gui_data;
+  dt_iop_negadoctor_gui_data_t *g = (dt_iop_negadoctor_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_negadoctor_params_t *p = (dt_iop_negadoctor_params_t *)self->params;
 
   dt_aligned_pixel_t RGB;
@@ -712,7 +712,7 @@ static void apply_auto_offset(dt_iop_module_t *self)
   dt_bauhaus_slider_set(g->offset, p->offset);
   dt_gui_freeze_end();
 
-  dt_control_queue_redraw_widget(self->widget);
+  dt_control_queue_redraw_widget(self->gui->widget);
   dt_dev_add_history_item(self->dev, self, TRUE, TRUE);
 }
 
@@ -721,7 +721,7 @@ static void apply_auto_offset(dt_iop_module_t *self)
 static void apply_auto_WB_low(dt_iop_module_t *self)
 {
   if(dt_gui_widgets_suppressed()) return;
-  dt_iop_negadoctor_gui_data_t *g = (dt_iop_negadoctor_gui_data_t *)self->gui_data;
+  dt_iop_negadoctor_gui_data_t *g = (dt_iop_negadoctor_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_negadoctor_params_t *p = (dt_iop_negadoctor_params_t *)self->params;
 
   dt_aligned_pixel_t RGB_min;
@@ -738,7 +738,7 @@ static void apply_auto_WB_low(dt_iop_module_t *self)
   dt_gui_freeze_end();
 
   WB_low_picker_update(self);
-  dt_control_queue_redraw_widget(self->widget);
+  dt_control_queue_redraw_widget(self->gui->widget);
   dt_dev_add_history_item(self->dev, self, TRUE, TRUE);
 }
 
@@ -747,7 +747,7 @@ static void apply_auto_WB_low(dt_iop_module_t *self)
 static void apply_auto_WB_high(dt_iop_module_t *self)
 {
   if(dt_gui_widgets_suppressed()) return;
-  dt_iop_negadoctor_gui_data_t *g = (dt_iop_negadoctor_gui_data_t *)self->gui_data;
+  dt_iop_negadoctor_gui_data_t *g = (dt_iop_negadoctor_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_negadoctor_params_t *p = (dt_iop_negadoctor_params_t *)self->params;
 
   dt_aligned_pixel_t RGB_min;
@@ -764,7 +764,7 @@ static void apply_auto_WB_high(dt_iop_module_t *self)
   dt_gui_freeze_end();
 
   WB_high_picker_update(self);
-  dt_control_queue_redraw_widget(self->widget);
+  dt_control_queue_redraw_widget(self->gui->widget);
   dt_dev_add_history_item(self->dev, self, TRUE, TRUE);
 }
 
@@ -773,7 +773,7 @@ static void apply_auto_WB_high(dt_iop_module_t *self)
 static void apply_auto_black(dt_iop_module_t *self)
 {
   if(dt_gui_widgets_suppressed()) return;
-  dt_iop_negadoctor_gui_data_t *g = (dt_iop_negadoctor_gui_data_t *)self->gui_data;
+  dt_iop_negadoctor_gui_data_t *g = (dt_iop_negadoctor_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_negadoctor_params_t *p = (dt_iop_negadoctor_params_t *)self->params;
 
   dt_aligned_pixel_t RGB;
@@ -790,7 +790,7 @@ static void apply_auto_black(dt_iop_module_t *self)
   dt_bauhaus_slider_set(g->black, p->black);
   dt_gui_freeze_end();
 
-  dt_control_queue_redraw_widget(self->widget);
+  dt_control_queue_redraw_widget(self->gui->widget);
   dt_dev_add_history_item(self->dev, self, TRUE, TRUE);
 }
 
@@ -799,7 +799,7 @@ static void apply_auto_black(dt_iop_module_t *self)
 static void apply_auto_exposure(dt_iop_module_t *self)
 {
   if(dt_gui_widgets_suppressed()) return;
-  dt_iop_negadoctor_gui_data_t *g = (dt_iop_negadoctor_gui_data_t *)self->gui_data;
+  dt_iop_negadoctor_gui_data_t *g = (dt_iop_negadoctor_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_negadoctor_params_t *p = (dt_iop_negadoctor_params_t *)self->params;
 
   dt_aligned_pixel_t RGB;
@@ -816,7 +816,7 @@ static void apply_auto_exposure(dt_iop_module_t *self)
   dt_bauhaus_slider_set(g->exposure, log2f(p->exposure));
   dt_gui_freeze_end();
 
-  dt_control_queue_redraw_widget(self->widget);
+  dt_control_queue_redraw_widget(self->gui->widget);
   dt_dev_add_history_item(self->dev, self, TRUE, TRUE);
 }
 
@@ -826,7 +826,7 @@ void color_picker_apply(dt_iop_module_t *self, GtkWidget *picker, dt_dev_pixelpi
   (void)pipe;
   (void)piece;
   if(dt_gui_widgets_suppressed()) return;
-  dt_iop_negadoctor_gui_data_t *g = (dt_iop_negadoctor_gui_data_t *)self->gui_data;
+  dt_iop_negadoctor_gui_data_t *g = (dt_iop_negadoctor_gui_data_t *)dt_iop_gui_data(self);
 
   if     (picker == g->Dmin_sampler)
     apply_auto_Dmin(self);
@@ -857,7 +857,7 @@ void gui_init(dt_iop_module_t *self)
   dt_ui_notebook_set_picker_owner(g->notebook, self);
 
   // Page FILM PROPERTIES
-  GtkWidget *page1 = self->widget = dt_ui_notebook_page(g->notebook, N_("film properties"), NULL);
+  GtkWidget *page1 = self->gui->widget = dt_ui_notebook_page(g->notebook, N_("film properties"), NULL);
 
   // Dmin
 
@@ -924,7 +924,7 @@ void gui_init(dt_iop_module_t *self)
                                            "before the inversion, so blacks are neither clipped or too pale."));
 
   // Page CORRECTIONS
-  GtkWidget *page2 = self->widget = dt_ui_notebook_page(g->notebook, N_("corrections"), NULL);
+  GtkWidget *page2 = self->gui->widget = dt_ui_notebook_page(g->notebook, N_("corrections"), NULL);
 
   // WB shadows
   gtk_box_pack_start(GTK_BOX(page2), dt_ui_section_label_new(_("shadows color cast")), FALSE, FALSE, 0);
@@ -1007,7 +1007,7 @@ void gui_init(dt_iop_module_t *self)
                                               "recovering the global white balance in difficult cases."));
 
   // Page PRINT PROPERTIES
-  GtkWidget *page3 = self->widget = dt_ui_notebook_page(g->notebook, N_("print properties"), NULL);
+  GtkWidget *page3 = self->gui->widget = dt_ui_notebook_page(g->notebook, N_("print properties"), NULL);
 
   // print corrections
   gtk_box_pack_start(GTK_BOX(page3), dt_ui_section_label_new(_("virtual paper properties")), FALSE, FALSE, 0);
@@ -1044,13 +1044,13 @@ void gui_init(dt_iop_module_t *self)
                                              "the global contrast and avoid clipping highlights."));
 
   // start building top level widget
-  self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_GUI_BOX_SPACING);
+  self->gui->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_GUI_BOX_SPACING);
 
   // Film emulsion
   g->film_stock = dt_bauhaus_combobox_from_params(self, "film_stock");
   gtk_widget_set_tooltip_text(g->film_stock, _("toggle on or off the color controls"));
 
-  gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(g->notebook), FALSE, FALSE, 0);
+  gtk_box_pack_start(GTK_BOX(self->gui->widget), GTK_WIDGET(g->notebook), FALSE, FALSE, 0);
   const int active_page = dt_conf_get_int("plugins/darkroom/negadoctor/gui_page");
   gtk_widget_show(gtk_notebook_get_nth_page(g->notebook, active_page));
   gtk_notebook_set_current_page(g->notebook, active_page);
@@ -1059,7 +1059,7 @@ void gui_init(dt_iop_module_t *self)
 
 void gui_cleanup(struct dt_iop_module_t *self)
 {
-  dt_iop_negadoctor_gui_data_t *g = (dt_iop_negadoctor_gui_data_t *)self->gui_data;
+  dt_iop_negadoctor_gui_data_t *g = (dt_iop_negadoctor_gui_data_t *)dt_iop_gui_data(self);
   if(!IS_NULL_PTR(g) && GTK_IS_NOTEBOOK(g->notebook))
     dt_conf_set_int("plugins/darkroom/negadoctor/gui_page", gtk_notebook_get_current_page(g->notebook));
   IOP_GUI_FREE;
@@ -1068,7 +1068,7 @@ void gui_cleanup(struct dt_iop_module_t *self)
 void gui_changed(dt_iop_module_t *self, GtkWidget *w, void *previous)
 {
   dt_iop_negadoctor_params_t *p = (dt_iop_negadoctor_params_t *)self->params;
-  dt_iop_negadoctor_gui_data_t *g = (dt_iop_negadoctor_gui_data_t *)self->gui_data;
+  dt_iop_negadoctor_gui_data_t *g = (dt_iop_negadoctor_gui_data_t *)dt_iop_gui_data(self);
   if(IS_NULL_PTR(w) || w == g->film_stock)
   {
     toggle_stock_controls(self);
@@ -1103,7 +1103,7 @@ void gui_changed(dt_iop_module_t *self, GtkWidget *w, void *previous)
 void gui_update(dt_iop_module_t *const self)
 {
   // let gui slider match current parameters:
-  dt_iop_negadoctor_gui_data_t *const g = (dt_iop_negadoctor_gui_data_t *)self->gui_data;
+  dt_iop_negadoctor_gui_data_t *const g = (dt_iop_negadoctor_gui_data_t *)dt_iop_gui_data(self);
   const dt_iop_negadoctor_params_t *const p = (dt_iop_negadoctor_params_t *)self->params;
 
   dt_iop_color_picker_reset(self, TRUE);

--- a/src/iop/overexposed.c
+++ b/src/iop/overexposed.c
@@ -54,6 +54,7 @@
 #include "system/target_clones.h"
 #include "config.h"
 #endif
+#include "develop/imageop_gui.h"
 #include <stdlib.h>
 
 #include <cairo.h>
@@ -410,7 +411,6 @@ void init(dt_iop_module_t *module)
   module->hide_enable_button = 1;
   module->default_enabled = 1;
   module->params_size = sizeof(dt_iop_overexposed_t);
-  module->gui_data = NULL;
 
   // This module permanently bypasses the cache because it takes input from GUI
   // and doesn't leave internal parameters to compute an integrity hash on.

--- a/src/iop/profile_gamma.c
+++ b/src/iop/profile_gamma.c
@@ -283,7 +283,7 @@ static void apply_auto_grey(dt_iop_module_t *self)
 {
   if(dt_gui_widgets_suppressed()) return;
   dt_iop_profilegamma_params_t *p = (dt_iop_profilegamma_params_t *)self->params;
-  dt_iop_profilegamma_gui_data_t *g = (dt_iop_profilegamma_gui_data_t *)self->gui_data;
+  dt_iop_profilegamma_gui_data_t *g = (dt_iop_profilegamma_gui_data_t *)dt_iop_gui_data(self);
 
   float grey = fmax(fmax(self->picked_color[0], self->picked_color[1]), self->picked_color[2]);
   p->grey_point = 100.f * grey;
@@ -299,7 +299,7 @@ static void apply_auto_black(dt_iop_module_t *self)
 {
   if(dt_gui_widgets_suppressed()) return;
   dt_iop_profilegamma_params_t *p = (dt_iop_profilegamma_params_t *)self->params;
-  dt_iop_profilegamma_gui_data_t *g = (dt_iop_profilegamma_gui_data_t *)self->gui_data;
+  dt_iop_profilegamma_gui_data_t *g = (dt_iop_profilegamma_gui_data_t *)dt_iop_gui_data(self);
 
   float noise = powf(2.0f, -16.0f);
 
@@ -321,7 +321,7 @@ static void apply_auto_dynamic_range(dt_iop_module_t *self)
 {
   if(dt_gui_widgets_suppressed()) return;
   dt_iop_profilegamma_params_t *p = (dt_iop_profilegamma_params_t *)self->params;
-  dt_iop_profilegamma_gui_data_t *g = (dt_iop_profilegamma_gui_data_t *)self->gui_data;
+  dt_iop_profilegamma_gui_data_t *g = (dt_iop_profilegamma_gui_data_t *)dt_iop_gui_data(self);
 
   float noise = powf(2.0f, -16.0f);
 
@@ -345,7 +345,7 @@ static void apply_auto_dynamic_range(dt_iop_module_t *self)
 static void apply_autotune(dt_iop_module_t *self)
 {
   dt_iop_profilegamma_params_t *p = (dt_iop_profilegamma_params_t *)self->params;
-  dt_iop_profilegamma_gui_data_t *g = (dt_iop_profilegamma_gui_data_t *)self->gui_data;
+  dt_iop_profilegamma_gui_data_t *g = (dt_iop_profilegamma_gui_data_t *)dt_iop_gui_data(self);
 
   float noise = powf(2.0f, -16.0f);
 
@@ -378,7 +378,7 @@ static void apply_autotune(dt_iop_module_t *self)
 
 void gui_changed(dt_iop_module_t *self, GtkWidget *w, void *previous)
 {
-  dt_iop_profilegamma_gui_data_t *g = (dt_iop_profilegamma_gui_data_t *)self->gui_data;
+  dt_iop_profilegamma_gui_data_t *g = (dt_iop_profilegamma_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_profilegamma_params_t *p = (dt_iop_profilegamma_params_t *)self->params;
 
   if(w == g->mode)
@@ -421,7 +421,7 @@ void gui_changed(dt_iop_module_t *self, GtkWidget *w, void *previous)
 
 void color_picker_apply(dt_iop_module_t *self, GtkWidget *picker, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
 {
-  dt_iop_profilegamma_gui_data_t *g = (dt_iop_profilegamma_gui_data_t *)self->gui_data;
+  dt_iop_profilegamma_gui_data_t *g = (dt_iop_profilegamma_gui_data_t *)dt_iop_gui_data(self);
   if     (picker == g->grey_point)
     apply_auto_grey(self);
   else if(picker == g->shadows_range)
@@ -526,7 +526,7 @@ void gui_reset(dt_iop_module_t *self)
 
 void gui_update(dt_iop_module_t *self)
 {
-  dt_iop_profilegamma_gui_data_t *g = (dt_iop_profilegamma_gui_data_t *)self->gui_data;
+  dt_iop_profilegamma_gui_data_t *g = (dt_iop_profilegamma_gui_data_t *)dt_iop_gui_data(self);
 
   dt_iop_color_picker_reset(self, TRUE);
 
@@ -543,7 +543,7 @@ void gui_init(dt_iop_module_t *self)
 
   /**** GAMMA MODE ***/
 
-  GtkWidget *vbox_gamma = self->widget = GTK_WIDGET(gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_GUI_BOX_SPACING));
+  GtkWidget *vbox_gamma = self->gui->widget = GTK_WIDGET(gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_GUI_BOX_SPACING));
 
   g->linear = dt_bauhaus_slider_from_params(self, N_("linear"));
   dt_bauhaus_slider_set_digits(g->linear, 4);
@@ -557,7 +557,7 @@ void gui_init(dt_iop_module_t *self)
 
   /**** LOG MODE ****/
 
-  GtkWidget *vbox_log = self->widget = GTK_WIDGET(gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_GUI_BOX_SPACING));
+  GtkWidget *vbox_log = self->gui->widget = GTK_WIDGET(gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_GUI_BOX_SPACING));
 
   g->grey_point
       = dt_color_picker_new(self, DT_COLOR_PICKER_AREA, dt_bauhaus_slider_from_params(self, "grey_point"));
@@ -590,12 +590,12 @@ void gui_init(dt_iop_module_t *self)
   gtk_stack_add_named(GTK_STACK(g->mode_stack), vbox_log, "log");
 
   // start building top level widget
-  self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_GUI_BOX_SPACING);
+  self->gui->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_GUI_BOX_SPACING);
 
   g->mode = dt_bauhaus_combobox_from_params(self, N_("mode"));
   gtk_widget_set_tooltip_text(g->mode, _("tone mapping method"));
 
-  gtk_box_pack_start(GTK_BOX(self->widget), g->mode_stack, TRUE, TRUE, 0);
+  gtk_box_pack_start(GTK_BOX(self->gui->widget), g->mode_stack, TRUE, TRUE, 0);
 }
 
 

--- a/src/iop/rawdenoise.c
+++ b/src/iop/rawdenoise.c
@@ -632,8 +632,8 @@ void cleanup_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev
 void gui_update(dt_iop_module_t *self)
 {
   // raw vs non_raw page, from the per-image support flag computed by reload_defaults()
-  gtk_stack_set_visible_child_name(GTK_STACK(self->widget), self->hide_enable_button ? "non_raw" : "raw");
-  gtk_widget_queue_draw(self->widget);
+  gtk_stack_set_visible_child_name(GTK_STACK(self->gui->widget), self->hide_enable_button ? "non_raw" : "raw");
+  gtk_widget_queue_draw(self->gui->widget);
 }
 
 static void dt_iop_rawdenoise_get_params(dt_iop_rawdenoise_params_t *p, const int ch, const double mouse_x,
@@ -649,7 +649,7 @@ static void dt_iop_rawdenoise_get_params(dt_iop_rawdenoise_params_t *p, const in
 static gboolean rawdenoise_draw(GtkWidget *widget, cairo_t *crf, gpointer user_data)
 {
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
-  dt_iop_rawdenoise_gui_data_t *c = (dt_iop_rawdenoise_gui_data_t *)self->gui_data;
+  dt_iop_rawdenoise_gui_data_t *c = (dt_iop_rawdenoise_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_rawdenoise_params_t p = *(dt_iop_rawdenoise_params_t *)self->params;
 
   int ch = (int)c->channel;
@@ -839,7 +839,7 @@ static gboolean rawdenoise_draw(GtkWidget *widget, cairo_t *crf, gpointer user_d
 static gboolean rawdenoise_motion_notify(GtkWidget *widget, GdkEventMotion *event, gpointer user_data)
 {
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
-  dt_iop_rawdenoise_gui_data_t *c = (dt_iop_rawdenoise_gui_data_t *)self->gui_data;
+  dt_iop_rawdenoise_gui_data_t *c = (dt_iop_rawdenoise_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_rawdenoise_params_t *p = (dt_iop_rawdenoise_params_t *)self->params;
   const int inset = DT_IOP_RAWDENOISE_INSET;
   GtkAllocation allocation;
@@ -868,7 +868,7 @@ static gboolean rawdenoise_motion_notify(GtkWidget *widget, GdkEventMotion *even
 static gboolean rawdenoise_button_press(GtkWidget *widget, GdkEventButton *event, gpointer user_data)
 {
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
-  dt_iop_rawdenoise_gui_data_t *c = (dt_iop_rawdenoise_gui_data_t *)self->gui_data;
+  dt_iop_rawdenoise_gui_data_t *c = (dt_iop_rawdenoise_gui_data_t *)dt_iop_gui_data(self);
   const int ch = c->channel;
   if(event->button == 1 && event->type == GDK_2BUTTON_PRESS)
   {
@@ -881,7 +881,7 @@ static gboolean rawdenoise_button_press(GtkWidget *widget, GdkEventButton *event
       p->y[ch][k] = d->y[ch][k];
     }
     dt_dev_add_history_item(self->dev, self, TRUE, TRUE);
-    gtk_widget_queue_draw(self->widget);
+    gtk_widget_queue_draw(self->gui->widget);
   }
   else if(event->button == 1)
   {
@@ -904,7 +904,7 @@ static gboolean rawdenoise_button_release(GtkWidget *widget, GdkEventButton *eve
   if(event->button == 1)
   {
     dt_iop_module_t *self = (dt_iop_module_t *)user_data;
-    dt_iop_rawdenoise_gui_data_t *c = (dt_iop_rawdenoise_gui_data_t *)self->gui_data;
+    dt_iop_rawdenoise_gui_data_t *c = (dt_iop_rawdenoise_gui_data_t *)dt_iop_gui_data(self);
     c->dragging = 0;
     return TRUE;
   }
@@ -914,7 +914,7 @@ static gboolean rawdenoise_button_release(GtkWidget *widget, GdkEventButton *eve
 static gboolean rawdenoise_leave_notify(GtkWidget *widget, GdkEventCrossing *event, gpointer user_data)
 {
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
-  dt_iop_rawdenoise_gui_data_t *c = (dt_iop_rawdenoise_gui_data_t *)self->gui_data;
+  dt_iop_rawdenoise_gui_data_t *c = (dt_iop_rawdenoise_gui_data_t *)dt_iop_gui_data(self);
   if(!c->dragging) c->mouse_y = -1.0;
   gtk_widget_queue_draw(widget);
   return TRUE;
@@ -923,7 +923,7 @@ static gboolean rawdenoise_leave_notify(GtkWidget *widget, GdkEventCrossing *eve
 static gboolean rawdenoise_scrolled(GtkWidget *widget, GdkEventScroll *event, gpointer user_data)
 {
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
-  dt_iop_rawdenoise_gui_data_t *c = (dt_iop_rawdenoise_gui_data_t *)self->gui_data;
+  dt_iop_rawdenoise_gui_data_t *c = (dt_iop_rawdenoise_gui_data_t *)dt_iop_gui_data(self);
 
   int delta_y;
   if(dt_gui_get_scroll_unit_deltas(event, NULL, &delta_y))
@@ -939,9 +939,9 @@ static void rawdenoise_tab_switch(GtkNotebook *notebook, GtkWidget *page, guint 
 {
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
   if(dt_gui_widgets_suppressed()) return;
-  dt_iop_rawdenoise_gui_data_t *c = (dt_iop_rawdenoise_gui_data_t *)self->gui_data;
+  dt_iop_rawdenoise_gui_data_t *c = (dt_iop_rawdenoise_gui_data_t *)dt_iop_gui_data(self);
   c->channel = (dt_iop_rawdenoise_channel_t)page_num;
-  gtk_widget_queue_draw(self->widget);
+  gtk_widget_queue_draw(self->gui->widget);
 }
 
 void gui_init(dt_iop_module_t *self)
@@ -972,10 +972,10 @@ void gui_init(dt_iop_module_t *self)
   c->mouse_x = c->mouse_y = c->mouse_pick = -1.0;
   c->dragging = 0;
   c->x_move = -1;
-  self->timeout_handle = 0;
+  self->gui->timeout_handle = 0;
   c->mouse_radius = 1.0 / (DT_IOP_RAWDENOISE_BANDS * 2);
 
-  GtkWidget *box_raw = self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_GUI_BOX_SPACING);
+  GtkWidget *box_raw = self->gui->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_GUI_BOX_SPACING);
 
   c->area = GTK_DRAWING_AREA(gtk_drawing_area_new());
   gtk_widget_set_hexpand(GTK_WIDGET(c->area), TRUE);
@@ -1002,18 +1002,18 @@ void gui_init(dt_iop_module_t *self)
   dt_bauhaus_slider_set_digits(c->threshold, 3);
 
   // start building top level widget
-  self->widget = gtk_stack_new();
-  gtk_stack_set_homogeneous(GTK_STACK(self->widget), FALSE);
+  self->gui->widget = gtk_stack_new();
+  gtk_stack_set_homogeneous(GTK_STACK(self->gui->widget), FALSE);
 
   GtkWidget *label_non_raw = dt_ui_label_new(_("raw denoising\nonly works for raw images."));
 
-  gtk_stack_add_named(GTK_STACK(self->widget), label_non_raw, "non_raw");
-  gtk_stack_add_named(GTK_STACK(self->widget), box_raw, "raw");
+  gtk_stack_add_named(GTK_STACK(self->gui->widget), label_non_raw, "non_raw");
+  gtk_stack_add_named(GTK_STACK(self->gui->widget), box_raw, "raw");
 }
 
 void gui_cleanup(dt_iop_module_t *self)
 {
-  dt_iop_rawdenoise_gui_data_t *c = (dt_iop_rawdenoise_gui_data_t *)self->gui_data;
+  dt_iop_rawdenoise_gui_data_t *c = (dt_iop_rawdenoise_gui_data_t *)dt_iop_gui_data(self);
   dt_conf_set_int("plugins/darkroom/rawdenoise/gui_channel", c->channel);
   dt_draw_curve_destroy(c->transition_curve);
 

--- a/src/iop/rawdenoiseai.c
+++ b/src/iop/rawdenoiseai.c
@@ -1708,7 +1708,7 @@ static void _custom_model_callback(GtkWidget *w, dt_iop_module_t *self)
 
 static void _custom_model_populate(dt_iop_module_t *self)
 {
-  dt_iop_rawdenoiseai_gui_data_t *g = (dt_iop_rawdenoiseai_gui_data_t *)self->gui_data;
+  dt_iop_rawdenoiseai_gui_data_t *g = (dt_iop_rawdenoiseai_gui_data_t *)dt_iop_gui_data(self);
   const dt_iop_rawdenoiseai_params_t *const p = (dt_iop_rawdenoiseai_params_t *)self->params;
   dt_bauhaus_combobox_clear(g->custom_model);
   dt_bauhaus_combobox_add(g->custom_model, _("(shipped model)"));
@@ -1737,10 +1737,10 @@ static void _custom_model_populate(dt_iop_module_t *self)
 
 void gui_update(dt_iop_module_t *self)
 {
-  dt_iop_rawdenoiseai_gui_data_t *g = (dt_iop_rawdenoiseai_gui_data_t *)self->gui_data;
+  dt_iop_rawdenoiseai_gui_data_t *g = (dt_iop_rawdenoiseai_gui_data_t *)dt_iop_gui_data(self);
   const dt_iop_rawdenoiseai_params_t *p = (dt_iop_rawdenoiseai_params_t *)self->params;
   dt_iop_rawdenoiseai_global_data_t *gd = (dt_iop_rawdenoiseai_global_data_t *)self->global_data;
-  gtk_stack_set_visible_child_name(GTK_STACK(self->widget), self->hide_enable_button ? "unsupported" : "raw");
+  gtk_stack_set_visible_child_name(GTK_STACK(self->gui->widget), self->hide_enable_button ? "unsupported" : "raw");
 
   // rescan on every panel update: the user may have dropped a file in since
   _custom_model_populate(self);
@@ -1771,7 +1771,7 @@ void gui_init(dt_iop_module_t *self)
 {
   dt_iop_rawdenoiseai_gui_data_t *g = IOP_GUI_ALLOC(rawdenoiseai);
 
-  GtkWidget *box_raw = self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_GUI_BOX_SPACING);
+  GtkWidget *box_raw = self->gui->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_GUI_BOX_SPACING);
 
   g->strength = dt_bauhaus_slider_from_params(self, "strength");
   dt_bauhaus_slider_set_digits(g->strength, 3);
@@ -1822,7 +1822,7 @@ void gui_init(dt_iop_module_t *self)
 
   dt_gui_new_collapsible_section(&g->cs, "plugins/darkroom/rawdenoiseai/expand_channel",
                                  _("per-channel corrections"), GTK_BOX(box_raw), GTK_PACK_START);
-  self->widget = GTK_WIDGET(g->cs.container); // sliders below pack into the section
+  self->gui->widget = GTK_WIDGET(g->cs.container); // sliders below pack into the section
 
   const char *sigma_tooltip = _("per-channel correction of the camera noise profile, applied on top\n"
                                 "of the global correction. Profiles are measured after demosaicing,\n"
@@ -1845,15 +1845,15 @@ void gui_init(dt_iop_module_t *self)
   dt_bauhaus_slider_set_format(g->sigma_blue, "%");
   gtk_widget_set_tooltip_text(g->sigma_blue, sigma_tooltip);
 
-  self->widget = box_raw; // done packing into the collapsible section
+  self->gui->widget = box_raw; // done packing into the collapsible section
 
   GtkWidget *label_unsupported = dt_ui_label_new(_("AI raw denoising needs a mosaiced raw image\n"
                                                    "and an installed rawdenoiseai model file."));
 
-  self->widget = gtk_stack_new();
-  gtk_stack_set_homogeneous(GTK_STACK(self->widget), FALSE);
-  gtk_stack_add_named(GTK_STACK(self->widget), label_unsupported, "unsupported");
-  gtk_stack_add_named(GTK_STACK(self->widget), box_raw, "raw");
+  self->gui->widget = gtk_stack_new();
+  gtk_stack_set_homogeneous(GTK_STACK(self->gui->widget), FALSE);
+  gtk_stack_add_named(GTK_STACK(self->gui->widget), label_unsupported, "unsupported");
+  gtk_stack_add_named(GTK_STACK(self->gui->widget), box_raw, "raw");
 }
 
 void gui_cleanup(dt_iop_module_t *self)

--- a/src/iop/rawoverexposed.c
+++ b/src/iop/rawoverexposed.c
@@ -35,6 +35,7 @@
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif
+#include "develop/imageop_gui.h"
 
 #include "system/macros.h"
 #include "system/openmp.h"
@@ -496,7 +497,6 @@ void init(dt_iop_module_t *module)
   module->hide_enable_button = 1;
   module->default_enabled = 1;
   module->params_size = sizeof(dt_iop_rawoverexposed_t);
-  module->gui_data = NULL;
 
   // This module permanently bypasses the cache because it takes input from GUI
   // and doesn't leave internal parameters to compute an integrity hash on.

--- a/src/iop/rawprepare.c
+++ b/src/iop/rawprepare.c
@@ -1006,7 +1006,7 @@ void cleanup_global(dt_iop_module_so_t *self)
 
 void gui_update(dt_iop_module_t *self)
 {
-  dt_iop_rawprepare_gui_data_t *g = (dt_iop_rawprepare_gui_data_t *)self->gui_data;
+  dt_iop_rawprepare_gui_data_t *g = (dt_iop_rawprepare_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_rawprepare_params_t *p = (dt_iop_rawprepare_params_t *)self->params;
 
   const gboolean is_monochrome = (self->dev->image_storage.flags & (DT_IMAGE_MONOCHROME | DT_IMAGE_MONOCHROME_BAYER)) != 0;
@@ -1029,12 +1029,12 @@ void gui_update(dt_iop_module_t *self)
   dt_bauhaus_combobox_set(g->flat_field, p->flat_field);
 
   // raw vs non_raw page, from the per-image default computed by reload_defaults()
-  gtk_stack_set_visible_child_name(GTK_STACK(self->widget), self->default_enabled ? "raw" : "non_raw");
+  gtk_stack_set_visible_child_name(GTK_STACK(self->gui->widget), self->default_enabled ? "raw" : "non_raw");
 }
 
 void gui_changed(dt_iop_module_t *self, GtkWidget *w, void *previous)
 {
-  dt_iop_rawprepare_gui_data_t *g = (dt_iop_rawprepare_gui_data_t *)self->gui_data;
+  dt_iop_rawprepare_gui_data_t *g = (dt_iop_rawprepare_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_rawprepare_params_t *p = (dt_iop_rawprepare_params_t *)self->params;
 
   const gboolean is_monochrome = (self->dev->image_storage.flags & (DT_IMAGE_MONOCHROME | DT_IMAGE_MONOCHROME_BAYER)) != 0;
@@ -1059,7 +1059,7 @@ void gui_init(dt_iop_module_t *self)
 {
   dt_iop_rawprepare_gui_data_t *g = IOP_GUI_ALLOC(rawprepare);
 
-  GtkWidget *box_raw = self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_GUI_BOX_SPACING);
+  GtkWidget *box_raw = self->gui->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_GUI_BOX_SPACING);
 
   for(int i = 0; i < 4; i++)
   {
@@ -1080,7 +1080,7 @@ void gui_init(dt_iop_module_t *self)
   g->flat_field = dt_bauhaus_combobox_from_params(self, "flat_field");
   gtk_widget_set_tooltip_text(g->flat_field, _("flat field correction to compensate for lens shading"));
 
-  gtk_box_pack_start(GTK_BOX(self->widget),
+  gtk_box_pack_start(GTK_BOX(self->gui->widget),
                       dt_ui_section_label_new(_("In-camera crop")), FALSE, FALSE, 0);
 
   g->x = dt_bauhaus_slider_from_params(self, "x");
@@ -1100,13 +1100,13 @@ void gui_init(dt_iop_module_t *self)
   dt_bauhaus_slider_set_soft_max(g->height, 256);
 
   // start building top level widget
-  self->widget = gtk_stack_new();
-  gtk_stack_set_homogeneous(GTK_STACK(self->widget), FALSE);
+  self->gui->widget = gtk_stack_new();
+  gtk_stack_set_homogeneous(GTK_STACK(self->gui->widget), FALSE);
 
   GtkWidget *label_non_raw = dt_ui_label_new(_("raw black/white point correction\nonly works for the sensors that need it."));
 
-  gtk_stack_add_named(GTK_STACK(self->widget), label_non_raw, "non_raw");
-  gtk_stack_add_named(GTK_STACK(self->widget), box_raw, "raw");
+  gtk_stack_add_named(GTK_STACK(self->gui->widget), label_non_raw, "non_raw");
+  gtk_stack_add_named(GTK_STACK(self->gui->widget), box_raw, "raw");
 }
 
 // clang-format off

--- a/src/iop/relight.c
+++ b/src/iop/relight.c
@@ -207,14 +207,14 @@ void cleanup_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev
 
 void gui_update(struct dt_iop_module_t *self)
 {
-  dt_iop_relight_gui_data_t *g = (dt_iop_relight_gui_data_t *)self->gui_data;
+  dt_iop_relight_gui_data_t *g = (dt_iop_relight_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_relight_params_t *p = (dt_iop_relight_params_t *)self->params;
   dtgtk_gradient_slider_set_value(g->center, p->center);
 }
 
 void color_picker_apply(dt_iop_module_t *self, GtkWidget *picker, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
 {
-  dt_iop_relight_gui_data_t *g = (dt_iop_relight_gui_data_t *)self->gui_data;
+  dt_iop_relight_gui_data_t *g = (dt_iop_relight_gui_data_t *)dt_iop_gui_data(self);
   float mean, min, max;
 
   if(self->picked_color_max[0] >= 0.0f)
@@ -251,7 +251,7 @@ void gui_init(struct dt_iop_module_t *self)
   gtk_box_pack_start(sliderbox, GTK_WIDGET(g->center), TRUE, TRUE, 0);
   g->colorpicker = dt_color_picker_new(self, DT_COLOR_PICKER_POINT_AREA, GTK_WIDGET(sliderbox));
   gtk_widget_set_tooltip_text(GTK_WIDGET(g->colorpicker), _("toggle tool for picking median lightness in image"));
-  gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(sliderbox), TRUE, FALSE, 0);
+  gtk_box_pack_start(GTK_BOX(self->gui->widget), GTK_WIDGET(sliderbox), TRUE, FALSE, 0);
 
   g->width = dt_bauhaus_slider_from_params(self, N_("width"));
   gtk_widget_set_tooltip_text(g->width, _("width of fill-light area defined in zones"));

--- a/src/iop/retouch.c
+++ b/src/iop/retouch.c
@@ -459,7 +459,7 @@ static void rt_display_selected_fill_color(dt_iop_retouch_gui_data_t *g, dt_iop_
 
 static void rt_show_hide_controls(const dt_iop_module_t *self)
 {
-  dt_iop_retouch_gui_data_t *g = (dt_iop_retouch_gui_data_t *)self->gui_data;
+  dt_iop_retouch_gui_data_t *g = (dt_iop_retouch_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_retouch_params_t *p = (dt_iop_retouch_params_t *)self->params;
 
   switch(p->algorithm)
@@ -523,7 +523,7 @@ static int rt_get_selected_shape_index(dt_develop_t *dev, dt_iop_retouch_params_
 static void rt_load_shape_algo_in_gui(dt_iop_module_t *self, const int form_selected_id)
 {
   dt_iop_retouch_params_t *p = (dt_iop_retouch_params_t *)self->params;
-  dt_iop_retouch_gui_data_t *g = (dt_iop_retouch_gui_data_t *)self->gui_data;
+  dt_iop_retouch_gui_data_t *g = (dt_iop_retouch_gui_data_t *)dt_iop_gui_data(self);
 
   dt_gui_freeze_begin();
 
@@ -639,8 +639,8 @@ static void rt_show_forms_for_current_scale(dt_iop_module_t *self)
     return;
 
   dt_iop_retouch_params_t *p = (dt_iop_retouch_params_t *)self->params;
-  dt_iop_gui_blend_data_t *bd = (dt_iop_gui_blend_data_t *)self->blend_data;
-  dt_iop_retouch_gui_data_t *g = (dt_iop_retouch_gui_data_t *)self->gui_data;
+  dt_iop_gui_blend_data_t *bd = (dt_iop_gui_blend_data_t *)self->gui->blend_data;
+  dt_iop_retouch_gui_data_t *g = (dt_iop_retouch_gui_data_t *)dt_iop_gui_data(self);
   if(IS_NULL_PTR(bd)) return;
 
   const int scale = p->curr_scale;
@@ -786,7 +786,7 @@ void post_history_commit(dt_iop_module_t *self)
   rt_resynch_params(self, (dt_iop_retouch_params_t *)self->params, self->dev->forms);
   dt_pthread_rwlock_unlock(&self->dev->masks_mutex);
 
-  dt_iop_retouch_gui_data_t *g = (dt_iop_retouch_gui_data_t *)self->gui_data;
+  dt_iop_retouch_gui_data_t *g = (dt_iop_retouch_gui_data_t *)dt_iop_gui_data(self);
   if(IS_NULL_PTR(g)) return;
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->bt_circle), rt_shape_is_being_added(self, DT_MASKS_CIRCLE));
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->bt_polygon), rt_shape_is_being_added(self, DT_MASKS_POLYGON));
@@ -804,7 +804,7 @@ void post_history_commit(dt_iop_module_t *self)
   //only toggle shape show button if shapes exist
   if(!IS_NULL_PTR(grp) && (grp->type & DT_MASKS_GROUP) && grp->points)
   {
-    dt_iop_gui_blend_data_t *bd = (dt_iop_gui_blend_data_t *)self->blend_data;
+    dt_iop_gui_blend_data_t *bd = (dt_iop_gui_blend_data_t *)self->gui->blend_data;
     if(IS_NULL_PTR(bd)) return;
     gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->bt_edit_masks),
                                  (bd->masks_shown != DT_MASKS_EDIT_OFF) && (self->dev->gui_module == self));
@@ -1001,16 +1001,16 @@ static gboolean rt_shape_buttons_can_start(GtkWidget *button, dt_iop_module_t *s
                                            dt_masks_type_t type, gpointer user_data)
 {
   //turn module on (else shape creation won't work)
-  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(self->off), TRUE);
+  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(self->gui->off), TRUE);
 
   //switch mask edit mode off
-  dt_iop_gui_blend_data_t *bd = (dt_iop_gui_blend_data_t *)self->blend_data;
+  dt_iop_gui_blend_data_t *bd = (dt_iop_gui_blend_data_t *)self->gui->blend_data;
   if(bd) bd->masks_shown = DT_MASKS_EDIT_OFF;
 
   const int allow = rt_allow_create_form(self);
   if(allow)
   {
-    dt_iop_retouch_gui_data_t *g = (dt_iop_retouch_gui_data_t *)self->gui_data;
+    dt_iop_retouch_gui_data_t *g = (dt_iop_retouch_gui_data_t *)dt_iop_gui_data(self);
 
     // we want to be sure that Retouch has focus
     dt_iop_request_focus(self);
@@ -1088,7 +1088,7 @@ static void rt_num_scales_update(const int _num_scales, dt_iop_module_t *self)
   if(dt_gui_widgets_suppressed()) return;
 
   dt_iop_retouch_params_t *p = (dt_iop_retouch_params_t *)self->params;
-  dt_iop_retouch_gui_data_t *g = (dt_iop_retouch_gui_data_t *)self->gui_data;
+  dt_iop_retouch_gui_data_t *g = (dt_iop_retouch_gui_data_t *)dt_iop_gui_data(self);
 
   const int num_scales = CLAMP(_num_scales, 0, RETOUCH_MAX_SCALES);
   if(p->num_scales == num_scales) return;
@@ -1107,7 +1107,7 @@ static void rt_curr_scale_update(const int _curr_scale, dt_iop_module_t *self)
   if(dt_gui_widgets_suppressed()) return;
 
   dt_iop_retouch_params_t *p = (dt_iop_retouch_params_t *)self->params;
-  dt_iop_retouch_gui_data_t *g = (dt_iop_retouch_gui_data_t *)self->gui_data;
+  dt_iop_retouch_gui_data_t *g = (dt_iop_retouch_gui_data_t *)dt_iop_gui_data(self);
 
   const int curr_scale = CLAMP(_curr_scale, 0, RETOUCH_MAX_SCALES + 1);
   if(p->curr_scale == curr_scale) return;
@@ -1139,7 +1139,7 @@ static void rt_merge_from_scale_update(const int _merge_from_scale, dt_iop_modul
   if(dt_gui_widgets_suppressed()) return;
 
   dt_iop_retouch_params_t *p = (dt_iop_retouch_params_t *)self->params;
-  dt_iop_retouch_gui_data_t *g = (dt_iop_retouch_gui_data_t *)self->gui_data;
+  dt_iop_retouch_gui_data_t *g = (dt_iop_retouch_gui_data_t *)dt_iop_gui_data(self);
 
   const int merge_from_scale = CLAMP(_merge_from_scale, 0, p->num_scales);
   if(p->merge_from_scale == merge_from_scale) return;
@@ -1153,7 +1153,7 @@ static void rt_merge_from_scale_update(const int _merge_from_scale, dt_iop_modul
 
 static gboolean rt_wdbar_leave_notify(GtkWidget *widget, GdkEventCrossing *event, dt_iop_module_t *self)
 {
-  dt_iop_retouch_gui_data_t *g = (dt_iop_retouch_gui_data_t *)self->gui_data;
+  dt_iop_retouch_gui_data_t *g = (dt_iop_retouch_gui_data_t *)dt_iop_gui_data(self);
 
   g->wdbar_mouse_x = g->wdbar_mouse_y = -1;
   g->curr_scale = -1;
@@ -1170,7 +1170,7 @@ static gboolean rt_wdbar_button_press(GtkWidget *widget, GdkEventButton *event, 
 
   dt_iop_request_focus(self);
 
-  dt_iop_retouch_gui_data_t *g = (dt_iop_retouch_gui_data_t *)self->gui_data;
+  dt_iop_retouch_gui_data_t *g = (dt_iop_retouch_gui_data_t *)dt_iop_gui_data(self);
   GtkAllocation allocation;
   gtk_widget_get_allocation(widget, &allocation);
   const int inset = round(RT_WDBAR_INSET * allocation.height);
@@ -1202,7 +1202,7 @@ static gboolean rt_wdbar_button_press(GtkWidget *widget, GdkEventButton *event, 
 
 static gboolean rt_wdbar_button_release(GtkWidget *widget, GdkEventButton *event, dt_iop_module_t *self)
 {
-  dt_iop_retouch_gui_data_t *g = (dt_iop_retouch_gui_data_t *)self->gui_data;
+  dt_iop_retouch_gui_data_t *g = (dt_iop_retouch_gui_data_t *)dt_iop_gui_data(self);
 
   if(event->button == 1) g->is_dragging = 0;
 
@@ -1215,7 +1215,7 @@ static gboolean rt_wdbar_scrolled(GtkWidget *widget, GdkEventScroll *event, dt_i
   if(dt_gui_widgets_suppressed()) return TRUE;
 
   dt_iop_retouch_params_t *p = (dt_iop_retouch_params_t *)self->params;
-  dt_iop_retouch_gui_data_t *g = (dt_iop_retouch_gui_data_t *)self->gui_data;
+  dt_iop_retouch_gui_data_t *g = (dt_iop_retouch_gui_data_t *)dt_iop_gui_data(self);
 
   dt_iop_request_focus(self);
 
@@ -1236,7 +1236,7 @@ static gboolean rt_wdbar_scrolled(GtkWidget *widget, GdkEventScroll *event, dt_i
 
 static gboolean rt_wdbar_motion_notify(GtkWidget *widget, GdkEventMotion *event, dt_iop_module_t *self)
 {
-  dt_iop_retouch_gui_data_t *g = (dt_iop_retouch_gui_data_t *)self->gui_data;
+  dt_iop_retouch_gui_data_t *g = (dt_iop_retouch_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_retouch_params_t *p = (dt_iop_retouch_params_t *)self->params;
 
   GtkAllocation allocation;
@@ -1290,7 +1290,7 @@ static int rt_scale_has_shapes(dt_iop_retouch_params_t *p, const int scale)
 
 static gboolean rt_wdbar_draw(GtkWidget *widget, cairo_t *crf, dt_iop_module_t *self)
 {
-  dt_iop_retouch_gui_data_t *g = (dt_iop_retouch_gui_data_t *)self->gui_data;
+  dt_iop_retouch_gui_data_t *g = (dt_iop_retouch_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_retouch_params_t *p = (dt_iop_retouch_params_t *)self->params;
 
 
@@ -1472,7 +1472,7 @@ static void rt_gslider_changed(GtkDarktableGradientSlider *gslider, dt_iop_modul
 
 void color_picker_apply(dt_iop_module_t *self, GtkWidget *picker, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
 {
-  dt_iop_retouch_gui_data_t *g = (dt_iop_retouch_gui_data_t *)self->gui_data;
+  dt_iop_retouch_gui_data_t *g = (dt_iop_retouch_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_retouch_params_t *p = (dt_iop_retouch_params_t *)self->params;
 
   if(fabsf(p->fill_color[0] - self->picked_output_color[0]) < 0.0001f
@@ -1512,7 +1512,7 @@ static gboolean rt_copypaste_scale_callback(GtkToggleButton *togglebutton, GdkEv
   int scale_copied = 0;
   const int active = !gtk_toggle_button_get_active(togglebutton);
   dt_iop_retouch_params_t *p = (dt_iop_retouch_params_t *)self->params;
-  dt_iop_retouch_gui_data_t *g = (dt_iop_retouch_gui_data_t *)self->gui_data;
+  dt_iop_retouch_gui_data_t *g = (dt_iop_retouch_gui_data_t *)dt_iop_gui_data(self);
 
   if(togglebutton == (GtkToggleButton *)g->bt_copy_scale)
   {
@@ -1593,7 +1593,7 @@ static gboolean rt_display_wavelet_scale_callback(GtkToggleButton *togglebutton,
   if(dt_gui_widgets_suppressed()) return TRUE;
 
   dt_iop_retouch_params_t *p = (dt_iop_retouch_params_t *)self->params;
-  dt_iop_retouch_gui_data_t *g = (dt_iop_retouch_gui_data_t *)self->gui_data;
+  dt_iop_retouch_gui_data_t *g = (dt_iop_retouch_gui_data_t *)dt_iop_gui_data(self);
 
   // if blend module is displaying mask do not display wavelet scales
   if(rt_blend_mask_conflicts(self, g))
@@ -1606,7 +1606,7 @@ static gboolean rt_display_wavelet_scale_callback(GtkToggleButton *togglebutton,
     return TRUE;
   }
 
-  if(self->off) gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(self->off), 1);
+  if(self->gui->off) gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(self->gui->off), 1);
   dt_iop_request_focus(self);
 
   g->display_wavelet_scale = !gtk_toggle_button_get_active(togglebutton);
@@ -1638,7 +1638,7 @@ static void rt_develop_ui_pipe_finished_callback(gpointer instance, gpointer use
 {
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
   dt_iop_retouch_params_t *p = (dt_iop_retouch_params_t *)self->params;
-  dt_iop_retouch_gui_data_t *g = (dt_iop_retouch_gui_data_t *)self->gui_data;
+  dt_iop_retouch_gui_data_t *g = (dt_iop_retouch_gui_data_t *)dt_iop_gui_data(self);
 
   // FIXME: this doesn't seems the right place to update params and GUI ...
   // update auto levels
@@ -1675,9 +1675,9 @@ static gboolean rt_auto_levels_callback(GtkToggleButton *togglebutton, GdkEventB
 {
   if(dt_gui_widgets_suppressed()) return FALSE;
 
-  dt_iop_retouch_gui_data_t *g = (dt_iop_retouch_gui_data_t *)self->gui_data;
+  dt_iop_retouch_gui_data_t *g = (dt_iop_retouch_gui_data_t *)dt_iop_gui_data(self);
 
-  if(self->off) gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(self->off), 1);
+  if(self->gui->off) gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(self->gui->off), 1);
   dt_iop_request_focus(self);
 
   dt_iop_gui_enter_critical_section(self);
@@ -1714,7 +1714,7 @@ void gui_post_expose (struct dt_iop_module_t *self,
                       int32_t pointerx,
                       int32_t pointery)
 {
-  dt_iop_retouch_gui_data_t *g = (dt_iop_retouch_gui_data_t *)self->gui_data;
+  dt_iop_retouch_gui_data_t *g = (dt_iop_retouch_gui_data_t *)dt_iop_gui_data(self);
   if(IS_NULL_PTR(g)) return;
 
   const int shape_id = rt_get_selected_shape_id(self);
@@ -1738,8 +1738,8 @@ static gboolean rt_edit_masks_callback(GtkWidget *widget, GdkEventButton *event,
     return FALSE;
   }
 
-  dt_iop_gui_blend_data_t *bd = (dt_iop_gui_blend_data_t *)self->blend_data;
-  dt_iop_retouch_gui_data_t *g = (dt_iop_retouch_gui_data_t *)self->gui_data;
+  dt_iop_gui_blend_data_t *bd = (dt_iop_gui_blend_data_t *)self->gui->blend_data;
+  dt_iop_retouch_gui_data_t *g = (dt_iop_retouch_gui_data_t *)dt_iop_gui_data(self);
 
   //hide all shapes and free if some are in creation
   if(self->dev->form_gui->creation && self->dev->form_gui->creation_module == self)
@@ -1807,7 +1807,7 @@ static gboolean rt_select_algorithm_callback(GtkToggleButton *togglebutton, GdkE
   dt_gui_freeze_begin();
 
   dt_iop_retouch_params_t *p = (dt_iop_retouch_params_t *)self->params;
-  dt_iop_retouch_gui_data_t *g = (dt_iop_retouch_gui_data_t *)self->gui_data;
+  dt_iop_retouch_gui_data_t *g = (dt_iop_retouch_gui_data_t *)dt_iop_gui_data(self);
 
   dt_iop_retouch_algo_type_t new_algo = DT_IOP_RETOUCH_HEAL;
 
@@ -1904,7 +1904,7 @@ static gboolean rt_showmask_callback(GtkToggleButton *togglebutton, GdkEventButt
 {
   if(dt_gui_widgets_suppressed()) return TRUE;
 
-  dt_iop_retouch_gui_data_t *g = (dt_iop_retouch_gui_data_t *)module->gui_data;
+  dt_iop_retouch_gui_data_t *g = (dt_iop_retouch_gui_data_t *)dt_iop_gui_data(module);
 
   // if blend module is displaying mask do not display it here
   if(rt_blend_mask_conflicts(module, g))
@@ -1919,7 +1919,7 @@ static gboolean rt_showmask_callback(GtkToggleButton *togglebutton, GdkEventButt
   rt_sync_mask_display_request(module, g);
   rt_sync_bypass_cache(module, g);
 
-  if(module->off) gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(module->off), 1);
+  if(module->gui->off) gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(module->gui->off), 1);
   dt_iop_request_focus(module);
 
   dt_dev_pixelpipe_update_history_main(module->dev);
@@ -1932,14 +1932,14 @@ static gboolean rt_suppress_callback(GtkToggleButton *togglebutton, GdkEventButt
 {
   if(dt_gui_widgets_suppressed()) return TRUE;
 
-  dt_iop_retouch_gui_data_t *g = (dt_iop_retouch_gui_data_t *)module->gui_data;
+  dt_iop_retouch_gui_data_t *g = (dt_iop_retouch_gui_data_t *)dt_iop_gui_data(module);
   g->suppress_mask = !gtk_toggle_button_get_active(togglebutton);
   // No rt_blend_mask_conflicts() guard on this button, so only bypass_cache/bypass_cache_variant
   // are synced here -- request_mask_display may currently belong to the blend-mask display, not
   // to retouch.
   rt_sync_bypass_cache(module, g);
 
-  if(module->off) gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(module->off), 1);
+  if(module->gui->off) gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(module->gui->off), 1);
   dt_iop_request_focus(module);
 
   dt_dev_pixelpipe_update_history_main(module->dev);
@@ -1951,7 +1951,7 @@ static gboolean rt_suppress_callback(GtkToggleButton *togglebutton, GdkEventButt
 void gui_changed(dt_iop_module_t *self, GtkWidget *w, void *previous)
 {
   dt_iop_retouch_params_t *p = (dt_iop_retouch_params_t *)self->params;
-  dt_iop_retouch_gui_data_t *g = (dt_iop_retouch_gui_data_t *)self->gui_data;
+  dt_iop_retouch_gui_data_t *g = (dt_iop_retouch_gui_data_t *)dt_iop_gui_data(self);
 
   if(w == g->cmb_fill_mode)
   {
@@ -1984,7 +1984,7 @@ void gui_changed(dt_iop_module_t *self, GtkWidget *w, void *previous)
 
 void masks_selection_changed(struct dt_iop_module_t *self, const int form_selected_id)
 {
-  dt_iop_retouch_gui_data_t *g = (dt_iop_retouch_gui_data_t *)self->gui_data;
+  dt_iop_retouch_gui_data_t *g = (dt_iop_retouch_gui_data_t *)dt_iop_gui_data(self);
   if(IS_NULL_PTR(g)) return;
 
   dt_iop_gui_enter_critical_section(self);
@@ -2045,11 +2045,11 @@ void gui_focus(struct dt_iop_module_t *self, gboolean in)
 {
   if(self->enabled)
   {
-    dt_iop_retouch_gui_data_t *g = (dt_iop_retouch_gui_data_t *)self->gui_data;
+    dt_iop_retouch_gui_data_t *g = (dt_iop_retouch_gui_data_t *)dt_iop_gui_data(self);
 
     if(in)
     {
-      dt_iop_gui_blend_data_t *bd = (dt_iop_gui_blend_data_t *)self->blend_data;
+      dt_iop_gui_blend_data_t *bd = (dt_iop_gui_blend_data_t *)self->gui->blend_data;
       //only show shapes if shapes exist
       dt_masks_form_t *grp = dt_masks_get_from_id(self->dev, self->blend_params->mask_id);
       if(!IS_NULL_PTR(grp) && (grp->type & DT_MASKS_GROUP) && grp->points)
@@ -2135,7 +2135,7 @@ void cleanup_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev
 
 void gui_update(dt_iop_module_t *self)
 {
-  dt_iop_retouch_gui_data_t *g = (dt_iop_retouch_gui_data_t *)self->gui_data;
+  dt_iop_retouch_gui_data_t *g = (dt_iop_retouch_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_retouch_params_t *p = (dt_iop_retouch_params_t *)self->params;
 
   // check if there is new or deleted forms
@@ -2191,7 +2191,7 @@ void gui_update(dt_iop_module_t *self)
   rt_show_hide_controls(self);
 
   // update edit shapes status
-  dt_iop_gui_blend_data_t *bd = (dt_iop_gui_blend_data_t *)self->blend_data;
+  dt_iop_gui_blend_data_t *bd = (dt_iop_gui_blend_data_t *)self->gui->blend_data;
 
   //only toggle shape show button if shapes exist
   if(!IS_NULL_PTR(grp) && (grp->type & DT_MASKS_GROUP) && grp->points)
@@ -2212,7 +2212,7 @@ void gui_update(dt_iop_module_t *self)
 
 void change_image(struct dt_iop_module_t *self)
 {
-  dt_iop_retouch_gui_data_t *g = (dt_iop_retouch_gui_data_t *)self->gui_data;
+  dt_iop_retouch_gui_data_t *g = (dt_iop_retouch_gui_data_t *)dt_iop_gui_data(self);
   if(!IS_NULL_PTR(g))
   {
     g->copied_scale = -1;
@@ -2436,7 +2436,7 @@ void gui_init(dt_iop_module_t *self)
   gtk_box_pack_start(GTK_BOX(hbox_shape_sel), GTK_WIDGET(g->label_form_selected), FALSE, TRUE, 0);
 
   // fill properties
-  g->vbox_fill = self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_GUI_BOX_SPACING);
+  g->vbox_fill = self->gui->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_GUI_BOX_SPACING);
 
   g->cmb_fill_mode = dt_bauhaus_combobox_from_params(self, "fill_mode");
   gtk_widget_set_tooltip_text(g->cmb_fill_mode, _("erase the detail or fills with chosen color"));
@@ -2468,7 +2468,7 @@ void gui_init(dt_iop_module_t *self)
                               _("adjusts color brightness to fine-tune it. works with erase as well"));
 
   // blur properties
-  g->vbox_blur = self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_GUI_BOX_SPACING);
+  g->vbox_blur = self->gui->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_GUI_BOX_SPACING);
 
   g->cmb_blur_type = dt_bauhaus_combobox_from_params(self, "blur_type");
   gtk_widget_set_tooltip_text(g->cmb_blur_type, _("type for the blur algorithm"));
@@ -2485,42 +2485,42 @@ void gui_init(dt_iop_module_t *self)
   g_signal_connect(G_OBJECT(g->sl_mask_opacity), "value-changed", G_CALLBACK(rt_mask_opacity_callback), self);
 
   // start building top level widget
-  self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_GUI_BOX_SPACING);
+  self->gui->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_GUI_BOX_SPACING);
 
   GtkWidget *lbl_rt_tools = dt_ui_section_label_new(_("retouch tools"));
-  gtk_box_pack_start(GTK_BOX(self->widget), lbl_rt_tools, FALSE, TRUE, 0);
+  gtk_box_pack_start(GTK_BOX(self->gui->widget), lbl_rt_tools, FALSE, TRUE, 0);
 
   // shapes toolbar
-  gtk_box_pack_start(GTK_BOX(self->widget), hbox_shapes, TRUE, TRUE, 0);
+  gtk_box_pack_start(GTK_BOX(self->gui->widget), hbox_shapes, TRUE, TRUE, 0);
   // algorithms toolbar
-  gtk_box_pack_start(GTK_BOX(self->widget), hbox_algo, TRUE, TRUE, 0);
+  gtk_box_pack_start(GTK_BOX(self->gui->widget), hbox_algo, TRUE, TRUE, 0);
 
   // wavelet decompose
   GtkWidget *lbl_wd = dt_ui_section_label_new(_("wavelet decompose"));
-  gtk_box_pack_start(GTK_BOX(self->widget), lbl_wd, FALSE, TRUE, 0);
+  gtk_box_pack_start(GTK_BOX(self->gui->widget), lbl_wd, FALSE, TRUE, 0);
 
   // wavelet decompose bar & labels
-  gtk_box_pack_start(GTK_BOX(self->widget), grid_wd_labels, TRUE, TRUE, 0);
-  gtk_box_pack_start(GTK_BOX(self->widget), g->wd_bar, TRUE, TRUE, DT_PIXEL_APPLY_DPI(3));
+  gtk_box_pack_start(GTK_BOX(self->gui->widget), grid_wd_labels, TRUE, TRUE, 0);
+  gtk_box_pack_start(GTK_BOX(self->gui->widget), g->wd_bar, TRUE, TRUE, DT_PIXEL_APPLY_DPI(3));
 
   // preview scale & cut/paste scale
-  gtk_box_pack_start(GTK_BOX(self->widget), hbox_scale, TRUE, TRUE, 0);
+  gtk_box_pack_start(GTK_BOX(self->gui->widget), hbox_scale, TRUE, TRUE, 0);
 
   // preview single scale
-  gtk_box_pack_start(GTK_BOX(self->widget), g->vbox_preview_scale, TRUE, TRUE, 0);
+  gtk_box_pack_start(GTK_BOX(self->gui->widget), g->vbox_preview_scale, TRUE, TRUE, 0);
 
   // shapes
   GtkWidget *lbl_shapes = dt_ui_section_label_new(_("shapes"));
-  gtk_box_pack_start(GTK_BOX(self->widget), lbl_shapes, FALSE, TRUE, 0);
+  gtk_box_pack_start(GTK_BOX(self->gui->widget), lbl_shapes, FALSE, TRUE, 0);
 
   // shape selected
-  gtk_box_pack_start(GTK_BOX(self->widget), hbox_shape_sel, TRUE, TRUE, 0);
+  gtk_box_pack_start(GTK_BOX(self->gui->widget), hbox_shape_sel, TRUE, TRUE, 0);
   // blur radius
-  gtk_box_pack_start(GTK_BOX(self->widget), g->vbox_blur, TRUE, TRUE, 0);
+  gtk_box_pack_start(GTK_BOX(self->gui->widget), g->vbox_blur, TRUE, TRUE, 0);
   // fill color
-  gtk_box_pack_start(GTK_BOX(self->widget), g->vbox_fill, TRUE, TRUE, 0);
+  gtk_box_pack_start(GTK_BOX(self->gui->widget), g->vbox_fill, TRUE, TRUE, 0);
   // mask (shape) opacity
-  gtk_box_pack_start(GTK_BOX(self->widget), g->sl_mask_opacity, TRUE, TRUE, 0);
+  gtk_box_pack_start(GTK_BOX(self->gui->widget), g->sl_mask_opacity, TRUE, TRUE, 0);
 
   /* add signal handler for preview pipe finish to redraw the preview */
   DT_DEBUG_CONTROL_SIGNAL_CONNECT(dt_control_signal_get_global(), DT_SIGNAL_DEVELOP_UI_PIPE_FINISHED,
@@ -3490,7 +3490,7 @@ static int process_internal(struct dt_iop_module_t *self, const dt_dev_pixelpipe
 {
 
   dt_iop_retouch_params_t *p = (dt_iop_retouch_params_t *)piece->data;
-  dt_iop_retouch_gui_data_t *g = (dt_iop_retouch_gui_data_t *)self->gui_data;
+  dt_iop_retouch_gui_data_t *g = (dt_iop_retouch_gui_data_t *)dt_iop_gui_data(self);
 
   float *in_retouch = NULL;
   int err = 0;
@@ -4317,7 +4317,7 @@ int process_cl(struct dt_iop_module_t *self, const dt_dev_pixelpipe_t *pipe, con
   const dt_iop_roi_t *const roi_out = &piece->roi_out;
   dt_iop_retouch_params_t *p = (dt_iop_retouch_params_t *)piece->data;
   dt_iop_retouch_global_data_t *gd = (dt_iop_retouch_global_data_t *)self->global_data;
-  dt_iop_retouch_gui_data_t *g = (dt_iop_retouch_gui_data_t *)self->gui_data;
+  dt_iop_retouch_gui_data_t *g = (dt_iop_retouch_gui_data_t *)dt_iop_gui_data(self);
 
   cl_int err = CL_SUCCESS;
   const int devid = pipe->devid;

--- a/src/iop/rgbcurve.c
+++ b/src/iop/rgbcurve.c
@@ -366,7 +366,7 @@ static gboolean _is_identity(dt_iop_rgbcurve_params_t *p, rgbcurve_channel_t cha
 
 void gui_changed(dt_iop_module_t *self, GtkWidget *w, void *previous)
 {
-  dt_iop_rgbcurve_gui_data_t *g = (dt_iop_rgbcurve_gui_data_t *)self->gui_data;
+  dt_iop_rgbcurve_gui_data_t *g = (dt_iop_rgbcurve_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_rgbcurve_params_t *p = (dt_iop_rgbcurve_params_t *)self->params;
 
   if(w == g->autoscale)
@@ -424,7 +424,7 @@ static void interpolator_callback(GtkWidget *widget, dt_iop_module_t *self)
 {
   if(dt_gui_widgets_suppressed()) return;
   dt_iop_rgbcurve_params_t *p = (dt_iop_rgbcurve_params_t *)self->params;
-  dt_iop_rgbcurve_gui_data_t *g = (dt_iop_rgbcurve_gui_data_t *)self->gui_data;
+  dt_iop_rgbcurve_gui_data_t *g = (dt_iop_rgbcurve_gui_data_t *)dt_iop_gui_data(self);
 
   const int combo = dt_bauhaus_combobox_get(widget);
 
@@ -446,11 +446,11 @@ static void tab_switch_callback(GtkNotebook *notebook, GtkWidget *page, guint pa
 {
   if(dt_gui_widgets_suppressed()) return;
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
-  dt_iop_rgbcurve_gui_data_t *g = (dt_iop_rgbcurve_gui_data_t *)self->gui_data;
+  dt_iop_rgbcurve_gui_data_t *g = (dt_iop_rgbcurve_gui_data_t *)dt_iop_gui_data(self);
 
   g->channel = (rgbcurve_channel_t)page_num;
 
-  gtk_widget_queue_draw(self->widget);
+  gtk_widget_queue_draw(self->gui->widget);
 }
 
 static gboolean _area_resized_callback(GtkWidget *widget, GdkEvent *event, gpointer user_data)
@@ -528,7 +528,7 @@ static inline int _add_node_from_picker(dt_iop_rgbcurve_params_t *p, const float
 void color_picker_apply(dt_iop_module_t *self, GtkWidget *picker, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
 {
   (void)piece;
-  dt_iop_rgbcurve_gui_data_t *g = (dt_iop_rgbcurve_gui_data_t *)self->gui_data;
+  dt_iop_rgbcurve_gui_data_t *g = (dt_iop_rgbcurve_gui_data_t *)dt_iop_gui_data(self);
   if(picker == g->colorpicker_set_values)
   {
     dt_iop_rgbcurve_params_t *p = (dt_iop_rgbcurve_params_t *)self->params;
@@ -570,7 +570,7 @@ void color_picker_apply(dt_iop_module_t *self, GtkWidget *picker, dt_dev_pixelpi
     dt_dev_add_history_item(self->dev, self, TRUE, TRUE);
   }
 
-  dt_control_queue_redraw_widget(self->widget);
+  dt_control_queue_redraw_widget(self->gui->widget);
 }
 
 static gboolean _sanity_check(const float x, const int selected, const int nodes,
@@ -597,7 +597,7 @@ static gboolean _sanity_check(const float x, const int selected, const int nodes
 static gboolean _move_point_internal(dt_iop_module_t *self, GtkWidget *widget, float dx, float dy, guint state)
 {
   dt_iop_rgbcurve_params_t *p = (dt_iop_rgbcurve_params_t *)self->params;
-  dt_iop_rgbcurve_gui_data_t *g = (dt_iop_rgbcurve_gui_data_t *)self->gui_data;
+  dt_iop_rgbcurve_gui_data_t *g = (dt_iop_rgbcurve_gui_data_t *)dt_iop_gui_data(self);
 
   const int ch = g->channel;
   dt_iop_rgbcurve_node_t *curve = p->curve_nodes[ch];
@@ -623,7 +623,7 @@ static gboolean _move_point_internal(dt_iop_module_t *self, GtkWidget *widget, f
 static gboolean _area_scrolled_callback(GtkWidget *widget, GdkEventScroll *event, dt_iop_module_t *self)
 {
   dt_iop_rgbcurve_params_t *p = (dt_iop_rgbcurve_params_t *)self->params;
-  dt_iop_rgbcurve_gui_data_t *g = (dt_iop_rgbcurve_gui_data_t *)self->gui_data;
+  dt_iop_rgbcurve_gui_data_t *g = (dt_iop_rgbcurve_gui_data_t *)dt_iop_gui_data(self);
 
   gdouble delta_y;
 
@@ -646,7 +646,7 @@ static gboolean _area_scrolled_callback(GtkWidget *widget, GdkEventScroll *event
 static gboolean _area_key_press_callback(GtkWidget *widget, GdkEventKey *event, dt_iop_module_t *self)
 {
   dt_iop_rgbcurve_params_t *p = (dt_iop_rgbcurve_params_t *)self->params;
-  dt_iop_rgbcurve_gui_data_t *g = (dt_iop_rgbcurve_gui_data_t *)self->gui_data;
+  dt_iop_rgbcurve_gui_data_t *g = (dt_iop_rgbcurve_gui_data_t *)dt_iop_gui_data(self);
 
   // if autoscale is on: do not modify g and b curves
   if((p->curve_autoscale != DT_S_SCALE_MANUAL_RGB) && g->channel != DT_IOP_RGBCURVE_R) return TRUE;
@@ -699,7 +699,7 @@ static gboolean _area_leave_notify_callback(GtkWidget *widget, GdkEventCrossing 
 
 static gboolean _area_draw_callback(GtkWidget *widget, cairo_t *crf, dt_iop_module_t *self)
 {
-  dt_iop_rgbcurve_gui_data_t *g = (dt_iop_rgbcurve_gui_data_t *)self->gui_data;
+  dt_iop_rgbcurve_gui_data_t *g = (dt_iop_rgbcurve_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_rgbcurve_params_t *p = (dt_iop_rgbcurve_params_t *)self->params;
   dt_develop_t *dev = self->dev;
 
@@ -1043,7 +1043,7 @@ finally:
 
 static gboolean _area_motion_notify_callback(GtkWidget *widget, GdkEventMotion *event, dt_iop_module_t *self)
 {
-  dt_iop_rgbcurve_gui_data_t *g = (dt_iop_rgbcurve_gui_data_t *)self->gui_data;
+  dt_iop_rgbcurve_gui_data_t *g = (dt_iop_rgbcurve_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_rgbcurve_params_t *p = (dt_iop_rgbcurve_params_t *)self->params;
 
   const int inset = DT_GUI_CURVE_EDITOR_INSET;
@@ -1126,7 +1126,7 @@ static gboolean _area_button_press_callback(GtkWidget *widget, GdkEventButton *e
 {
   dt_iop_rgbcurve_params_t *p = (dt_iop_rgbcurve_params_t *)self->params;
   dt_iop_rgbcurve_params_t *d = (dt_iop_rgbcurve_params_t *)self->default_params;
-  dt_iop_rgbcurve_gui_data_t *g = (dt_iop_rgbcurve_gui_data_t *)self->gui_data;
+  dt_iop_rgbcurve_gui_data_t *g = (dt_iop_rgbcurve_gui_data_t *)dt_iop_gui_data(self);
 
   const int ch = g->channel;
   const int autoscale = p->curve_autoscale;
@@ -1187,7 +1187,7 @@ static gboolean _area_button_press_callback(GtkWidget *widget, GdkEventButton *e
 
           dt_iop_color_picker_reset(self, TRUE);
           dt_dev_add_history_item(self->dev, self, TRUE, TRUE);
-          gtk_widget_queue_draw(self->widget);
+          gtk_widget_queue_draw(self->gui->widget);
         }
 
       return TRUE;
@@ -1209,7 +1209,7 @@ static gboolean _area_button_press_callback(GtkWidget *widget, GdkEventButton *e
         dt_bauhaus_combobox_set(g->interpolator, p->curve_type[DT_IOP_RGBCURVE_R]);
         dt_iop_color_picker_reset(self, TRUE);
         dt_dev_add_history_item(self->dev, self, TRUE, TRUE);
-        gtk_widget_queue_draw(self->widget);
+        gtk_widget_queue_draw(self->gui->widget);
       }
       else
       {
@@ -1220,7 +1220,7 @@ static gboolean _area_button_press_callback(GtkWidget *widget, GdkEventButton *e
           dt_bauhaus_combobox_set(g->autoscale, 1);
           dt_iop_color_picker_reset(self, TRUE);
           dt_dev_add_history_item(self->dev, self, TRUE, TRUE);
-          gtk_widget_queue_draw(self->widget);
+          gtk_widget_queue_draw(self->gui->widget);
         }
       }
       return TRUE;
@@ -1234,7 +1234,7 @@ static gboolean _area_button_press_callback(GtkWidget *widget, GdkEventButton *e
       curve_nodes[g->selected].y = curve_nodes[g->selected].x = reset_value;
       dt_iop_color_picker_reset(self, TRUE);
       dt_dev_add_history_item(self->dev, self, TRUE, TRUE);
-      gtk_widget_queue_draw(self->widget);
+      gtk_widget_queue_draw(self->gui->widget);
       return TRUE;
     }
 
@@ -1248,7 +1248,7 @@ static gboolean _area_button_press_callback(GtkWidget *widget, GdkEventButton *e
     p->curve_num_nodes[ch]--;
     dt_iop_color_picker_reset(self, TRUE);
     dt_dev_add_history_item(self->dev, self, TRUE, TRUE);
-    gtk_widget_queue_draw(self->widget);
+    gtk_widget_queue_draw(self->gui->widget);
     return TRUE;
   }
   return FALSE;
@@ -1256,7 +1256,7 @@ static gboolean _area_button_press_callback(GtkWidget *widget, GdkEventButton *e
 
 void gui_reset(struct dt_iop_module_t *self)
 {
-  dt_iop_rgbcurve_gui_data_t *g = (dt_iop_rgbcurve_gui_data_t *)self->gui_data;
+  dt_iop_rgbcurve_gui_data_t *g = (dt_iop_rgbcurve_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_rgbcurve_params_t *p = (dt_iop_rgbcurve_params_t *)self->params;
 
   g->channel = DT_IOP_RGBCURVE_R;
@@ -1266,12 +1266,12 @@ void gui_reset(struct dt_iop_module_t *self)
 
   dt_bauhaus_combobox_set(g->interpolator, p->curve_type[DT_IOP_RGBCURVE_R]);
 
-  gtk_widget_queue_draw(self->widget);
+  gtk_widget_queue_draw(self->gui->widget);
 }
 
 void change_image(struct dt_iop_module_t *self)
 {
-  dt_iop_rgbcurve_gui_data_t *g = (dt_iop_rgbcurve_gui_data_t *)self->gui_data;
+  dt_iop_rgbcurve_gui_data_t *g = (dt_iop_rgbcurve_gui_data_t *)dt_iop_gui_data(self);
   if(!IS_NULL_PTR(g))
   {
     if(!g->channel)
@@ -1298,7 +1298,7 @@ void gui_init(struct dt_iop_module_t *self)
   }
 
   g->channel = DT_IOP_RGBCURVE_R;
-  self->timeout_handle = 0;
+  self->gui->timeout_handle = 0;
   change_image(self);
 
   g->autoscale = dt_bauhaus_combobox_from_params(self, "curve_autoscale");
@@ -1329,7 +1329,7 @@ void gui_init(struct dt_iop_module_t *self)
                                                            "shift+drag to create a negative curve"));
 
   GtkWidget *vbox = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_GUI_BOX_SPACING);
-  gtk_box_pack_start(GTK_BOX(self->widget), vbox, FALSE, FALSE, 0);
+  gtk_box_pack_start(GTK_BOX(self->gui->widget), vbox, FALSE, FALSE, 0);
   gtk_box_pack_start(GTK_BOX(vbox), GTK_WIDGET(hbox), TRUE, TRUE, 0);
 
   g->area = GTK_DRAWING_AREA(gtk_drawing_area_new());
@@ -1366,7 +1366,7 @@ void gui_init(struct dt_iop_module_t *self)
   dt_bauhaus_combobox_add(g->interpolator, _("cubic spline"));
   dt_bauhaus_combobox_add(g->interpolator, _("centripetal spline"));
   dt_bauhaus_combobox_add(g->interpolator, _("monotonic spline"));
-  gtk_box_pack_start(GTK_BOX(self->widget), g->interpolator, TRUE, TRUE, 0);
+  gtk_box_pack_start(GTK_BOX(self->gui->widget), g->interpolator, TRUE, TRUE, 0);
   gtk_widget_set_tooltip_text(g->interpolator,
       _("change this method if you see oscillations or cusps in the curve\n"
         "- cubic spline is better to produce smooth curves but oscillates when nodes are too close\n"
@@ -1383,7 +1383,7 @@ void gui_init(struct dt_iop_module_t *self)
 
 void gui_update(struct dt_iop_module_t *self)
 {
-  dt_iop_rgbcurve_gui_data_t *g = (dt_iop_rgbcurve_gui_data_t *)self->gui_data;
+  dt_iop_rgbcurve_gui_data_t *g = (dt_iop_rgbcurve_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_rgbcurve_params_t *p = (dt_iop_rgbcurve_params_t *)self->params;
 
   dt_bauhaus_combobox_set(g->autoscale, p->curve_autoscale);
@@ -1395,12 +1395,12 @@ void gui_update(struct dt_iop_module_t *self)
   _rgbcurve_show_hide_controls(p, g);
 
   // that's all, gui curve is read directly from params during expose event.
-  gtk_widget_queue_draw(self->widget);
+  gtk_widget_queue_draw(self->gui->widget);
 }
 
 void gui_cleanup(struct dt_iop_module_t *self)
 {
-  dt_iop_rgbcurve_gui_data_t *g = (dt_iop_rgbcurve_gui_data_t *)self->gui_data;
+  dt_iop_rgbcurve_gui_data_t *g = (dt_iop_rgbcurve_gui_data_t *)dt_iop_gui_data(self);
 
   for(int k = 0; k < DT_IOP_RGBCURVE_MAX_CHANNELS; k++) dt_draw_curve_destroy(g->minmax_curve[k]);
 

--- a/src/iop/rgblevels.c
+++ b/src/iop/rgblevels.c
@@ -149,7 +149,7 @@ const char **description(struct dt_iop_module_t *self)
 
 static void _turn_select_region_off(struct dt_iop_module_t *self)
 {
-  dt_iop_rgblevels_gui_data_t *g = (dt_iop_rgblevels_gui_data_t *)self->gui_data;
+  dt_iop_rgblevels_gui_data_t *g = (dt_iop_rgblevels_gui_data_t *)dt_iop_gui_data(self);
   if(!IS_NULL_PTR(g))
   {
     g->button_down = g->draw_selected_region = 0;
@@ -166,7 +166,7 @@ static void _turn_selregion_picker_off(struct dt_iop_module_t *self)
 static void _develop_ui_pipe_finished_callback(gpointer instance, dt_iop_module_t *self)
 {
   dt_iop_rgblevels_params_t *p = (dt_iop_rgblevels_params_t *)self->params;
-  dt_iop_rgblevels_gui_data_t *g = (dt_iop_rgblevels_gui_data_t *)self->gui_data;
+  dt_iop_rgblevels_gui_data_t *g = (dt_iop_rgblevels_gui_data_t *)dt_iop_gui_data(self);
 
   if(IS_NULL_PTR(g)) return;
 
@@ -256,7 +256,7 @@ static void _rgblevels_show_hide_controls(dt_iop_rgblevels_params_t *p, dt_iop_r
 
 static gboolean _area_leave_notify_callback(GtkWidget *widget, GdkEventCrossing *event, dt_iop_module_t *self)
 {
-  dt_iop_rgblevels_gui_data_t *c = (dt_iop_rgblevels_gui_data_t *)self->gui_data;
+  dt_iop_rgblevels_gui_data_t *c = (dt_iop_rgblevels_gui_data_t *)dt_iop_gui_data(self);
   c->mouse_x = c->mouse_y = -1.0;
   gtk_widget_queue_draw(widget);
   return TRUE;
@@ -264,7 +264,7 @@ static gboolean _area_leave_notify_callback(GtkWidget *widget, GdkEventCrossing 
 
 static gboolean _area_draw_callback(GtkWidget *widget, cairo_t *crf, dt_iop_module_t *self)
 {
-  dt_iop_rgblevels_gui_data_t *c = (dt_iop_rgblevels_gui_data_t *)self->gui_data;
+  dt_iop_rgblevels_gui_data_t *c = (dt_iop_rgblevels_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_rgblevels_params_t *p = (dt_iop_rgblevels_params_t *)self->params;
 
   const int inset = DT_GUI_CURVE_EDITOR_INSET;
@@ -397,7 +397,7 @@ static gboolean _area_draw_callback(GtkWidget *widget, cairo_t *crf, dt_iop_modu
 static void _rgblevels_move_handle(dt_iop_module_t *self, const int handle_move, const float new_pos, float *levels,
                                       const float drag_start_percentage)
 {
-  dt_iop_rgblevels_gui_data_t *c = (dt_iop_rgblevels_gui_data_t *)self->gui_data;
+  dt_iop_rgblevels_gui_data_t *c = (dt_iop_rgblevels_gui_data_t *)dt_iop_gui_data(self);
   float min_x = 0.f;
   float max_x = 1.f;
 
@@ -437,7 +437,7 @@ static void _rgblevels_move_handle(dt_iop_module_t *self, const int handle_move,
 
 static gboolean _area_motion_notify_callback(GtkWidget *widget, GdkEventMotion *event, dt_iop_module_t *self)
 {
-  dt_iop_rgblevels_gui_data_t *c = (dt_iop_rgblevels_gui_data_t *)self->gui_data;
+  dt_iop_rgblevels_gui_data_t *c = (dt_iop_rgblevels_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_rgblevels_params_t *p = (dt_iop_rgblevels_params_t *)self->params;
   const int inset = DT_GUI_CURVE_EDITOR_INSET;
   GtkAllocation allocation;
@@ -492,7 +492,7 @@ static gboolean _area_button_press_callback(GtkWidget *widget, GdkEventButton *e
       _turn_selregion_picker_off(self);
 
       // Reset
-      dt_iop_rgblevels_gui_data_t *c = (dt_iop_rgblevels_gui_data_t *)self->gui_data;
+      dt_iop_rgblevels_gui_data_t *c = (dt_iop_rgblevels_gui_data_t *)dt_iop_gui_data(self);
       dt_iop_rgblevels_params_t *p = (dt_iop_rgblevels_params_t *)self->params;
       dt_iop_rgblevels_params_t *default_params = (dt_iop_rgblevels_params_t *)self->default_params;
 
@@ -503,13 +503,13 @@ static gboolean _area_button_press_callback(GtkWidget *widget, GdkEventButton *e
       // as drag_start_percentage is only updated when the mouse is moved.
       c->drag_start_percentage = 0.5;
       dt_dev_add_history_item(self->dev, self, TRUE, TRUE);
-      gtk_widget_queue_draw(self->widget);
+      gtk_widget_queue_draw(self->gui->widget);
     }
     else
     {
       _turn_selregion_picker_off(self);
 
-      dt_iop_rgblevels_gui_data_t *c = (dt_iop_rgblevels_gui_data_t *)self->gui_data;
+      dt_iop_rgblevels_gui_data_t *c = (dt_iop_rgblevels_gui_data_t *)dt_iop_gui_data(self);
       c->dragging = 1;
     }
     return TRUE;
@@ -521,7 +521,7 @@ static gboolean _area_button_release_callback(GtkWidget *widget, GdkEventButton 
 {
   if(event->button == 1)
   {
-    dt_iop_rgblevels_gui_data_t *c = (dt_iop_rgblevels_gui_data_t *)self->gui_data;
+    dt_iop_rgblevels_gui_data_t *c = (dt_iop_rgblevels_gui_data_t *)dt_iop_gui_data(self);
     c->dragging = 0;
     return TRUE;
   }
@@ -530,7 +530,7 @@ static gboolean _area_button_release_callback(GtkWidget *widget, GdkEventButton 
 
 static gboolean _area_scroll_callback(GtkWidget *widget, GdkEventScroll *event, dt_iop_module_t *self)
 {
-  dt_iop_rgblevels_gui_data_t *c = (dt_iop_rgblevels_gui_data_t *)self->gui_data;
+  dt_iop_rgblevels_gui_data_t *c = (dt_iop_rgblevels_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_rgblevels_params_t *p = (dt_iop_rgblevels_params_t *)self->params;
 
   int delta_y;
@@ -559,12 +559,12 @@ static void _auto_levels_callback(GtkButton *button, dt_iop_module_t *self)
 {
   if(dt_gui_widgets_suppressed()) return;
 
-  dt_iop_rgblevels_gui_data_t *g = (dt_iop_rgblevels_gui_data_t *)self->gui_data;
+  dt_iop_rgblevels_gui_data_t *g = (dt_iop_rgblevels_gui_data_t *)dt_iop_gui_data(self);
 
   dt_iop_request_focus(self);
-  if(self->off)
+  if(self->gui->off)
   {
-    gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(self->off), 1);
+    gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(self->gui->off), 1);
     dt_dev_add_history_item(self->dev, self, TRUE, TRUE);
   }
 
@@ -585,12 +585,12 @@ static void _select_region_toggled_callback(GtkToggleButton *togglebutton, dt_io
 {
   if(dt_gui_widgets_suppressed()) return;
 
-  dt_iop_rgblevels_gui_data_t *g = (dt_iop_rgblevels_gui_data_t *)self->gui_data;
+  dt_iop_rgblevels_gui_data_t *g = (dt_iop_rgblevels_gui_data_t *)dt_iop_gui_data(self);
 
   dt_iop_request_focus(self);
-  if(self->off)
+  if(self->gui->off)
   {
-    gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(self->off), 1);
+    gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(self->gui->off), 1);
     dt_dev_add_history_item(self->dev, self, TRUE, TRUE);
   }
 
@@ -612,7 +612,7 @@ static void _select_region_toggled_callback(GtkToggleButton *togglebutton, dt_io
 
 void gui_changed(dt_iop_module_t *self, GtkWidget *w, void *previous)
 {
-  dt_iop_rgblevels_gui_data_t *g = (dt_iop_rgblevels_gui_data_t *)self->gui_data;
+  dt_iop_rgblevels_gui_data_t *g = (dt_iop_rgblevels_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_rgblevels_params_t *p = (dt_iop_rgblevels_params_t *)self->params;
 
   _turn_selregion_picker_off(self);
@@ -629,11 +629,11 @@ void gui_changed(dt_iop_module_t *self, GtkWidget *w, void *previous)
 static void _tab_switch_callback(GtkNotebook *notebook, GtkWidget *page, guint page_num, dt_iop_module_t *self)
 {
   if(dt_gui_widgets_suppressed()) return;
-  dt_iop_rgblevels_gui_data_t *g = (dt_iop_rgblevels_gui_data_t *)self->gui_data;
+  dt_iop_rgblevels_gui_data_t *g = (dt_iop_rgblevels_gui_data_t *)dt_iop_gui_data(self);
 
   g->channel = (dt_iop_rgblevels_channel_t)page_num;
 
-  gtk_widget_queue_draw(self->widget);
+  gtk_widget_queue_draw(self->gui->widget);
 }
 
 static void _color_picker_callback(GtkWidget *button, dt_iop_module_t *self)
@@ -645,7 +645,7 @@ void color_picker_apply(dt_iop_module_t *self, GtkWidget *picker, dt_dev_pixelpi
 {
   (void)pipe;
   (void)piece;
-  dt_iop_rgblevels_gui_data_t *c = (dt_iop_rgblevels_gui_data_t *)self->gui_data;
+  dt_iop_rgblevels_gui_data_t *c = (dt_iop_rgblevels_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_rgblevels_params_t *p = (dt_iop_rgblevels_params_t *)self->params;
 
   const dt_iop_rgblevels_channel_t channel = c->channel;
@@ -751,14 +751,14 @@ void cleanup_pipe(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelp
 void gui_update(dt_iop_module_t *self)
 {
   dt_iop_rgblevels_params_t *p = (dt_iop_rgblevels_params_t *)self->params;
-  dt_iop_rgblevels_gui_data_t *g = (dt_iop_rgblevels_gui_data_t *)self->gui_data;
+  dt_iop_rgblevels_gui_data_t *g = (dt_iop_rgblevels_gui_data_t *)dt_iop_gui_data(self);
 
   dt_bauhaus_combobox_set(g->cmb_autoscale, p->autoscale);
   dt_bauhaus_combobox_set(g->cmb_preserve_colors, p->preserve_colors);
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->bt_select_region), g->draw_selected_region);
   _rgblevels_show_hide_controls(p, g);
 
-  gtk_widget_queue_draw(self->widget);
+  gtk_widget_queue_draw(self->gui->widget);
 }
 
 void gui_focus(struct dt_iop_module_t *self, gboolean in)
@@ -768,13 +768,13 @@ void gui_focus(struct dt_iop_module_t *self, gboolean in)
 
 void gui_reset(struct dt_iop_module_t *self)
 {
-  dt_iop_rgblevels_gui_data_t *g = (dt_iop_rgblevels_gui_data_t *)self->gui_data;
+  dt_iop_rgblevels_gui_data_t *g = (dt_iop_rgblevels_gui_data_t *)dt_iop_gui_data(self);
 
   _turn_selregion_picker_off(self);
 
   g->channel = DT_IOP_RGBLEVELS_R;
 
-  gtk_widget_queue_draw(self->widget);
+  gtk_widget_queue_draw(self->gui->widget);
 }
 
 void init(dt_iop_module_t *self)
@@ -795,7 +795,7 @@ void init(dt_iop_module_t *self)
 
 void change_image(struct dt_iop_module_t *self)
 {
-  dt_iop_rgblevels_gui_data_t *g = (dt_iop_rgblevels_gui_data_t *)self->gui_data;
+  dt_iop_rgblevels_gui_data_t *g = (dt_iop_rgblevels_gui_data_t *)dt_iop_gui_data(self);
 
   g->channel = DT_IOP_RGBLEVELS_R;
   g->call_auto_levels = 0;
@@ -824,12 +824,12 @@ void gui_init(dt_iop_module_t *self)
   dt_ui_notebook_page(c->channel_tabs, N_("B"), _("curve nodes for b channel"));
   g_signal_connect(G_OBJECT(c->channel_tabs), "switch_page", G_CALLBACK(_tab_switch_callback), self);
   dt_ui_notebook_set_picker_owner(c->channel_tabs, self);
-  gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(c->channel_tabs), FALSE, FALSE, 0);
+  gtk_box_pack_start(GTK_BOX(self->gui->widget), GTK_WIDGET(c->channel_tabs), FALSE, FALSE, 0);
 
   c->area = GTK_DRAWING_AREA(gtk_drawing_area_new());
   gtk_widget_set_hexpand(GTK_WIDGET(c->area), TRUE);
 
-  gtk_box_pack_start(GTK_BOX(self->widget),
+  gtk_box_pack_start(GTK_BOX(self->gui->widget),
                      dt_ui_resizable_drawing_area(GTK_WIDGET(c->area),
                                                   "plugins/darkroom/rgblevels/graphheight", 280, 100),
                      FALSE, FALSE, 0);
@@ -870,7 +870,7 @@ void gui_init(dt_iop_module_t *self)
   gtk_box_pack_start(GTK_BOX(pick_hbox), GTK_WIDGET(c->greypick ), TRUE, TRUE, 0);
   gtk_box_pack_start(GTK_BOX(pick_hbox), GTK_WIDGET(c->whitepick), TRUE, TRUE, 0);
 
-  gtk_box_pack_start(GTK_BOX(self->widget), pick_hbox, TRUE, TRUE, 0);
+  gtk_box_pack_start(GTK_BOX(self->gui->widget), pick_hbox, TRUE, TRUE, 0);
 
   c->bt_auto_levels = gtk_button_new_with_label(_("auto"));
   gtk_widget_set_tooltip_text(c->bt_auto_levels, _("apply auto levels"));
@@ -886,7 +886,7 @@ void gui_init(dt_iop_module_t *self)
   gtk_box_pack_start(GTK_BOX(autolevels_box), c->bt_auto_levels, TRUE, TRUE, 0);
   gtk_box_pack_start(GTK_BOX(autolevels_box), c->bt_select_region, TRUE, TRUE, 0);
 
-  gtk_box_pack_start(GTK_BOX(self->widget), autolevels_box, TRUE, TRUE, 0);
+  gtk_box_pack_start(GTK_BOX(self->gui->widget), autolevels_box, TRUE, TRUE, 0);
 
   g_signal_connect(G_OBJECT(c->bt_auto_levels), "clicked", G_CALLBACK(_auto_levels_callback), self);
   g_signal_connect(G_OBJECT(c->bt_select_region), "toggled", G_CALLBACK(_select_region_toggled_callback), self);
@@ -1044,7 +1044,7 @@ int process(dt_iop_module_t *self, const dt_dev_pixelpipe_t *pipe, const dt_dev_
 
   const dt_iop_rgblevels_data_t *const d = (dt_iop_rgblevels_data_t *)piece->data;
   dt_iop_rgblevels_params_t *p = (dt_iop_rgblevels_params_t *)&d->params;
-  dt_iop_rgblevels_gui_data_t *g = (dt_iop_rgblevels_gui_data_t *)self->gui_data;
+  dt_iop_rgblevels_gui_data_t *g = (dt_iop_rgblevels_gui_data_t *)dt_iop_gui_data(self);
   const dt_iop_order_iccprofile_info_t *const work_profile = dt_ioppr_get_pipe_work_profile_info(pipe);
 
   // process auto levels

--- a/src/iop/rotatepixels.c
+++ b/src/iop/rotatepixels.c
@@ -34,6 +34,7 @@
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif
+#include "develop/imageop_gui.h"
 #include "common/module_versioning.h"
 #include "system/target_clones.h"
 #include "pixel/interpolation.h"
@@ -370,7 +371,7 @@ void reload_defaults(dt_iop_module_t *self)
 
 void gui_update(dt_iop_module_t *self)
 {
-  gtk_label_set_text(GTK_LABEL(self->widget), self->default_enabled
+  gtk_label_set_text(GTK_LABEL(self->gui->widget), self->default_enabled
                      ? _("automatic pixel rotation")
                      : _("automatic pixel rotation\nonly works for the sensors that need it."));
 }
@@ -378,8 +379,8 @@ void gui_init(dt_iop_module_t *self)
 {
   IOP_GUI_ALLOC(rotatepixels);
 
-  self->widget = dt_ui_label_new("");
-  gtk_label_set_line_wrap(GTK_LABEL(self->widget), TRUE);
+  self->gui->widget = dt_ui_label_new("");
+  gtk_label_set_line_wrap(GTK_LABEL(self->gui->widget), TRUE);
 
 }
 

--- a/src/iop/scalepixels.c
+++ b/src/iop/scalepixels.c
@@ -33,6 +33,7 @@
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif
+#include "develop/imageop_gui.h"
 #include "widgets/bauhaus.h"
 #include "common/module_versioning.h"
 #include "system/target_clones.h"
@@ -293,7 +294,7 @@ void reload_defaults(dt_iop_module_t *self)
 
 void gui_update(dt_iop_module_t *self)
 {
-  gtk_label_set_text(GTK_LABEL(self->widget), self->default_enabled
+  gtk_label_set_text(GTK_LABEL(self->gui->widget), self->default_enabled
                      ? _("automatic pixel scaling")
                      : _("automatic pixel scaling\nonly works for the sensors that need it."));
 }
@@ -302,8 +303,8 @@ void gui_init(dt_iop_module_t *self)
 {
   IOP_GUI_ALLOC(scalepixels);
 
-  self->widget = dt_ui_label_new("");
-  gtk_label_set_line_wrap(GTK_LABEL(self->widget), TRUE);
+  self->gui->widget = dt_ui_label_new("");
+  gtk_label_set_line_wrap(GTK_LABEL(self->gui->widget), TRUE);
 
 }
 

--- a/src/iop/splittoning.c
+++ b/src/iop/splittoning.c
@@ -275,7 +275,7 @@ static inline void update_balance_slider_colors(
 void gui_changed(dt_iop_module_t *self, GtkWidget *w, void *previous)
 {
   dt_iop_splittoning_params_t *p = (dt_iop_splittoning_params_t *)self->params;
-  dt_iop_splittoning_gui_data_t *g = (dt_iop_splittoning_gui_data_t *)self->gui_data;
+  dt_iop_splittoning_gui_data_t *g = (dt_iop_splittoning_gui_data_t *)dt_iop_gui_data(self);
 
   if(w == g->shadow_sat_gslider || w == g->shadow_hue_gslider)
   {
@@ -307,7 +307,7 @@ static void colorpick_callback(GtkColorButton *widget, dt_iop_module_t *self)
 {
   if(dt_gui_widgets_suppressed()) return;
 
-  dt_iop_splittoning_gui_data_t *g = (dt_iop_splittoning_gui_data_t *)self->gui_data;
+  dt_iop_splittoning_gui_data_t *g = (dt_iop_splittoning_gui_data_t *)dt_iop_gui_data(self);
 
   dt_aligned_pixel_t color;
   float h, s, l;
@@ -339,7 +339,7 @@ static void colorpick_callback(GtkColorButton *widget, dt_iop_module_t *self)
 
 void color_picker_apply(dt_iop_module_t *self, GtkWidget *picker, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
 {
-  dt_iop_splittoning_gui_data_t *g = (dt_iop_splittoning_gui_data_t *)self->gui_data;
+  dt_iop_splittoning_gui_data_t *g = (dt_iop_splittoning_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_splittoning_params_t *p = (dt_iop_splittoning_params_t *)self->params;
 
   float *p_hue, *p_saturation;
@@ -417,7 +417,7 @@ void cleanup_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev
 
 void gui_update(struct dt_iop_module_t *self)
 {
-  dt_iop_splittoning_gui_data_t *g = (dt_iop_splittoning_gui_data_t *)self->gui_data;
+  dt_iop_splittoning_gui_data_t *g = (dt_iop_splittoning_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_splittoning_params_t *p = (dt_iop_splittoning_params_t *)self->params;
 
   dt_bauhaus_slider_set(g->shadow_hue_gslider, p->shadow_hue);
@@ -440,7 +440,7 @@ static inline void gui_init_section(struct dt_iop_module_t *self, char *section,
 {
   GtkWidget *label = dt_ui_section_label_new(_(section));
 
-  gtk_box_pack_start(GTK_BOX(self->widget), label, FALSE, FALSE, 0);
+  gtk_box_pack_start(GTK_BOX(self->gui->widget), label, FALSE, FALSE, 0);
 
   dt_bauhaus_widget_set_label(hue, N_("hue"));
   dt_bauhaus_slider_set_feedback(hue, 0);
@@ -467,34 +467,34 @@ static inline void gui_init_section(struct dt_iop_module_t *self, char *section,
   GtkWidget *hbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, DT_GUI_BOX_SPACING);
   gtk_box_pack_start(GTK_BOX(hbox), slider_box, TRUE, TRUE, 0);
   gtk_box_pack_end(GTK_BOX(hbox), *picker, FALSE, FALSE, 0);
-  gtk_box_pack_start(GTK_BOX(self->widget), hbox, FALSE, FALSE, 0);
+  gtk_box_pack_start(GTK_BOX(self->gui->widget), hbox, FALSE, FALSE, 0);
 }
 
 void gui_init(struct dt_iop_module_t *self)
 {
   dt_iop_splittoning_gui_data_t *g = IOP_GUI_ALLOC(splittoning);
 
-  GtkWidget *shadows_box = self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_GUI_BOX_SPACING);
+  GtkWidget *shadows_box = self->gui->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_GUI_BOX_SPACING);
   g->shadow_hue_gslider = dt_bauhaus_slider_from_params(self, "shadow_hue");
   dt_bauhaus_slider_set_factor(g->shadow_hue_gslider, 360.0f);
   dt_bauhaus_slider_set_format(g->shadow_hue_gslider, "\302\260");
   g->shadow_sat_gslider = dt_bauhaus_slider_from_params(self, "shadow_saturation");
 
-  GtkWidget *highlights_box = self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_GUI_BOX_SPACING);
+  GtkWidget *highlights_box = self->gui->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_GUI_BOX_SPACING);
   g->highlight_hue_gslider = dt_bauhaus_slider_from_params(self, "highlight_hue");
   dt_bauhaus_slider_set_factor(g->highlight_hue_gslider, 360.0f);
   dt_bauhaus_slider_set_format(g->highlight_hue_gslider, "\302\260");
   g->highlight_sat_gslider = dt_bauhaus_slider_from_params(self, "highlight_saturation");
 
   // start building top level widget
-  self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_GUI_BOX_SPACING);
+  self->gui->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_GUI_BOX_SPACING);
 
   gui_init_section(self, N_("shadows"), shadows_box, g->shadow_hue_gslider, g->shadow_sat_gslider, &g->shadow_colorpick, TRUE);
 
   gui_init_section(self, N_("highlights"), highlights_box, g->highlight_hue_gslider, g->highlight_sat_gslider, &g->highlight_colorpick, FALSE);
 
   // Additional parameters
-  gtk_box_pack_start(GTK_BOX(self->widget), dt_ui_section_label_new(_("properties")), FALSE, FALSE, 0);
+  gtk_box_pack_start(GTK_BOX(self->gui->widget), dt_ui_section_label_new(_("properties")), FALSE, FALSE, 0);
 
   g->balance_scale = dt_bauhaus_slider_from_params(self, N_("balance"));
   dt_bauhaus_slider_set_feedback(g->balance_scale, 0);

--- a/src/iop/splittoningrgb.c
+++ b/src/iop/splittoningrgb.c
@@ -20,6 +20,7 @@
 #include "config.h"
 #include "common/conf.h"
 #endif
+#include "develop/imageop_gui.h"
 
 #include "widgets/bauhaus.h"
 #include "pixel/chromatic_adaptation.h"
@@ -379,7 +380,7 @@ static inline __attribute__((always_inline)) void _get_split_matrix(const float 
 
 static gboolean _sync_simple_from_params(dt_iop_module_t *self, const int point, float *error)
 {
-  dt_iop_splittoning_rgb_gui_data_t *g = (dt_iop_splittoning_rgb_gui_data_t *)self->gui_data;
+  dt_iop_splittoning_rgb_gui_data_t *g = (dt_iop_splittoning_rgb_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_splittoning_rgb_params_t *p = (dt_iop_splittoning_rgb_params_t *)self->params;
   GtkWidget *const widgets[6]
       = { g->point[point].simple_theta, g->point[point].simple_psi, g->point[point].simple_stretch_1,
@@ -412,7 +413,7 @@ static gboolean _sync_simple_from_params(dt_iop_module_t *self, const int point,
 
 static gboolean _sync_primaries_from_params(dt_iop_module_t *self, const int point, float *error)
 {
-  dt_iop_splittoning_rgb_gui_data_t *g = (dt_iop_splittoning_rgb_gui_data_t *)self->gui_data;
+  dt_iop_splittoning_rgb_gui_data_t *g = (dt_iop_splittoning_rgb_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_splittoning_rgb_params_t *p = (dt_iop_splittoning_rgb_params_t *)self->params;
   GtkWidget *const widgets[9]
       = { g->point[point].primaries_achromatic_hue, g->point[point].primaries_achromatic_purity,
@@ -449,7 +450,7 @@ static gboolean _sync_primaries_from_params(dt_iop_module_t *self, const int poi
 
 static void _queue_preview_redraw(dt_iop_module_t *self)
 {
-  dt_iop_splittoning_rgb_gui_data_t *g = (dt_iop_splittoning_rgb_gui_data_t *)self->gui_data;
+  dt_iop_splittoning_rgb_gui_data_t *g = (dt_iop_splittoning_rgb_gui_data_t *)dt_iop_gui_data(self);
   if(g && g->preview) gtk_widget_queue_draw(g->preview);
 }
 
@@ -467,7 +468,7 @@ static void _queue_preview_redraw(dt_iop_module_t *self)
 static void _pipe_finished_callback(gpointer instance, gpointer user_data)
 {
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
-  dt_iop_splittoning_rgb_gui_data_t *g = (dt_iop_splittoning_rgb_gui_data_t *)self->gui_data;
+  dt_iop_splittoning_rgb_gui_data_t *g = (dt_iop_splittoning_rgb_gui_data_t *)dt_iop_gui_data(self);
 
   if(IS_NULL_PTR(g)) return;
 
@@ -496,7 +497,7 @@ static void _pipe_finished_callback(gpointer instance, gpointer user_data)
  */
 static void _update_point_slider_colors(dt_iop_module_t *self, const int point)
 {
-  dt_iop_splittoning_rgb_gui_data_t *g = (dt_iop_splittoning_rgb_gui_data_t *)self->gui_data;
+  dt_iop_splittoning_rgb_gui_data_t *g = (dt_iop_splittoning_rgb_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_splittoning_rgb_params_t *p = (dt_iop_splittoning_rgb_params_t *)self->params;
   const dt_iop_order_iccprofile_info_t *work_profile = self->dev && self->dev->pipe
                                                            ? dt_ioppr_get_pipe_work_profile_info(self->dev->pipe)
@@ -541,7 +542,7 @@ static void _update_point_slider_colors(dt_iop_module_t *self, const int point)
 
 static void _update_point_gui(dt_iop_module_t *self, const int point, GtkWidget *changed)
 {
-  dt_iop_splittoning_rgb_gui_data_t *g = (dt_iop_splittoning_rgb_gui_data_t *)self->gui_data;
+  dt_iop_splittoning_rgb_gui_data_t *g = (dt_iop_splittoning_rgb_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_splittoning_rgb_params_t *p = (dt_iop_splittoning_rgb_params_t *)self->params;
 
   const dt_iop_splittoning_rgb_mixer_mode_t active_mode = dt_bauhaus_combobox_get(g->point[point].mixer_mode);
@@ -588,7 +589,7 @@ static void _update_point_gui(dt_iop_module_t *self, const int point, GtkWidget 
 
 static void _commit_gui_change(dt_iop_module_t *self, GtkWidget *changed)
 {
-  dt_iop_splittoning_rgb_gui_data_t *g = (dt_iop_splittoning_rgb_gui_data_t *)self->gui_data;
+  dt_iop_splittoning_rgb_gui_data_t *g = (dt_iop_splittoning_rgb_gui_data_t *)dt_iop_gui_data(self);
   const int point = GPOINTER_TO_INT(g_object_get_data(G_OBJECT(changed), "split-point"));
 
   _update_point_slider_colors(self, point);
@@ -680,7 +681,7 @@ static void _render_preview_surface(dt_iop_module_t *self, cairo_surface_t *surf
 static gboolean _preview_draw(GtkWidget *widget, cairo_t *cr, gpointer user_data)
 {
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
-  dt_iop_splittoning_rgb_gui_data_t *g = (dt_iop_splittoning_rgb_gui_data_t *)self->gui_data;
+  dt_iop_splittoning_rgb_gui_data_t *g = (dt_iop_splittoning_rgb_gui_data_t *)dt_iop_gui_data(self);
   GtkAllocation allocation;
 
   gtk_widget_get_allocation(widget, &allocation);
@@ -707,7 +708,7 @@ static void _general_callback(GtkWidget *widget, gpointer user_data)
   if(dt_gui_widgets_suppressed()) return;
 
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
-  dt_iop_splittoning_rgb_gui_data_t *g = (dt_iop_splittoning_rgb_gui_data_t *)self->gui_data;
+  dt_iop_splittoning_rgb_gui_data_t *g = (dt_iop_splittoning_rgb_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_splittoning_rgb_params_t *p = (dt_iop_splittoning_rgb_params_t *)self->params;
   const int point = GPOINTER_TO_INT(g_object_get_data(G_OBJECT(widget), "split-point"));
   gboolean changed_complete = FALSE;
@@ -745,7 +746,7 @@ static void _mixer_mode_callback(GtkWidget *widget, gpointer user_data)
   if(dt_gui_widgets_suppressed()) return;
 
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
-  dt_iop_splittoning_rgb_gui_data_t *g = (dt_iop_splittoning_rgb_gui_data_t *)self->gui_data;
+  dt_iop_splittoning_rgb_gui_data_t *g = (dt_iop_splittoning_rgb_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_splittoning_rgb_params_t *p = (dt_iop_splittoning_rgb_params_t *)self->params;
   const int point = GPOINTER_TO_INT(g_object_get_data(G_OBJECT(widget), "split-point"));
   const dt_iop_splittoning_rgb_mixer_mode_t mode = dt_bauhaus_combobox_get(widget);
@@ -796,7 +797,7 @@ static void _simple_slider_callback(GtkWidget *widget, gpointer user_data)
   if(dt_gui_widgets_suppressed()) return;
 
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
-  dt_iop_splittoning_rgb_gui_data_t *g = (dt_iop_splittoning_rgb_gui_data_t *)self->gui_data;
+  dt_iop_splittoning_rgb_gui_data_t *g = (dt_iop_splittoning_rgb_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_splittoning_rgb_params_t *p = (dt_iop_splittoning_rgb_params_t *)self->params;
   const int point = GPOINTER_TO_INT(g_object_get_data(G_OBJECT(widget), "split-point"));
   GtkWidget *const widgets[6]
@@ -825,7 +826,7 @@ static void _primaries_slider_callback(GtkWidget *widget, gpointer user_data)
   if(dt_gui_widgets_suppressed()) return;
 
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
-  dt_iop_splittoning_rgb_gui_data_t *g = (dt_iop_splittoning_rgb_gui_data_t *)self->gui_data;
+  dt_iop_splittoning_rgb_gui_data_t *g = (dt_iop_splittoning_rgb_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_splittoning_rgb_params_t *p = (dt_iop_splittoning_rgb_params_t *)self->params;
   const int point = GPOINTER_TO_INT(g_object_get_data(G_OBJECT(widget), "split-point"));
   GtkWidget *const widgets[9]
@@ -1027,7 +1028,7 @@ void color_picker_apply(dt_iop_module_t *self, GtkWidget *picker, dt_dev_pixelpi
 {
   if(dt_gui_widgets_suppressed()) return;
 
-  dt_iop_splittoning_rgb_gui_data_t *g = (dt_iop_splittoning_rgb_gui_data_t *)self->gui_data;
+  dt_iop_splittoning_rgb_gui_data_t *g = (dt_iop_splittoning_rgb_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_splittoning_rgb_params_t *p = (dt_iop_splittoning_rgb_params_t *)self->params;
   const dt_iop_module_t *const sampled_module = piece && piece->module ? piece->module : self;
   const dt_iop_order_iccprofile_info_t *const work_profile
@@ -1062,7 +1063,7 @@ void color_picker_apply(dt_iop_module_t *self, GtkWidget *picker, dt_dev_pixelpi
 
 void gui_update(struct dt_iop_module_t *self)
 {
-  dt_iop_splittoning_rgb_gui_data_t *g = (dt_iop_splittoning_rgb_gui_data_t *)self->gui_data;
+  dt_iop_splittoning_rgb_gui_data_t *g = (dt_iop_splittoning_rgb_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_splittoning_rgb_params_t *p = (dt_iop_splittoning_rgb_params_t *)self->params;
 
   dt_gui_freeze_begin();
@@ -1270,7 +1271,7 @@ static void _build_primaries_ui(dt_iop_module_t *self, dt_iop_splittoning_rgb_gu
 void gui_init(struct dt_iop_module_t *self)
 {
   dt_iop_splittoning_rgb_gui_data_t *g = IOP_GUI_ALLOC(splittoning_rgb);
-  self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_GUI_BOX_SPACING);
+  self->gui->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_GUI_BOX_SPACING);
   g->preview_surface = NULL;
   g->preview_width = 0;
   g->preview_height = 0;
@@ -1278,11 +1279,11 @@ void gui_init(struct dt_iop_module_t *self)
   g->preview = GTK_WIDGET(gtk_drawing_area_new());
   gtk_widget_set_size_request(g->preview, -1, DT_PIXEL_APPLY_DPI(DT_SPLITTONING_RGB_PREVIEW_HEIGHT));
   g_signal_connect(G_OBJECT(g->preview), "draw", G_CALLBACK(_preview_draw), self);
-  gtk_box_pack_start(GTK_BOX(self->widget), g->preview, FALSE, FALSE, 0);
+  gtk_box_pack_start(GTK_BOX(self->gui->widget), g->preview, FALSE, FALSE, 0);
 
   g->tabs = dt_ui_notebook_new();
   dt_ui_notebook_set_picker_owner(g->tabs, self);
-  gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(g->tabs), FALSE, FALSE, 0);
+  gtk_box_pack_start(GTK_BOX(self->gui->widget), GTK_WIDGET(g->tabs), FALSE, FALSE, 0);
 
   for(int point = 0; point < DT_SPLITTONING_RGB_POINT_COUNT; point++)
   {
@@ -1346,7 +1347,7 @@ void gui_init(struct dt_iop_module_t *self)
 
 void gui_cleanup(struct dt_iop_module_t *self)
 {
-  dt_iop_splittoning_rgb_gui_data_t *g = (dt_iop_splittoning_rgb_gui_data_t *)self->gui_data;
+  dt_iop_splittoning_rgb_gui_data_t *g = (dt_iop_splittoning_rgb_gui_data_t *)dt_iop_gui_data(self);
   DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(dt_control_signal_get_global(), G_CALLBACK(_pipe_finished_callback), self);
   if(g->preview_surface) cairo_surface_destroy(g->preview_surface);
   IOP_GUI_FREE;

--- a/src/iop/spots.c
+++ b/src/iop/spots.c
@@ -241,7 +241,7 @@ static void _resynch_params(struct dt_iop_module_t *self)
 
 static gboolean _reset_form_creation(GtkWidget *widget, dt_iop_module_t *self)
 {
-  dt_iop_spots_gui_data_t *g = (dt_iop_spots_gui_data_t *)self->gui_data;
+  dt_iop_spots_gui_data_t *g = (dt_iop_spots_gui_data_t *)dt_iop_gui_data(self);
 
   // we check the nb of shapes limit
   dt_masks_form_t *grp = dt_masks_get_from_id(self->dev, self->blend_params->mask_id);
@@ -299,16 +299,16 @@ static int _shape_is_being_added(dt_iop_module_t *self, const int shape_type)
 static gboolean _add_shape(GtkWidget *widget, dt_iop_module_t *self)
 {
   //turn module on (else shape creation won't work)
-  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(self->off), TRUE);
+  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(self->gui->off), TRUE);
 
   //switch mask edit mode off
-  dt_iop_gui_blend_data_t *bd = (dt_iop_gui_blend_data_t *)self->blend_data;
+  dt_iop_gui_blend_data_t *bd = (dt_iop_gui_blend_data_t *)self->gui->blend_data;
   if(bd) bd->masks_shown = DT_MASKS_EDIT_OFF;
 
   if(!_reset_form_creation(widget, self)) return TRUE;
   if(gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(widget))) return FALSE;
 
-  dt_iop_spots_gui_data_t *g = (dt_iop_spots_gui_data_t *)self->gui_data;
+  dt_iop_spots_gui_data_t *g = (dt_iop_spots_gui_data_t *)dt_iop_gui_data(self);
   // we want to be sure that the iop has focus
   dt_iop_request_focus(self);
   // we create the new form
@@ -333,7 +333,7 @@ static gboolean _add_shape_callback(GtkWidget *widget, GdkEventButton *e, dt_iop
 {
   if(dt_gui_widgets_suppressed()) return FALSE;
 
-  const dt_iop_spots_gui_data_t *g = (dt_iop_spots_gui_data_t *) self->gui_data;
+  const dt_iop_spots_gui_data_t *g = (dt_iop_spots_gui_data_t *)dt_iop_gui_data(self);
 
   _add_shape(widget, self);
 
@@ -355,8 +355,8 @@ static gboolean _edit_masks(GtkWidget *widget, GdkEventButton *e, dt_iop_module_
     return FALSE;
   }
 
-  dt_iop_gui_blend_data_t *bd = (dt_iop_gui_blend_data_t *)self->blend_data;
-  dt_iop_spots_gui_data_t *g = (dt_iop_spots_gui_data_t *)self->gui_data;
+  dt_iop_gui_blend_data_t *bd = (dt_iop_gui_blend_data_t *)self->gui->blend_data;
+  dt_iop_spots_gui_data_t *g = (dt_iop_spots_gui_data_t *)dt_iop_gui_data(self);
 
   //hide all shapes and free if some are in creation
   if(self->dev->form_gui->creation && self->dev->form_gui->creation_module == self)
@@ -730,7 +730,6 @@ void init(dt_iop_module_t *module)
   // by default:
   module->default_enabled = 0;
   module->params_size = sizeof(dt_iop_spots_params_t);
-  module->gui_data = NULL;
   // init defaults:
   dt_iop_spots_params_t tmp = (dt_iop_spots_params_t){ { 0 }, { 2 } };
 
@@ -741,11 +740,11 @@ void gui_focus(struct dt_iop_module_t *self, gboolean in)
 {
   if(self->enabled)
   {
-    dt_iop_spots_gui_data_t *g = (dt_iop_spots_gui_data_t *)self->gui_data;
+    dt_iop_spots_gui_data_t *g = (dt_iop_spots_gui_data_t *)dt_iop_gui_data(self);
 
     if(in)
     {
-      dt_iop_gui_blend_data_t *bd = (dt_iop_gui_blend_data_t *)self->blend_data;
+      dt_iop_gui_blend_data_t *bd = (dt_iop_gui_blend_data_t *)self->gui->blend_data;
 
       // update edit shapes status
       dt_develop_blend_params_t *bp = self->blend_params;
@@ -801,7 +800,7 @@ void cleanup_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev
 void gui_update(dt_iop_module_t *self)
 {
   _resynch_params(self);
-  dt_iop_spots_gui_data_t *g = (dt_iop_spots_gui_data_t *)self->gui_data;
+  dt_iop_spots_gui_data_t *g = (dt_iop_spots_gui_data_t *)dt_iop_gui_data(self);
   // update clones count
   dt_masks_form_t *grp = dt_masks_get_from_id(self->dev, self->blend_params->mask_id);
   guint nb = 0;
@@ -816,7 +815,7 @@ void gui_update(dt_iop_module_t *self)
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->bt_ellipse), _shape_is_being_added(self, DT_MASKS_ELLIPSE));
 
   // update edit shapes status
-  dt_iop_gui_blend_data_t *bd = (dt_iop_gui_blend_data_t *)self->blend_data;
+  dt_iop_gui_blend_data_t *bd = (dt_iop_gui_blend_data_t *)self->gui->blend_data;
 
   //only toggle shape show button if shapes exist
   if(grp && (grp->type & DT_MASKS_GROUP) && grp->points)
@@ -835,7 +834,7 @@ void gui_init(dt_iop_module_t *self)
 {
   dt_iop_spots_gui_data_t *g = IOP_GUI_ALLOC(spots);
 
-  self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_GUI_BOX_SPACING);
+  self->gui->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_GUI_BOX_SPACING);
 
   GtkWidget *hbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, DT_GUI_BOX_SPACING);
   gtk_box_pack_start(GTK_BOX(hbox), dt_ui_label_new(_("number of strokes:")), FALSE, TRUE, 0);
@@ -860,7 +859,7 @@ void gui_init(dt_iop_module_t *self)
                                          dtgtk_cairo_paint_masks_circle, hbox);
 
   gtk_box_pack_start(GTK_BOX(hbox), GTK_WIDGET(g->label), FALSE, TRUE, 0);
-  gtk_box_pack_start(GTK_BOX(self->widget), hbox, TRUE, TRUE, 0);
+  gtk_box_pack_start(GTK_BOX(self->gui->widget), hbox, TRUE, TRUE, 0);
 }
 
 void gui_reset(struct dt_iop_module_t *self)

--- a/src/iop/temperature.c
+++ b/src/iop/temperature.c
@@ -424,7 +424,7 @@ static void XYZ_to_temperature(cmsCIEXYZ XYZ, float *TempK, float *tint)
 
 static void xyz2mul(dt_iop_module_t *self, cmsCIEXYZ xyz, double mul[4])
 {
-  dt_iop_temperature_gui_data_t *g = (dt_iop_temperature_gui_data_t *)self->gui_data;
+  dt_iop_temperature_gui_data_t *g = (dt_iop_temperature_gui_data_t *)dt_iop_gui_data(self);
 
   double XYZ[3] = { xyz.X, xyz.Y, xyz.Z };
 
@@ -459,7 +459,7 @@ static void temp2mul(dt_iop_module_t *self, double TempK, double tint, double mu
 
 static cmsCIEXYZ mul2xyz(dt_iop_module_t *self, const dt_iop_temperature_params_t *p)
 {
-  dt_iop_temperature_gui_data_t *g = (dt_iop_temperature_gui_data_t *)self->gui_data;
+  dt_iop_temperature_gui_data_t *g = (dt_iop_temperature_gui_data_t *)dt_iop_gui_data(self);
 
   double CAM[4];
   _temp_array_from_params(CAM, p);
@@ -721,7 +721,7 @@ void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pix
 {
   dt_iop_temperature_params_t *p = (dt_iop_temperature_params_t *)p1;
   dt_iop_temperature_data_t *d = (dt_iop_temperature_data_t *)piece->data;
-  dt_iop_temperature_gui_data_t *g = (dt_iop_temperature_gui_data_t *)self->gui_data;
+  dt_iop_temperature_gui_data_t *g = (dt_iop_temperature_gui_data_t *)dt_iop_gui_data(self);
 
   d->coeffs[0] = p->red;
   d->coeffs[1] = p->green;
@@ -774,7 +774,7 @@ void cleanup_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev
 
 void color_rgb_sliders(struct dt_iop_module_t *self)
 {
-  dt_iop_temperature_gui_data_t *g = (dt_iop_temperature_gui_data_t *)self->gui_data;
+  dt_iop_temperature_gui_data_t *g = (dt_iop_temperature_gui_data_t *)dt_iop_gui_data(self);
 
   const gboolean color_rgb = g->colored_sliders &&
                              !(self->dev->image_storage.flags & DT_IMAGE_4BAYER);
@@ -863,7 +863,7 @@ void color_rgb_sliders(struct dt_iop_module_t *self)
 
 void color_temptint_sliders(struct dt_iop_module_t *self)
 {
-  dt_iop_temperature_gui_data_t *g = (dt_iop_temperature_gui_data_t *)self->gui_data;
+  dt_iop_temperature_gui_data_t *g = (dt_iop_temperature_gui_data_t *)dt_iop_gui_data(self);
 
   dt_bauhaus_slider_clear_stops(g->scale_k);
   dt_bauhaus_slider_clear_stops(g->scale_tint);
@@ -994,14 +994,14 @@ void color_temptint_sliders(struct dt_iop_module_t *self)
 
 void gui_update(struct dt_iop_module_t *self)
 {
-  dt_iop_temperature_gui_data_t *g = (dt_iop_temperature_gui_data_t *)self->gui_data;
+  dt_iop_temperature_gui_data_t *g = (dt_iop_temperature_gui_data_t *)self->gui->gui_data;
   dt_iop_temperature_params_t *p = (dt_iop_temperature_params_t *)self->params;
 
   const gboolean monochrome = dt_image_is_monochrome(&self->dev->image_storage);
   const gboolean is_raw = dt_image_is_matrix_correction_supported(&self->dev->image_storage);
   self->hide_enable_button = monochrome;
   self->default_enabled = is_raw;
-  gtk_stack_set_visible_child_name(GTK_STACK(self->widget), self->hide_enable_button ? "disabled" : "enabled");
+  gtk_stack_set_visible_child_name(GTK_STACK(self->gui->widget), self->hide_enable_button ? "disabled" : "enabled");
 
 //  if(self->hide_enable_button) return;
 
@@ -1106,7 +1106,7 @@ void gui_update(struct dt_iop_module_t *self)
 
   dt_gui_update_collapsible_section(&g->cs);
 
-  gtk_widget_queue_draw(self->widget);
+  gtk_widget_queue_draw(self->gui->widget);
 }
 
 static int calculate_bogus_daylight_wb(dt_iop_module_t *module, double bwb[4])
@@ -1140,7 +1140,9 @@ static int calculate_bogus_daylight_wb(dt_iop_module_t *module, double bwb[4])
 
 static void prepare_matrices(dt_iop_module_t *module)
 {
-  dt_iop_temperature_gui_data_t *g = (dt_iop_temperature_gui_data_t *)module->gui_data;
+  // called exclusively from gui_update(): the gui struct exists by construction here,
+  // and the NULL-tolerant accessor would only teach the analyzer a NULL that cannot be
+  dt_iop_temperature_gui_data_t *g = (dt_iop_temperature_gui_data_t *)module->gui->gui_data;
 
   // sRGB D65
   const double RGB_to_XYZ[3][4] = { { 0.4124564, 0.3575761, 0.1804375, 0 },
@@ -1325,7 +1327,7 @@ static void temp_tint_callback(GtkWidget *slider, dt_iop_module_t *self)
 {
   if(dt_gui_widgets_suppressed()) return;
 
-  dt_iop_temperature_gui_data_t *g = (dt_iop_temperature_gui_data_t *)self->gui_data;
+  dt_iop_temperature_gui_data_t *g = (dt_iop_temperature_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_temperature_params_t *p = (dt_iop_temperature_params_t *)self->params;
 
   dt_iop_color_picker_reset(self, TRUE);
@@ -1356,7 +1358,7 @@ static void temp_tint_callback(GtkWidget *slider, dt_iop_module_t *self)
 
 void gui_changed(dt_iop_module_t *self, GtkWidget *w, void *previous)
 {
-  dt_iop_temperature_gui_data_t *g = (dt_iop_temperature_gui_data_t *)self->gui_data;
+  dt_iop_temperature_gui_data_t *g = (dt_iop_temperature_gui_data_t *)self->gui->gui_data;
   dt_iop_temperature_params_t *p = (dt_iop_temperature_params_t *)self->params;
 
   _temp_array_from_params(g->mod_coeff, p);
@@ -1370,7 +1372,7 @@ static gboolean btn_toggled(GtkWidget *togglebutton, GdkEventButton *event, dt_i
 {
   if(dt_gui_widgets_suppressed()) return TRUE;
 
-  dt_iop_temperature_gui_data_t *g = (dt_iop_temperature_gui_data_t*)self->gui_data;
+  dt_iop_temperature_gui_data_t *g = (dt_iop_temperature_gui_data_t *)dt_iop_gui_data(self);
 
   int preset = togglebutton == g->btn_asshot ? DT_IOP_TEMP_AS_SHOT :
                togglebutton == g->btn_d65 ? DT_IOP_TEMP_D65 :
@@ -1393,7 +1395,7 @@ static void preset_tune_callback(GtkWidget *widget, dt_iop_module_t *self)
 {
   if(dt_gui_widgets_suppressed()) return;
 
-  dt_iop_temperature_gui_data_t *g = (dt_iop_temperature_gui_data_t *)self->gui_data;
+  dt_iop_temperature_gui_data_t *g = (dt_iop_temperature_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_temperature_params_t *p = (dt_iop_temperature_params_t *)self->params;
 
   const int pos = dt_bauhaus_combobox_get(g->presets);
@@ -1427,7 +1429,7 @@ static void preset_tune_callback(GtkWidget *widget, dt_iop_module_t *self)
       break;
   }
 
-  if(self->off) gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(self->off), 1);
+  if(self->gui->off) gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(self->gui->off), 1);
 
   float TempK, tint;
 
@@ -1463,7 +1465,7 @@ void color_picker_apply(dt_iop_module_t *self, GtkWidget *picker, dt_dev_pixelpi
   (void)piece;
   if(dt_gui_widgets_suppressed()) return;
 
-  dt_iop_temperature_gui_data_t *g = (dt_iop_temperature_gui_data_t *)self->gui_data;
+  dt_iop_temperature_gui_data_t *g = (dt_iop_temperature_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_temperature_params_t *p = (dt_iop_temperature_params_t *)self->params;
 
   // capture gui color picked event.
@@ -1500,7 +1502,7 @@ void color_picker_apply(dt_iop_module_t *self, GtkWidget *picker, dt_dev_pixelpi
 static void gui_sliders_update(struct dt_iop_module_t *self)
 {
   const dt_image_t *img = &self->dev->image_storage;
-  dt_iop_temperature_gui_data_t *g = (dt_iop_temperature_gui_data_t *)self->gui_data;
+  dt_iop_temperature_gui_data_t *g = (dt_iop_temperature_gui_data_t *)dt_iop_gui_data(self);
 
   if(FILTERS_ARE_CYGM(img->dsc.filters))
   {
@@ -1622,7 +1624,7 @@ void gui_init(struct dt_iop_module_t *self)
      _("channel coefficients"),
      GTK_BOX(box_enabled), GTK_PACK_END);
 
-  self->widget = GTK_WIDGET(g->cs.container);
+  self->gui->widget = GTK_WIDGET(g->cs.container);
 
   g->scale_r = dt_bauhaus_slider_from_params(self, N_("red"));
   g->scale_g = dt_bauhaus_slider_from_params(self, N_("green"));
@@ -1641,15 +1643,15 @@ void gui_init(struct dt_iop_module_t *self)
   g_signal_connect(G_OBJECT(g->presets), "value-changed", G_CALLBACK(preset_tune_callback), self);
 
   // start building top level widget
-  self->widget = gtk_stack_new();
-  gtk_stack_set_homogeneous(GTK_STACK(self->widget), FALSE);
+  self->gui->widget = gtk_stack_new();
+  gtk_stack_set_homogeneous(GTK_STACK(self->gui->widget), FALSE);
 
   GtkWidget *label_disabled = gtk_label_new(_("white balance disabled for camera"));
   gtk_widget_set_halign(label_disabled, GTK_ALIGN_START);
   gtk_label_set_ellipsize(GTK_LABEL(label_disabled), PANGO_ELLIPSIZE_END);
 
-  gtk_stack_add_named(GTK_STACK(self->widget), GTK_WIDGET(box_enabled), "enabled");
-  gtk_stack_add_named(GTK_STACK(self->widget), label_disabled, "disabled");
+  gtk_stack_add_named(GTK_STACK(self->gui->widget), GTK_WIDGET(box_enabled), "enabled");
+  gtk_stack_add_named(GTK_STACK(self->gui->widget), label_disabled, "disabled");
 }
 
 void gui_cleanup(struct dt_iop_module_t *self)
@@ -1661,7 +1663,7 @@ void gui_cleanup(struct dt_iop_module_t *self)
 
 void gui_reset(struct dt_iop_module_t *self)
 {
-  dt_iop_temperature_gui_data_t *g = (dt_iop_temperature_gui_data_t *)self->gui_data;
+  dt_iop_temperature_gui_data_t *g = (dt_iop_temperature_gui_data_t *)dt_iop_gui_data(self);
 
   const int preset = dt_bauhaus_combobox_get(g->presets);
   dt_iop_color_picker_reset(self, TRUE);

--- a/src/iop/tonecurve.c
+++ b/src/iop/tonecurve.c
@@ -766,7 +766,7 @@ void cleanup_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev
 
 void gui_reset(struct dt_iop_module_t *self)
 {
-  dt_iop_tonecurve_gui_data_t *g = (dt_iop_tonecurve_gui_data_t *)self->gui_data;
+  dt_iop_tonecurve_gui_data_t *g = (dt_iop_tonecurve_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_tonecurve_params_t *p = (dt_iop_tonecurve_params_t *)self->params;
   dt_bauhaus_combobox_set(g->interpolator, p->tonecurve_type[ch_L]);
   dt_bauhaus_combobox_set(g->preserve_colors, p->preserve_colors);
@@ -775,12 +775,12 @@ void gui_reset(struct dt_iop_module_t *self)
   g->semilog = 0;
 
   g->channel = (tonecurve_channel_t)ch_L;
-  gtk_widget_queue_draw(self->widget);
+  gtk_widget_queue_draw(self->gui->widget);
 }
 
 void gui_update(struct dt_iop_module_t *self)
 {
-  dt_iop_tonecurve_gui_data_t *g = (dt_iop_tonecurve_gui_data_t *)self->gui_data;
+  dt_iop_tonecurve_gui_data_t *g = (dt_iop_tonecurve_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_tonecurve_params_t *p = (dt_iop_tonecurve_params_t *)self->params;
 
   gui_changed(self, g->autoscale_ab, 0);
@@ -788,7 +788,7 @@ void gui_update(struct dt_iop_module_t *self)
   dt_bauhaus_combobox_set(g->interpolator, p->tonecurve_type[ch_L]);
   g->loglogscale = eval_grey(dt_bauhaus_slider_get(g->logbase));
   // that's all, gui curve is read directly from params during expose event.
-  gtk_widget_queue_draw(self->widget);
+  gtk_widget_queue_draw(self->gui->widget);
 }
 
 void init(dt_iop_module_t *module)
@@ -831,14 +831,14 @@ void cleanup_global(dt_iop_module_so_t *module)
 static void logbase_callback(GtkWidget *slider, dt_iop_module_t *self)
 {
   if(dt_gui_widgets_suppressed()) return;
-  dt_iop_tonecurve_gui_data_t *g = (dt_iop_tonecurve_gui_data_t *)self->gui_data;
+  dt_iop_tonecurve_gui_data_t *g = (dt_iop_tonecurve_gui_data_t *)dt_iop_gui_data(self);
   g->loglogscale = eval_grey(dt_bauhaus_slider_get(g->logbase));
   gtk_widget_queue_draw(GTK_WIDGET(g->area));
 }
 
 void gui_changed(dt_iop_module_t *self, GtkWidget *w, void *previous)
 {
-  dt_iop_tonecurve_gui_data_t *g = (dt_iop_tonecurve_gui_data_t *)self->gui_data;
+  dt_iop_tonecurve_gui_data_t *g = (dt_iop_tonecurve_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_tonecurve_params_t *p = (dt_iop_tonecurve_params_t *)self->params;
 
   if(w == g->autoscale_ab)
@@ -849,7 +849,7 @@ void gui_changed(dt_iop_module_t *self, GtkWidget *w, void *previous)
     gtk_notebook_set_show_tabs(g->channel_tabs, p->tonecurve_autoscale_ab == DT_S_SCALE_MANUAL);
     gtk_widget_set_visible(g->preserve_colors, p->tonecurve_autoscale_ab == DT_S_SCALE_AUTOMATIC_RGB);
 
-    gtk_widget_queue_draw(self->widget);
+    gtk_widget_queue_draw(self->gui->widget);
   }
 }
 
@@ -857,7 +857,7 @@ static void interpolator_callback(GtkWidget *widget, dt_iop_module_t *self)
 {
   if(dt_gui_widgets_suppressed()) return;
   dt_iop_tonecurve_params_t *p = (dt_iop_tonecurve_params_t *)self->params;
-  dt_iop_tonecurve_gui_data_t *g = (dt_iop_tonecurve_gui_data_t *)self->gui_data;
+  dt_iop_tonecurve_gui_data_t *g = (dt_iop_tonecurve_gui_data_t *)dt_iop_gui_data(self);
   const int combo = dt_bauhaus_combobox_get(widget);
   if(combo == 0) p->tonecurve_type[ch_L] = p->tonecurve_type[ch_a] = p->tonecurve_type[ch_b] = CUBIC_SPLINE;
   if(combo == 1) p->tonecurve_type[ch_L] = p->tonecurve_type[ch_a] = p->tonecurve_type[ch_b] = CATMULL_ROM;
@@ -869,10 +869,10 @@ static void interpolator_callback(GtkWidget *widget, dt_iop_module_t *self)
 static void tab_switch(GtkNotebook *notebook, GtkWidget *page, guint page_num, gpointer user_data)
 {
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
-  dt_iop_tonecurve_gui_data_t *c = (dt_iop_tonecurve_gui_data_t *)self->gui_data;
+  dt_iop_tonecurve_gui_data_t *c = (dt_iop_tonecurve_gui_data_t *)dt_iop_gui_data(self);
   if(dt_gui_widgets_suppressed()) return;
   c->channel = (tonecurve_channel_t)page_num;
-  gtk_widget_queue_draw(self->widget);
+  gtk_widget_queue_draw(self->gui->widget);
 }
 
 static gboolean area_resized(GtkWidget *widget, GdkEvent *event, gpointer user_data)
@@ -950,12 +950,12 @@ void color_picker_apply(dt_iop_module_t *self, GtkWidget *picker, dt_dev_pixelpi
     gd->picked_color_max[k] = self->picked_color_max[k];
     gd->picked_output_color[k] = self->picked_output_color[k];
   }
-  dt_control_queue_redraw_widget(self->widget);
+  dt_control_queue_redraw_widget(self->gui->widget);
 }
 
 static void dt_iop_tonecurve_sanity_check(dt_iop_module_t *self, GtkWidget *widget)
 {
-  dt_iop_tonecurve_gui_data_t *c = (dt_iop_tonecurve_gui_data_t *)self->gui_data;
+  dt_iop_tonecurve_gui_data_t *c = (dt_iop_tonecurve_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_tonecurve_params_t *p = (dt_iop_tonecurve_params_t *)self->params;
 
   int ch = c->channel;
@@ -989,7 +989,7 @@ static void dt_iop_tonecurve_sanity_check(dt_iop_module_t *self, GtkWidget *widg
 static gboolean _move_point_internal(dt_iop_module_t *self, GtkWidget *widget, float dx, float dy, guint state)
 {
   dt_iop_tonecurve_params_t *p = (dt_iop_tonecurve_params_t *)self->params;
-  dt_iop_tonecurve_gui_data_t *c = (dt_iop_tonecurve_gui_data_t *)self->gui_data;
+  dt_iop_tonecurve_gui_data_t *c = (dt_iop_tonecurve_gui_data_t *)dt_iop_gui_data(self);
 
   int ch = c->channel;
   dt_iop_tonecurve_node_t *tonecurve = p->tonecurve[ch];
@@ -1011,7 +1011,7 @@ static gboolean _scrolled(GtkWidget *widget, GdkEventScroll *event, gpointer use
 {
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
   dt_iop_tonecurve_params_t *p = (dt_iop_tonecurve_params_t *)self->params;
-  dt_iop_tonecurve_gui_data_t *c = (dt_iop_tonecurve_gui_data_t *)self->gui_data;
+  dt_iop_tonecurve_gui_data_t *c = (dt_iop_tonecurve_gui_data_t *)dt_iop_gui_data(self);
 
   int ch = c->channel;
   int autoscale_ab = p->tonecurve_autoscale_ab;
@@ -1035,7 +1035,7 @@ static gboolean dt_iop_tonecurve_key_press(GtkWidget *widget, GdkEventKey *event
 {
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
   dt_iop_tonecurve_params_t *p = (dt_iop_tonecurve_params_t *)self->params;
-  dt_iop_tonecurve_gui_data_t *c = (dt_iop_tonecurve_gui_data_t *)self->gui_data;
+  dt_iop_tonecurve_gui_data_t *c = (dt_iop_tonecurve_gui_data_t *)dt_iop_gui_data(self);
 
   int ch = c->channel;
   int autoscale_ab = p->tonecurve_autoscale_ab;
@@ -1095,7 +1095,7 @@ void gui_init(struct dt_iop_module_t *self)
   c->selected = -1;
   c->loglogscale = 0;
   c->semilog = 0;
-  self->timeout_handle = 0;
+  self->gui->timeout_handle = 0;
 
   c->autoscale_ab = dt_bauhaus_combobox_from_params(self, "tonecurve_autoscale_ab");
   gtk_widget_set_tooltip_text(c->autoscale_ab, _("if set to auto, a and b curves have no effect and are "
@@ -1116,12 +1116,12 @@ void gui_init(struct dt_iop_module_t *self)
   c->colorpicker = dt_color_picker_new(self, DT_COLOR_PICKER_POINT_AREA, hbox);
   gtk_widget_set_tooltip_text(c->colorpicker, _("pick GUI color from image\nctrl+click or right-click to select an area"));
 
-  gtk_box_pack_start(GTK_BOX(self->widget), hbox, FALSE, FALSE, 0);
+  gtk_box_pack_start(GTK_BOX(self->gui->widget), hbox, FALSE, FALSE, 0);
 
   c->area = GTK_DRAWING_AREA(gtk_drawing_area_new());
   gtk_widget_set_hexpand(GTK_WIDGET(c->area), TRUE);
   g_object_set_data(G_OBJECT(c->area), "iop-instance", self);
-  gtk_box_pack_start(GTK_BOX(self->widget),
+  gtk_box_pack_start(GTK_BOX(self->gui->widget),
                      dt_ui_resizable_drawing_area(GTK_WIDGET(c->area),
                                                   "plugins/darkroom/tonecurve/graphheight", 280, 100),
                      FALSE, FALSE, 0);
@@ -1152,7 +1152,7 @@ void gui_init(struct dt_iop_module_t *self)
   dt_bauhaus_combobox_add(c->interpolator, _("cubic spline"));
   dt_bauhaus_combobox_add(c->interpolator, _("centripetal spline"));
   dt_bauhaus_combobox_add(c->interpolator, _("monotonic spline"));
-  gtk_box_pack_start(GTK_BOX(self->widget), c->interpolator , TRUE, TRUE, 0);
+  gtk_box_pack_start(GTK_BOX(self->gui->widget), c->interpolator , TRUE, TRUE, 0);
   gtk_widget_set_tooltip_text(c->interpolator, _("change this method if you see oscillations or cusps in the curve\n"
                                                  "- cubic spline is better to produce smooth curves but oscillates when nodes are too close\n"
                                                  "- centripetal is better to avoids cusps and oscillations with close nodes but is less smooth\n"
@@ -1164,7 +1164,7 @@ void gui_init(struct dt_iop_module_t *self)
 
   c->logbase = dt_bauhaus_slider_new_with_range(dt_bauhaus_get_global(), DT_GUI_MODULE(self), 0.0f, 40.0f, 0, 0.0f, 2);
   dt_bauhaus_widget_set_label(c->logbase, N_("scale for graph"));
-  gtk_box_pack_start(GTK_BOX(self->widget), c->logbase , TRUE, TRUE, 0);
+  gtk_box_pack_start(GTK_BOX(self->gui->widget), c->logbase , TRUE, TRUE, 0);
   g_signal_connect(G_OBJECT(c->logbase), "value-changed", G_CALLBACK(logbase_callback), self);
 
   c->sizegroup = GTK_SIZE_GROUP(gtk_size_group_new(GTK_SIZE_GROUP_HORIZONTAL));
@@ -1174,7 +1174,7 @@ void gui_init(struct dt_iop_module_t *self)
 
 void gui_cleanup(struct dt_iop_module_t *self)
 {
-  dt_iop_tonecurve_gui_data_t *c = (dt_iop_tonecurve_gui_data_t *)self->gui_data;
+  dt_iop_tonecurve_gui_data_t *c = (dt_iop_tonecurve_gui_data_t *)dt_iop_gui_data(self);
   // this one we need to unref manually. not so the initially unowned widgets.
   g_object_unref(c->sizegroup);
   dt_draw_curve_destroy(c->minmax_curve[ch_L]);
@@ -1206,7 +1206,7 @@ static void picker_scale(const float *in, float *out)
 static gboolean dt_iop_tonecurve_draw(GtkWidget *widget, cairo_t *crf, gpointer user_data)
 {
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
-  dt_iop_tonecurve_gui_data_t *c = (dt_iop_tonecurve_gui_data_t *)self->gui_data;
+  dt_iop_tonecurve_gui_data_t *c = (dt_iop_tonecurve_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_tonecurve_params_t *p = (dt_iop_tonecurve_params_t *)self->params;
   dt_iop_tonecurve_global_data_t *gd = (dt_iop_tonecurve_global_data_t *)self->global_data;
 
@@ -1572,7 +1572,7 @@ static inline int _add_node(dt_iop_tonecurve_node_t *tonecurve, int *nodes, floa
 static gboolean dt_iop_tonecurve_motion_notify(GtkWidget *widget, GdkEventMotion *event, gpointer user_data)
 {
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
-  dt_iop_tonecurve_gui_data_t *c = (dt_iop_tonecurve_gui_data_t *)self->gui_data;
+  dt_iop_tonecurve_gui_data_t *c = (dt_iop_tonecurve_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_tonecurve_params_t *p = (dt_iop_tonecurve_params_t *)self->params;
 
   int ch = c->channel;
@@ -1649,7 +1649,7 @@ static gboolean dt_iop_tonecurve_button_press(GtkWidget *widget, GdkEventButton 
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
   dt_iop_tonecurve_params_t *p = (dt_iop_tonecurve_params_t *)self->params;
   dt_iop_tonecurve_params_t *d = (dt_iop_tonecurve_params_t *)self->default_params;
-  dt_iop_tonecurve_gui_data_t *c = (dt_iop_tonecurve_gui_data_t *)self->gui_data;
+  dt_iop_tonecurve_gui_data_t *c = (dt_iop_tonecurve_gui_data_t *)dt_iop_gui_data(self);
 
   int ch = c->channel;
   int autoscale_ab = p->tonecurve_autoscale_ab;
@@ -1712,7 +1712,7 @@ static gboolean dt_iop_tonecurve_button_press(GtkWidget *widget, GdkEventButton 
           }
 
           dt_dev_add_history_item(self->dev, self, TRUE, TRUE);
-          gtk_widget_queue_draw(self->widget);
+          gtk_widget_queue_draw(self->gui->widget);
         }
       }
       return TRUE;
@@ -1733,7 +1733,7 @@ static gboolean dt_iop_tonecurve_button_press(GtkWidget *widget, GdkEventButton 
         c->selected = -2; // avoid motion notify re-inserting immediately.
         dt_bauhaus_combobox_set(c->interpolator, p->tonecurve_type[ch_L]);
         dt_dev_add_history_item(self->dev, self, TRUE, TRUE);
-        gtk_widget_queue_draw(self->widget);
+        gtk_widget_queue_draw(self->gui->widget);
       }
       else
       {
@@ -1743,7 +1743,7 @@ static gboolean dt_iop_tonecurve_button_press(GtkWidget *widget, GdkEventButton 
           c->selected = -2; // avoid motion notify re-inserting immediately.
           dt_bauhaus_combobox_set(c->autoscale_ab, 1);
           dt_dev_add_history_item(self->dev, self, TRUE, TRUE);
-          gtk_widget_queue_draw(self->widget);
+          gtk_widget_queue_draw(self->gui->widget);
         }
       }
       return TRUE;
@@ -1755,7 +1755,7 @@ static gboolean dt_iop_tonecurve_button_press(GtkWidget *widget, GdkEventButton 
     {
       float reset_value = c->selected == 0 ? 0 : 1;
       tonecurve[c->selected].y = tonecurve[c->selected].x = reset_value;
-      gtk_widget_queue_draw(self->widget);
+      gtk_widget_queue_draw(self->gui->widget);
       dt_dev_add_history_item(self->dev, self, TRUE, TRUE);
       return TRUE;
     }
@@ -1768,7 +1768,7 @@ static gboolean dt_iop_tonecurve_button_press(GtkWidget *widget, GdkEventButton 
     tonecurve[nodes - 1].x = tonecurve[nodes - 1].y = 0;
     c->selected = -2; // avoid re-insertion of that point immediately after this
     p->tonecurve_nodes[ch]--;
-    gtk_widget_queue_draw(self->widget);
+    gtk_widget_queue_draw(self->gui->widget);
     dt_dev_add_history_item(self->dev, self, TRUE, TRUE);
     return TRUE;
   }

--- a/src/iop/toneequal.c
+++ b/src/iop/toneequal.c
@@ -597,7 +597,7 @@ static void invalidate_luminance_cache(dt_iop_module_t *const self)
   // entry under the GUI lock, then release the retained cache ref afterwards.
   // This is one of the cases that used to go wrong when tone equalizer stored
   // ad-hoc GUI buffers outside the pixelpipe cache.
-  dt_iop_toneequalizer_gui_data_t *const restrict g = (dt_iop_toneequalizer_gui_data_t *)self->gui_data;
+  dt_iop_toneequalizer_gui_data_t *const restrict g = (dt_iop_toneequalizer_gui_data_t *)dt_iop_gui_data(self);
   if(IS_NULL_PTR(g)) return;
 
   dt_pixel_cache_entry_t *preview_entry = NULL;
@@ -637,10 +637,10 @@ static inline __attribute__((always_inline)) int sanity_check(dt_iop_module_t *s
     if(self->dev->gui_attached)
     {
       // Repaint the on/off icon
-      if(self->off)
+      if(self->gui->off)
       {
         dt_gui_freeze_begin();
-        gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(self->off), self->enabled);
+        gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(self->gui->off), self->enabled);
         dt_gui_freeze_end();
       }
     }
@@ -938,7 +938,7 @@ static inline __attribute__((always_inline)) int toneeq_process(struct dt_iop_mo
                           const dt_iop_roi_t *const roi_out)
 {
   const dt_iop_toneequalizer_data_t *const d = (const dt_iop_toneequalizer_data_t *const)piece->data;
-  dt_iop_toneequalizer_gui_data_t *const g = (dt_iop_toneequalizer_gui_data_t *)self->gui_data;
+  dt_iop_toneequalizer_gui_data_t *const g = (dt_iop_toneequalizer_gui_data_t *)dt_iop_gui_data(self);
 
   const float *const restrict in = dt_check_sse_aligned((float *const)ivoid);
   float *const restrict out = dt_check_sse_aligned((float *const)ovoid);
@@ -1291,7 +1291,7 @@ static int commit_channels_gains(const float factors[CHANNELS], dt_iop_toneequal
 
 static void gui_cache_init(struct dt_iop_module_t *self)
 {
-  dt_iop_toneequalizer_gui_data_t *g = (dt_iop_toneequalizer_gui_data_t *)self->gui_data;
+  dt_iop_toneequalizer_gui_data_t *g = (dt_iop_toneequalizer_gui_data_t *)dt_iop_gui_data(self);
   if(IS_NULL_PTR(g)) return;
 
   dt_iop_gui_enter_critical_section(self);
@@ -1435,7 +1435,7 @@ static inline void compute_log_histogram_and_stats(const float *const restrict l
 
 static inline void update_histogram(struct dt_iop_module_t *const self)
 {
-  dt_iop_toneequalizer_gui_data_t *const g = (dt_iop_toneequalizer_gui_data_t *)self->gui_data;
+  dt_iop_toneequalizer_gui_data_t *const g = (dt_iop_toneequalizer_gui_data_t *)dt_iop_gui_data(self);
   if(IS_NULL_PTR(g)) return;
 
   dt_pixel_cache_entry_t *preview_entry = NULL;
@@ -1526,7 +1526,7 @@ static inline void compute_lut_correction(struct dt_iop_toneequalizer_gui_data_t
 static inline gboolean update_curve_lut(struct dt_iop_module_t *self)
 {
   dt_iop_toneequalizer_params_t *p = (dt_iop_toneequalizer_params_t *)self->params;
-  dt_iop_toneequalizer_gui_data_t *g = (dt_iop_toneequalizer_gui_data_t *)self->gui_data;
+  dt_iop_toneequalizer_gui_data_t *g = (dt_iop_toneequalizer_gui_data_t *)dt_iop_gui_data(self);
 
   if(IS_NULL_PTR(g)) return FALSE;
 
@@ -1594,7 +1594,7 @@ void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pix
 {
   dt_iop_toneequalizer_params_t *p = (dt_iop_toneequalizer_params_t *)p1;
   dt_iop_toneequalizer_data_t *d = (dt_iop_toneequalizer_data_t *)piece->data;
-  dt_iop_toneequalizer_gui_data_t *g = (dt_iop_toneequalizer_gui_data_t *)self->gui_data;
+  dt_iop_toneequalizer_gui_data_t *g = (dt_iop_toneequalizer_gui_data_t *)dt_iop_gui_data(self);
 
   // Trivial params passing
   d->method = p->method;
@@ -1664,7 +1664,7 @@ void cleanup_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev
 void show_guiding_controls(struct dt_iop_module_t *self)
 {
   dt_iop_module_t *module = (dt_iop_module_t *)self;
-  dt_iop_toneequalizer_gui_data_t *g = (dt_iop_toneequalizer_gui_data_t *)self->gui_data;
+  dt_iop_toneequalizer_gui_data_t *g = (dt_iop_toneequalizer_gui_data_t *)dt_iop_gui_data(self);
   const dt_iop_toneequalizer_params_t *p = (const dt_iop_toneequalizer_params_t *)module->params;
 
   switch(p->details)
@@ -1721,7 +1721,7 @@ void update_exposure_sliders(dt_iop_toneequalizer_gui_data_t *g, dt_iop_toneequa
 
 void gui_update(struct dt_iop_module_t *self)
 {
-  dt_iop_toneequalizer_gui_data_t *g = (dt_iop_toneequalizer_gui_data_t *)self->gui_data;
+  dt_iop_toneequalizer_gui_data_t *g = (dt_iop_toneequalizer_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_toneequalizer_params_t *p = (dt_iop_toneequalizer_params_t *)self->params;
 
   dt_bauhaus_slider_set(g->smoothing, logf(p->smoothing) / logf(sqrtf(2.0f)) - 1.0f);
@@ -1734,7 +1734,7 @@ void gui_update(struct dt_iop_module_t *self)
 
 void gui_changed(dt_iop_module_t *self, GtkWidget *w, void *previous)
 {
-  dt_iop_toneequalizer_gui_data_t *g = (dt_iop_toneequalizer_gui_data_t *)self->gui_data;
+  dt_iop_toneequalizer_gui_data_t *g = (dt_iop_toneequalizer_gui_data_t *)dt_iop_gui_data(self);
   if(w == g->method     ||
      w == g->blending   ||
      w == g->feathering ||
@@ -1760,7 +1760,7 @@ static void smoothing_callback(GtkWidget *slider, gpointer user_data)
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
   if(dt_gui_widgets_suppressed()) return;
   dt_iop_toneequalizer_params_t *p = (dt_iop_toneequalizer_params_t *)self->params;
-  dt_iop_toneequalizer_gui_data_t *g = (dt_iop_toneequalizer_gui_data_t *)self->gui_data;
+  dt_iop_toneequalizer_gui_data_t *g = (dt_iop_toneequalizer_gui_data_t *)dt_iop_gui_data(self);
 
   p->smoothing= powf(sqrtf(2.0f), 1.0f +  dt_bauhaus_slider_get(slider));
 
@@ -1785,9 +1785,9 @@ static void show_luminance_mask_callback(GtkWidget *togglebutton, GdkEventButton
   if(dt_gui_widgets_suppressed()) return;
   dt_iop_request_focus(self);
 
-  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(self->off), TRUE);
+  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(self->gui->off), TRUE);
 
-  dt_iop_toneequalizer_gui_data_t *g = (dt_iop_toneequalizer_gui_data_t *)self->gui_data;
+  dt_iop_toneequalizer_gui_data_t *g = (dt_iop_toneequalizer_gui_data_t *)dt_iop_gui_data(self);
 
   // if blend module is displaying mask do not display it here
   if(self->request_mask_display != DT_DEV_PIXELPIPE_DISPLAY_NONE)
@@ -1813,10 +1813,10 @@ static void show_luminance_mask_callback(GtkWidget *togglebutton, GdkEventButton
 
 static void _switch_cursors(struct dt_iop_module_t *self)
 {
-  dt_iop_toneequalizer_gui_data_t *g = (dt_iop_toneequalizer_gui_data_t *)self->gui_data;
+  dt_iop_toneequalizer_gui_data_t *g = (dt_iop_toneequalizer_gui_data_t *)dt_iop_gui_data(self);
   if(IS_NULL_PTR(g) || !self->dev->gui_attached) return;
 
-  if(!self->expanded)
+  if(!self->gui->expanded)
   {
     // If the module lost focus, do nothing and let the app decide.
     return;
@@ -1875,7 +1875,7 @@ int mouse_moved(struct dt_iop_module_t *self, double x, double y, double pressur
   // meaning all distortions, cropping, rotations etc. are applied before this module in the pipe.
 
   dt_develop_t *dev = self->dev;
-  dt_iop_toneequalizer_gui_data_t *g = (dt_iop_toneequalizer_gui_data_t *)self->gui_data;
+  dt_iop_toneequalizer_gui_data_t *g = (dt_iop_toneequalizer_gui_data_t *)dt_iop_gui_data(self);
 
   const int fail = !sanity_check(self);
   if(fail) return 0;
@@ -1963,7 +1963,7 @@ int mouse_moved(struct dt_iop_module_t *self, double x, double y, double pressur
 
 int mouse_leave(struct dt_iop_module_t *self)
 {
-  dt_iop_toneequalizer_gui_data_t *g = (dt_iop_toneequalizer_gui_data_t *)self->gui_data;
+  dt_iop_toneequalizer_gui_data_t *g = (dt_iop_toneequalizer_gui_data_t *)dt_iop_gui_data(self);
 
   if(IS_NULL_PTR(g)) return 0;
 
@@ -2035,21 +2035,21 @@ static inline int set_new_params_interactive(const float control_exposure, const
 int scrolled(struct dt_iop_module_t *self, double x, double y, int up, uint32_t state)
 {
   dt_develop_t *dev = self->dev;
-  dt_iop_toneequalizer_gui_data_t *g = (dt_iop_toneequalizer_gui_data_t *)self->gui_data;
+  dt_iop_toneequalizer_gui_data_t *g = (dt_iop_toneequalizer_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_toneequalizer_params_t *p = (dt_iop_toneequalizer_params_t *)self->params;
 
   if(!sanity_check(self)) return 0;
   if(dt_gui_widgets_suppressed()) return 1;
   if(IS_NULL_PTR(g)) return 0;
-  if(!self->expanded) return 0;
+  if(!self->gui->expanded) return 0;
   if(in_mask_editing(self) || dt_iop_color_picker_is_visible(dev)) return 0;
 
   // turn-on the module if off
   if(!self->enabled)
-    if(self->off) gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(self->off), 1);
+    if(self->gui->off) gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(self->gui->off), 1);
 
   // if GUI buffers not ready, exit but still handle the cursor
-  const int fail = (!g->cursor_valid || !g->interpolation_valid || !g->user_param_valid || dev->pipe->processing || !self->expanded);
+  const int fail = (!g->cursor_valid || !g->interpolation_valid || !g->user_param_valid || dev->pipe->processing || !self->gui->expanded);
   if(fail) return 1;
 
   // Re-read the exposure in case the preview changed after the mouse moved.
@@ -2213,18 +2213,18 @@ void gui_post_expose(struct dt_iop_module_t *self, cairo_t *cr, int32_t width, i
   // Draw the custom exposure cursor over the image preview
 
   dt_develop_t *dev = self->dev;
-  dt_iop_toneequalizer_gui_data_t *g = (dt_iop_toneequalizer_gui_data_t *)self->gui_data;
+  dt_iop_toneequalizer_gui_data_t *g = (dt_iop_toneequalizer_gui_data_t *)dt_iop_gui_data(self);
   if(IS_NULL_PTR(g)) return;
 
   // If the darkroom picker owns the center view, keep tone equalizer overlays out of the way.
   if(in_mask_editing(self) || dt_iop_color_picker_is_visible(dev)) return;
 
   const int fail = (!g->cursor_valid || !g->interpolation_valid || dev->pipe->processing
-                    || !sanity_check(self) || !self->expanded);
+                    || !sanity_check(self) || !self->gui->expanded);
   if(fail) return;
 
   if(!g->graph_valid)
-    if(!_init_drawing(self, self->widget, g)) return;
+    if(!_init_drawing(self, self->gui->widget, g)) return;
 
   // Get coordinates
   const float x_pointer = g->cursor_pos_x;
@@ -2390,7 +2390,7 @@ void gui_post_expose(struct dt_iop_module_t *self, cairo_t *cr, int32_t width, i
 
 void gui_focus(struct dt_iop_module_t *self, gboolean in)
 {
-  dt_iop_toneequalizer_gui_data_t *g = (dt_iop_toneequalizer_gui_data_t *)self->gui_data;
+  dt_iop_toneequalizer_gui_data_t *g = (dt_iop_toneequalizer_gui_data_t *)dt_iop_gui_data(self);
   _switch_cursors(self);
   if(!in)
   {
@@ -2638,7 +2638,7 @@ static gboolean area_draw(GtkWidget *widget, cairo_t *cr, gpointer user_data)
 {
   // Draw the widget equalizer view
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
-  dt_iop_toneequalizer_gui_data_t *g = (dt_iop_toneequalizer_gui_data_t *)self->gui_data;
+  dt_iop_toneequalizer_gui_data_t *g = (dt_iop_toneequalizer_gui_data_t *)dt_iop_gui_data(self);
   if(IS_NULL_PTR(g)) return FALSE;
 
   // Init or refresh the drawing cache
@@ -2814,7 +2814,7 @@ static gboolean area_enter_notify(GtkWidget *widget, GdkEventCrossing *event, gp
   if(dt_gui_widgets_suppressed()) return 1;
   if(!self->enabled) return 0;
 
-  dt_iop_toneequalizer_gui_data_t *g = (dt_iop_toneequalizer_gui_data_t *)self->gui_data;
+  dt_iop_toneequalizer_gui_data_t *g = (dt_iop_toneequalizer_gui_data_t *)dt_iop_gui_data(self);
   g->area_x = (event->x - g->inset);
   g->area_y = (event->y - g->inset);
   g->area_dragging = FALSE;
@@ -2832,7 +2832,7 @@ static gboolean area_leave_notify(GtkWidget *widget, GdkEventCrossing *event, gp
   if(dt_gui_widgets_suppressed()) return 1;
   if(!self->enabled) return 0;
 
-  dt_iop_toneequalizer_gui_data_t *g = (dt_iop_toneequalizer_gui_data_t *)self->gui_data;
+  dt_iop_toneequalizer_gui_data_t *g = (dt_iop_toneequalizer_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_toneequalizer_params_t *p = (dt_iop_toneequalizer_params_t *)self->params;
 
   if(g->area_dragging)
@@ -2858,7 +2858,7 @@ static gboolean area_button_press(GtkWidget *widget, GdkEventButton *event, gpoi
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
   if(dt_gui_widgets_suppressed()) return 1;
 
-  dt_iop_toneequalizer_gui_data_t *g = (dt_iop_toneequalizer_gui_data_t *)self->gui_data;
+  dt_iop_toneequalizer_gui_data_t *g = (dt_iop_toneequalizer_gui_data_t *)dt_iop_gui_data(self);
 
   dt_iop_request_focus(self);
 
@@ -2882,7 +2882,7 @@ static gboolean area_button_press(GtkWidget *widget, GdkEventButton *event, gpoi
     update_exposure_sliders(g, p);
 
     // Redraw graph
-    gtk_widget_queue_draw(self->widget);
+    gtk_widget_queue_draw(self->gui->widget);
     dt_dev_add_history_item(self->dev, self, TRUE, TRUE);
     return TRUE;
   }
@@ -2913,7 +2913,7 @@ static gboolean area_motion_notify(GtkWidget *widget, GdkEventMotion *event, gpo
   if(dt_gui_widgets_suppressed()) return 1;
   if(!self->enabled) return 0;
 
-  dt_iop_toneequalizer_gui_data_t *g = (dt_iop_toneequalizer_gui_data_t *)self->gui_data;
+  dt_iop_toneequalizer_gui_data_t *g = (dt_iop_toneequalizer_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_toneequalizer_params_t *p = (dt_iop_toneequalizer_params_t *)self->params;
 
   if(g->area_dragging)
@@ -2957,7 +2957,7 @@ static gboolean area_button_release(GtkWidget *widget, GdkEventButton *event, gp
   if(dt_gui_widgets_suppressed()) return 1;
   if(!self->enabled) return 0;
 
-  dt_iop_toneequalizer_gui_data_t *g = (dt_iop_toneequalizer_gui_data_t *)self->gui_data;
+  dt_iop_toneequalizer_gui_data_t *g = (dt_iop_toneequalizer_gui_data_t *)dt_iop_gui_data(self);
 
   // Give focus to module
   dt_iop_request_focus(self);
@@ -3001,12 +3001,12 @@ static gboolean notebook_button_press(GtkWidget *widget, GdkEventButton *event, 
 static void _develop_ui_pipe_started_callback(gpointer instance, gpointer user_data)
 {
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
-  dt_iop_toneequalizer_gui_data_t *g = (dt_iop_toneequalizer_gui_data_t *)self->gui_data;
+  dt_iop_toneequalizer_gui_data_t *g = (dt_iop_toneequalizer_gui_data_t *)dt_iop_gui_data(self);
   if(IS_NULL_PTR(g)) return;
   _switch_cursors(self);
 
   // if module is not active, disable mask preview
-  if(!self->expanded || !self->enabled)
+  if(!self->gui->expanded || !self->enabled)
   {
     g->mask_display = 0;
   }
@@ -3021,7 +3021,7 @@ static void _develop_history_resync_callback(gpointer instance, gpointer user_da
 {
   (void)instance;
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
-  dt_iop_toneequalizer_gui_data_t *g = (dt_iop_toneequalizer_gui_data_t *)self->gui_data;
+  dt_iop_toneequalizer_gui_data_t *g = (dt_iop_toneequalizer_gui_data_t *)dt_iop_gui_data(self);
   if(IS_NULL_PTR(g) || IS_NULL_PTR(self->dev) || IS_NULL_PTR(self->dev->preview_pipe)) return;
 
   const uint64_t preview_hash = _current_preview_luminance_hash(self, NULL, NULL);
@@ -3107,7 +3107,7 @@ static void _develop_cacheline_ready_callback(gpointer instance, const guint64 h
   (void)instance;
   (void)producer_node_key;
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
-  dt_iop_toneequalizer_gui_data_t *g = (dt_iop_toneequalizer_gui_data_t *)self->gui_data;
+  dt_iop_toneequalizer_gui_data_t *g = (dt_iop_toneequalizer_gui_data_t *)dt_iop_gui_data(self);
   if(IS_NULL_PTR(g) || IS_NULL_PTR(self->dev) || IS_NULL_PTR(self->dev->preview_pipe)) return;
 
   dt_iop_gui_enter_critical_section(self);
@@ -3163,7 +3163,7 @@ static void _develop_cacheline_ready_callback(gpointer instance, const guint64 h
 static void _develop_ui_pipe_finished_callback(gpointer instance, gpointer user_data)
 {
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
-  dt_iop_toneequalizer_gui_data_t *g = (dt_iop_toneequalizer_gui_data_t *)self->gui_data;
+  dt_iop_toneequalizer_gui_data_t *g = (dt_iop_toneequalizer_gui_data_t *)dt_iop_gui_data(self);
   if(IS_NULL_PTR(g)) return;
   _switch_cursors(self);
 }
@@ -3171,7 +3171,7 @@ static void _develop_ui_pipe_finished_callback(gpointer instance, gpointer user_
 
 void gui_reset(struct dt_iop_module_t *self)
 {
-  dt_iop_toneequalizer_gui_data_t *g = (dt_iop_toneequalizer_gui_data_t *)self->gui_data;
+  dt_iop_toneequalizer_gui_data_t *g = (dt_iop_toneequalizer_gui_data_t *)dt_iop_gui_data(self);
   if(IS_NULL_PTR(g)) return;
   dt_iop_request_focus(self);
   dt_bauhaus_widget_set_quad_active(g->exposure_boost, FALSE);
@@ -3179,7 +3179,7 @@ void gui_reset(struct dt_iop_module_t *self)
   dt_dev_add_history_item(self->dev, self, TRUE, TRUE);
 
   // Redraw graph
-  gtk_widget_queue_draw(self->widget);
+  gtk_widget_queue_draw(self->gui->widget);
 }
 
 static gboolean _sample_picker_luminance_mask(const dt_develop_t *const dev, const float *const buffer,
@@ -3261,7 +3261,7 @@ static gboolean _sample_picker_luminance_mask(const dt_develop_t *const dev, con
 void color_picker_apply(dt_iop_module_t *self, GtkWidget *picker, dt_dev_pixelpipe_t *pipe,
                         dt_dev_pixelpipe_iop_t *piece)
 {
-  dt_iop_toneequalizer_gui_data_t *g = (dt_iop_toneequalizer_gui_data_t *)self->gui_data;
+  dt_iop_toneequalizer_gui_data_t *g = (dt_iop_toneequalizer_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_toneequalizer_params_t *p = (dt_iop_toneequalizer_params_t *)self->params;
   dt_pixel_cache_entry_t *preview_entry = NULL;
   size_t preview_width = 0;
@@ -3438,11 +3438,11 @@ void gui_init(struct dt_iop_module_t *self)
 
   // Advanced view
 
-  self->widget = dt_ui_notebook_page(g->notebook, N_("graph"), NULL);
+  self->gui->widget = dt_ui_notebook_page(g->notebook, N_("graph"), NULL);
 
   g->area = GTK_DRAWING_AREA(gtk_drawing_area_new());
   gtk_widget_set_hexpand(GTK_WIDGET(g->area), TRUE);
-  gtk_box_pack_start(GTK_BOX(self->widget),
+  gtk_box_pack_start(GTK_BOX(self->gui->widget),
                      dt_ui_resizable_drawing_area(GTK_WIDGET(g->area),
                                                   "plugins/darkroom/toneequal/graphheight", 280, 120),
                      FALSE, FALSE, 0);
@@ -3465,7 +3465,7 @@ void gui_init(struct dt_iop_module_t *self)
                                               "but the curve might become oscillatory in some settings.\n"
                                               "negative values will avoid oscillations and behave more robustly\n"
                                               "but may produce brutal tone transitions and damage local contrast."));
-  gtk_box_pack_start(GTK_BOX(self->widget), g->smoothing, FALSE, FALSE, 0);
+  gtk_box_pack_start(GTK_BOX(self->gui->widget), g->smoothing, FALSE, FALSE, 0);
   g_signal_connect(G_OBJECT(g->smoothing), "value-changed", G_CALLBACK(smoothing_callback), self);
 
   g->exposure_boost = dt_color_picker_new(self, DT_COLOR_PICKER_AREA,
@@ -3488,7 +3488,7 @@ void gui_init(struct dt_iop_module_t *self)
 
   // Simple view
 
-  self->widget = dt_ui_notebook_page(g->notebook, N_("sliders"), NULL);
+  self->gui->widget = dt_ui_notebook_page(g->notebook, N_("sliders"), NULL);
 
   g->noise = dt_bauhaus_slider_from_params(self, "noise");
   dt_bauhaus_slider_set_format(g->noise, _(" EV"));
@@ -3529,7 +3529,7 @@ void gui_init(struct dt_iop_module_t *self)
 
   // Masking options
 
-  self->widget = dt_ui_notebook_page(g->notebook, N_("masking"), NULL);
+  self->gui->widget = dt_ui_notebook_page(g->notebook, N_("masking"), NULL);
 
   g->method = dt_bauhaus_combobox_from_params(self, "method");
   dt_bauhaus_combobox_remove_at(g->method, DT_TONEEQ_LAST);
@@ -3571,14 +3571,14 @@ void gui_init(struct dt_iop_module_t *self)
                                                  "produce piece-wise smooth areas when using high feathering values"));
 
   // start building top level widget
-  self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_GUI_BOX_SPACING);
+  self->gui->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_GUI_BOX_SPACING);
 
   const int active_page = dt_conf_get_int("plugins/darkroom/toneequal/gui_page");
   gtk_widget_show(gtk_notebook_get_nth_page(g->notebook, active_page));
   gtk_notebook_set_current_page(g->notebook, active_page);
 
   g_signal_connect(G_OBJECT(g->notebook), "button-press-event", G_CALLBACK(notebook_button_press), self);
-  gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(g->notebook), FALSE, FALSE, 0);
+  gtk_box_pack_start(GTK_BOX(self->gui->widget), GTK_WIDGET(g->notebook), FALSE, FALSE, 0);
 
   GtkWidget *hbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, DT_GUI_BOX_SPACING);
   gtk_box_pack_start(GTK_BOX(hbox), dt_ui_label_new(_("display exposure mask")), TRUE, TRUE, 0);
@@ -3587,7 +3587,7 @@ void gui_init(struct dt_iop_module_t *self)
 
   dtgtk_togglebutton_set_paint(DTGTK_TOGGLEBUTTON(g->show_luminance_mask), dtgtk_cairo_paint_showmask, 0, NULL);
   dt_gui_add_class(g->show_luminance_mask, "dt_bauhaus_alignment");
-  gtk_box_pack_start(GTK_BOX(self->widget), hbox, FALSE, FALSE, 0);
+  gtk_box_pack_start(GTK_BOX(self->gui->widget), hbox, FALSE, FALSE, 0);
 
   // Force UI redraws when pipe starts/finishes computing and switch cursors
   DT_DEBUG_CONTROL_SIGNAL_CONNECT(dt_control_signal_get_global(), DT_SIGNAL_HISTORY_RESYNC,
@@ -3604,7 +3604,7 @@ void gui_init(struct dt_iop_module_t *self)
 
 void gui_cleanup(struct dt_iop_module_t *self)
 {
-  dt_iop_toneequalizer_gui_data_t *g = (dt_iop_toneequalizer_gui_data_t *)self->gui_data;
+  dt_iop_toneequalizer_gui_data_t *g = (dt_iop_toneequalizer_gui_data_t *)dt_iop_gui_data(self);
   self->request_color_pick = DT_REQUEST_COLORPICK_OFF;
 
   dt_conf_set_int("plugins/darkroom/toneequal/gui_page", gtk_notebook_get_current_page (g->notebook));

--- a/src/iop/velvia.c
+++ b/src/iop/velvia.c
@@ -223,7 +223,7 @@ void cleanup_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev
 
 void gui_update(struct dt_iop_module_t *self)
 {
-  dt_iop_velvia_gui_data_t *g = (dt_iop_velvia_gui_data_t *)self->gui_data;
+  dt_iop_velvia_gui_data_t *g = (dt_iop_velvia_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_velvia_params_t *p = (dt_iop_velvia_params_t *)self->params;
   dt_bauhaus_slider_set(g->strength_scale, p->strength);
   dt_bauhaus_slider_set(g->bias_scale, p->bias);

--- a/src/iop/vibrance.c
+++ b/src/iop/vibrance.c
@@ -164,7 +164,7 @@ void cleanup_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev
 
 void gui_update(struct dt_iop_module_t *self)
 {
-  dt_iop_vibrance_gui_data_t *g = (dt_iop_vibrance_gui_data_t *)self->gui_data;
+  dt_iop_vibrance_gui_data_t *g = (dt_iop_vibrance_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_vibrance_params_t *p = (dt_iop_vibrance_params_t *)self->params;
   dt_bauhaus_slider_set(g->amount_scale, p->amount);
 }

--- a/src/iop/vignette.c
+++ b/src/iop/vignette.c
@@ -373,7 +373,7 @@ void gui_post_expose(struct dt_iop_module_t *self, cairo_t *cr, int32_t width, i
                      int32_t pointerx, int32_t pointery)
 {
   dt_develop_t *dev = self->dev;
-  dt_iop_vignette_gui_data_t *g = (dt_iop_vignette_gui_data_t *)self->gui_data;
+  dt_iop_vignette_gui_data_t *g = (dt_iop_vignette_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_vignette_params_t *p = (dt_iop_vignette_params_t *)self->params;
   if(IS_NULL_PTR(g) || IS_NULL_PTR(p)) return;
 
@@ -461,7 +461,7 @@ void gui_post_expose(struct dt_iop_module_t *self, cairo_t *cr, int32_t width, i
 int mouse_moved(struct dt_iop_module_t *self, double x, double y, double pressure, int which)
 {
   const dt_develop_t *dev = (const dt_develop_t *)self->dev;
-  dt_iop_vignette_gui_data_t *g = (dt_iop_vignette_gui_data_t *)self->gui_data;
+  dt_iop_vignette_gui_data_t *g = (dt_iop_vignette_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_vignette_params_t *p = (dt_iop_vignette_params_t *)self->params;
   if(IS_NULL_PTR(g) || IS_NULL_PTR(p)) return 0;
   const float wd = dev->roi.preview_width;
@@ -945,7 +945,7 @@ void cleanup_global(dt_iop_module_so_t *module)
 
 void gui_changed(dt_iop_module_t *self, GtkWidget *w, void *previous)
 {
-  dt_iop_vignette_gui_data_t *g = (dt_iop_vignette_gui_data_t *)self->gui_data;
+  dt_iop_vignette_gui_data_t *g = (dt_iop_vignette_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_vignette_params_t *p = (dt_iop_vignette_params_t *)self->params;
   if(IS_NULL_PTR(g) || IS_NULL_PTR(p)) return;
 
@@ -1003,7 +1003,7 @@ void cleanup_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev
 
 void gui_update(struct dt_iop_module_t *self)
 {
-  dt_iop_vignette_gui_data_t *g = (dt_iop_vignette_gui_data_t *)self->gui_data;
+  dt_iop_vignette_gui_data_t *g = (dt_iop_vignette_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_vignette_params_t *p = (dt_iop_vignette_params_t *)self->params;
   if(IS_NULL_PTR(g) || IS_NULL_PTR(p)) return;
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->autoratio), p->autoratio);
@@ -1019,7 +1019,7 @@ void gui_init(struct dt_iop_module_t *self)
   g->brightness = dt_bauhaus_slider_from_params(self, N_("brightness"));
   g->saturation = dt_bauhaus_slider_from_params(self, N_("saturation"));
 
-  gtk_box_pack_start(GTK_BOX(self->widget),
+  gtk_box_pack_start(GTK_BOX(self->gui->widget),
                      dt_ui_section_label_new(_("position / form")), FALSE, FALSE, 0);
 
   g->center_x = dt_bauhaus_slider_from_params(self, "center.x");

--- a/src/iop/watermark.c
+++ b/src/iop/watermark.c
@@ -869,7 +869,7 @@ int process(struct dt_iop_module_t *self, const dt_dev_pixelpipe_t *pipe, const 
 static void watermark_callback(GtkWidget *tb, gpointer user_data)
 {
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
-  dt_iop_watermark_gui_data_t *g = (dt_iop_watermark_gui_data_t *)self->gui_data;
+  dt_iop_watermark_gui_data_t *g = (dt_iop_watermark_gui_data_t *)dt_iop_gui_data(self);
 
   if(dt_gui_widgets_suppressed()) return;
   dt_iop_watermark_params_t *p = (dt_iop_watermark_params_t *)self->params;
@@ -882,7 +882,7 @@ static void watermark_callback(GtkWidget *tb, gpointer user_data)
 
 void color_picker_apply(dt_iop_module_t *self, GtkWidget *picker, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
 {
-  dt_iop_watermark_gui_data_t *g = (dt_iop_watermark_gui_data_t *)self->gui_data;
+  dt_iop_watermark_gui_data_t *g = (dt_iop_watermark_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_watermark_params_t *p = (dt_iop_watermark_params_t *)self->params;
 
   if(fabsf(p->color[0] - self->picked_color[0]) < 0.0001f
@@ -948,7 +948,7 @@ static void load_watermarks(const char *basedir, dt_iop_watermark_gui_data_t *g)
 
 static void refresh_watermarks(dt_iop_module_t *self)
 {
-  dt_iop_watermark_gui_data_t *g = (dt_iop_watermark_gui_data_t *)self->gui_data;
+  dt_iop_watermark_gui_data_t *g = (dt_iop_watermark_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_watermark_params_t *p = (dt_iop_watermark_params_t *)self->params;
 
   g_signal_handlers_block_by_func(g->watermarks, watermark_callback, self);
@@ -982,7 +982,7 @@ static void alignment_callback(GtkWidget *tb, gpointer user_data)
 {
   int index = -1;
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
-  dt_iop_watermark_gui_data_t *g = (dt_iop_watermark_gui_data_t *)self->gui_data;
+  dt_iop_watermark_gui_data_t *g = (dt_iop_watermark_gui_data_t *)dt_iop_gui_data(self);
 
   if(dt_gui_widgets_suppressed()) return;
   dt_iop_watermark_params_t *p = (dt_iop_watermark_params_t *)self->params;
@@ -1089,7 +1089,7 @@ void cleanup_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev
 
 void gui_update(struct dt_iop_module_t *self)
 {
-  dt_iop_watermark_gui_data_t *g = (dt_iop_watermark_gui_data_t *)self->gui_data;
+  dt_iop_watermark_gui_data_t *g = (dt_iop_watermark_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_watermark_params_t *p = (dt_iop_watermark_params_t *)self->params;
   for(int i = 0; i < 9; i++)
   {
@@ -1120,7 +1120,7 @@ void gui_init(struct dt_iop_module_t *self)
   dt_iop_watermark_gui_data_t *g = IOP_GUI_ALLOC(watermark);
   dt_iop_watermark_params_t *p = (dt_iop_watermark_params_t *)self->params;
 
-  self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_GUI_BOX_SPACING);
+  self->gui->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_GUI_BOX_SPACING);
 
   GtkGrid *grid = GTK_GRID(gtk_grid_new());
   gtk_grid_set_row_spacing(grid, DT_GUI_BOX_SPACING);
@@ -1188,13 +1188,13 @@ void gui_init(struct dt_iop_module_t *self)
   gtk_grid_attach_next_to(grid, g->colorpick, label, GTK_POS_RIGHT, 1, 1);
   gtk_grid_attach_next_to(grid, g->color_picker_button, g->colorpick, GTK_POS_RIGHT, 1, 1);
 
-  gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(grid), TRUE, TRUE, 0);
+  gtk_box_pack_start(GTK_BOX(self->gui->widget), GTK_WIDGET(grid), TRUE, TRUE, 0);
 
   // Add opacity/scale sliders to table
   g->opacity = dt_bauhaus_slider_from_params(self, N_("opacity"));
   dt_bauhaus_slider_set_format(g->opacity, "%");
 
-  gtk_box_pack_start(GTK_BOX(self->widget), dt_ui_section_label_new(_("placement")), TRUE, TRUE, 0);
+  gtk_box_pack_start(GTK_BOX(self->gui->widget), dt_ui_section_label_new(_("placement")), TRUE, TRUE, 0);
 
   // rotate
   g->rotate = dt_bauhaus_slider_from_params(self, "rotate");
@@ -1223,7 +1223,7 @@ void gui_init(struct dt_iop_module_t *self)
     g_signal_connect(G_OBJECT(g->align[i]), "toggled", G_CALLBACK(alignment_callback), self);
   }
 
-  gtk_box_pack_start(GTK_BOX(self->widget), bat, FALSE, FALSE, 0);
+  gtk_box_pack_start(GTK_BOX(self->gui->widget), bat, FALSE, FALSE, 0);
 
   // x/y offset
   g->x_offset = dt_bauhaus_slider_from_params(self, "xoffset");
@@ -1247,7 +1247,7 @@ void gui_init(struct dt_iop_module_t *self)
 
 void gui_cleanup(struct dt_iop_module_t *self)
 {
-  dt_iop_watermark_gui_data_t *g = (dt_iop_watermark_gui_data_t *)self->gui_data;
+  dt_iop_watermark_gui_data_t *g = (dt_iop_watermark_gui_data_t *)dt_iop_gui_data(self);
   g_list_free_full(g->watermarks_filenames, dt_free_gpointer);
   g->watermarks_filenames = NULL;
 

--- a/src/iop/zonesystem.c
+++ b/src/iop/zonesystem.c
@@ -53,6 +53,7 @@
 #include "config.h"
 #include "widgets/widget_settings.h"
 #endif
+#include "develop/imageop_gui.h"
 #include <assert.h>
 #include <stdlib.h>
 #include <string.h>
@@ -206,7 +207,7 @@ static inline __attribute__((always_inline)) void process_common_setup(struct dt
 
   if(self->dev->gui_attached && dt_dev_pixelpipe_has_preview_output(self->dev, pipe, roi_out))
   {
-    dt_iop_zonesystem_gui_data_t *g = (dt_iop_zonesystem_gui_data_t *)self->gui_data;
+    dt_iop_zonesystem_gui_data_t *g = (dt_iop_zonesystem_gui_data_t *)dt_iop_gui_data(self);
     if(IS_NULL_PTR(g)) return;
 
     dt_iop_gui_enter_critical_section(self);
@@ -231,7 +232,7 @@ static void process_common_cleanup(struct dt_iop_module_t *self, const dt_dev_pi
                                    const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {
   dt_iop_zonesystem_data_t *d = (dt_iop_zonesystem_data_t *)piece->data;
-  dt_iop_zonesystem_gui_data_t *g = (dt_iop_zonesystem_gui_data_t *)self->gui_data;
+  dt_iop_zonesystem_gui_data_t *g = (dt_iop_zonesystem_gui_data_t *)dt_iop_gui_data(self);
 
   const int width = roi_out->width;
   const int height = roi_out->height;
@@ -361,7 +362,7 @@ void cleanup_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev
 void gui_update(struct dt_iop_module_t *self)
 {
   //  dt_iop_module_t *module = (dt_iop_module_t *)self;
-  dt_iop_zonesystem_gui_data_t *g = (dt_iop_zonesystem_gui_data_t *)self->gui_data;
+  dt_iop_zonesystem_gui_data_t *g = (dt_iop_zonesystem_gui_data_t *)dt_iop_gui_data(self);
   // dt_iop_zonesystem_params_t *p = (dt_iop_zonesystem_params_t *)module->params;
   gtk_widget_queue_draw(GTK_WIDGET(g->zones));
 }
@@ -386,7 +387,7 @@ static gboolean dt_iop_zonesystem_bar_scrolled(GtkWidget *widget, GdkEventScroll
 static void size_allocate_callback(GtkWidget *widget, GtkAllocation *allocation, gpointer user_data)
 {
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
-  dt_iop_zonesystem_gui_data_t *g = (dt_iop_zonesystem_gui_data_t *)self->gui_data;
+  dt_iop_zonesystem_gui_data_t *g = (dt_iop_zonesystem_gui_data_t *)dt_iop_gui_data(self);
 
   if(g->image) cairo_surface_destroy(g->image);
   dt_free(g->image_buffer);
@@ -416,7 +417,7 @@ void gui_init(struct dt_iop_module_t *self)
   g->preview_width = g->preview_height = 0;
   g->mouse_over_output_zones = FALSE;
 
-  self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_GUI_BOX_SPACING);
+  self->gui->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_GUI_BOX_SPACING);
 
   g->preview = dtgtk_drawing_area_new_with_aspect_ratio(1.0);
   g_signal_connect(G_OBJECT(g->preview), "size-allocate", G_CALLBACK(size_allocate_callback), self);
@@ -445,8 +446,8 @@ void gui_init(struct dt_iop_module_t *self)
                                               | GDK_LEAVE_NOTIFY_MASK | dt_widget_scroll_mask());
   gtk_widget_set_size_request(g->zones, -1, DT_PIXEL_APPLY_DPI(40));
 
-  gtk_box_pack_start(GTK_BOX(self->widget), g->preview, TRUE, TRUE, 0);
-  gtk_box_pack_start(GTK_BOX(self->widget), g->zones, TRUE, TRUE, 0);
+  gtk_box_pack_start(GTK_BOX(self->gui->widget), g->preview, TRUE, TRUE, 0);
+  gtk_box_pack_start(GTK_BOX(self->gui->widget), g->zones, TRUE, TRUE, 0);
 
   /* add signal handler for preview pipe finish to redraw the preview */
   DT_DEBUG_CONTROL_SIGNAL_CONNECT(dt_control_signal_get_global(), DT_SIGNAL_DEVELOP_PREVIEW_PIPE_FINISHED,
@@ -463,7 +464,7 @@ void gui_cleanup(struct dt_iop_module_t *self)
 {
   DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(dt_control_signal_get_global(), G_CALLBACK(_iop_zonesystem_redraw_preview_callback), self);
 
-  dt_iop_zonesystem_gui_data_t *g = (dt_iop_zonesystem_gui_data_t *)self->gui_data;
+  dt_iop_zonesystem_gui_data_t *g = (dt_iop_zonesystem_gui_data_t *)dt_iop_gui_data(self);
   dt_free(g->in_preview_buffer);
   dt_free(g->out_preview_buffer);
   if(g->image) cairo_surface_destroy(g->image);
@@ -477,7 +478,7 @@ void gui_cleanup(struct dt_iop_module_t *self)
 #define DT_ZONESYSTEM_REFERENCE_SPLIT 0.30
 static gboolean dt_iop_zonesystem_bar_draw(GtkWidget *widget, cairo_t *crf, dt_iop_module_t *self)
 {
-  dt_iop_zonesystem_gui_data_t *g = (dt_iop_zonesystem_gui_data_t *)self->gui_data;
+  dt_iop_zonesystem_gui_data_t *g = (dt_iop_zonesystem_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_zonesystem_params_t *p = (dt_iop_zonesystem_params_t *)self->params;
 
   const int inset = DT_ZONESYSTEM_INSET;
@@ -571,7 +572,7 @@ static gboolean dt_iop_zonesystem_bar_button_press(GtkWidget *widget, GdkEventBu
                                                    dt_iop_module_t *self)
 {
   dt_iop_zonesystem_params_t *p = (dt_iop_zonesystem_params_t *)self->params;
-  dt_iop_zonesystem_gui_data_t *g = (dt_iop_zonesystem_gui_data_t *)self->gui_data;
+  dt_iop_zonesystem_gui_data_t *g = (dt_iop_zonesystem_gui_data_t *)dt_iop_gui_data(self);
   const int inset = DT_ZONESYSTEM_INSET;
   GtkAllocation allocation;
   gtk_widget_get_allocation(widget, &allocation);
@@ -610,7 +611,7 @@ static gboolean dt_iop_zonesystem_bar_button_press(GtkWidget *widget, GdkEventBu
 static gboolean dt_iop_zonesystem_bar_button_release(GtkWidget *widget, GdkEventButton *event,
                                                      dt_iop_module_t *self)
 {
-  dt_iop_zonesystem_gui_data_t *g = (dt_iop_zonesystem_gui_data_t *)self->gui_data;
+  dt_iop_zonesystem_gui_data_t *g = (dt_iop_zonesystem_gui_data_t *)dt_iop_gui_data(self);
   if(event->button == 1)
   {
     g->is_dragging = FALSE;
@@ -638,7 +639,7 @@ static gboolean dt_iop_zonesystem_bar_scrolled(GtkWidget *widget, GdkEventScroll
 static gboolean dt_iop_zonesystem_bar_leave_notify(GtkWidget *widget, GdkEventCrossing *event,
                                                    dt_iop_module_t *self)
 {
-  dt_iop_zonesystem_gui_data_t *g = (dt_iop_zonesystem_gui_data_t *)self->gui_data;
+  dt_iop_zonesystem_gui_data_t *g = (dt_iop_zonesystem_gui_data_t *)dt_iop_gui_data(self);
   g->hilite_zone = FALSE;
   gtk_widget_queue_draw(g->preview);
   return TRUE;
@@ -648,7 +649,7 @@ static gboolean dt_iop_zonesystem_bar_motion_notify(GtkWidget *widget, GdkEventM
                                                     dt_iop_module_t *self)
 {
   dt_iop_zonesystem_params_t *p = (dt_iop_zonesystem_params_t *)self->params;
-  dt_iop_zonesystem_gui_data_t *g = (dt_iop_zonesystem_gui_data_t *)self->gui_data;
+  dt_iop_zonesystem_gui_data_t *g = (dt_iop_zonesystem_gui_data_t *)dt_iop_gui_data(self);
   const int inset = DT_ZONESYSTEM_INSET;
   GtkAllocation allocation;
   gtk_widget_get_allocation(widget, &allocation);
@@ -695,7 +696,7 @@ static gboolean dt_iop_zonesystem_bar_motion_notify(GtkWidget *widget, GdkEventM
     g->hilite_zone = (g->mouse_y < height) ? TRUE : FALSE;
   }
 
-  gtk_widget_queue_draw(self->widget);
+  gtk_widget_queue_draw(self->gui->widget);
   gtk_widget_queue_draw(g->preview);
   return TRUE;
 }
@@ -708,14 +709,14 @@ static gboolean dt_iop_zonesystem_preview_draw(GtkWidget *widget, cairo_t *crf, 
   gtk_widget_get_allocation(widget, &allocation);
   int width = allocation.width, height = allocation.height;
 
-  dt_iop_zonesystem_gui_data_t *g = (dt_iop_zonesystem_gui_data_t *)self->gui_data;
+  dt_iop_zonesystem_gui_data_t *g = (dt_iop_zonesystem_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_zonesystem_params_t *p = (dt_iop_zonesystem_params_t *)self->params;
 
   cairo_surface_t *cst = dt_cairo_image_surface_create(CAIRO_FORMAT_ARGB32, width, height);
   cairo_t *cr = cairo_create(cst);
 
   /* clear background */
-  GtkStyleContext *context = gtk_widget_get_style_context(self->expander);
+  GtkStyleContext *context = gtk_widget_get_style_context(self->gui->expander);
   gtk_render_background(context, cr, 0, 0, allocation.width, allocation.height);
 
   width -= 2 * inset;
@@ -769,7 +770,7 @@ static gboolean dt_iop_zonesystem_preview_draw(GtkWidget *widget, cairo_t *crf, 
     if(g->image)
     {
       GdkRGBA *color;
-      gtk_style_context_get(context, gtk_widget_get_state_flags(self->expander), "background-color", &color,
+      gtk_style_context_get(context, gtk_widget_get_state_flags(self->gui->expander), "background-color", &color,
                             NULL);
 
       cairo_set_source_surface(cr, g->image, (width - g->image_width) * 0.5, (height - g->image_height) * 0.5);
@@ -798,7 +799,7 @@ static gboolean dt_iop_zonesystem_preview_draw(GtkWidget *widget, cairo_t *crf, 
 void _iop_zonesystem_redraw_preview_callback(gpointer instance, gpointer user_data)
 {
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
-  dt_iop_zonesystem_gui_data_t *g = (dt_iop_zonesystem_gui_data_t *)self->gui_data;
+  dt_iop_zonesystem_gui_data_t *g = (dt_iop_zonesystem_gui_data_t *)dt_iop_gui_data(self);
 
   dt_control_queue_redraw_widget(g->preview);
 }

--- a/src/libs/histogram.c
+++ b/src/libs/histogram.c
@@ -54,6 +54,7 @@
 #include <stdint.h>
 #include <inttypes.h>
 
+#include "develop/imageop_gui.h"
 #include "widgets/bauhaus.h"
 #include "widgets/resize_handle.h"
 #include "widgets/widget_settings.h"
@@ -259,7 +260,7 @@ static void _refresh_module_histogram(const dt_dev_pixelpipe_t *pipe, const dt_d
                           &module->histogram, module->histogram_max);
   dt_iop_gui_leave_critical_section(module);
 
-  if(module->widget) dt_control_queue_redraw_widget(module->widget);
+  if(module->gui && module->gui->widget) dt_control_queue_redraw_widget(module->gui->widget);
 }
 
 static dt_backbuf_t *_get_histogram_backbuf(dt_develop_t *dev, const char *op)

--- a/src/libs/history.c
+++ b/src/libs/history.c
@@ -50,6 +50,7 @@
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#include "develop/imageop_gui.h"
 #include "widgets/widget_settings.h"
 #include "common/history_actions.h"
 #include "gui/common/history_actions_gui.h"
@@ -492,7 +493,7 @@ static gchar *_create_tooltip_text(const dt_dev_history_item_t *hitem)
                                 ? g_strdup_printf(_("the drawn mask was removed"))
                                 : g_strdup_printf(_("the drawn mask was changed"));
 
-    dt_iop_gui_blend_data_t *bd = hitem->module->blend_data;
+    dt_iop_gui_blend_data_t *bd = hitem->module->gui ? hitem->module->gui->blend_data : NULL;
 
     for(int in_out = 1; in_out >= 0; in_out--)
     {

--- a/src/libs/ioporder.c
+++ b/src/libs/ioporder.c
@@ -24,6 +24,7 @@
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#include "develop/imageop_gui.h"
 #include "widgets/widget_settings.h"
 #include "colorprofiles/colorspaces.h"
 #include "database/preset_repository.h"
@@ -698,11 +699,11 @@ static void _ioporder_set_enable_button_icon(GtkWidget *widget, dt_iop_module_t 
 static void _ioporder_node_toggle_enable(GtkToggleButton *togglebutton, gpointer user_data)
 {
   const dt_ioporder_graph_node_t *node = (const dt_ioporder_graph_node_t *)user_data;
-  if(!node || !GTK_IS_TOGGLE_BUTTON(node->module->off)) return;
+  if(!node || !node->module->gui || !GTK_IS_TOGGLE_BUTTON(node->module->gui->off)) return;
 
   const gboolean active = gtk_toggle_button_get_active(togglebutton);
-  if(gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(node->module->off)) != active)
-    gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(node->module->off), active);
+  if(gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(node->module->gui->off)) != active)
+    gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(node->module->gui->off), active);
 }
 
 /**
@@ -714,11 +715,11 @@ static void _ioporder_node_toggle_enable(GtkToggleButton *togglebutton, gpointer
 static void _ioporder_node_toggle_mask(GtkToggleButton *togglebutton, gpointer user_data)
 {
   const dt_ioporder_graph_node_t *node = (const dt_ioporder_graph_node_t *)user_data;
-  if(!node || !GTK_IS_TOGGLE_BUTTON(node->module->mask_indicator)) return;
+  if(!node || !node->module->gui || !GTK_IS_TOGGLE_BUTTON(node->module->gui->mask_indicator)) return;
 
   const gboolean active = gtk_toggle_button_get_active(togglebutton);
-  if(gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(node->module->mask_indicator)) != active)
-    gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(node->module->mask_indicator), active);
+  if(gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(node->module->gui->mask_indicator)) != active)
+    gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(node->module->gui->mask_indicator), active);
 }
 
 /**

--- a/src/libs/masks.c
+++ b/src/libs/masks.c
@@ -38,6 +38,7 @@
     You should have received a copy of the GNU General Public License
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
+#include "develop/imageop_gui.h"
 #include "develop/masks.h"
 #include "develop/masks_gui.h"
 #include "common/logging.h"
@@ -180,7 +181,7 @@ static void _lib_masks_clear_blending_box(dt_lib_module_t *self)
 static gboolean _lib_masks_can_host_blending(const dt_iop_module_t *module)
 {
   if(!_lib_masks_module_is_current(module) || !module->flags
-     || !(module->flags() & IOP_FLAGS_SUPPORTS_BLENDING) || !module->blend_data)
+     || !(module->flags() & IOP_FLAGS_SUPPORTS_BLENDING) || !module->gui || !module->gui->blend_data)
     return FALSE;
 
   return TRUE;
@@ -976,11 +977,11 @@ static void _tree_selection_change(GtkTreeSelection *selection, dt_lib_masks_t *
           dt_iop_module_t *module = NULL;
           _lib_masks_get_values(model, &iter, &module, NULL, NULL);
 
-          if(module && module->blend_data
+          if(module && module->gui && module->gui->blend_data
              && (module->flags() & IOP_FLAGS_SUPPORTS_BLENDING)
              && !(module->flags() & IOP_FLAGS_NO_MASKS))
           {
-            dt_iop_gui_blend_data_t *bd = (dt_iop_gui_blend_data_t *)module->blend_data;
+            dt_iop_gui_blend_data_t *bd = (dt_iop_gui_blend_data_t *)module->gui->blend_data;
             bd->masks_shown = 1;
             gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(bd->masks_edit), TRUE);
             gtk_widget_queue_draw(bd->masks_edit);

--- a/src/libs/modulegroups.c
+++ b/src/libs/modulegroups.c
@@ -45,6 +45,7 @@
 */
 
 
+#include "develop/imageop_gui.h"
 #include "widgets/widget_settings.h"
 #include "develop/iop_order.h"
 #include "common/logging.h"
@@ -166,9 +167,9 @@ static void _modulegroups_sync_section_label_margins(dt_lib_modulegroups_t *d)
   for(const GList *modules = g_list_first(dt_dev_get_global()->iop); modules; modules = g_list_next(modules))
   {
     dt_iop_module_t *module = (dt_iop_module_t *)modules->data;
-    if(!dt_iop_is_hidden(module) && module->expander)
+    if(!dt_iop_is_hidden(module) && module->gui && module->gui->expander)
     {
-      reference = module->expander;
+      reference = module->gui->expander;
       break;
     }
   }
@@ -209,9 +210,9 @@ static void _modulegroups_clear_drop_state(dt_lib_modulegroups_t *d)
   for(const GList *modules = g_list_last(dt_dev_get_global()->iop); modules; modules = g_list_previous(modules))
   {
     dt_iop_module_t *module = (dt_iop_module_t *)(modules->data);
-    if(!module->expander) continue;
-    dt_gui_remove_class(module->expander, "iop_drop_after");
-    dt_gui_remove_class(module->expander, "iop_drop_before");
+    if(!module->gui || !module->gui->expander) continue;
+    dt_gui_remove_class(module->gui->expander, "iop_drop_after");
+    dt_gui_remove_class(module->gui->expander, "iop_drop_before");
   }
 }
 
@@ -298,7 +299,7 @@ static dt_iop_module_t *_modulegroups_get_dnd_dest_module(GtkWidget *page, const
   if(!GTK_IS_WIDGET(page) || !module_src) return NULL;
 
   GtkAllocation source_allocation = { 0 };
-  gtk_widget_get_allocation(module_src->header, &source_allocation);
+  gtk_widget_get_allocation(module_src->gui->header, &source_allocation);
   const int y_slop = source_allocation.height / 2;
   gboolean after_src = TRUE;
   dt_iop_module_t *module_dest = NULL;
@@ -310,7 +311,7 @@ static dt_iop_module_t *_modulegroups_get_dnd_dest_module(GtkWidget *page, const
   for(GList *l = children; l; l = g_list_next(l))
   {
     GtkWidget *w = GTK_WIDGET(l->data);
-    if(w == module_src->expander) after_src = FALSE;
+    if(w == module_src->gui->expander) after_src = FALSE;
 
     int widget_x = 0;
     int widget_y = 0;
@@ -509,7 +510,8 @@ static GtkWidget *_get_target_container(dt_lib_module_t *self, const dt_iop_modu
  */
 static void _modulegroups_setup_drag_source(dt_lib_module_t *self, dt_iop_module_t *module)
 {
-  GtkWidget *widget = module->expander;
+  if(IS_NULL_PTR(module->gui) || IS_NULL_PTR(module->gui->expander)) return;
+  GtkWidget *widget = module->gui->expander;
   g_object_set_data(G_OBJECT(widget), "dt-module", module);
 
   if(g_object_get_data(G_OBJECT(widget), "modulegroups-dnd")) return;
@@ -540,10 +542,11 @@ static gboolean _modulegroups_reorder_target(GtkWidget *target)
   for(GList *modules = g_list_last(dt_dev_get_global()->iop); modules; modules = g_list_previous(modules))
   {
     dt_iop_module_t *module = (dt_iop_module_t *)modules->data;
-    if(dt_iop_is_hidden(module) || !module->expander || !gtk_widget_get_visible(module->expander)) continue;
-    if(gtk_widget_get_parent(module->expander) != target) continue;
+    if(dt_iop_is_hidden(module) || !module->gui || !module->gui->expander
+       || !gtk_widget_get_visible(module->gui->expander)) continue;
+    if(gtk_widget_get_parent(module->gui->expander) != target) continue;
 
-    gtk_box_reorder_child(GTK_BOX(target), module->expander, position++);
+    gtk_box_reorder_child(GTK_BOX(target), module->gui->expander, position++);
     has_visible = TRUE;
   }
 
@@ -560,19 +563,19 @@ static void _modulegroups_drag_begin(GtkWidget *widget, GdkDragContext *context,
   _modulegroups_clear_drop_state(d);
   g_object_set_data(G_OBJECT(widget), "dt-module-dragged", GINT_TO_POINTER(TRUE));
 
-  if(!module_src || !module_src->header) return;
+  if(!module_src || !module_src->gui->header) return;
 
-  GdkWindow *window = gtk_widget_get_parent_window(module_src->header);
+  GdkWindow *window = gtk_widget_get_parent_window(module_src->gui->header);
   if(IS_NULL_PTR(window)) return;
 
   GtkAllocation allocation = { 0 };
-  gtk_widget_get_allocation(module_src->header, &allocation);
+  gtk_widget_get_allocation(module_src->gui->header, &allocation);
   cairo_surface_t *surface = dt_cairo_image_surface_create(CAIRO_FORMAT_RGB24, allocation.width, allocation.height);
   cairo_t *cr = cairo_create(surface);
 
-  dt_gui_add_class(module_src->header, "iop_drag_icon");
-  gtk_widget_draw(module_src->header, cr);
-  dt_gui_remove_class(module_src->header, "iop_drag_icon");
+  dt_gui_add_class(module_src->gui->header, "iop_drag_icon");
+  gtk_widget_draw(module_src->gui->header, cr);
+  dt_gui_remove_class(module_src->gui->header, "iop_drag_icon");
 
   cairo_surface_set_device_offset(surface, -allocation.width * dt_gui_get_global()->ppd / 2,
                                   -allocation.height * dt_gui_get_global()->ppd / 2);
@@ -634,12 +637,12 @@ static gboolean _modulegroups_drag_motion(GtkWidget *widget, GdkDragContext *dc,
   }
 
   if(module_src->iop_order < module_dest->iop_order)
-    dt_gui_add_class(module_dest->expander, "iop_drop_after");
+    dt_gui_add_class(module_dest->gui->expander, "iop_drop_after");
   else
-    dt_gui_add_class(module_dest->expander, "iop_drop_before");
+    dt_gui_add_class(module_dest->gui->expander, "iop_drop_before");
 
-  d->drag_highlight = module_dest->expander;
-  gtk_drag_highlight(module_dest->expander);
+  d->drag_highlight = module_dest->gui->expander;
+  gtk_drag_highlight(module_dest->gui->expander);
   gdk_drag_status(dc, GDK_ACTION_COPY, time);
   return TRUE;
 }
@@ -796,7 +799,7 @@ static gboolean _focus_previous_module(GtkAccelGroup *accel_group, GObject *acce
     for(const GList *module = g_list_first((GList *)children); module; module = g_list_next(module))
     {
       GtkWidget *widget = GTK_WIDGET(module->data);
-      if(widget == focused->expander) break;
+      if(widget == focused->gui->expander) break;
       target = (dt_iop_module_t *)g_object_get_data(G_OBJECT(widget), "dt-module");
     }
     if(IS_NULL_PTR(target))
@@ -844,7 +847,7 @@ static gboolean _focus_next_module(GtkAccelGroup *accel_group, GObject *accelera
     for(const GList *module = g_list_last((GList *)children); module; module = g_list_previous(module))
     {
       GtkWidget *widget = GTK_WIDGET(module->data);
-      if(widget == focused->expander) break;
+      if(widget == focused->gui->expander) break;
       target = (dt_iop_module_t *)g_object_get_data(G_OBJECT(widget), "dt-module");
     }
     if(IS_NULL_PTR(target))
@@ -1105,7 +1108,7 @@ void gui_cleanup(dt_lib_module_t *self)
       for(GList *modules = g_list_first(dt_dev_get_global()->iop); modules; modules = g_list_next(modules))
       {
         dt_iop_module_t *module = (dt_iop_module_t *)modules->data;
-        if(module->expander) _modulegroups_move_widget(module->expander, GTK_WIDGET(root));
+        if(module->gui && module->gui->expander) _modulegroups_move_widget(module->gui->expander, GTK_WIDGET(root));
       }
     }
     for(int i = 0; i < MOD_TAB_ALL; i++)
@@ -1166,7 +1169,7 @@ static gboolean _update_iop_visibility(gpointer user_data)
     dt_iop_module_t *module = (dt_iop_module_t *)modules->data;
     if(dt_iop_is_hidden(module)) continue; // Hidden modules don't have a widget
 
-    GtkWidget *w = module->expander;
+    GtkWidget *w = module->gui ? module->gui->expander : NULL;
     if(IS_NULL_PTR(w)) continue; // Module GUI may not be inited yet
 
     const gboolean visible = _is_module_in_tab(module, tab);
@@ -1209,15 +1212,15 @@ static gboolean _update_iop_visibility(gpointer user_data)
 
   // Ensure the module is visible
   dt_iop_module_t *active = dev->gui_module;
-  if(!IS_NULL_PTR(active) && !IS_NULL_PTR(active->expander))
+  if(!IS_NULL_PTR(active) && !IS_NULL_PTR(active->gui->expander))
   {
-    if(dt_gui_get_global()->scroll_to[1] != active->header)
+    if(dt_gui_get_global()->scroll_to[1] != active->gui->header)
     {
       const gboolean scroll_new_instance_to_header
-        = (dt_gui_get_global()->scroll_to_header_once == active->expander
-           && !IS_NULL_PTR(active->header) && GTK_IS_WIDGET(active->header));
+        = (dt_gui_get_global()->scroll_to_header_once == active->gui->expander
+           && !IS_NULL_PTR(active->gui->header) && GTK_IS_WIDGET(active->gui->header));
 
-      dt_gui_get_global()->scroll_to[1] = scroll_new_instance_to_header ? active->header : active->expander;
+      dt_gui_get_global()->scroll_to[1] = scroll_new_instance_to_header ? active->gui->header : active->gui->expander;
 
       if(scroll_new_instance_to_header) dt_gui_get_global()->scroll_to_header_once = NULL;
     }
@@ -1260,19 +1263,20 @@ static void _lib_modulegroups_signal_set(gpointer instance, gpointer module, gpo
   if(IS_NULL_PTR(iop_module)) return;
 
   const dt_modulesgroups_tabs_t current_tab = _get_current_tab(self);
+  GtkWidget *expander = iop_module->gui ? iop_module->gui->expander : NULL;
   const gboolean prefer_active_once
-      = !IS_NULL_PTR(iop_module->expander)
-        && GPOINTER_TO_INT(g_object_get_data(G_OBJECT(iop_module->expander),
+      = !IS_NULL_PTR(expander)
+        && GPOINTER_TO_INT(g_object_get_data(G_OBJECT(expander),
                                              "dt-modulegroups-prefer-active-once"));
   const gboolean allow_switch_from_active
-      = !IS_NULL_PTR(iop_module->expander)
-        && GPOINTER_TO_INT(g_object_get_data(G_OBJECT(iop_module->expander),
+      = !IS_NULL_PTR(expander)
+        && GPOINTER_TO_INT(g_object_get_data(G_OBJECT(expander),
                                              "dt-modulegroups-switch-from-active-once"));
   const gboolean module_in_active_tab = _is_module_in_tab(iop_module, MOD_TAB_ACTIVE);
-  if(!IS_NULL_PTR(iop_module->expander))
+  if(!IS_NULL_PTR(expander))
   {
-    g_object_set_data(G_OBJECT(iop_module->expander), "dt-modulegroups-prefer-active-once", NULL);
-    g_object_set_data(G_OBJECT(iop_module->expander), "dt-modulegroups-switch-from-active-once", NULL);
+    g_object_set_data(G_OBJECT(expander), "dt-modulegroups-prefer-active-once", NULL);
+    g_object_set_data(G_OBJECT(expander), "dt-modulegroups-switch-from-active-once", NULL);
   }
 
   // Direct actions (enable/toggle) should prioritize Pipeline for the focused module.

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -81,6 +81,7 @@
 */
 /** this is the view for the darkroom module.  */
 
+#include "develop/imageop_gui.h"
 #include "widgets/bauhaus.h"
 #include "widgets/widget_settings.h"
 #include <glib/gstdio.h>
@@ -1827,7 +1828,7 @@ void enter(dt_view_t *self)
       if(module->multi_priority == 0)
       {
         snprintf(option, sizeof(option), "plugins/darkroom/%s/expanded", module->op);
-        module->expanded = dt_conf_get_bool(option);
+        module->gui->expanded = dt_conf_get_bool(option);
         dt_iop_gui_update_expanded(module);
 
         if(active_plugin && !strcmp(module->op, active_plugin))


### PR DESCRIPTION
Eighth tranche of `doc/develop-split.md` — the first T4 struct split, per the maintainer's decision **D3 = 3b**.

## What changed

`dt_iop_module_t` carried ~15 widget pointers, the GUI data blob + its lock, and the blending panel state — all NULL headless, and the reason `imageop.h` needs GTK. They live in **`dt_iop_module_gui_t`** now (`imageop_gui.h`), held as one opaque pointer: allocated by `dt_iop_gui_init()`, freed by `dt_iop_gui_cleanup_module()`, **NULL for every headless module**. "Does this module have a GUI" is one pointer, asked once. `gui_attached`'s death starts here.

## How ~1550 call sites were rewritten safely

**Compiler-driven, not sed-driven**: delete the members, build with `-k`, rewrite exactly the `file:line:column` each error names — type-checked by construction, immune to the name collisions a textual sed of `->widget` across the tree would hit. (GCC anchors the caret on the arrow for plain members but on the member name for `{aka}`-elaborated errors; the fixer handles both plus the C++ shape.)

## Headless NULL-safety — the substance

- **825 `gui_data` reads** go through a new NULL-safe accessor `dt_iop_gui_data()` — IOP `process()` reads the blob for darkroom-only feedback and must get NULL, not a crash. 85 `blend_data` fetches made conditional the same way.
- **Fourteen IOP `init()` hooks and the module loader zeroed the old inline members at load time** — headless-reachable writes through a NULL pointer. All deleted; a headless load must not touch `module->gui` at all.
- The critical-section pair tolerates NULL gui; `reload_defaults`' header refresh, the modulegroups expander poke, and multishow are guarded.
- Every one of these was found the same way: **the headless export segfaulted, gdb named the line, the whole class got swept** — three crash→fix→sweep rounds until clean. Final state: zero raw gui derefs in pipeline-side IOP functions (measured), zero in headless-reachable core paths.

## Layering held by API, not includes

The rewrite initially handed `imageop_gui.h` to `common/iop-autoset.c` and three `gui/` files — +4 upward edges, ratchet red. Fixed the right way: the critical-section pair de-inlined behind `imageop.h` prototypes, and two accessors (`dt_iop_gui_get_off`, `dt_iop_gui_owns_widget`) replace the gui files' struct derefs. **Violations: 187, baseline held.**

## Scope note

The survey's "commit_params must use the caller's forms snapshot" item is **dropped, not deferred** — the tree evolved past it: `compute_module_hash` already takes forms with a documented caller-owns-choice contract (#1060 blind-hash family), and the commit path passing live `dev->forms` is that contract's deliberate half.

## Verification

Release, Debug (`-Werror`), nofeatures; ctest 7/7; all gates, layering 187 held; **headless export A/B on decoded pixels: zero differing pixels** — and this tranche's A/B is load-bearing, since it walks module load, defaults, replay and process with `gui == NULL` everywhere. GUI pass worth doing: general darkroom smoke (every module header), plus one undo/redo and one module rename — the widget lifecycle now flows through the owned struct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)