### PR TITLE
Develop T4b (part 1): the image geometry leaves the viewport struct

### DIFF
--- a/doc/develop-split.md
+++ b/doc/develop-split.md
@@ -182,3 +182,58 @@ immediately redraws.
 So: merge #1130 as it stands; stop growing `src/history`; start T0+T1 — they are the
 cheapest cuts with the largest fan-out, they are fully specified by the survey, and nothing
 in them blocks on a design decision.
+
+## T4b field survey: what `dev->roi` actually is, measured
+
+The tranche list above assigns `dev->roi` three artifacts. Before writing them, every one of
+its 416 access sites was traced to a writer, a reader and a thread — six independent passes,
+each classification then attacked by a checker whose brief was to find one counter-example.
+Six of the checker's attacks succeeded, and they are the reason this section exists: the
+first-pass classification was right about *meaning* and wrong about *reach*, which is the
+same mistake that shipped the `raw_width == 0` masks bug.
+
+**The site count is larger than a grep suggests.** `grep 'dev->roi'` finds 349; the real
+figure is 416, because the struct is also reached through `self->dev->roi`,
+`mask_gui->dev->roi`, `pipe->dev->roi`, `module->dev->roi` and `d->dev->roi`. Of those, 57
+are writes, and they sit in just 17 functions — `_zoom_preset_change()` (12),
+`_change_scaling()` (6), `mouse_moved()`/`key_pressed()` (4 each), `dt_dev_get_thumbnail_size()`
+(4), `dt_dev_reset_roi()` (4). That concentration is what makes the D1=A2 setter API
+tractable: seventeen call sites to reroute, not fifty-seven.
+
+**The classification, after the checkers.** `raw_width`/`raw_height`/`raw_inited` are backend
+and reached headless (confirmed: `_dt_dev_mipmap_prefetch_full()` still writes all three
+unconditionally, the CLAUDE.md fix intact). `processed_width`/`height` survived the
+refutation attempt as GUI-populated: nothing reads them with `gui_attached == FALSE`, and the
+backend keeps its own copy in `pipe->processed_*` (pixelpipe_hb.h:239) — the mask coordinate
+path reaches absolute positions through the virtual pipe, not through these. `scaling`, `x`,
+`y`, `border_size`, `orig_width`, `orig_height`, `gui_inited` are viewport; `preview_*`,
+`natural_scale`, `output_inited` are derived. `main_width`/`main_height` were neither: zero
+readers tree-wide, deleted in T4b-1.
+
+**The hazard is a torn pair, not a stale scalar.** `x` and `y` are written as two separate
+statements at every one of the eight write sites, and read as two separate statements by
+`_update_darkroom_roi()` on the worker thread — so a frame can be planned from half the old
+pan and half the new one. `preview_width`/`preview_height` have the identical shape. Any
+channel that only guarantees freshness, without publishing the tuple atomically, leaves this
+in place.
+
+**Three defects the survey found, which are not bookkeeping:**
+
+* `iop/finalscale.c`'s `commit_params()` reads `pipe->dev->roi.scaling` and `natural_scale`
+  to decide `piece->enabled` — on the pipeline thread, unsynchronised, and for the export and
+  thumbnail pipes as well, where the dev is headless and those fields hold their `calloc`
+  zero. The later clauses of the predicate decide those two pipe types on their own, so the
+  read is load-bearing only for the darkroom pipes, which are exactly the ones that race.
+* The drawlayer paint thread reads viewport state and drives the virtual pipe. Chain:
+  `_drawlayer_worker_main` (a pthread, worker.c:1378) → `process_sample` →
+  `_backend_worker_process_sample` → `_process_backend_input` →
+  `dt_drawlayer_paint_interpolate_path` → the `layer_to_widget` callback →
+  `dt_dev_coordinates_image_norm_to_widget()`, which reads `roi.orig_width`/`orig_height`
+  (develop.c:1100-1101) and calls `dt_dev_distort_transform_plus(self->dev->virtual_pipe, …)`
+  — a pipe documented as owned by the GUI main thread. It runs once per dab, so a window
+  resize or panel toggle during a stroke races it.
+* `dt_focus_draw_clusters()` (gui/dtgtk/focus.h:288) reads
+  `dt_dev_get_global()->roi.border_size` from `_get_image_buffer`, a `dt_control_job` body
+  (thumbnail.c:657). A lighttable thumbnail render job thus reads darkroom viewport state
+  through the global, from a view that is not darkroom. After the split that viewport may not
+  exist, so this call site needs rewriting rather than re-pointing.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -182,6 +182,7 @@ FILE(GLOB SOURCE_FILES
   "control/progress.c"
   "control/signal.c"
   "develop/develop.c"
+  "develop/dev_geometry.c"
   "develop/gui_throttle.c"
   "develop/dev_history.c"
   "develop/dev_history_gui.c"

--- a/src/develop/dev_geometry.c
+++ b/src/develop/dev_geometry.c
@@ -1,0 +1,158 @@
+/*
+    This file is part of Ansel.
+    Copyright (C) 2026 Aurélien Pierre.
+
+    Ansel is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Ansel is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Ansel.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "develop/dev_geometry.h"
+#include "develop/develop.h"
+
+#include <string.h>
+
+/* The seqlock, both halves in one place.
+ *
+ * Writers are serialised by convention, not by a lock: the raw pair is published by the one
+ * function that loads the image, the processed pair by the one function that runs the virtual
+ * pipe, and both run on whichever thread owns that dev. Two concurrent writers would break
+ * this, so if a second publisher ever appears it needs a real lock, not a second odd counter.
+ */
+
+static inline void _publish_begin(dt_dev_geometry_store_t *store)
+{
+  dt_atomic_set_uint64(&store->generation, dt_atomic_get_uint64(&store->generation) + 1);
+}
+
+static inline void _publish_end(dt_dev_geometry_store_t *store)
+{
+  dt_atomic_set_uint64(&store->generation, dt_atomic_get_uint64(&store->generation) + 1);
+}
+
+void dt_dev_geometry_init(dt_develop_t *dev)
+{
+  if(IS_NULL_PTR(dev)) return;
+
+  memset(&dev->geometry.value, 0, sizeof(dev->geometry.value));
+  dt_atomic_set_uint64(&dev->geometry.generation, 0);
+}
+
+void dt_dev_geometry_set_raw_size(dt_develop_t *dev, const int32_t width, const int32_t height,
+                                  const gboolean valid)
+{
+  if(IS_NULL_PTR(dev)) return;
+
+  _publish_begin(&dev->geometry);
+  dev->geometry.value.raw_width = width;
+  dev->geometry.value.raw_height = height;
+  dev->geometry.value.raw_inited = valid;
+  _publish_end(&dev->geometry);
+}
+
+void dt_dev_geometry_set_processed_size(dt_develop_t *dev, const int32_t width, const int32_t height)
+{
+  if(IS_NULL_PTR(dev)) return;
+
+  _publish_begin(&dev->geometry);
+  dev->geometry.value.processed_width = width;
+  dev->geometry.value.processed_height = height;
+  dev->geometry.value.processed_inited = TRUE;
+  _publish_end(&dev->geometry);
+}
+
+gboolean dt_dev_geometry_get(const dt_develop_t *dev, dt_dev_image_geometry_t *out)
+{
+  if(IS_NULL_PTR(out)) return FALSE;
+
+  memset(out, 0, sizeof(*out));
+  if(IS_NULL_PTR(dev)) return FALSE;
+
+  const dt_dev_geometry_store_t *store = &dev->geometry;
+
+  // Retry until we read a settled generation twice with no write in between. A publication is
+  // three stores between two counter bumps, so this converges immediately unless a writer is
+  // running right now; there is no waiting and no lock to order against anything.
+  for(;;)
+  {
+    const uint64_t before = dt_atomic_get_uint64(&store->generation);
+    if(before & 1) continue;   // publication in flight
+
+    *out = store->value;
+
+    const uint64_t after = dt_atomic_get_uint64(&store->generation);
+    if(before == after) break;
+  }
+
+  return out->raw_inited || out->processed_inited;
+}
+
+gboolean dt_dev_geometry_get_raw_size(const dt_develop_t *dev, int32_t *width, int32_t *height)
+{
+  dt_dev_image_geometry_t geometry;
+  dt_dev_geometry_get(dev, &geometry);
+
+  if(!IS_NULL_PTR(width)) *width = geometry.raw_width;
+  if(!IS_NULL_PTR(height)) *height = geometry.raw_height;
+
+  return geometry.raw_inited;
+}
+
+gboolean dt_dev_geometry_get_processed_size(const dt_develop_t *dev, int32_t *width, int32_t *height)
+{
+  dt_dev_image_geometry_t geometry;
+  dt_dev_geometry_get(dev, &geometry);
+
+  if(!IS_NULL_PTR(width)) *width = geometry.processed_width;
+  if(!IS_NULL_PTR(height)) *height = geometry.processed_height;
+
+  return geometry.processed_inited;
+}
+
+int32_t dt_dev_geometry_raw_width(const dt_develop_t *dev)
+{
+  int32_t width = 0;
+  dt_dev_geometry_get_raw_size(dev, &width, NULL);
+  return width;
+}
+
+int32_t dt_dev_geometry_raw_height(const dt_develop_t *dev)
+{
+  int32_t height = 0;
+  dt_dev_geometry_get_raw_size(dev, NULL, &height);
+  return height;
+}
+
+int32_t dt_dev_geometry_processed_width(const dt_develop_t *dev)
+{
+  int32_t width = 0;
+  dt_dev_geometry_get_processed_size(dev, &width, NULL);
+  return width;
+}
+
+int32_t dt_dev_geometry_processed_height(const dt_develop_t *dev)
+{
+  int32_t height = 0;
+  dt_dev_geometry_get_processed_size(dev, NULL, &height);
+  return height;
+}
+
+gboolean dt_dev_geometry_raw_inited(const dt_develop_t *dev)
+{
+  return dt_dev_geometry_get_raw_size(dev, NULL, NULL);
+}
+
+// clang-format off
+// modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py
+// vim: shiftwidth=2 expandtab tabstop=2 cindent
+// kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;
+// clang-format on

--- a/src/develop/dev_geometry.c
+++ b/src/develop/dev_geometry.c
@@ -96,10 +96,16 @@ gboolean dt_dev_geometry_get(const dt_develop_t *dev, dt_dev_image_geometry_t *o
   return out->raw_inited || out->processed_inited;
 }
 
-gboolean dt_dev_geometry_get_raw_size(const dt_develop_t *dev, int32_t *width, int32_t *height)
+dt_dev_image_geometry_t dt_dev_geometry_snapshot(const dt_develop_t *dev)
 {
   dt_dev_image_geometry_t geometry;
   dt_dev_geometry_get(dev, &geometry);
+  return geometry;
+}
+
+gboolean dt_dev_geometry_get_raw_size(const dt_develop_t *dev, int32_t *width, int32_t *height)
+{
+  const dt_dev_image_geometry_t geometry = dt_dev_geometry_snapshot(dev);
 
   if(!IS_NULL_PTR(width)) *width = geometry.raw_width;
   if(!IS_NULL_PTR(height)) *height = geometry.raw_height;
@@ -109,8 +115,7 @@ gboolean dt_dev_geometry_get_raw_size(const dt_develop_t *dev, int32_t *width, i
 
 gboolean dt_dev_geometry_get_processed_size(const dt_develop_t *dev, int32_t *width, int32_t *height)
 {
-  dt_dev_image_geometry_t geometry;
-  dt_dev_geometry_get(dev, &geometry);
+  const dt_dev_image_geometry_t geometry = dt_dev_geometry_snapshot(dev);
 
   if(!IS_NULL_PTR(width)) *width = geometry.processed_width;
   if(!IS_NULL_PTR(height)) *height = geometry.processed_height;
@@ -120,35 +125,27 @@ gboolean dt_dev_geometry_get_processed_size(const dt_develop_t *dev, int32_t *wi
 
 int32_t dt_dev_geometry_raw_width(const dt_develop_t *dev)
 {
-  int32_t width = 0;
-  dt_dev_geometry_get_raw_size(dev, &width, NULL);
-  return width;
+  return dt_dev_geometry_snapshot(dev).raw_width;
 }
 
 int32_t dt_dev_geometry_raw_height(const dt_develop_t *dev)
 {
-  int32_t height = 0;
-  dt_dev_geometry_get_raw_size(dev, NULL, &height);
-  return height;
+  return dt_dev_geometry_snapshot(dev).raw_height;
 }
 
 int32_t dt_dev_geometry_processed_width(const dt_develop_t *dev)
 {
-  int32_t width = 0;
-  dt_dev_geometry_get_processed_size(dev, &width, NULL);
-  return width;
+  return dt_dev_geometry_snapshot(dev).processed_width;
 }
 
 int32_t dt_dev_geometry_processed_height(const dt_develop_t *dev)
 {
-  int32_t height = 0;
-  dt_dev_geometry_get_processed_size(dev, NULL, &height);
-  return height;
+  return dt_dev_geometry_snapshot(dev).processed_height;
 }
 
 gboolean dt_dev_geometry_raw_inited(const dt_develop_t *dev)
 {
-  return dt_dev_geometry_get_raw_size(dev, NULL, NULL);
+  return dt_dev_geometry_snapshot(dev).raw_inited;
 }
 
 // clang-format off

--- a/src/develop/dev_geometry.h
+++ b/src/develop/dev_geometry.h
@@ -87,8 +87,16 @@ void dt_dev_geometry_set_raw_size(struct dt_develop_t *dev, int32_t width, int32
 /** Publish the processed pair. GUI thread only: its producer runs the virtual pipe. */
 void dt_dev_geometry_set_processed_size(struct dt_develop_t *dev, int32_t width, int32_t height);
 
-/** Coherent copy of the whole record. Returns FALSE, and zeroes *out, when nothing has been
- *  published yet. */
+/** Coherent copy of the whole record, by value -- the ordinary way to read it:
+ *
+ *    const dt_dev_image_geometry_t geometry = dt_dev_geometry_snapshot(dev);
+ *
+ *  One seqlock read, then plain member access, so a caller that needs several fields cannot
+ *  accidentally pair them across a publication. Zeroed, with both _inited bits FALSE, when
+ *  nothing has been published yet. */
+dt_dev_image_geometry_t dt_dev_geometry_snapshot(const struct dt_develop_t *dev);
+
+/** Out-param form, for callers that also want the "is anything published" answer. */
 gboolean dt_dev_geometry_get(const struct dt_develop_t *dev, dt_dev_image_geometry_t *out);
 
 /** Coherent copy of the raw pair. Returns raw_inited; the out-params are written either way,

--- a/src/develop/dev_geometry.h
+++ b/src/develop/dev_geometry.h
@@ -1,0 +1,119 @@
+/*
+    This file is part of Ansel.
+    Copyright (C) 2026 Aurélien Pierre.
+
+    Ansel is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Ansel is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Ansel.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef DT_DEVELOP_DEV_GEOMETRY_H
+#define DT_DEVELOP_DEV_GEOMETRY_H
+
+#include <glib.h>
+#include <stdint.h>
+
+#include "system/atomic.h"
+
+struct dt_develop_t;
+
+/**
+ * @brief Objective facts about the image a dev is working on.
+ *
+ * @details This is not GUI state, and the distinction is not academic. Every field here is
+ * needed with no GUI at all: export, thumbnail generation and dev_snapshot's frozen dev all
+ * resolve drawn-mask geometry against the raw dimensions, and the darkroom worker feeds them
+ * to dt_dev_pixelpipe_set_input() on every loop tick.
+ *
+ * Leaving them at zero does not fail loudly. dt_dev_coordinates_raw_norm_to_raw_abs()
+ * early-returns on raw_width == 0 WITHOUT transforming, so a shape's normalized centre
+ * masquerades as absolute pixel coordinates and every mask on the image collapses to within a
+ * few hundred pixels of the origin. That shipped once, because these fields were mistaken for
+ * GUI state and written only `if(dev->gui_attached)`. See CLAUDE.md, and do not gate
+ * dt_dev_geometry_set_raw_size() on anything.
+ */
+typedef struct dt_dev_image_geometry_t
+{
+  /** Dimensions of the full-resolution RAW image being worked on. */
+  int32_t raw_width, raw_height;
+
+  /** Dimensions of the final processed image if it were processed full-resolution: the final
+   *  aspect ratio, with all cropping and distortions taken into account. */
+  int32_t processed_width, processed_height;
+
+  /** TRUE once the raw pair has been published from a successful mipmap read. */
+  gboolean raw_inited;
+
+  /** TRUE once the processed pair has been published from the virtual pipe. There is no
+   *  headless producer for it today, so a caller that gets FALSE must not read 0x0 as though
+   *  it were an answer -- that is the raw_width mistake, one field over. */
+  gboolean processed_inited;
+} dt_dev_image_geometry_t;
+
+/**
+ * @brief Single-writer seqlock around the record.
+ *
+ * @details `generation` is odd while a publication is in flight and even once it has settled.
+ * A reader copies the value, re-reads the generation and retries on a mismatch, so a pipeline
+ * thread can never observe a new width paired with an old height -- which is the failure this
+ * record exists to remove, the pair having been two independent unlocked stores before.
+ *
+ * Deliberately not a mutex: one here would create a lock-ordering obligation against
+ * history_mutex and the pipe's busy_mutex, both of which are already held across reads of
+ * these values.
+ */
+typedef struct dt_dev_geometry_store_t
+{
+  dt_atomic_uint64 generation;
+  dt_dev_image_geometry_t value;
+} dt_dev_geometry_store_t;
+
+/** Seed the store. Call once, from dt_dev_init(), before anything can read it. */
+void dt_dev_geometry_init(struct dt_develop_t *dev);
+
+/** Publish the raw pair, and whether it is usable. MUST NOT be gated on gui_attached. */
+void dt_dev_geometry_set_raw_size(struct dt_develop_t *dev, int32_t width, int32_t height,
+                                  gboolean valid);
+
+/** Publish the processed pair. GUI thread only: its producer runs the virtual pipe. */
+void dt_dev_geometry_set_processed_size(struct dt_develop_t *dev, int32_t width, int32_t height);
+
+/** Coherent copy of the whole record. Returns FALSE, and zeroes *out, when nothing has been
+ *  published yet. */
+gboolean dt_dev_geometry_get(const struct dt_develop_t *dev, dt_dev_image_geometry_t *out);
+
+/** Coherent copy of the raw pair. Returns raw_inited; the out-params are written either way,
+ *  so a caller that ignores the result sees exactly today's values. */
+gboolean dt_dev_geometry_get_raw_size(const struct dt_develop_t *dev, int32_t *width,
+                                      int32_t *height);
+
+/** Coherent copy of the processed pair. Returns processed_inited, same out-param contract. */
+gboolean dt_dev_geometry_get_processed_size(const struct dt_develop_t *dev, int32_t *width,
+                                            int32_t *height);
+
+/* Single-field readers, each a coherent read of the whole record returning one member.
+ * Use the pair getters above wherever the two are consumed as one geometric fact -- these
+ * exist for the many sites that genuinely want one number, and for a mechanical migration
+ * off the old struct members that cannot silently change what a site reads. */
+int32_t dt_dev_geometry_raw_width(const struct dt_develop_t *dev);
+int32_t dt_dev_geometry_raw_height(const struct dt_develop_t *dev);
+int32_t dt_dev_geometry_processed_width(const struct dt_develop_t *dev);
+int32_t dt_dev_geometry_processed_height(const struct dt_develop_t *dev);
+gboolean dt_dev_geometry_raw_inited(const struct dt_develop_t *dev);
+
+#endif // DT_DEVELOP_DEV_GEOMETRY_H
+
+// clang-format off
+// modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py
+// vim: shiftwidth=2 expandtab tabstop=2 cindent
+// kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;
+// clang-format on

--- a/src/develop/dev_pixelpipe.c
+++ b/src/develop/dev_pixelpipe.c
@@ -1766,16 +1766,18 @@ static void _sync_virtual_pipe(dt_develop_t *dev, dt_dev_pixelpipe_change_t flag
 {
   // Virtual pipe exists only for GUI geometry (ROI/mask transforms) and never processes pixels.
   if(IS_NULL_PTR(dev) || !dev->gui_attached || IS_NULL_PTR(dev->virtual_pipe)) return;
-  if(!dt_dev_geometry_raw_inited(dev) || dev->image_storage.id <= 0) return;
+  int32_t raw_width = 0;
+  int32_t raw_height = 0;
+  if(!dt_dev_geometry_get_raw_size(dev, &raw_width, &raw_height) || dev->image_storage.id <= 0) return;
 
   // Ensure its input image metadata matches the current dev state.
   if(dev->virtual_pipe->imgid != dev->image_storage.id
-     || dev->virtual_pipe->iwidth != dt_dev_geometry_raw_width(dev)
-     || dev->virtual_pipe->iheight != dt_dev_geometry_raw_height(dev)
+     || dev->virtual_pipe->iwidth != raw_width
+     || dev->virtual_pipe->iheight != raw_height
      || dev->virtual_pipe->dev->image_storage.id != dev->image_storage.id)
   {
     dt_dev_pixelpipe_set_input(dev->virtual_pipe, dev->image_storage.id,
-                               dt_dev_geometry_raw_width(dev), dt_dev_geometry_raw_height(dev), 1.0f, DT_MIPMAP_FULL);
+                               raw_width, raw_height, 1.0f, DT_MIPMAP_FULL);
   }
 
   // Mirror the preview-pipe change flags and commit immediately.

--- a/src/develop/dev_pixelpipe.c
+++ b/src/develop/dev_pixelpipe.c
@@ -1766,16 +1766,16 @@ static void _sync_virtual_pipe(dt_develop_t *dev, dt_dev_pixelpipe_change_t flag
 {
   // Virtual pipe exists only for GUI geometry (ROI/mask transforms) and never processes pixels.
   if(IS_NULL_PTR(dev) || !dev->gui_attached || IS_NULL_PTR(dev->virtual_pipe)) return;
-  if(!dev->roi.raw_inited || dev->image_storage.id <= 0) return;
+  if(!dt_dev_geometry_raw_inited(dev) || dev->image_storage.id <= 0) return;
 
   // Ensure its input image metadata matches the current dev state.
   if(dev->virtual_pipe->imgid != dev->image_storage.id
-     || dev->virtual_pipe->iwidth != dev->roi.raw_width
-     || dev->virtual_pipe->iheight != dev->roi.raw_height
+     || dev->virtual_pipe->iwidth != dt_dev_geometry_raw_width(dev)
+     || dev->virtual_pipe->iheight != dt_dev_geometry_raw_height(dev)
      || dev->virtual_pipe->dev->image_storage.id != dev->image_storage.id)
   {
     dt_dev_pixelpipe_set_input(dev->virtual_pipe, dev->image_storage.id,
-                               dev->roi.raw_width, dev->roi.raw_height, 1.0f, DT_MIPMAP_FULL);
+                               dt_dev_geometry_raw_width(dev), dt_dev_geometry_raw_height(dev), 1.0f, DT_MIPMAP_FULL);
   }
 
   // Mirror the preview-pipe change flags and commit immediately.

--- a/src/develop/dev_snapshot.c
+++ b/src/develop/dev_snapshot.c
@@ -146,7 +146,7 @@ gboolean dt_dev_snapshot_is_valid(const dt_dev_snapshot_t *snap)
 }
 
 // Mirrors _update_darkroom_roi()'s main-pipe branch (develop/develop.c), substituting `pipe`'s
-// own processed size for dev->roi.processed_width/height -- the snapshot's own image may have
+// own processed size for dt_dev_geometry_processed_width(dev)/height -- the snapshot's own image may have
 // different dimensions than the one currently open in darkroom. Deliberately ignores the caller's
 // clip rect: only dev's pan/zoom (dev->roi) drives what gets processed, so resizing/dragging a
 // compare split line never triggers a reprocess.

--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -900,7 +900,11 @@ static gboolean _dt_dev_mipmap_prefetch_full(dt_develop_t *dev, const int32_t im
   // dev_snapshot.c's frozen dev) resolve to the wrong location, so a module needing mask history
   // (retouch's clone/heal/blur/fill, or any masked blend) either processes empty geometry or
   // silently produces zero visible effect outside the live darkroom.
-  dt_dev_geometry_set_raw_size(dev, buf.width, buf.height, TRUE);
+  // Publish what the read actually produced. `ok' is FALSE when the mipmap cache handed back
+  // no buffer or a 0-sized one; claiming raw_inited in that case told every later reader that
+  // 0x0 was a measured fact about the image, and dt_dev_geometry_refresh()'s own guard
+  // (dt_dev_geometry_raw_inited) then let the virtual pipe run on it.
+  dt_dev_geometry_set_raw_size(dev, ok ? buf.width : 0, ok ? buf.height : 0, ok);
 
   dt_mipmap_cache_release(&buf);
 

--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -347,9 +347,9 @@ int dt_dev_get_thumbnail_size(dt_develop_t *dev)
 
   // Keep the virtual pipe synced so ROI computations on the GUI thread
   // always use up-to-date history and input sizes.
-  int32_t raw_width = 0;
-  int32_t raw_height = 0;
-  dt_dev_geometry_get_raw_size(dev, &raw_width, &raw_height);
+  const dt_dev_image_geometry_t geometry = dt_dev_geometry_snapshot(dev);
+  const int32_t raw_width = geometry.raw_width;
+  const int32_t raw_height = geometry.raw_height;
 
   if(dev->virtual_pipe->imgid != dev->image_storage.id
       || dev->virtual_pipe->iwidth != raw_width
@@ -477,9 +477,9 @@ static gboolean _update_darkroom_roi(dt_develop_t *dev, dt_dev_pixelpipe_t *pipe
 
   // Width, height, x and y are already expressed in raster pixels, so they
   // must follow the same raster-space sampling ratio as roi->scale.
-  int32_t processed_width = 0;
-  int32_t processed_height = 0;
-  dt_dev_geometry_get_processed_size(dev, &processed_width, &processed_height);
+  const dt_dev_image_geometry_t geometry = dt_dev_geometry_snapshot(dev);
+  const int32_t processed_width = geometry.processed_width;
+  const int32_t processed_height = geometry.processed_height;
 
   int roi_width = roundf(*scale * processed_width);
   int roi_height = roundf(*scale * processed_height);
@@ -627,9 +627,9 @@ void dt_dev_darkroom_pipeline(dt_develop_t *dev)
     }
 
     // This is cheap to run, keep it in sync always.
-    int32_t input_width = 0;
-    int32_t input_height = 0;
-    dt_dev_geometry_get_raw_size(dev, &input_width, &input_height);
+    const dt_dev_image_geometry_t geometry = dt_dev_geometry_snapshot(dev);
+    const int32_t input_width = geometry.raw_width;
+    const int32_t input_height = geometry.raw_height;
     for(size_t i = 0; i < G_N_ELEMENTS(pipes); i++)
       dt_dev_pixelpipe_set_input(pipes[i], dev->image_storage.id, input_width, input_height,
                                  1.0f, DT_MIPMAP_FULL);
@@ -956,9 +956,9 @@ static inline dt_dev_image_storage_t _dt_dev_load_raw(dt_develop_t *dev, const i
 // return the zoom scale to fit into the viewport
 float dt_dev_get_zoom_scale(const dt_develop_t *dev, const gboolean preview)
 {
-  int32_t processed_width = 0;
-  int32_t processed_height = 0;
-  dt_dev_geometry_get_processed_size(dev, &processed_width, &processed_height);
+  const dt_dev_image_geometry_t geometry = dt_dev_geometry_snapshot(dev);
+  const int32_t processed_width = geometry.processed_width;
+  const int32_t processed_height = geometry.processed_height;
 
   const float w = preview ? processed_width : dev->pipe->processed_width;
   const float h = preview ? processed_height : dev->pipe->processed_height;
@@ -1060,9 +1060,9 @@ void dt_dev_check_zoom_pos_bounds(dt_develop_t *dev, float *dev_x, float *dev_y,
 void dt_dev_get_processed_size(const dt_develop_t *dev, int *procw, int *proch)
 {
   if(IS_NULL_PTR(dev)) return;
-  int32_t processed_width = 0;
-  int32_t processed_height = 0;
-  dt_dev_geometry_get_processed_size(dev, &processed_width, &processed_height);
+  const dt_dev_image_geometry_t geometry = dt_dev_geometry_snapshot(dev);
+  const int32_t processed_width = geometry.processed_width;
+  const int32_t processed_height = geometry.processed_height;
   *procw = processed_width;
   *proch = processed_height;
  }
@@ -1087,11 +1087,9 @@ void dt_dev_coordinates_widget_delta_to_image_delta(dt_develop_t *dev, float *po
 void dt_dev_coordinates_widget_to_image_norm(dt_develop_t *dev, float *points, size_t num_points)
 {
   if(IS_NULL_PTR(dev) || IS_NULL_PTR(points) || num_points == 0) return;
-  int32_t processed_size_w = 0;
-  int32_t processed_size_h = 0;
-  dt_dev_geometry_get_processed_size(dev, &processed_size_w, &processed_size_h);
-  const float processed_width = processed_size_w;
-  const float processed_height = processed_size_h;
+  const dt_dev_image_geometry_t geometry = dt_dev_geometry_snapshot(dev);
+  const float processed_width = geometry.processed_width;
+  const float processed_height = geometry.processed_height;
   if(processed_width == 0.0f || processed_height == 0.0f) return;
 
   // Widget events are expressed in GUI logical coordinates, while the pipeline
@@ -1118,11 +1116,9 @@ void dt_dev_coordinates_widget_to_image_norm(dt_develop_t *dev, float *points, s
 void dt_dev_coordinates_image_norm_to_widget(dt_develop_t *dev, float *points, size_t num_points)
 {
   if(IS_NULL_PTR(dev) || IS_NULL_PTR(points) || num_points == 0) return;
-  int32_t processed_size_w = 0;
-  int32_t processed_size_h = 0;
-  dt_dev_geometry_get_processed_size(dev, &processed_size_w, &processed_size_h);
-  const float processed_width = processed_size_w;
-  const float processed_height = processed_size_h;
+  const dt_dev_image_geometry_t geometry = dt_dev_geometry_snapshot(dev);
+  const float processed_width = geometry.processed_width;
+  const float processed_height = geometry.processed_height;
   if(processed_width == 0.0f || processed_height == 0.0f) return;
 
   // GUI overlays are drawn in logical widget coordinates, so use the same
@@ -1150,11 +1146,9 @@ void dt_dev_coordinates_image_norm_to_widget(dt_develop_t *dev, float *points, s
 void dt_dev_coordinates_image_norm_to_image_abs(dt_develop_t *dev, float *points, size_t num_points)
 {
   if(IS_NULL_PTR(dev) || IS_NULL_PTR(points) || num_points == 0) return;
-  int32_t processed_size_w = 0;
-  int32_t processed_size_h = 0;
-  dt_dev_geometry_get_processed_size(dev, &processed_size_w, &processed_size_h);
-  const float processed_width = processed_size_w;
-  const float processed_height = processed_size_h;
+  const dt_dev_image_geometry_t geometry = dt_dev_geometry_snapshot(dev);
+  const float processed_width = geometry.processed_width;
+  const float processed_height = geometry.processed_height;
   if(processed_width == 0.0f || processed_height == 0.0f) return;
 
   for(size_t i = 0; i < num_points; ++i)
@@ -1168,11 +1162,9 @@ void dt_dev_coordinates_image_norm_to_image_abs(dt_develop_t *dev, float *points
 void dt_dev_coordinates_image_abs_to_image_norm(dt_develop_t *dev, float *points, size_t num_points)
 {
   if(IS_NULL_PTR(dev) || IS_NULL_PTR(points) || num_points == 0) return;
-  int32_t processed_size_w = 0;
-  int32_t processed_size_h = 0;
-  dt_dev_geometry_get_processed_size(dev, &processed_size_w, &processed_size_h);
-  const float processed_width = processed_size_w;
-  const float processed_height = processed_size_h;
+  const dt_dev_image_geometry_t geometry = dt_dev_geometry_snapshot(dev);
+  const float processed_width = geometry.processed_width;
+  const float processed_height = geometry.processed_height;
   if(processed_width == 0.0f || processed_height == 0.0f) return;
 
   const float inv_width = 1.0f / processed_width;
@@ -1188,11 +1180,9 @@ void dt_dev_coordinates_image_abs_to_image_norm(dt_develop_t *dev, float *points
 void dt_dev_coordinates_raw_abs_to_raw_norm(dt_develop_t *dev, float *points, size_t num_points)
 {
   if(IS_NULL_PTR(dev) || IS_NULL_PTR(points) || num_points == 0) return;
-  int32_t raw_size_w = 0;
-  int32_t raw_size_h = 0;
-  dt_dev_geometry_get_raw_size(dev, &raw_size_w, &raw_size_h);
-  const float raw_width = raw_size_w;
-  const float raw_height = raw_size_h;
+  const dt_dev_image_geometry_t geometry = dt_dev_geometry_snapshot(dev);
+  const float raw_width = geometry.raw_width;
+  const float raw_height = geometry.raw_height;
   if(raw_width == 0.0f || raw_height == 0.0f) return;
   
   const float inv_width = 1.f / raw_width;
@@ -1208,11 +1198,9 @@ void dt_dev_coordinates_raw_abs_to_raw_norm(dt_develop_t *dev, float *points, si
 void dt_dev_coordinates_raw_norm_to_raw_abs(dt_develop_t *dev, float *points, size_t num_points)
 {
   if(IS_NULL_PTR(dev) || IS_NULL_PTR(points) || num_points == 0) return;
-  int32_t raw_size_w = 0;
-  int32_t raw_size_h = 0;
-  dt_dev_geometry_get_raw_size(dev, &raw_size_w, &raw_size_h);
-  const float raw_width = raw_size_w;
-  const float raw_height = raw_size_h;
+  const dt_dev_image_geometry_t geometry = dt_dev_geometry_snapshot(dev);
+  const float raw_width = geometry.raw_width;
+  const float raw_height = geometry.raw_height;
   if(raw_width == 0.0f || raw_height == 0.0f) return;
   
   for(size_t i = 0; i < num_points; i++)

--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -127,6 +127,7 @@ GList *dt_dev_load_modules(dt_develop_t *dev)
 void dt_dev_init(dt_develop_t *dev, int32_t gui_attached)
 {
   memset(dev, 0, sizeof(dt_develop_t));
+  dt_dev_geometry_init(dev);
   dt_dev_set_history_hash(dev, DT_PIXELPIPE_CACHE_HASH_INVALID);
   dt_pthread_rwlock_init(&dev->history_mutex, NULL);
   dt_pthread_rwlock_set_name(&dev->history_mutex, "history_mutex"); // find_history_mutex_blocker, temporary
@@ -329,26 +330,26 @@ static gboolean _darkroom_pipeline_inputs_ready(const dt_develop_t *dev)
   return dev->image_storage.id > 0
          && dev->roi.width >= 32
          && dev->roi.height >= 32
-         && dev->roi.raw_width >= 32
-         && dev->roi.raw_height >= 32
-         && dev->roi.processed_width >= 32
-         && dev->roi.processed_height >= 32
+         && dt_dev_geometry_raw_width(dev) >= 32
+         && dt_dev_geometry_raw_height(dev) >= 32
+         && dt_dev_geometry_processed_width(dev) >= 32
+         && dt_dev_geometry_processed_height(dev) >= 32
          && dev->roi.preview_width >= 32
          && dev->roi.preview_height >= 32;
 }
 
 int dt_dev_get_thumbnail_size(dt_develop_t *dev)
 {
-  if(!dev->roi.raw_inited || !dev->roi.gui_inited) return 1;
+  if(!dt_dev_geometry_raw_inited(dev) || !dev->roi.gui_inited) return 1;
 
   // Keep the virtual pipe synced so ROI computations on the GUI thread
   // always use up-to-date history and input sizes.
   if(dev->virtual_pipe->imgid != dev->image_storage.id
-      || dev->virtual_pipe->iwidth != dev->roi.raw_width
-      || dev->virtual_pipe->iheight != dev->roi.raw_height
+      || dev->virtual_pipe->iwidth != dt_dev_geometry_raw_width(dev)
+      || dev->virtual_pipe->iheight != dt_dev_geometry_raw_height(dev)
       || dev->virtual_pipe->dev->image_storage.id != dev->image_storage.id)
     dt_dev_pixelpipe_set_input(dev->virtual_pipe, dev->image_storage.id,
-                                dev->roi.raw_width, dev->roi.raw_height, 1.0f, DT_MIPMAP_FULL);
+                                dt_dev_geometry_raw_width(dev), dt_dev_geometry_raw_height(dev), 1.0f, DT_MIPMAP_FULL);
 
   if(!dev->virtual_pipe->nodes)
     dt_dev_pixelpipe_or_changed(dev->virtual_pipe, DT_DEV_PIPE_REMOVE);
@@ -364,8 +365,15 @@ int dt_dev_get_thumbnail_size(dt_develop_t *dev)
     dt_dev_pixelpipe_change(dev->virtual_pipe);
 
   // Compute the virtual full-res output. This needs an inited history
-  dt_dev_pixelpipe_get_roi_out(dev->virtual_pipe, dev->roi.raw_width, dev->roi.raw_height, 
-                               &dev->roi.processed_width, &dev->roi.processed_height);
+  int32_t raw_width = 0;
+  int32_t raw_height = 0;
+  dt_dev_geometry_get_raw_size(dev, &raw_width, &raw_height);
+
+  int processed_width = 0;
+  int processed_height = 0;
+  dt_dev_pixelpipe_get_roi_out(dev->virtual_pipe, raw_width, raw_height,
+                               &processed_width, &processed_height);
+  dt_dev_geometry_set_processed_size(dev, processed_width, processed_height);
 
   // Compute the scaling factor that makes full-res output fit within widget
   dev->roi.natural_scale = dt_dev_get_natural_scale(dev);
@@ -381,15 +389,15 @@ int dt_dev_get_thumbnail_size(dt_develop_t *dev)
   // (hence ashift structure detection / drawing) on some images but not others,
   // and resetting the module to neutral did not help because the mismatch does
   // not depend on the module parameters at all.
-  dev->roi.preview_width = roundf(dev->roi.natural_scale * dev->roi.processed_width);
-  dev->roi.preview_height = roundf(dev->roi.natural_scale * dev->roi.processed_height);
+  dev->roi.preview_width = roundf(dev->roi.natural_scale * dt_dev_geometry_processed_width(dev));
+  dev->roi.preview_height = roundf(dev->roi.natural_scale * dt_dev_geometry_processed_height(dev));
   dev->roi.output_inited = TRUE;
 
   dt_dev_update_mouse_effect_radius(dev); 
 
   dt_print(DT_DEBUG_DEV,
             "[pixelpipe] thumbnail sizes raw %dx%d -> processed %dx%d -> preview %dx%d (scale %.5f)\n",
-            dev->roi.raw_width, dev->roi.raw_height, dev->roi.processed_width, dev->roi.processed_height,
+            dt_dev_geometry_raw_width(dev), dt_dev_geometry_raw_height(dev), dt_dev_geometry_processed_width(dev), dt_dev_geometry_processed_height(dev),
             dev->roi.preview_width, dev->roi.preview_height, dev->roi.natural_scale);
   
   return 0;
@@ -464,8 +472,8 @@ static gboolean _update_darkroom_roi(dt_develop_t *dev, dt_dev_pixelpipe_t *pipe
 
   // Width, height, x and y are already expressed in raster pixels, so they
   // must follow the same raster-space sampling ratio as roi->scale.
-  int roi_width = roundf(*scale * dev->roi.processed_width);
-  int roi_height = roundf(*scale * dev->roi.processed_height);
+  int roi_width = roundf(*scale * dt_dev_geometry_processed_width(dev));
+  int roi_height = roundf(*scale * dt_dev_geometry_processed_height(dev));
   int widget_wd = dev->roi.width;
   int widget_ht = dev->roi.height;
 
@@ -611,7 +619,7 @@ void dt_dev_darkroom_pipeline(dt_develop_t *dev)
 
     // This is cheap to run, keep it in sync always.
     for(size_t i = 0; i < G_N_ELEMENTS(pipes); i++)
-      dt_dev_pixelpipe_set_input(pipes[i], dev->image_storage.id, dev->roi.raw_width, dev->roi.raw_height,
+      dt_dev_pixelpipe_set_input(pipes[i], dev->image_storage.id, dt_dev_geometry_raw_width(dev), dt_dev_geometry_raw_height(dev),
                                  1.0f, DT_MIPMAP_FULL);
 
     gboolean pipe_needs_update[G_N_ELEMENTS(pipes)] = { FALSE };
@@ -867,11 +875,11 @@ static gboolean _dt_dev_mipmap_prefetch_full(dt_develop_t *dev, const int32_t im
 
   const gboolean ok = (!IS_NULL_PTR(buf.buf)) && buf.width != 0 && buf.height != 0;
 
-  // dev->roi.raw_width/height are the raw image's own pixel dimensions -- an objective fact
+  // dt_dev_geometry_raw_width(dev)/height are the raw image's own pixel dimensions -- an objective fact
   // about the loaded buffer, not GUI viewport state -- and must be set for every dev, not just
   // gui_attached ones. dt_dev_coordinates_raw_norm_to_raw_abs() (develop.c) and every drawn-mask
   // shape's own geometry function (masks/circle.c, ellipse.c, brush.c, gradient.c, polygon.c) read
-  // dev->roi.raw_width/height to convert a form's normalized center/points into absolute pixel
+  // dt_dev_geometry_raw_width(dev)/height to convert a form's normalized center/points into absolute pixel
   // coordinates; with raw_width/height left at 0 (their calloc default), that conversion silently
   // no-ops (dt_dev_coordinates_raw_norm_to_raw_abs() early-returns on raw_width==0), leaving the
   // shape's normalized (0..1) coordinates masquerading as pixel coordinates -- collapsing every
@@ -880,9 +888,7 @@ static gboolean _dt_dev_mipmap_prefetch_full(dt_develop_t *dev, const int32_t im
   // dev_snapshot.c's frozen dev) resolve to the wrong location, so a module needing mask history
   // (retouch's clone/heal/blur/fill, or any masked blend) either processes empty geometry or
   // silently produces zero visible effect outside the live darkroom.
-  dev->roi.raw_height = buf.height;
-  dev->roi.raw_width = buf.width;
-  dev->roi.raw_inited = TRUE;
+  dt_dev_geometry_set_raw_size(dev, buf.width, buf.height, TRUE);
 
   dt_mipmap_cache_release(&buf);
 
@@ -934,8 +940,8 @@ static inline dt_dev_image_storage_t _dt_dev_load_raw(dt_develop_t *dev, const i
 // return the zoom scale to fit into the viewport
 float dt_dev_get_zoom_scale(const dt_develop_t *dev, const gboolean preview)
 {
-  const float w = preview ? dev->roi.processed_width : dev->pipe->processed_width;
-  const float h = preview ? dev->roi.processed_height : dev->pipe->processed_height;
+  const float w = preview ? dt_dev_geometry_processed_width(dev) : dev->pipe->processed_width;
+  const float h = preview ? dt_dev_geometry_processed_height(dev) : dev->pipe->processed_height;
   return fminf(dev->roi.width / w, dev->roi.height / h);
 }
 
@@ -1034,8 +1040,8 @@ void dt_dev_check_zoom_pos_bounds(dt_develop_t *dev, float *dev_x, float *dev_y,
 void dt_dev_get_processed_size(const dt_develop_t *dev, int *procw, int *proch)
 {
   if(IS_NULL_PTR(dev)) return;
-  *procw = dev->roi.processed_width;
-  *proch = dev->roi.processed_height;
+  *procw = dt_dev_geometry_processed_width(dev);
+  *proch = dt_dev_geometry_processed_height(dev);
  }
 
 void dt_dev_coordinates_widget_delta_to_image_delta(dt_develop_t *dev, float *points, size_t num_points)
@@ -1058,8 +1064,8 @@ void dt_dev_coordinates_widget_delta_to_image_delta(dt_develop_t *dev, float *po
 void dt_dev_coordinates_widget_to_image_norm(dt_develop_t *dev, float *points, size_t num_points)
 {
   if(IS_NULL_PTR(dev) || IS_NULL_PTR(points) || num_points == 0) return;
-  const float processed_width = dev->roi.processed_width;
-  const float processed_height = dev->roi.processed_height;
+  const float processed_width = dt_dev_geometry_processed_width(dev);
+  const float processed_height = dt_dev_geometry_processed_height(dev);
   if(processed_width == 0.0f || processed_height == 0.0f) return;
 
   // Widget events are expressed in GUI logical coordinates, while the pipeline
@@ -1086,8 +1092,8 @@ void dt_dev_coordinates_widget_to_image_norm(dt_develop_t *dev, float *points, s
 void dt_dev_coordinates_image_norm_to_widget(dt_develop_t *dev, float *points, size_t num_points)
 {
   if(IS_NULL_PTR(dev) || IS_NULL_PTR(points) || num_points == 0) return;
-  const float processed_width = dev->roi.processed_width;
-  const float processed_height = dev->roi.processed_height;
+  const float processed_width = dt_dev_geometry_processed_width(dev);
+  const float processed_height = dt_dev_geometry_processed_height(dev);
   if(processed_width == 0.0f || processed_height == 0.0f) return;
 
   // GUI overlays are drawn in logical widget coordinates, so use the same
@@ -1115,8 +1121,8 @@ void dt_dev_coordinates_image_norm_to_widget(dt_develop_t *dev, float *points, s
 void dt_dev_coordinates_image_norm_to_image_abs(dt_develop_t *dev, float *points, size_t num_points)
 {
   if(IS_NULL_PTR(dev) || IS_NULL_PTR(points) || num_points == 0) return;
-  const float processed_width = dev->roi.processed_width;
-  const float processed_height = dev->roi.processed_height;
+  const float processed_width = dt_dev_geometry_processed_width(dev);
+  const float processed_height = dt_dev_geometry_processed_height(dev);
   if(processed_width == 0.0f || processed_height == 0.0f) return;
 
   for(size_t i = 0; i < num_points; ++i)
@@ -1130,8 +1136,8 @@ void dt_dev_coordinates_image_norm_to_image_abs(dt_develop_t *dev, float *points
 void dt_dev_coordinates_image_abs_to_image_norm(dt_develop_t *dev, float *points, size_t num_points)
 {
   if(IS_NULL_PTR(dev) || IS_NULL_PTR(points) || num_points == 0) return;
-  const float processed_width = dev->roi.processed_width;
-  const float processed_height = dev->roi.processed_height;
+  const float processed_width = dt_dev_geometry_processed_width(dev);
+  const float processed_height = dt_dev_geometry_processed_height(dev);
   if(processed_width == 0.0f || processed_height == 0.0f) return;
 
   const float inv_width = 1.0f / processed_width;
@@ -1147,8 +1153,8 @@ void dt_dev_coordinates_image_abs_to_image_norm(dt_develop_t *dev, float *points
 void dt_dev_coordinates_raw_abs_to_raw_norm(dt_develop_t *dev, float *points, size_t num_points)
 {
   if(IS_NULL_PTR(dev) || IS_NULL_PTR(points) || num_points == 0) return;
-  const float raw_width = dev->roi.raw_width;
-  const float raw_height = dev->roi.raw_height;
+  const float raw_width = dt_dev_geometry_raw_width(dev);
+  const float raw_height = dt_dev_geometry_raw_height(dev);
   if(raw_width == 0.0f || raw_height == 0.0f) return;
   
   const float inv_width = 1.f / raw_width;
@@ -1164,8 +1170,8 @@ void dt_dev_coordinates_raw_abs_to_raw_norm(dt_develop_t *dev, float *points, si
 void dt_dev_coordinates_raw_norm_to_raw_abs(dt_develop_t *dev, float *points, size_t num_points)
 {
   if(IS_NULL_PTR(dev) || IS_NULL_PTR(points) || num_points == 0) return;
-  const float raw_width = dev->roi.raw_width;
-  const float raw_height = dev->roi.raw_height;
+  const float raw_width = dt_dev_geometry_raw_width(dev);
+  const float raw_height = dt_dev_geometry_raw_height(dev);
   if(raw_width == 0.0f || raw_height == 0.0f) return;
   
   for(size_t i = 0; i < num_points; i++)
@@ -1771,10 +1777,10 @@ void dt_dev_masks_update_hash(dt_develop_t *dev)
 
 float dt_dev_get_natural_scale(dt_develop_t *dev)
 {
-  if(!dev->roi.gui_inited || !dev->roi.raw_inited) return -1.f;
+  if(!dev->roi.gui_inited || !dt_dev_geometry_raw_inited(dev)) return -1.f;
 
-  return fminf(fminf((float)dev->roi.width / (float)dev->roi.processed_width,
-                      (float)dev->roi.height / (float)dev->roi.processed_height),
+  return fminf(fminf((float)dev->roi.width / (float)dt_dev_geometry_processed_width(dev),
+                      (float)dev->roi.height / (float)dt_dev_geometry_processed_height(dev)),
                 1.f);
 }
 

--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -327,13 +327,16 @@ static gboolean _darkroom_pipeline_inputs_ready(const dt_develop_t *dev)
 {
   if(IS_NULL_PTR(dev)) return FALSE;
 
+  dt_dev_image_geometry_t geometry;
+  dt_dev_geometry_get(dev, &geometry);
+
   return dev->image_storage.id > 0
          && dev->roi.width >= 32
          && dev->roi.height >= 32
-         && dt_dev_geometry_raw_width(dev) >= 32
-         && dt_dev_geometry_raw_height(dev) >= 32
-         && dt_dev_geometry_processed_width(dev) >= 32
-         && dt_dev_geometry_processed_height(dev) >= 32
+         && geometry.raw_width >= 32
+         && geometry.raw_height >= 32
+         && geometry.processed_width >= 32
+         && geometry.processed_height >= 32
          && dev->roi.preview_width >= 32
          && dev->roi.preview_height >= 32;
 }
@@ -344,12 +347,16 @@ int dt_dev_get_thumbnail_size(dt_develop_t *dev)
 
   // Keep the virtual pipe synced so ROI computations on the GUI thread
   // always use up-to-date history and input sizes.
+  int32_t raw_width = 0;
+  int32_t raw_height = 0;
+  dt_dev_geometry_get_raw_size(dev, &raw_width, &raw_height);
+
   if(dev->virtual_pipe->imgid != dev->image_storage.id
-      || dev->virtual_pipe->iwidth != dt_dev_geometry_raw_width(dev)
-      || dev->virtual_pipe->iheight != dt_dev_geometry_raw_height(dev)
+      || dev->virtual_pipe->iwidth != raw_width
+      || dev->virtual_pipe->iheight != raw_height
       || dev->virtual_pipe->dev->image_storage.id != dev->image_storage.id)
     dt_dev_pixelpipe_set_input(dev->virtual_pipe, dev->image_storage.id,
-                                dt_dev_geometry_raw_width(dev), dt_dev_geometry_raw_height(dev), 1.0f, DT_MIPMAP_FULL);
+                                raw_width, raw_height, 1.0f, DT_MIPMAP_FULL);
 
   if(!dev->virtual_pipe->nodes)
     dt_dev_pixelpipe_or_changed(dev->virtual_pipe, DT_DEV_PIPE_REMOVE);
@@ -364,11 +371,9 @@ int dt_dev_get_thumbnail_size(dt_develop_t *dev)
   if(dt_dev_pixelpipe_get_changed(dev->virtual_pipe) != DT_DEV_PIPE_UNCHANGED)
     dt_dev_pixelpipe_change(dev->virtual_pipe);
 
-  // Compute the virtual full-res output. This needs an inited history
-  int32_t raw_width = 0;
-  int32_t raw_height = 0;
-  dt_dev_geometry_get_raw_size(dev, &raw_width, &raw_height);
-
+  // Compute the virtual full-res output. This needs an inited history.
+  // raw_width/raw_height come from the single coherent read at the top of this function:
+  // nothing between here and there republishes the raw geometry.
   int processed_width = 0;
   int processed_height = 0;
   dt_dev_pixelpipe_get_roi_out(dev->virtual_pipe, raw_width, raw_height,
@@ -472,8 +477,12 @@ static gboolean _update_darkroom_roi(dt_develop_t *dev, dt_dev_pixelpipe_t *pipe
 
   // Width, height, x and y are already expressed in raster pixels, so they
   // must follow the same raster-space sampling ratio as roi->scale.
-  int roi_width = roundf(*scale * dt_dev_geometry_processed_width(dev));
-  int roi_height = roundf(*scale * dt_dev_geometry_processed_height(dev));
+  int32_t processed_width = 0;
+  int32_t processed_height = 0;
+  dt_dev_geometry_get_processed_size(dev, &processed_width, &processed_height);
+
+  int roi_width = roundf(*scale * processed_width);
+  int roi_height = roundf(*scale * processed_height);
   int widget_wd = dev->roi.width;
   int widget_ht = dev->roi.height;
 
@@ -618,8 +627,11 @@ void dt_dev_darkroom_pipeline(dt_develop_t *dev)
     }
 
     // This is cheap to run, keep it in sync always.
+    int32_t input_width = 0;
+    int32_t input_height = 0;
+    dt_dev_geometry_get_raw_size(dev, &input_width, &input_height);
     for(size_t i = 0; i < G_N_ELEMENTS(pipes); i++)
-      dt_dev_pixelpipe_set_input(pipes[i], dev->image_storage.id, dt_dev_geometry_raw_width(dev), dt_dev_geometry_raw_height(dev),
+      dt_dev_pixelpipe_set_input(pipes[i], dev->image_storage.id, input_width, input_height,
                                  1.0f, DT_MIPMAP_FULL);
 
     gboolean pipe_needs_update[G_N_ELEMENTS(pipes)] = { FALSE };
@@ -940,8 +952,12 @@ static inline dt_dev_image_storage_t _dt_dev_load_raw(dt_develop_t *dev, const i
 // return the zoom scale to fit into the viewport
 float dt_dev_get_zoom_scale(const dt_develop_t *dev, const gboolean preview)
 {
-  const float w = preview ? dt_dev_geometry_processed_width(dev) : dev->pipe->processed_width;
-  const float h = preview ? dt_dev_geometry_processed_height(dev) : dev->pipe->processed_height;
+  int32_t processed_width = 0;
+  int32_t processed_height = 0;
+  dt_dev_geometry_get_processed_size(dev, &processed_width, &processed_height);
+
+  const float w = preview ? processed_width : dev->pipe->processed_width;
+  const float h = preview ? processed_height : dev->pipe->processed_height;
   return fminf(dev->roi.width / w, dev->roi.height / h);
 }
 
@@ -1040,8 +1056,11 @@ void dt_dev_check_zoom_pos_bounds(dt_develop_t *dev, float *dev_x, float *dev_y,
 void dt_dev_get_processed_size(const dt_develop_t *dev, int *procw, int *proch)
 {
   if(IS_NULL_PTR(dev)) return;
-  *procw = dt_dev_geometry_processed_width(dev);
-  *proch = dt_dev_geometry_processed_height(dev);
+  int32_t processed_width = 0;
+  int32_t processed_height = 0;
+  dt_dev_geometry_get_processed_size(dev, &processed_width, &processed_height);
+  *procw = processed_width;
+  *proch = processed_height;
  }
 
 void dt_dev_coordinates_widget_delta_to_image_delta(dt_develop_t *dev, float *points, size_t num_points)
@@ -1064,8 +1083,11 @@ void dt_dev_coordinates_widget_delta_to_image_delta(dt_develop_t *dev, float *po
 void dt_dev_coordinates_widget_to_image_norm(dt_develop_t *dev, float *points, size_t num_points)
 {
   if(IS_NULL_PTR(dev) || IS_NULL_PTR(points) || num_points == 0) return;
-  const float processed_width = dt_dev_geometry_processed_width(dev);
-  const float processed_height = dt_dev_geometry_processed_height(dev);
+  int32_t processed_size_w = 0;
+  int32_t processed_size_h = 0;
+  dt_dev_geometry_get_processed_size(dev, &processed_size_w, &processed_size_h);
+  const float processed_width = processed_size_w;
+  const float processed_height = processed_size_h;
   if(processed_width == 0.0f || processed_height == 0.0f) return;
 
   // Widget events are expressed in GUI logical coordinates, while the pipeline
@@ -1092,8 +1114,11 @@ void dt_dev_coordinates_widget_to_image_norm(dt_develop_t *dev, float *points, s
 void dt_dev_coordinates_image_norm_to_widget(dt_develop_t *dev, float *points, size_t num_points)
 {
   if(IS_NULL_PTR(dev) || IS_NULL_PTR(points) || num_points == 0) return;
-  const float processed_width = dt_dev_geometry_processed_width(dev);
-  const float processed_height = dt_dev_geometry_processed_height(dev);
+  int32_t processed_size_w = 0;
+  int32_t processed_size_h = 0;
+  dt_dev_geometry_get_processed_size(dev, &processed_size_w, &processed_size_h);
+  const float processed_width = processed_size_w;
+  const float processed_height = processed_size_h;
   if(processed_width == 0.0f || processed_height == 0.0f) return;
 
   // GUI overlays are drawn in logical widget coordinates, so use the same
@@ -1121,8 +1146,11 @@ void dt_dev_coordinates_image_norm_to_widget(dt_develop_t *dev, float *points, s
 void dt_dev_coordinates_image_norm_to_image_abs(dt_develop_t *dev, float *points, size_t num_points)
 {
   if(IS_NULL_PTR(dev) || IS_NULL_PTR(points) || num_points == 0) return;
-  const float processed_width = dt_dev_geometry_processed_width(dev);
-  const float processed_height = dt_dev_geometry_processed_height(dev);
+  int32_t processed_size_w = 0;
+  int32_t processed_size_h = 0;
+  dt_dev_geometry_get_processed_size(dev, &processed_size_w, &processed_size_h);
+  const float processed_width = processed_size_w;
+  const float processed_height = processed_size_h;
   if(processed_width == 0.0f || processed_height == 0.0f) return;
 
   for(size_t i = 0; i < num_points; ++i)
@@ -1136,8 +1164,11 @@ void dt_dev_coordinates_image_norm_to_image_abs(dt_develop_t *dev, float *points
 void dt_dev_coordinates_image_abs_to_image_norm(dt_develop_t *dev, float *points, size_t num_points)
 {
   if(IS_NULL_PTR(dev) || IS_NULL_PTR(points) || num_points == 0) return;
-  const float processed_width = dt_dev_geometry_processed_width(dev);
-  const float processed_height = dt_dev_geometry_processed_height(dev);
+  int32_t processed_size_w = 0;
+  int32_t processed_size_h = 0;
+  dt_dev_geometry_get_processed_size(dev, &processed_size_w, &processed_size_h);
+  const float processed_width = processed_size_w;
+  const float processed_height = processed_size_h;
   if(processed_width == 0.0f || processed_height == 0.0f) return;
 
   const float inv_width = 1.0f / processed_width;
@@ -1153,8 +1184,11 @@ void dt_dev_coordinates_image_abs_to_image_norm(dt_develop_t *dev, float *points
 void dt_dev_coordinates_raw_abs_to_raw_norm(dt_develop_t *dev, float *points, size_t num_points)
 {
   if(IS_NULL_PTR(dev) || IS_NULL_PTR(points) || num_points == 0) return;
-  const float raw_width = dt_dev_geometry_raw_width(dev);
-  const float raw_height = dt_dev_geometry_raw_height(dev);
+  int32_t raw_size_w = 0;
+  int32_t raw_size_h = 0;
+  dt_dev_geometry_get_raw_size(dev, &raw_size_w, &raw_size_h);
+  const float raw_width = raw_size_w;
+  const float raw_height = raw_size_h;
   if(raw_width == 0.0f || raw_height == 0.0f) return;
   
   const float inv_width = 1.f / raw_width;
@@ -1170,8 +1204,11 @@ void dt_dev_coordinates_raw_abs_to_raw_norm(dt_develop_t *dev, float *points, si
 void dt_dev_coordinates_raw_norm_to_raw_abs(dt_develop_t *dev, float *points, size_t num_points)
 {
   if(IS_NULL_PTR(dev) || IS_NULL_PTR(points) || num_points == 0) return;
-  const float raw_width = dt_dev_geometry_raw_width(dev);
-  const float raw_height = dt_dev_geometry_raw_height(dev);
+  int32_t raw_size_w = 0;
+  int32_t raw_size_h = 0;
+  dt_dev_geometry_get_raw_size(dev, &raw_size_w, &raw_size_h);
+  const float raw_width = raw_size_w;
+  const float raw_height = raw_size_h;
   if(raw_width == 0.0f || raw_height == 0.0f) return;
   
   for(size_t i = 0; i < num_points; i++)

--- a/src/develop/develop.h
+++ b/src/develop/develop.h
@@ -214,13 +214,6 @@ typedef struct dt_develop_t
     // the width x height bounding box.
     int32_t preview_width, preview_height;
 
-    // Dimension of the main image backbuffer
-    // They are at lower than or equal to (width, height),
-    // the bounding box defined by the widget where main image fits.
-    // Since the ROI may clip the zoomed-in image, they don't respect
-    // the final image aspect ratio
-    int32_t main_width, main_height;
-
     // natural scaling = MIN(dev->width / dev->roi.processed_width, dev->height / dev->roi.processed_height)
     // aka ensure that image fits into widget minus margins/borders.
     float natural_scale;

--- a/src/develop/develop.h
+++ b/src/develop/develop.h
@@ -59,6 +59,7 @@
 #include "common/image.h"
 #include "develop/imageop.h"
 #include "develop/pixelpipe_hb.h"
+#include "develop/dev_geometry.h"
 #include "develop/dev_history.h"
 #include "develop/dev_pixelpipe.h"
 
@@ -177,6 +178,16 @@ typedef struct dt_develop_t
    */
   dt_atomic_int mask_preview_settings_revision;
 
+  /**
+   * @brief Objective geometry of the image being worked on: the raw dimensions and the
+   * full-resolution processed dimensions.
+   *
+   * @details Not GUI state -- every dev has it, headless ones included, and reading it
+   * through dt_dev_geometry_get*() is what makes the pair coherent for the pipeline
+   * threads that consume it. See develop/dev_geometry.h.
+   */
+  dt_dev_geometry_store_t geometry;
+
   // The roi structure is used in darkroom GUI only.
   // It defines the output size of the image backbuffer fitting
   // into the darkroom center widget. This is critically used for all
@@ -214,24 +225,12 @@ typedef struct dt_develop_t
     // the width x height bounding box.
     int32_t preview_width, preview_height;
 
-    // natural scaling = MIN(dev->width / dev->roi.processed_width, dev->height / dev->roi.processed_height)
+    // natural scaling = MIN(dev->width / dt_dev_geometry_processed_width(dev), dev->height / dt_dev_geometry_processed_height(dev))
     // aka ensure that image fits into widget minus margins/borders.
     float natural_scale;
 
-    // Dimensions of the full-resolution RAW image
-    // being worked on.
-    int32_t raw_width, raw_height;
-
-    // Dimensions of the final processed image if we processed it full-resolution.
-    // This is used to get the final aspect ratio of an image,
-    // taking all cropping and distortions into account.
-    int32_t processed_width, processed_height;
-
     // Conveniency state to check if all widget sizes are inited
     gboolean gui_inited;
-
-    // Conveniency state to check if input (raw image) sizes are inited
-    gboolean raw_inited;
 
     // Conveniency state to check if all output (backbuffer) sizes are inited
     gboolean output_inited;

--- a/src/develop/masks/brush.c
+++ b/src/develop/masks/brush.c
@@ -1983,8 +1983,11 @@ static int _brush_events_mouse_moved(struct dt_iop_module_t *module, double widg
                                      dt_masks_form_gui_t *mask_gui, int index)
 {
   dt_develop_t *dev = mask_gui->dev;
-  const int iwidth = dt_dev_geometry_raw_width(dev);
-  const int iheight = dt_dev_geometry_raw_height(dev);
+  int32_t raw_size_w = 0;
+  int32_t raw_size_h = 0;
+  dt_dev_geometry_get_raw_size(dev, &raw_size_w, &raw_size_h);
+  const int iwidth = raw_size_w;
+  const int iheight = raw_size_h;
 
   if(mask_gui->creation)
   {
@@ -2274,8 +2277,11 @@ static void _brush_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks_fo
   // in creation mode
   if(mask_gui->creation)
   {
-    const float iwd = dt_dev_geometry_raw_width(mask_gui->dev);
-    const float iht = dt_dev_geometry_raw_height(mask_gui->dev);
+    int32_t raw_size_w = 0;
+    int32_t raw_size_h = 0;
+    dt_dev_geometry_get_raw_size(mask_gui->dev, &raw_size_w, &raw_size_h);
+    const float iwd = raw_size_w;
+    const float iht = raw_size_h;
     const float min_iwd_iht = MIN(iwd, iht);
 
     if(mask_gui->guipoints_count == 0)

--- a/src/develop/masks/brush.c
+++ b/src/develop/masks/brush.c
@@ -1983,11 +1983,9 @@ static int _brush_events_mouse_moved(struct dt_iop_module_t *module, double widg
                                      dt_masks_form_gui_t *mask_gui, int index)
 {
   dt_develop_t *dev = mask_gui->dev;
-  int32_t raw_size_w = 0;
-  int32_t raw_size_h = 0;
-  dt_dev_geometry_get_raw_size(dev, &raw_size_w, &raw_size_h);
-  const int iwidth = raw_size_w;
-  const int iheight = raw_size_h;
+  const dt_dev_image_geometry_t geometry = dt_dev_geometry_snapshot(dev);
+  const int iwidth = geometry.raw_width;
+  const int iheight = geometry.raw_height;
 
   if(mask_gui->creation)
   {
@@ -2277,11 +2275,9 @@ static void _brush_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks_fo
   // in creation mode
   if(mask_gui->creation)
   {
-    int32_t raw_size_w = 0;
-    int32_t raw_size_h = 0;
-    dt_dev_geometry_get_raw_size(mask_gui->dev, &raw_size_w, &raw_size_h);
-    const float iwd = raw_size_w;
-    const float iht = raw_size_h;
+    const dt_dev_image_geometry_t geometry = dt_dev_geometry_snapshot(mask_gui->dev);
+    const float iwd = geometry.raw_width;
+    const float iht = geometry.raw_height;
     const float min_iwd_iht = MIN(iwd, iht);
 
     if(mask_gui->guipoints_count == 0)

--- a/src/develop/masks/brush.c
+++ b/src/develop/masks/brush.c
@@ -1983,8 +1983,8 @@ static int _brush_events_mouse_moved(struct dt_iop_module_t *module, double widg
                                      dt_masks_form_gui_t *mask_gui, int index)
 {
   dt_develop_t *dev = mask_gui->dev;
-  const int iwidth = dev->roi.raw_width;
-  const int iheight = dev->roi.raw_height;
+  const int iwidth = dt_dev_geometry_raw_width(dev);
+  const int iheight = dt_dev_geometry_raw_height(dev);
 
   if(mask_gui->creation)
   {
@@ -2274,8 +2274,8 @@ static void _brush_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks_fo
   // in creation mode
   if(mask_gui->creation)
   {
-    const float iwd = mask_gui->dev->roi.raw_width;
-    const float iht = mask_gui->dev->roi.raw_height;
+    const float iwd = dt_dev_geometry_raw_width(mask_gui->dev);
+    const float iht = dt_dev_geometry_raw_height(mask_gui->dev);
     const float min_iwd_iht = MIN(iwd, iht);
 
     if(mask_gui->guipoints_count == 0)

--- a/src/develop/masks/circle.c
+++ b/src/develop/masks/circle.c
@@ -507,11 +507,9 @@ static int _circle_get_points_source(dt_develop_t *dev, float x, float y, float 
 {
    // global callback signature
   
-  int32_t raw_size_w = 0;
-  int32_t raw_size_h = 0;
-  dt_dev_geometry_get_raw_size(dev, &raw_size_w, &raw_size_h);
-  const float wd = raw_size_w;
-  const float ht = raw_size_h;
+  const dt_dev_image_geometry_t geometry = dt_dev_geometry_snapshot(dev);
+  const float wd = geometry.raw_width;
+  const float ht = geometry.raw_height;
 
   // compute the points of the target (center and circumference of circle)
   // we get the point in RAW image reference
@@ -564,11 +562,9 @@ static int _circle_get_points(dt_develop_t *dev, float x, float y, float radius,
 {
    // global callback signature
   
-  int32_t raw_size_w = 0;
-  int32_t raw_size_h = 0;
-  dt_dev_geometry_get_raw_size(dev, &raw_size_w, &raw_size_h);
-  const float wd = raw_size_w;
-  const float ht = raw_size_h;
+  const dt_dev_image_geometry_t geometry = dt_dev_geometry_snapshot(dev);
+  const float wd = geometry.raw_width;
+  const float ht = geometry.raw_height;
 
   // compute the points we need to transform (center and circumference of circle)
   *points = _points_to_transform(dev, x, y, radius, wd, ht, points_count);

--- a/src/develop/masks/circle.c
+++ b/src/develop/masks/circle.c
@@ -507,8 +507,8 @@ static int _circle_get_points_source(dt_develop_t *dev, float x, float y, float 
 {
    // global callback signature
   
-  const float wd = dev->roi.raw_width;
-  const float ht = dev->roi.raw_height;
+  const float wd = dt_dev_geometry_raw_width(dev);
+  const float ht = dt_dev_geometry_raw_height(dev);
 
   // compute the points of the target (center and circumference of circle)
   // we get the point in RAW image reference
@@ -561,8 +561,8 @@ static int _circle_get_points(dt_develop_t *dev, float x, float y, float radius,
 {
    // global callback signature
   
-  const float wd = dev->roi.raw_width;
-  const float ht = dev->roi.raw_height;
+  const float wd = dt_dev_geometry_raw_width(dev);
+  const float ht = dt_dev_geometry_raw_height(dev);
 
   // compute the points we need to transform (center and circumference of circle)
   *points = _points_to_transform(dev, x, y, radius, wd, ht, points_count);

--- a/src/develop/masks/circle.c
+++ b/src/develop/masks/circle.c
@@ -507,8 +507,11 @@ static int _circle_get_points_source(dt_develop_t *dev, float x, float y, float 
 {
    // global callback signature
   
-  const float wd = dt_dev_geometry_raw_width(dev);
-  const float ht = dt_dev_geometry_raw_height(dev);
+  int32_t raw_size_w = 0;
+  int32_t raw_size_h = 0;
+  dt_dev_geometry_get_raw_size(dev, &raw_size_w, &raw_size_h);
+  const float wd = raw_size_w;
+  const float ht = raw_size_h;
 
   // compute the points of the target (center and circumference of circle)
   // we get the point in RAW image reference
@@ -561,8 +564,11 @@ static int _circle_get_points(dt_develop_t *dev, float x, float y, float radius,
 {
    // global callback signature
   
-  const float wd = dt_dev_geometry_raw_width(dev);
-  const float ht = dt_dev_geometry_raw_height(dev);
+  int32_t raw_size_w = 0;
+  int32_t raw_size_h = 0;
+  dt_dev_geometry_get_raw_size(dev, &raw_size_w, &raw_size_h);
+  const float wd = raw_size_w;
+  const float ht = raw_size_h;
 
   // compute the points we need to transform (center and circumference of circle)
   *points = _points_to_transform(dev, x, y, radius, wd, ht, points_count);

--- a/src/develop/masks/ellipse.c
+++ b/src/develop/masks/ellipse.c
@@ -388,8 +388,8 @@ static int _ellipse_get_points_source(dt_develop_t *dev, float xx, float yy, flo
                                       float radius_b, float rotation, float **points, int *points_count,
                                       const dt_iop_module_t *module)
 {
-  const float wd = dev->roi.raw_width;
-  const float ht = dev->roi.raw_height;
+  const float wd = dt_dev_geometry_raw_width(dev);
+  const float ht = dt_dev_geometry_raw_height(dev);
 
   // compute the points of the target (center and circumference of ellipse)
   // we get the point in RAW image reference
@@ -442,8 +442,8 @@ error:
 static int _ellipse_get_points(dt_develop_t *dev, float xx, float yy, float radius_a, float radius_b,
                                float rotation, float **points, int *points_count)
 {
-  const float wd = dev->roi.raw_width;
-  const float ht = dev->roi.raw_height;
+  const float wd = dt_dev_geometry_raw_width(dev);
+  const float ht = dt_dev_geometry_raw_height(dev);
 
   *points = _points_to_transform(dev, xx, yy, radius_a, radius_b, rotation, wd, ht, points_count);
   if(IS_NULL_PTR(*points)) return 1;

--- a/src/develop/masks/ellipse.c
+++ b/src/develop/masks/ellipse.c
@@ -388,11 +388,9 @@ static int _ellipse_get_points_source(dt_develop_t *dev, float xx, float yy, flo
                                       float radius_b, float rotation, float **points, int *points_count,
                                       const dt_iop_module_t *module)
 {
-  int32_t raw_size_w = 0;
-  int32_t raw_size_h = 0;
-  dt_dev_geometry_get_raw_size(dev, &raw_size_w, &raw_size_h);
-  const float wd = raw_size_w;
-  const float ht = raw_size_h;
+  const dt_dev_image_geometry_t geometry = dt_dev_geometry_snapshot(dev);
+  const float wd = geometry.raw_width;
+  const float ht = geometry.raw_height;
 
   // compute the points of the target (center and circumference of ellipse)
   // we get the point in RAW image reference
@@ -445,11 +443,9 @@ error:
 static int _ellipse_get_points(dt_develop_t *dev, float xx, float yy, float radius_a, float radius_b,
                                float rotation, float **points, int *points_count)
 {
-  int32_t raw_size_w = 0;
-  int32_t raw_size_h = 0;
-  dt_dev_geometry_get_raw_size(dev, &raw_size_w, &raw_size_h);
-  const float wd = raw_size_w;
-  const float ht = raw_size_h;
+  const dt_dev_image_geometry_t geometry = dt_dev_geometry_snapshot(dev);
+  const float wd = geometry.raw_width;
+  const float ht = geometry.raw_height;
 
   *points = _points_to_transform(dev, xx, yy, radius_a, radius_b, rotation, wd, ht, points_count);
   if(IS_NULL_PTR(*points)) return 1;

--- a/src/develop/masks/ellipse.c
+++ b/src/develop/masks/ellipse.c
@@ -388,8 +388,11 @@ static int _ellipse_get_points_source(dt_develop_t *dev, float xx, float yy, flo
                                       float radius_b, float rotation, float **points, int *points_count,
                                       const dt_iop_module_t *module)
 {
-  const float wd = dt_dev_geometry_raw_width(dev);
-  const float ht = dt_dev_geometry_raw_height(dev);
+  int32_t raw_size_w = 0;
+  int32_t raw_size_h = 0;
+  dt_dev_geometry_get_raw_size(dev, &raw_size_w, &raw_size_h);
+  const float wd = raw_size_w;
+  const float ht = raw_size_h;
 
   // compute the points of the target (center and circumference of ellipse)
   // we get the point in RAW image reference
@@ -442,8 +445,11 @@ error:
 static int _ellipse_get_points(dt_develop_t *dev, float xx, float yy, float radius_a, float radius_b,
                                float rotation, float **points, int *points_count)
 {
-  const float wd = dt_dev_geometry_raw_width(dev);
-  const float ht = dt_dev_geometry_raw_height(dev);
+  int32_t raw_size_w = 0;
+  int32_t raw_size_h = 0;
+  dt_dev_geometry_get_raw_size(dev, &raw_size_w, &raw_size_h);
+  const float wd = raw_size_w;
+  const float ht = raw_size_h;
 
   *points = _points_to_transform(dev, xx, yy, radius_a, radius_b, rotation, wd, ht, points_count);
   if(IS_NULL_PTR(*points)) return 1;

--- a/src/develop/masks/gradient.c
+++ b/src/develop/masks/gradient.c
@@ -751,8 +751,11 @@ static int _gradient_get_points(dt_develop_t *dev, float x, float y, float rotat
   *points = NULL;
   *points_count = 0;
 
-  const float wd = dt_dev_geometry_raw_width(dev);
-  const float ht = dt_dev_geometry_raw_height(dev);
+  int32_t raw_size_w = 0;
+  int32_t raw_size_h = 0;
+  dt_dev_geometry_get_raw_size(dev, &raw_size_w, &raw_size_h);
+  const float wd = raw_size_w;
+  const float ht = raw_size_h;
   if(!isfinite(wd) || !isfinite(ht) || wd <= 0.0f || ht <= 0.0f) return 1;
 
   const float scale = sqrtf(wd * wd + ht * ht);
@@ -876,8 +879,11 @@ static int _gradient_get_pts_border(dt_develop_t *dev, float x, float y, float r
   distance = CLAMPF(distance, extent_MIN, extent_MAX);
 
   // Get border curve dimensions and scaling
-  const float wd = dt_dev_geometry_raw_width(dev);
-  const float ht = dt_dev_geometry_raw_height(dev);
+  int32_t raw_size_w = 0;
+  int32_t raw_size_h = 0;
+  dt_dev_geometry_get_raw_size(dev, &raw_size_w, &raw_size_h);
+  const float wd = raw_size_w;
+  const float ht = raw_size_h;
   const float scale = sqrtf(wd * wd + ht * ht);
   
   // Calculate perpendicular offsets (±90 degrees from rotation)
@@ -963,8 +969,11 @@ static void _gradient_draw_shape(struct dt_develop_t *dev, cairo_t *cr, const fl
   const float *points = (border) ? pts_line : pts_line + 6;
   const int points_count = (border) ? pts_line_count : pts_line_count - 3;
 
-  const float wd = dt_dev_geometry_raw_width(dev);
-  const float ht = dt_dev_geometry_raw_height(dev);
+  int32_t raw_size_w = 0;
+  int32_t raw_size_h = 0;
+  dt_dev_geometry_get_raw_size(dev, &raw_size_w, &raw_size_h);
+  const float wd = raw_size_w;
+  const float ht = raw_size_h;
 
   int i = 0;
   while(i < points_count)

--- a/src/develop/masks/gradient.c
+++ b/src/develop/masks/gradient.c
@@ -751,11 +751,9 @@ static int _gradient_get_points(dt_develop_t *dev, float x, float y, float rotat
   *points = NULL;
   *points_count = 0;
 
-  int32_t raw_size_w = 0;
-  int32_t raw_size_h = 0;
-  dt_dev_geometry_get_raw_size(dev, &raw_size_w, &raw_size_h);
-  const float wd = raw_size_w;
-  const float ht = raw_size_h;
+  const dt_dev_image_geometry_t geometry = dt_dev_geometry_snapshot(dev);
+  const float wd = geometry.raw_width;
+  const float ht = geometry.raw_height;
   if(!isfinite(wd) || !isfinite(ht) || wd <= 0.0f || ht <= 0.0f) return 1;
 
   const float scale = sqrtf(wd * wd + ht * ht);
@@ -879,11 +877,9 @@ static int _gradient_get_pts_border(dt_develop_t *dev, float x, float y, float r
   distance = CLAMPF(distance, extent_MIN, extent_MAX);
 
   // Get border curve dimensions and scaling
-  int32_t raw_size_w = 0;
-  int32_t raw_size_h = 0;
-  dt_dev_geometry_get_raw_size(dev, &raw_size_w, &raw_size_h);
-  const float wd = raw_size_w;
-  const float ht = raw_size_h;
+  const dt_dev_image_geometry_t geometry = dt_dev_geometry_snapshot(dev);
+  const float wd = geometry.raw_width;
+  const float ht = geometry.raw_height;
   const float scale = sqrtf(wd * wd + ht * ht);
   
   // Calculate perpendicular offsets (±90 degrees from rotation)
@@ -969,11 +965,9 @@ static void _gradient_draw_shape(struct dt_develop_t *dev, cairo_t *cr, const fl
   const float *points = (border) ? pts_line : pts_line + 6;
   const int points_count = (border) ? pts_line_count : pts_line_count - 3;
 
-  int32_t raw_size_w = 0;
-  int32_t raw_size_h = 0;
-  dt_dev_geometry_get_raw_size(dev, &raw_size_w, &raw_size_h);
-  const float wd = raw_size_w;
-  const float ht = raw_size_h;
+  const dt_dev_image_geometry_t geometry = dt_dev_geometry_snapshot(dev);
+  const float wd = geometry.raw_width;
+  const float ht = geometry.raw_height;
 
   int i = 0;
   while(i < points_count)

--- a/src/develop/masks/gradient.c
+++ b/src/develop/masks/gradient.c
@@ -751,8 +751,8 @@ static int _gradient_get_points(dt_develop_t *dev, float x, float y, float rotat
   *points = NULL;
   *points_count = 0;
 
-  const float wd = dev->roi.raw_width;
-  const float ht = dev->roi.raw_height;
+  const float wd = dt_dev_geometry_raw_width(dev);
+  const float ht = dt_dev_geometry_raw_height(dev);
   if(!isfinite(wd) || !isfinite(ht) || wd <= 0.0f || ht <= 0.0f) return 1;
 
   const float scale = sqrtf(wd * wd + ht * ht);
@@ -876,8 +876,8 @@ static int _gradient_get_pts_border(dt_develop_t *dev, float x, float y, float r
   distance = CLAMPF(distance, extent_MIN, extent_MAX);
 
   // Get border curve dimensions and scaling
-  const float wd = dev->roi.raw_width;
-  const float ht = dev->roi.raw_height;
+  const float wd = dt_dev_geometry_raw_width(dev);
+  const float ht = dt_dev_geometry_raw_height(dev);
   const float scale = sqrtf(wd * wd + ht * ht);
   
   // Calculate perpendicular offsets (±90 degrees from rotation)
@@ -963,8 +963,8 @@ static void _gradient_draw_shape(struct dt_develop_t *dev, cairo_t *cr, const fl
   const float *points = (border) ? pts_line : pts_line + 6;
   const int points_count = (border) ? pts_line_count : pts_line_count - 3;
 
-  const float wd = dev->roi.raw_width;
-  const float ht = dev->roi.raw_height;
+  const float wd = dt_dev_geometry_raw_width(dev);
+  const float ht = dt_dev_geometry_raw_height(dev);
 
   int i = 0;
   while(i < points_count)

--- a/src/develop/masks/masks_gui.c
+++ b/src/develop/masks/masks_gui.c
@@ -3972,8 +3972,11 @@ void dt_masks_set_source_pos_initial_state(dt_masks_form_gui_t *mask_gui, const 
 void dt_masks_set_source_pos_initial_value(dt_masks_form_gui_t *mask_gui, dt_masks_form_t *mask_form)
 {
   dt_develop_t *dev = mask_gui->dev;
-  const float raw_width = dt_dev_geometry_raw_width(dev);
-  const float raw_height = dt_dev_geometry_raw_height(dev);
+  int32_t raw_size_w = 0;
+  int32_t raw_size_h = 0;
+  dt_dev_geometry_get_raw_size(dev, &raw_size_w, &raw_size_h);
+  const float raw_width = raw_size_w;
+  const float raw_height = raw_size_h;
 
   const float xx = mask_gui->pos[0];
   const float yy = mask_gui->pos[1];
@@ -4046,8 +4049,11 @@ void dt_masks_calculate_source_pos_origin(dt_masks_form_gui_t *mask_gui, const f
 {
   float source_x = 0.0f;
   float source_y = 0.0f;
-  const float raw_width = dt_dev_geometry_raw_width(mask_gui->dev);
-  const float raw_height = dt_dev_geometry_raw_height(mask_gui->dev);
+  int32_t raw_size_w = 0;
+  int32_t raw_size_h = 0;
+  dt_dev_geometry_get_raw_size(mask_gui->dev, &raw_size_w, &raw_size_h);
+  const float raw_width = raw_size_w;
+  const float raw_height = raw_size_h;
   if(mask_gui->source_pos_type == DT_MASKS_SOURCE_POS_RELATIVE)
   {
     source_x = xpos + mask_gui->pos_source[0];

--- a/src/develop/masks/masks_gui.c
+++ b/src/develop/masks/masks_gui.c
@@ -3972,11 +3972,9 @@ void dt_masks_set_source_pos_initial_state(dt_masks_form_gui_t *mask_gui, const 
 void dt_masks_set_source_pos_initial_value(dt_masks_form_gui_t *mask_gui, dt_masks_form_t *mask_form)
 {
   dt_develop_t *dev = mask_gui->dev;
-  int32_t raw_size_w = 0;
-  int32_t raw_size_h = 0;
-  dt_dev_geometry_get_raw_size(dev, &raw_size_w, &raw_size_h);
-  const float raw_width = raw_size_w;
-  const float raw_height = raw_size_h;
+  const dt_dev_image_geometry_t geometry = dt_dev_geometry_snapshot(dev);
+  const float raw_width = geometry.raw_width;
+  const float raw_height = geometry.raw_height;
 
   const float xx = mask_gui->pos[0];
   const float yy = mask_gui->pos[1];
@@ -4049,11 +4047,9 @@ void dt_masks_calculate_source_pos_origin(dt_masks_form_gui_t *mask_gui, const f
 {
   float source_x = 0.0f;
   float source_y = 0.0f;
-  int32_t raw_size_w = 0;
-  int32_t raw_size_h = 0;
-  dt_dev_geometry_get_raw_size(mask_gui->dev, &raw_size_w, &raw_size_h);
-  const float raw_width = raw_size_w;
-  const float raw_height = raw_size_h;
+  const dt_dev_image_geometry_t geometry = dt_dev_geometry_snapshot(mask_gui->dev);
+  const float raw_width = geometry.raw_width;
+  const float raw_height = geometry.raw_height;
   if(mask_gui->source_pos_type == DT_MASKS_SOURCE_POS_RELATIVE)
   {
     source_x = xpos + mask_gui->pos_source[0];

--- a/src/develop/masks/masks_gui.c
+++ b/src/develop/masks/masks_gui.c
@@ -3972,8 +3972,8 @@ void dt_masks_set_source_pos_initial_state(dt_masks_form_gui_t *mask_gui, const 
 void dt_masks_set_source_pos_initial_value(dt_masks_form_gui_t *mask_gui, dt_masks_form_t *mask_form)
 {
   dt_develop_t *dev = mask_gui->dev;
-  const float raw_width = dev->roi.raw_width;
-  const float raw_height = dev->roi.raw_height;
+  const float raw_width = dt_dev_geometry_raw_width(dev);
+  const float raw_height = dt_dev_geometry_raw_height(dev);
 
   const float xx = mask_gui->pos[0];
   const float yy = mask_gui->pos[1];
@@ -4046,8 +4046,8 @@ void dt_masks_calculate_source_pos_origin(dt_masks_form_gui_t *mask_gui, const f
 {
   float source_x = 0.0f;
   float source_y = 0.0f;
-  const float raw_width = mask_gui->dev->roi.raw_width;
-  const float raw_height = mask_gui->dev->roi.raw_height;
+  const float raw_width = dt_dev_geometry_raw_width(mask_gui->dev);
+  const float raw_height = dt_dev_geometry_raw_height(mask_gui->dev);
   if(mask_gui->source_pos_type == DT_MASKS_SOURCE_POS_RELATIVE)
   {
     source_x = xpos + mask_gui->pos_source[0];

--- a/src/develop/masks/polygon.c
+++ b/src/develop/masks/polygon.c
@@ -2040,11 +2040,9 @@ static int _polygon_events_mouse_moved(struct dt_iop_module_t *module, double x,
       = (dt_masks_form_gui_points_t *)g_list_nth_data(mask_gui->points, form_index);
   if(IS_NULL_PTR(gui_points)) return 0;
 
-  int32_t raw_size_w = 0;
-  int32_t raw_size_h = 0;
-  dt_dev_geometry_get_raw_size(dev, &raw_size_w, &raw_size_h);
-  const int iwidth = raw_size_w;
-  const int iheight = raw_size_h;
+  const dt_dev_image_geometry_t geometry = dt_dev_geometry_snapshot(dev);
+  const int iwidth = geometry.raw_width;
+  const int iheight = geometry.raw_height;
 
   if(mask_gui->node_dragging >= 0)
   {

--- a/src/develop/masks/polygon.c
+++ b/src/develop/masks/polygon.c
@@ -2040,8 +2040,11 @@ static int _polygon_events_mouse_moved(struct dt_iop_module_t *module, double x,
       = (dt_masks_form_gui_points_t *)g_list_nth_data(mask_gui->points, form_index);
   if(IS_NULL_PTR(gui_points)) return 0;
 
-  const int iwidth = dt_dev_geometry_raw_width(dev);
-  const int iheight = dt_dev_geometry_raw_height(dev);
+  int32_t raw_size_w = 0;
+  int32_t raw_size_h = 0;
+  dt_dev_geometry_get_raw_size(dev, &raw_size_w, &raw_size_h);
+  const int iwidth = raw_size_w;
+  const int iheight = raw_size_h;
 
   if(mask_gui->node_dragging >= 0)
   {

--- a/src/develop/masks/polygon.c
+++ b/src/develop/masks/polygon.c
@@ -2040,8 +2040,8 @@ static int _polygon_events_mouse_moved(struct dt_iop_module_t *module, double x,
       = (dt_masks_form_gui_points_t *)g_list_nth_data(mask_gui->points, form_index);
   if(IS_NULL_PTR(gui_points)) return 0;
 
-  const int iwidth = dev->roi.raw_width;
-  const int iheight = dev->roi.raw_height;
+  const int iwidth = dt_dev_geometry_raw_width(dev);
+  const int iheight = dt_dev_geometry_raw_height(dev);
 
   if(mask_gui->node_dragging >= 0)
   {

--- a/src/gui/color_picker_proxy.c
+++ b/src/gui/color_picker_proxy.c
@@ -188,8 +188,8 @@ static void _picker_get_module_bounds_image_norm(const dt_develop_t *dev,
   bounds[3] = 1.0f;
 
   if(IS_NULL_PTR(dev) || IS_NULL_PTR(dev->preview_pipe) || IS_NULL_PTR(active_module)) return;
-  const float processed_width = dev->roi.processed_width;
-  const float processed_height = dev->roi.processed_height;
+  const float processed_width = dt_dev_geometry_processed_width(dev);
+  const float processed_height = dt_dev_geometry_processed_height(dev);
   if(processed_width <= 0.0f || processed_height <= 0.0f) return;
 
   const dt_dev_pixelpipe_iop_t *const piece = dt_dev_pixelpipe_get_module_piece(dev->preview_pipe,
@@ -227,8 +227,8 @@ static void _picker_initialize_geometry_raw(dt_iop_color_picker_t *picker, dt_de
   float bounds[4] = { 0.0f, 0.0f, 1.0f, 1.0f };
   _picker_get_module_bounds_image_norm(dev, picker->module, bounds);
 
-  const float processed_width = dev->roi.processed_width;
-  const float processed_height = dev->roi.processed_height;
+  const float processed_width = dt_dev_geometry_processed_width(dev);
+  const float processed_height = dt_dev_geometry_processed_height(dev);
   if(processed_width <= 0.0f || processed_height <= 0.0f) return;
   // Fixed border inset in scale-1 image pixels, then converted to image-norm.
   // Keep this explicit here so the caller directly controls default picker coverage.

--- a/src/gui/color_picker_proxy.c
+++ b/src/gui/color_picker_proxy.c
@@ -188,8 +188,11 @@ static void _picker_get_module_bounds_image_norm(const dt_develop_t *dev,
   bounds[3] = 1.0f;
 
   if(IS_NULL_PTR(dev) || IS_NULL_PTR(dev->preview_pipe) || IS_NULL_PTR(active_module)) return;
-  const float processed_width = dt_dev_geometry_processed_width(dev);
-  const float processed_height = dt_dev_geometry_processed_height(dev);
+  int32_t processed_size_w = 0;
+  int32_t processed_size_h = 0;
+  dt_dev_geometry_get_processed_size(dev, &processed_size_w, &processed_size_h);
+  const float processed_width = processed_size_w;
+  const float processed_height = processed_size_h;
   if(processed_width <= 0.0f || processed_height <= 0.0f) return;
 
   const dt_dev_pixelpipe_iop_t *const piece = dt_dev_pixelpipe_get_module_piece(dev->preview_pipe,
@@ -227,8 +230,11 @@ static void _picker_initialize_geometry_raw(dt_iop_color_picker_t *picker, dt_de
   float bounds[4] = { 0.0f, 0.0f, 1.0f, 1.0f };
   _picker_get_module_bounds_image_norm(dev, picker->module, bounds);
 
-  const float processed_width = dt_dev_geometry_processed_width(dev);
-  const float processed_height = dt_dev_geometry_processed_height(dev);
+  int32_t processed_size_w = 0;
+  int32_t processed_size_h = 0;
+  dt_dev_geometry_get_processed_size(dev, &processed_size_w, &processed_size_h);
+  const float processed_width = processed_size_w;
+  const float processed_height = processed_size_h;
   if(processed_width <= 0.0f || processed_height <= 0.0f) return;
   // Fixed border inset in scale-1 image pixels, then converted to image-norm.
   // Keep this explicit here so the caller directly controls default picker coverage.

--- a/src/gui/color_picker_proxy.c
+++ b/src/gui/color_picker_proxy.c
@@ -188,11 +188,9 @@ static void _picker_get_module_bounds_image_norm(const dt_develop_t *dev,
   bounds[3] = 1.0f;
 
   if(IS_NULL_PTR(dev) || IS_NULL_PTR(dev->preview_pipe) || IS_NULL_PTR(active_module)) return;
-  int32_t processed_size_w = 0;
-  int32_t processed_size_h = 0;
-  dt_dev_geometry_get_processed_size(dev, &processed_size_w, &processed_size_h);
-  const float processed_width = processed_size_w;
-  const float processed_height = processed_size_h;
+  const dt_dev_image_geometry_t geometry = dt_dev_geometry_snapshot(dev);
+  const float processed_width = geometry.processed_width;
+  const float processed_height = geometry.processed_height;
   if(processed_width <= 0.0f || processed_height <= 0.0f) return;
 
   const dt_dev_pixelpipe_iop_t *const piece = dt_dev_pixelpipe_get_module_piece(dev->preview_pipe,
@@ -230,11 +228,9 @@ static void _picker_initialize_geometry_raw(dt_iop_color_picker_t *picker, dt_de
   float bounds[4] = { 0.0f, 0.0f, 1.0f, 1.0f };
   _picker_get_module_bounds_image_norm(dev, picker->module, bounds);
 
-  int32_t processed_size_w = 0;
-  int32_t processed_size_h = 0;
-  dt_dev_geometry_get_processed_size(dev, &processed_size_w, &processed_size_h);
-  const float processed_width = processed_size_w;
-  const float processed_height = processed_size_h;
+  const dt_dev_image_geometry_t geometry = dt_dev_geometry_snapshot(dev);
+  const float processed_width = geometry.processed_width;
+  const float processed_height = geometry.processed_height;
   if(processed_width <= 0.0f || processed_height <= 0.0f) return;
   // Fixed border inset in scale-1 image pixels, then converted to image-norm.
   // Keep this explicit here so the caller directly controls default picker coverage.

--- a/src/iop/ashift.c
+++ b/src/iop/ashift.c
@@ -3049,8 +3049,8 @@ static void _do_get_structure_quad(dt_iop_module_t *self)
   else
   {
     // Create new lines
-    const float wd = self->dev->roi.processed_width;
-    const float ht = self->dev->roi.processed_height;
+    const float wd = dt_dev_geometry_processed_width(self->dev);
+    const float ht = dt_dev_geometry_processed_height(self->dev);
     float pts[8] = { wd * 0.2, ht * 0.2, wd * 0.2, ht * 0.8, wd * 0.8, ht * 0.2, wd * 0.8, ht * 0.8 };
     if(dt_dev_distort_backtransform_plus(self->dev->virtual_pipe, self->iop_order,
                                          DT_DEV_TRANSFORM_DIR_FORW_INCL, pts, 4))
@@ -4266,8 +4266,8 @@ int mouse_moved(struct dt_iop_module_t *self, double x, double y, double pressur
       return FALSE;
     }
 
-    const float pd_w = self->dev->roi.processed_width;
-    const float pd_h = self->dev->roi.processed_height;
+    const float pd_w = dt_dev_geometry_processed_width(self->dev);
+    const float pd_h = dt_dev_geometry_processed_height(self->dev);
     float pts[2] = { pzx * pd_w, pzy * pd_h };
     if(dt_dev_distort_backtransform_plus(self->dev->virtual_pipe, self->iop_order,
                                          DT_DEV_TRANSFORM_DIR_FORW_INCL, pts, 1))
@@ -4332,8 +4332,8 @@ int mouse_moved(struct dt_iop_module_t *self, double x, double y, double pressur
       return FALSE;
     }
 
-    const float pd_w = self->dev->roi.processed_width;
-    const float pd_h = self->dev->roi.processed_height;
+    const float pd_w = dt_dev_geometry_processed_width(self->dev);
+    const float pd_h = dt_dev_geometry_processed_height(self->dev);
     float pts[2] = { pzx * pd_w, pzy * pd_h };
     if(dt_dev_distort_backtransform_plus(self->dev->virtual_pipe, self->iop_order,
                                          DT_DEV_TRANSFORM_DIR_FORW_INCL, pts, 1))
@@ -4571,8 +4571,8 @@ int button_pressed(struct dt_iop_module_t *self, double x, double y, double pres
     {
       if(g->points_idx[n].is_near)
       {
-        const float pd_w = self->dev->roi.processed_width;
-        const float pd_h = self->dev->roi.processed_height;
+        const float pd_w = dt_dev_geometry_processed_width(self->dev);
+        const float pd_h = dt_dev_geometry_processed_height(self->dev);
         float pts[2] = { pzx * pd_w, pzy * pd_h };
         dt_dev_distort_backtransform_plus(self->dev->virtual_pipe, self->iop_order,
                                           DT_DEV_TRANSFORM_DIR_FORW_INCL, pts, 1);
@@ -4671,8 +4671,8 @@ int button_pressed(struct dt_iop_module_t *self, double x, double y, double pres
 
     // we instantiate a new line with both extrema at the current position
     // and enable the "move point" mode with the second extrema
-    const float pd_w = self->dev->roi.processed_width;
-    const float pd_h = self->dev->roi.processed_height;
+    const float pd_w = dt_dev_geometry_processed_width(self->dev);
+    const float pd_h = dt_dev_geometry_processed_height(self->dev);
     float pts[2] = { pzx * pd_w, pzy * pd_h };
     dt_dev_distort_backtransform_plus(self->dev->virtual_pipe, self->iop_order,
                                       DT_DEV_TRANSFORM_DIR_FORW_INCL, pts, 1);
@@ -4742,8 +4742,8 @@ int button_released(struct dt_iop_module_t *self, double x, double y, int which,
     dt_dev_coordinates_widget_to_image_norm(self->dev, pzxpy, 1);
     const float pzx = pzxpy[0];
     const float pzy = pzxpy[1];
-    const float pd_w = self->dev->roi.processed_width;
-    const float pd_h = self->dev->roi.processed_height;
+    const float pd_w = dt_dev_geometry_processed_width(self->dev);
+    const float pd_h = dt_dev_geometry_processed_height(self->dev);
     float pts[4] = { pzx * pd_w, pzy * pd_h, g->lastx * pd_w, g->lasty * pd_h };
     dt_dev_distort_backtransform_plus(self->dev->virtual_pipe,
                                       self->iop_order,

--- a/src/iop/ashift.c
+++ b/src/iop/ashift.c
@@ -3049,8 +3049,11 @@ static void _do_get_structure_quad(dt_iop_module_t *self)
   else
   {
     // Create new lines
-    const float wd = dt_dev_geometry_processed_width(self->dev);
-    const float ht = dt_dev_geometry_processed_height(self->dev);
+    int32_t processed_size_w = 0;
+    int32_t processed_size_h = 0;
+    dt_dev_geometry_get_processed_size(self->dev, &processed_size_w, &processed_size_h);
+    const float wd = processed_size_w;
+    const float ht = processed_size_h;
     float pts[8] = { wd * 0.2, ht * 0.2, wd * 0.2, ht * 0.8, wd * 0.8, ht * 0.2, wd * 0.8, ht * 0.8 };
     if(dt_dev_distort_backtransform_plus(self->dev->virtual_pipe, self->iop_order,
                                          DT_DEV_TRANSFORM_DIR_FORW_INCL, pts, 4))
@@ -4266,8 +4269,11 @@ int mouse_moved(struct dt_iop_module_t *self, double x, double y, double pressur
       return FALSE;
     }
 
-    const float pd_w = dt_dev_geometry_processed_width(self->dev);
-    const float pd_h = dt_dev_geometry_processed_height(self->dev);
+    int32_t processed_size_w = 0;
+    int32_t processed_size_h = 0;
+    dt_dev_geometry_get_processed_size(self->dev, &processed_size_w, &processed_size_h);
+    const float pd_w = processed_size_w;
+    const float pd_h = processed_size_h;
     float pts[2] = { pzx * pd_w, pzy * pd_h };
     if(dt_dev_distort_backtransform_plus(self->dev->virtual_pipe, self->iop_order,
                                          DT_DEV_TRANSFORM_DIR_FORW_INCL, pts, 1))
@@ -4332,8 +4338,11 @@ int mouse_moved(struct dt_iop_module_t *self, double x, double y, double pressur
       return FALSE;
     }
 
-    const float pd_w = dt_dev_geometry_processed_width(self->dev);
-    const float pd_h = dt_dev_geometry_processed_height(self->dev);
+    int32_t processed_size_w = 0;
+    int32_t processed_size_h = 0;
+    dt_dev_geometry_get_processed_size(self->dev, &processed_size_w, &processed_size_h);
+    const float pd_w = processed_size_w;
+    const float pd_h = processed_size_h;
     float pts[2] = { pzx * pd_w, pzy * pd_h };
     if(dt_dev_distort_backtransform_plus(self->dev->virtual_pipe, self->iop_order,
                                          DT_DEV_TRANSFORM_DIR_FORW_INCL, pts, 1))
@@ -4571,8 +4580,11 @@ int button_pressed(struct dt_iop_module_t *self, double x, double y, double pres
     {
       if(g->points_idx[n].is_near)
       {
-        const float pd_w = dt_dev_geometry_processed_width(self->dev);
-        const float pd_h = dt_dev_geometry_processed_height(self->dev);
+        int32_t processed_size_w = 0;
+        int32_t processed_size_h = 0;
+        dt_dev_geometry_get_processed_size(self->dev, &processed_size_w, &processed_size_h);
+        const float pd_w = processed_size_w;
+        const float pd_h = processed_size_h;
         float pts[2] = { pzx * pd_w, pzy * pd_h };
         dt_dev_distort_backtransform_plus(self->dev->virtual_pipe, self->iop_order,
                                           DT_DEV_TRANSFORM_DIR_FORW_INCL, pts, 1);
@@ -4671,8 +4683,11 @@ int button_pressed(struct dt_iop_module_t *self, double x, double y, double pres
 
     // we instantiate a new line with both extrema at the current position
     // and enable the "move point" mode with the second extrema
-    const float pd_w = dt_dev_geometry_processed_width(self->dev);
-    const float pd_h = dt_dev_geometry_processed_height(self->dev);
+    int32_t processed_size_w = 0;
+    int32_t processed_size_h = 0;
+    dt_dev_geometry_get_processed_size(self->dev, &processed_size_w, &processed_size_h);
+    const float pd_w = processed_size_w;
+    const float pd_h = processed_size_h;
     float pts[2] = { pzx * pd_w, pzy * pd_h };
     dt_dev_distort_backtransform_plus(self->dev->virtual_pipe, self->iop_order,
                                       DT_DEV_TRANSFORM_DIR_FORW_INCL, pts, 1);
@@ -4742,8 +4757,11 @@ int button_released(struct dt_iop_module_t *self, double x, double y, int which,
     dt_dev_coordinates_widget_to_image_norm(self->dev, pzxpy, 1);
     const float pzx = pzxpy[0];
     const float pzy = pzxpy[1];
-    const float pd_w = dt_dev_geometry_processed_width(self->dev);
-    const float pd_h = dt_dev_geometry_processed_height(self->dev);
+    int32_t processed_size_w = 0;
+    int32_t processed_size_h = 0;
+    dt_dev_geometry_get_processed_size(self->dev, &processed_size_w, &processed_size_h);
+    const float pd_w = processed_size_w;
+    const float pd_h = processed_size_h;
     float pts[4] = { pzx * pd_w, pzy * pd_h, g->lastx * pd_w, g->lasty * pd_h };
     dt_dev_distort_backtransform_plus(self->dev->virtual_pipe,
                                       self->iop_order,

--- a/src/iop/ashift.c
+++ b/src/iop/ashift.c
@@ -3049,11 +3049,9 @@ static void _do_get_structure_quad(dt_iop_module_t *self)
   else
   {
     // Create new lines
-    int32_t processed_size_w = 0;
-    int32_t processed_size_h = 0;
-    dt_dev_geometry_get_processed_size(self->dev, &processed_size_w, &processed_size_h);
-    const float wd = processed_size_w;
-    const float ht = processed_size_h;
+    const dt_dev_image_geometry_t geometry = dt_dev_geometry_snapshot(self->dev);
+    const float wd = geometry.processed_width;
+    const float ht = geometry.processed_height;
     float pts[8] = { wd * 0.2, ht * 0.2, wd * 0.2, ht * 0.8, wd * 0.8, ht * 0.2, wd * 0.8, ht * 0.8 };
     if(dt_dev_distort_backtransform_plus(self->dev->virtual_pipe, self->iop_order,
                                          DT_DEV_TRANSFORM_DIR_FORW_INCL, pts, 4))
@@ -4269,11 +4267,9 @@ int mouse_moved(struct dt_iop_module_t *self, double x, double y, double pressur
       return FALSE;
     }
 
-    int32_t processed_size_w = 0;
-    int32_t processed_size_h = 0;
-    dt_dev_geometry_get_processed_size(self->dev, &processed_size_w, &processed_size_h);
-    const float pd_w = processed_size_w;
-    const float pd_h = processed_size_h;
+    const dt_dev_image_geometry_t geometry = dt_dev_geometry_snapshot(self->dev);
+    const float pd_w = geometry.processed_width;
+    const float pd_h = geometry.processed_height;
     float pts[2] = { pzx * pd_w, pzy * pd_h };
     if(dt_dev_distort_backtransform_plus(self->dev->virtual_pipe, self->iop_order,
                                          DT_DEV_TRANSFORM_DIR_FORW_INCL, pts, 1))
@@ -4338,11 +4334,9 @@ int mouse_moved(struct dt_iop_module_t *self, double x, double y, double pressur
       return FALSE;
     }
 
-    int32_t processed_size_w = 0;
-    int32_t processed_size_h = 0;
-    dt_dev_geometry_get_processed_size(self->dev, &processed_size_w, &processed_size_h);
-    const float pd_w = processed_size_w;
-    const float pd_h = processed_size_h;
+    const dt_dev_image_geometry_t geometry = dt_dev_geometry_snapshot(self->dev);
+    const float pd_w = geometry.processed_width;
+    const float pd_h = geometry.processed_height;
     float pts[2] = { pzx * pd_w, pzy * pd_h };
     if(dt_dev_distort_backtransform_plus(self->dev->virtual_pipe, self->iop_order,
                                          DT_DEV_TRANSFORM_DIR_FORW_INCL, pts, 1))
@@ -4580,11 +4574,9 @@ int button_pressed(struct dt_iop_module_t *self, double x, double y, double pres
     {
       if(g->points_idx[n].is_near)
       {
-        int32_t processed_size_w = 0;
-        int32_t processed_size_h = 0;
-        dt_dev_geometry_get_processed_size(self->dev, &processed_size_w, &processed_size_h);
-        const float pd_w = processed_size_w;
-        const float pd_h = processed_size_h;
+        const dt_dev_image_geometry_t geometry = dt_dev_geometry_snapshot(self->dev);
+        const float pd_w = geometry.processed_width;
+        const float pd_h = geometry.processed_height;
         float pts[2] = { pzx * pd_w, pzy * pd_h };
         dt_dev_distort_backtransform_plus(self->dev->virtual_pipe, self->iop_order,
                                           DT_DEV_TRANSFORM_DIR_FORW_INCL, pts, 1);
@@ -4683,11 +4675,9 @@ int button_pressed(struct dt_iop_module_t *self, double x, double y, double pres
 
     // we instantiate a new line with both extrema at the current position
     // and enable the "move point" mode with the second extrema
-    int32_t processed_size_w = 0;
-    int32_t processed_size_h = 0;
-    dt_dev_geometry_get_processed_size(self->dev, &processed_size_w, &processed_size_h);
-    const float pd_w = processed_size_w;
-    const float pd_h = processed_size_h;
+    const dt_dev_image_geometry_t geometry = dt_dev_geometry_snapshot(self->dev);
+    const float pd_w = geometry.processed_width;
+    const float pd_h = geometry.processed_height;
     float pts[2] = { pzx * pd_w, pzy * pd_h };
     dt_dev_distort_backtransform_plus(self->dev->virtual_pipe, self->iop_order,
                                       DT_DEV_TRANSFORM_DIR_FORW_INCL, pts, 1);
@@ -4757,11 +4747,9 @@ int button_released(struct dt_iop_module_t *self, double x, double y, int which,
     dt_dev_coordinates_widget_to_image_norm(self->dev, pzxpy, 1);
     const float pzx = pzxpy[0];
     const float pzy = pzxpy[1];
-    int32_t processed_size_w = 0;
-    int32_t processed_size_h = 0;
-    dt_dev_geometry_get_processed_size(self->dev, &processed_size_w, &processed_size_h);
-    const float pd_w = processed_size_w;
-    const float pd_h = processed_size_h;
+    const dt_dev_image_geometry_t geometry = dt_dev_geometry_snapshot(self->dev);
+    const float pd_w = geometry.processed_width;
+    const float pd_h = geometry.processed_height;
     float pts[4] = { pzx * pd_w, pzy * pd_h, g->lastx * pd_w, g->lasty * pd_h };
     dt_dev_distort_backtransform_plus(self->dev->virtual_pipe,
                                       self->iop_order,

--- a/src/iop/drawlayer.c
+++ b/src/iop/drawlayer.c
@@ -395,11 +395,9 @@ static inline __attribute__((always_inline)) gboolean _resolve_layer_geometry(dt
   }
   else
   {
-    int32_t processed_size_w = 0;
-    int32_t processed_size_h = 0;
-    dt_dev_geometry_get_processed_size(self->dev, &processed_size_w, &processed_size_h);
-    resolved_width = processed_size_w;
-    resolved_height = processed_size_h;
+    const dt_dev_image_geometry_t geometry = dt_dev_geometry_snapshot(self->dev);
+    resolved_width = geometry.processed_width;
+    resolved_height = geometry.processed_height;
   }
 
   if(!IS_NULL_PTR(layer_width)) *layer_width = resolved_width;
@@ -1906,11 +1904,9 @@ static gboolean _delete_current_layer(dt_iop_module_t *self)
   int layer_height = 0;
   if(!_resolve_layer_geometry(self, NULL, NULL, &layer_width, &layer_height, NULL, NULL))
   {
-    int32_t raw_size_w = 0;
-    int32_t raw_size_h = 0;
-    dt_dev_geometry_get_raw_size(self->dev, &raw_size_w, &raw_size_h);
-    layer_width = raw_size_w;
-    layer_height = raw_size_h;
+    const dt_dev_image_geometry_t geometry = dt_dev_geometry_snapshot(self->dev);
+    layer_width = geometry.raw_width;
+    layer_height = geometry.raw_height;
   }
 
   char path[PATH_MAX] = { 0 };
@@ -2016,11 +2012,9 @@ static gboolean _rename_current_layer_from_gui(dt_iop_module_t *self, const char
   int layer_height = 0;
   if(!_resolve_layer_geometry(self, NULL, NULL, &layer_width, &layer_height, NULL, NULL))
   {
-    int32_t raw_size_w = 0;
-    int32_t raw_size_h = 0;
-    dt_dev_geometry_get_raw_size(self->dev, &raw_size_w, &raw_size_h);
-    layer_width = raw_size_w;
-    layer_height = raw_size_h;
+    const dt_dev_image_geometry_t geometry = dt_dev_geometry_snapshot(self->dev);
+    layer_width = geometry.raw_width;
+    layer_height = geometry.raw_height;
   }
 
   if(!_commit_dabs(self, FALSE))

--- a/src/iop/drawlayer.c
+++ b/src/iop/drawlayer.c
@@ -395,8 +395,8 @@ static inline __attribute__((always_inline)) gboolean _resolve_layer_geometry(dt
   }
   else
   {
-    resolved_width = self->dev->roi.processed_width;
-    resolved_height = self->dev->roi.processed_height;
+    resolved_width = dt_dev_geometry_processed_width(self->dev);
+    resolved_height = dt_dev_geometry_processed_height(self->dev);
   }
 
   if(!IS_NULL_PTR(layer_width)) *layer_width = resolved_width;
@@ -1903,8 +1903,8 @@ static gboolean _delete_current_layer(dt_iop_module_t *self)
   int layer_height = 0;
   if(!_resolve_layer_geometry(self, NULL, NULL, &layer_width, &layer_height, NULL, NULL))
   {
-    layer_width = self->dev->roi.raw_width;
-    layer_height = self->dev->roi.raw_height;
+    layer_width = dt_dev_geometry_raw_width(self->dev);
+    layer_height = dt_dev_geometry_raw_height(self->dev);
   }
 
   char path[PATH_MAX] = { 0 };
@@ -2010,8 +2010,8 @@ static gboolean _rename_current_layer_from_gui(dt_iop_module_t *self, const char
   int layer_height = 0;
   if(!_resolve_layer_geometry(self, NULL, NULL, &layer_width, &layer_height, NULL, NULL))
   {
-    layer_width = self->dev->roi.raw_width;
-    layer_height = self->dev->roi.raw_height;
+    layer_width = dt_dev_geometry_raw_width(self->dev);
+    layer_height = dt_dev_geometry_raw_height(self->dev);
   }
 
   if(!_commit_dabs(self, FALSE))

--- a/src/iop/drawlayer.c
+++ b/src/iop/drawlayer.c
@@ -395,8 +395,11 @@ static inline __attribute__((always_inline)) gboolean _resolve_layer_geometry(dt
   }
   else
   {
-    resolved_width = dt_dev_geometry_processed_width(self->dev);
-    resolved_height = dt_dev_geometry_processed_height(self->dev);
+    int32_t processed_size_w = 0;
+    int32_t processed_size_h = 0;
+    dt_dev_geometry_get_processed_size(self->dev, &processed_size_w, &processed_size_h);
+    resolved_width = processed_size_w;
+    resolved_height = processed_size_h;
   }
 
   if(!IS_NULL_PTR(layer_width)) *layer_width = resolved_width;
@@ -1903,8 +1906,11 @@ static gboolean _delete_current_layer(dt_iop_module_t *self)
   int layer_height = 0;
   if(!_resolve_layer_geometry(self, NULL, NULL, &layer_width, &layer_height, NULL, NULL))
   {
-    layer_width = dt_dev_geometry_raw_width(self->dev);
-    layer_height = dt_dev_geometry_raw_height(self->dev);
+    int32_t raw_size_w = 0;
+    int32_t raw_size_h = 0;
+    dt_dev_geometry_get_raw_size(self->dev, &raw_size_w, &raw_size_h);
+    layer_width = raw_size_w;
+    layer_height = raw_size_h;
   }
 
   char path[PATH_MAX] = { 0 };
@@ -2010,8 +2016,11 @@ static gboolean _rename_current_layer_from_gui(dt_iop_module_t *self, const char
   int layer_height = 0;
   if(!_resolve_layer_geometry(self, NULL, NULL, &layer_width, &layer_height, NULL, NULL))
   {
-    layer_width = dt_dev_geometry_raw_width(self->dev);
-    layer_height = dt_dev_geometry_raw_height(self->dev);
+    int32_t raw_size_w = 0;
+    int32_t raw_size_h = 0;
+    dt_dev_geometry_get_raw_size(self->dev, &raw_size_w, &raw_size_h);
+    layer_width = raw_size_w;
+    layer_height = raw_size_h;
   }
 
   if(!_commit_dabs(self, FALSE))

--- a/src/iop/drawlayer/coordinates.c
+++ b/src/iop/drawlayer/coordinates.c
@@ -39,11 +39,9 @@ static gboolean _virtual_piece_layer_geometry(dt_iop_module_t *self, int *layer_
   }
   else
   {
-    int32_t processed_size_w = 0;
-    int32_t processed_size_h = 0;
-    dt_dev_geometry_get_processed_size(self->dev, &processed_size_w, &processed_size_h);
-    resolved_width = processed_size_w;
-    resolved_height = processed_size_h;
+    const dt_dev_image_geometry_t geometry = dt_dev_geometry_snapshot(self->dev);
+    resolved_width = geometry.processed_width;
+    resolved_height = geometry.processed_height;
   }
   if(!IS_NULL_PTR(layer_width)) *layer_width = resolved_width;
   if(!IS_NULL_PTR(layer_height)) *layer_height = resolved_height;

--- a/src/iop/drawlayer/coordinates.c
+++ b/src/iop/drawlayer/coordinates.c
@@ -39,8 +39,8 @@ static gboolean _virtual_piece_layer_geometry(dt_iop_module_t *self, int *layer_
   }
   else
   {
-    resolved_width = self->dev->roi.processed_width;
-    resolved_height = self->dev->roi.processed_height;
+    resolved_width = dt_dev_geometry_processed_width(self->dev);
+    resolved_height = dt_dev_geometry_processed_height(self->dev);
   }
   if(!IS_NULL_PTR(layer_width)) *layer_width = resolved_width;
   if(!IS_NULL_PTR(layer_height)) *layer_height = resolved_height;

--- a/src/iop/drawlayer/coordinates.c
+++ b/src/iop/drawlayer/coordinates.c
@@ -39,8 +39,11 @@ static gboolean _virtual_piece_layer_geometry(dt_iop_module_t *self, int *layer_
   }
   else
   {
-    resolved_width = dt_dev_geometry_processed_width(self->dev);
-    resolved_height = dt_dev_geometry_processed_height(self->dev);
+    int32_t processed_size_w = 0;
+    int32_t processed_size_h = 0;
+    dt_dev_geometry_get_processed_size(self->dev, &processed_size_w, &processed_size_h);
+    resolved_width = processed_size_w;
+    resolved_height = processed_size_h;
   }
   if(!IS_NULL_PTR(layer_width)) *layer_width = resolved_width;
   if(!IS_NULL_PTR(layer_height)) *layer_height = resolved_height;

--- a/src/iop/drawlayer/layers.c
+++ b/src/iop/drawlayer/layers.c
@@ -141,8 +141,8 @@ gboolean dt_drawlayer_ensure_layer_cache(dt_iop_module_t *self)
   const gboolean ui_thread = ui_ctx && g_main_context_is_owner(ui_ctx);
   if(!_resolve_layer_geometry(self, NULL, NULL, &layer_width, &layer_height, NULL, NULL))
   {
-    layer_width = self->dev->roi.raw_width;
-    layer_height = self->dev->roi.raw_height;
+    layer_width = dt_dev_geometry_raw_width(self->dev);
+    layer_height = dt_dev_geometry_raw_height(self->dev);
   }
   if(imgid <= 0 || layer_width <= 0 || layer_height <= 0) return FALSE;
   if(!_layer_name_non_empty(params->layer_name))

--- a/src/iop/drawlayer/layers.c
+++ b/src/iop/drawlayer/layers.c
@@ -141,8 +141,11 @@ gboolean dt_drawlayer_ensure_layer_cache(dt_iop_module_t *self)
   const gboolean ui_thread = ui_ctx && g_main_context_is_owner(ui_ctx);
   if(!_resolve_layer_geometry(self, NULL, NULL, &layer_width, &layer_height, NULL, NULL))
   {
-    layer_width = dt_dev_geometry_raw_width(self->dev);
-    layer_height = dt_dev_geometry_raw_height(self->dev);
+    int32_t raw_size_w = 0;
+    int32_t raw_size_h = 0;
+    dt_dev_geometry_get_raw_size(self->dev, &raw_size_w, &raw_size_h);
+    layer_width = raw_size_w;
+    layer_height = raw_size_h;
   }
   if(imgid <= 0 || layer_width <= 0 || layer_height <= 0) return FALSE;
   if(!_layer_name_non_empty(params->layer_name))

--- a/src/iop/drawlayer/layers.c
+++ b/src/iop/drawlayer/layers.c
@@ -141,11 +141,9 @@ gboolean dt_drawlayer_ensure_layer_cache(dt_iop_module_t *self)
   const gboolean ui_thread = ui_ctx && g_main_context_is_owner(ui_ctx);
   if(!_resolve_layer_geometry(self, NULL, NULL, &layer_width, &layer_height, NULL, NULL))
   {
-    int32_t raw_size_w = 0;
-    int32_t raw_size_h = 0;
-    dt_dev_geometry_get_raw_size(self->dev, &raw_size_w, &raw_size_h);
-    layer_width = raw_size_w;
-    layer_height = raw_size_h;
+    const dt_dev_image_geometry_t geometry = dt_dev_geometry_snapshot(self->dev);
+    layer_width = geometry.raw_width;
+    layer_height = geometry.raw_height;
   }
   if(imgid <= 0 || layer_width <= 0 || layer_height <= 0) return FALSE;
   if(!_layer_name_non_empty(params->layer_name))

--- a/src/iop/finalscale.c
+++ b/src/iop/finalscale.c
@@ -158,13 +158,28 @@ error:
 void commit_params(dt_iop_module_t *self, dt_iop_params_t *params, dt_dev_pixelpipe_t *pipe,
                    dt_dev_pixelpipe_iop_t *piece)
 {
-  // Depending on ROI zoom level, we may need to enable finalscale so the pipeline runs
-  // at most at 100%, for pixel-level accuracy, and we upscale at the end. 
+  // Export always upscales at the end; thumbnails never do. Both are decided by the pipe
+  // type alone, so settle them before reading anything off dev: this callback runs on the
+  // pipeline thread, and for those two pipe types `dev` is a headless, throwaway one whose
+  // viewport fields still hold their calloc zero -- the old predicate read them and got the
+  // right answer only because its remaining clauses happened to decide first.
+  if(pipe->type == DT_DEV_PIXELPIPE_EXPORT)
+  {
+    piece->enabled = TRUE;
+    return;
+  }
+  if(pipe->type == DT_DEV_PIXELPIPE_THUMBNAIL)
+  {
+    piece->enabled = FALSE;
+    return;
+  }
+
+  // Darkroom pipes only. Depending on ROI zoom level, we may need to enable finalscale so
+  // the pipeline runs at most at 100%, for pixel-level accuracy, and we upscale at the end.
   // This is important for consistency with exports.
   const float darkroom_zoom = pipe->dev->roi.scaling * pipe->dev->roi.natural_scale;
-  piece->enabled = (darkroom_zoom > 1.f && pipe->type != DT_DEV_PIXELPIPE_THUMBNAIL) 
-    || (pipe->type == DT_DEV_PIXELPIPE_EXPORT)
-    || (dt_conf_get_int("darkroom/render_size") != 1 && darkroom_zoom != 1.f && pipe->type != DT_DEV_PIXELPIPE_THUMBNAIL);
+  piece->enabled = (darkroom_zoom > 1.f)
+    || (dt_conf_get_int("darkroom/render_size") != 1 && darkroom_zoom != 1.f);
 }
 
 void init_pipe(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)

--- a/src/iop/liquify.c
+++ b/src/iop/liquify.c
@@ -2845,8 +2845,8 @@ void gui_post_expose(struct dt_iop_module_t *module,
   if(IS_NULL_PTR(g))
     return;
 
-  const float bb_width = develop->roi.processed_width;
-  const float bb_height = develop->roi.processed_height;
+  const float bb_width = dt_dev_geometry_processed_width(develop);
+  const float bb_height = dt_dev_geometry_processed_height(develop);
   if(bb_width < 1.0 || bb_height < 1.0)
     return;
 
@@ -3180,8 +3180,8 @@ static void get_stamp_params(dt_iop_module_t *module, float *radius, float *r_st
   const int last_win_min = MIN(allocation.width, allocation.height);
 
   const dt_develop_t *dev = module->dev;
-  const float iwd_min = MIN(dev->roi.raw_width, dev->roi.raw_height);
-  const float proc_wdht_min = MIN(dev->roi.processed_width, dev->roi.processed_height);
+  const float iwd_min = MIN(dt_dev_geometry_raw_width(dev), dt_dev_geometry_raw_height(dev));
+  const float proc_wdht_min = MIN(dt_dev_geometry_processed_width(dev), dt_dev_geometry_processed_height(dev));
   const float scale = 1.f / (get_zoom_scale(dev));
   const float im_scale = 0.09f * iwd_min * last_win_min * scale / proc_wdht_min;
 

--- a/src/iop/liquify.c
+++ b/src/iop/liquify.c
@@ -2845,11 +2845,9 @@ void gui_post_expose(struct dt_iop_module_t *module,
   if(IS_NULL_PTR(g))
     return;
 
-  int32_t processed_size_w = 0;
-  int32_t processed_size_h = 0;
-  dt_dev_geometry_get_processed_size(develop, &processed_size_w, &processed_size_h);
-  const float bb_width = processed_size_w;
-  const float bb_height = processed_size_h;
+  const dt_dev_image_geometry_t geometry = dt_dev_geometry_snapshot(develop);
+  const float bb_width = geometry.processed_width;
+  const float bb_height = geometry.processed_height;
   if(bb_width < 1.0 || bb_height < 1.0)
     return;
 

--- a/src/iop/liquify.c
+++ b/src/iop/liquify.c
@@ -2845,8 +2845,11 @@ void gui_post_expose(struct dt_iop_module_t *module,
   if(IS_NULL_PTR(g))
     return;
 
-  const float bb_width = dt_dev_geometry_processed_width(develop);
-  const float bb_height = dt_dev_geometry_processed_height(develop);
+  int32_t processed_size_w = 0;
+  int32_t processed_size_h = 0;
+  dt_dev_geometry_get_processed_size(develop, &processed_size_w, &processed_size_h);
+  const float bb_width = processed_size_w;
+  const float bb_height = processed_size_h;
   if(bb_width < 1.0 || bb_height < 1.0)
     return;
 

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -718,6 +718,46 @@ static inline gboolean _darkroom_preview_fallback_valid(const dt_develop_t *dev,
          && _darkroom_preview_fallback_height == height;
 }
 
+/**
+ * @brief The frame-validity key for the locked main surface.
+ *
+ * @details Every viewport quantity that changes what the composed image should look like,
+ * named one by one. This used to be `dt_hash(5381, (char *)&dev->roi, sizeof(dev->roi))` --
+ * a raw hash of the whole struct, which silently absorbed whatever was added to it and would
+ * just as silently have absorbed the members leaving it as `dev->roi` is divided into its
+ * three real objects. Naming them makes the dependency reviewable and makes the compiler,
+ * rather than a stale cached frame, report the next member that moves.
+ *
+ * The value never leaves the process and is only ever compared against another value computed
+ * here, so it does not have to reproduce the old byte layout -- only to change exactly when
+ * the old one changed.
+ */
+static uint64_t _darkroom_zoom_hash(const dt_develop_t *dev)
+{
+  uint64_t hash = 5381;
+  hash = dt_hash(hash, (const char *)&dev->roi.width, sizeof(dev->roi.width));
+  hash = dt_hash(hash, (const char *)&dev->roi.height, sizeof(dev->roi.height));
+  hash = dt_hash(hash, (const char *)&dev->roi.scaling, sizeof(dev->roi.scaling));
+  hash = dt_hash(hash, (const char *)&dev->roi.x, sizeof(dev->roi.x));
+  hash = dt_hash(hash, (const char *)&dev->roi.y, sizeof(dev->roi.y));
+  hash = dt_hash(hash, (const char *)&dev->roi.border_size, sizeof(dev->roi.border_size));
+  hash = dt_hash(hash, (const char *)&dev->roi.orig_width, sizeof(dev->roi.orig_width));
+  hash = dt_hash(hash, (const char *)&dev->roi.orig_height, sizeof(dev->roi.orig_height));
+  hash = dt_hash(hash, (const char *)&dev->roi.preview_width, sizeof(dev->roi.preview_width));
+  hash = dt_hash(hash, (const char *)&dev->roi.preview_height, sizeof(dev->roi.preview_height));
+  hash = dt_hash(hash, (const char *)&dev->roi.natural_scale, sizeof(dev->roi.natural_scale));
+  hash = dt_hash(hash, (const char *)&dev->roi.gui_inited, sizeof(dev->roi.gui_inited));
+
+  // One coherent read of the image geometry, hashed as the record it is: hashing the four
+  // numbers through four separate accessor calls would let a publication land between two of
+  // them and produce a key for a geometry that never existed.
+  dt_dev_image_geometry_t geometry;
+  dt_dev_geometry_get(dev, &geometry);
+  hash = dt_hash(hash, (const char *)&geometry, sizeof(geometry));
+  hash = dt_hash(hash, (const char *)&dev->roi.output_inited, sizeof(dev->roi.output_inited));
+  return hash;
+}
+
 static inline gboolean _darkroom_locked_main_valid_for_zoom(const darkroom_expose_state_t *state,
                                                             const uint64_t zoom_hash)
 {
@@ -798,7 +838,7 @@ void expose(
     .main_zoom_hash = 0,
     .pending_main_hash = DT_PIXELPIPE_CACHE_HASH_INVALID,
   };
-  const uint64_t zoom_hash = dt_hash(5381, (char *)&dev->roi, sizeof(dev->roi));
+  const uint64_t zoom_hash = _darkroom_zoom_hash(dev);
   const gboolean roi_changed = !_darkroom_locked_main_valid_for_zoom(&expose_state, zoom_hash);
 
   _darkroom_prepare_image_surface(dev, width, height, &expose_state);
@@ -2340,8 +2380,8 @@ static gboolean _darkroom_edge_pan_apply(dt_view_t *self,
   dt_develop_t *dev = edge.dev;
   dt_dev_coordinates_widget_delta_to_image_delta(dev, delta, 1);
 
-  float roi[2] = { dev->roi.x + delta[0] / (float)dev->roi.processed_width,
-                   dev->roi.y + delta[1] / (float)dev->roi.processed_height
+  float roi[2] = { dev->roi.x + delta[0] / (float)dt_dev_geometry_processed_width(dev),
+                   dev->roi.y + delta[1] / (float)dt_dev_geometry_processed_height(dev)
                  };
   dt_dev_check_zoom_pos_bounds(dev, &roi[0], &roi[1], NULL, NULL);
 
@@ -2421,8 +2461,8 @@ void mouse_moved(dt_view_t *self, double x, double y, double pressure, int which
       float mouse_point[2] = { (float)x, (float)y };
       dt_dev_coordinates_widget_to_image_norm(dev, mouse_point, 1);
       const float delta[2] = {
-        1.0f / dev->roi.processed_width,
-        1.0f / dev->roi.processed_height
+        1.0f / dt_dev_geometry_processed_width(dev),
+        1.0f / dt_dev_geometry_processed_height(dev)
       };
 
       if(sample->size == DT_LIB_COLORPICKER_SIZE_BOX)
@@ -2529,8 +2569,8 @@ void mouse_moved(dt_view_t *self, double x, double y, double pressure, int which
     float delta[2] = { x - ctl->button_x, y - ctl->button_y };
     dt_dev_coordinates_widget_delta_to_image_delta(dev, delta, 1);
 
-    float roi[2] = { dev->roi.x - (delta[0] / dev->roi.processed_width),
-                     dev->roi.y - (delta[1] / dev->roi.processed_height) };
+    float roi[2] = { dev->roi.x - (delta[0] / dt_dev_geometry_processed_width(dev)),
+                     dev->roi.y - (delta[1] / dt_dev_geometry_processed_height(dev)) };
     dt_dev_check_zoom_pos_bounds(dev, &roi[0], &roi[1], NULL, NULL);
 
     dev->roi.x = roi[0];
@@ -2563,8 +2603,8 @@ void mouse_moved(dt_view_t *self, double x, double y, double pressure, int which
     dt_dev_coordinates_widget_delta_to_image_delta(dev, delta, 1);
 
     // new roi position in full image scale
-    float roi[2] = { dev->roi.x - (delta[0] / dev->roi.processed_width),
-                     dev->roi.y - (delta[1] / dev->roi.processed_height) };
+    float roi[2] = { dev->roi.x - (delta[0] / dt_dev_geometry_processed_width(dev)),
+                     dev->roi.y - (delta[1] / dt_dev_geometry_processed_height(dev)) };
     dt_dev_check_zoom_pos_bounds(dev, &roi[0], &roi[1], NULL, NULL);
 
     dev->roi.x = roi[0];
@@ -2653,8 +2693,8 @@ int button_pressed(dt_view_t *self, double x, double y, double pressure, int whi
     const float zoom_scale = dt_dev_get_fit_scale(dev);
     float handle[2] = { 6.0f, 6.0f };
     dt_dev_coordinates_widget_delta_to_image_delta(dev, handle, 1);
-    handle[0] /= dev->roi.processed_width;
-    handle[1] /= dev->roi.processed_height;
+    handle[0] /= dt_dev_geometry_processed_width(dev);
+    handle[1] /= dt_dev_geometry_processed_height(dev);
 
     if(which == 1)
     {
@@ -2662,7 +2702,7 @@ int button_pressed(dt_view_t *self, double x, double y, double pressure, int whi
       {
         // The default box will be a square with 1% of the image width
         const float delta_x = 0.01f;
-        const float delta_y = delta_x * (float)dev->roi.processed_width / (float)dev->roi.processed_height;
+        const float delta_y = delta_x * (float)dt_dev_geometry_processed_width(dev) / (float)dt_dev_geometry_processed_height(dev);
 
         if(sample->size == DT_LIB_COLORPICKER_SIZE_BOX)
         {
@@ -2749,8 +2789,8 @@ int button_pressed(dt_view_t *self, double x, double y, double pressure, int whi
               MAX(26.0f, roundf(3.0f * zoom_scale))
             };
             dt_dev_coordinates_widget_delta_to_image_delta(dev, slop, 1);
-            slop[0] /= dev->roi.processed_width;
-            slop[1] /= dev->roi.processed_height;
+            slop[0] /= dt_dev_geometry_processed_width(dev);
+            slop[1] /= dt_dev_geometry_processed_height(dev);
             float live_point[2] = { live_sample->point[0], live_sample->point[1] };
             dt_dev_coordinates_raw_norm_to_image_norm(dev, live_point, 1);
             if(fabsf(point[0] - live_point[0]) > slop[0]
@@ -2967,25 +3007,25 @@ int key_pressed(dt_view_t *self, GdkEventKey *event)
   {
     case GDK_KEY_Up:
     {
-      dev->roi.y -= delta[1] / (float)dev->roi.processed_height;
+      dev->roi.y -= delta[1] / (float)dt_dev_geometry_processed_height(dev);
       _key_scroll(dev);
       return 1;
     }
     case GDK_KEY_Down:
     {
-      dev->roi.y += delta[1] / (float)dev->roi.processed_height;
+      dev->roi.y += delta[1] / (float)dt_dev_geometry_processed_height(dev);
       _key_scroll(dev);
       return 1;
     }
     case GDK_KEY_Left:
     {
-      dev->roi.x -= delta[0] / (float)dev->roi.processed_width;
+      dev->roi.x -= delta[0] / (float)dt_dev_geometry_processed_width(dev);
       _key_scroll(dev);
       return 1;
     }
     case GDK_KEY_Right:
     {
-      dev->roi.x += delta[0] / (float)dev->roi.processed_width;
+      dev->roi.x += delta[0] / (float)dt_dev_geometry_processed_width(dev);
       _key_scroll(dev);
       return 1;
     }


### PR DESCRIPTION
First half of tranche T4b of the `src/develop` decomposition (`doc/develop-split.md`). It divides the backend half out of the anonymous `dev->roi` struct; the GUI viewport object and the versioned ROI channel are the second half and follow in their own PR.

### Why `dev->roi` has to be divided

It fuses three unrelated things behind one name: objective facts about the image (`raw_*`, `processed_*`), GUI viewport state (`scaling`, `x`, `y`, `border_size`, `orig_*`), and values derived from both (`preview_*`, `natural_scale`). All of it unlocked and unversioned, written by the GUI thread while the pipeline worker reads it to plan the ROI each frame is rendered at.

Every one of the 416 access sites was traced before anything moved — six independent passes, each classification then attacked by a checker briefed to find one counter-example. Six attacks landed. The findings are recorded in `doc/develop-split.md`; the important one is that the hazard is not a stale scalar but a **torn pair**: `x` and `y` are written as two statements at all eight write sites and read as two by the worker, so a frame can be planned from half the old pan and half the new.

### What is in this PR

- **`main_width`/`main_height` deleted** — declared with a doc comment, zero readers tree-wide.
- **The survey recorded** in the canonical doc, including three defects it found that are not bookkeeping.
- **`finalscale` stops asking a headless dev for the darkroom zoom.** Its `commit_params()` ran on the pipeline thread and opened by reading `pipe->dev->roi.scaling` for *every* pipe, including export and thumbnail, where the dev is a throwaway one whose viewport fields still hold their `calloc` zero. Both are decidable from the pipe type alone, so they now return first.
- **The geometry record** (`develop/dev_geometry.{h,c}`): the five backend fields become `dt_dev_image_geometry_t`, published under a single-writer seqlock, reached only through accessors. 132 read sites in 17 files, enumerated by the compiler rather than by grep.
- **The tuple consumers read coherently** — 38 sites, chosen by the criterion that they consume width and height as one geometric fact; the ones that motivate it are on the darkroom worker, the drawlayer "draw-back" pthread, and the mask shape files that run on pipeline threads during export.
- **A failed mipmap read stops publishing itself as valid**, so the two guards that open on `raw_inited` refuse instead of running the virtual pipe on 0×0.

`views/darkroom.c`'s zoom key also stops being `dt_hash(5381, (char *)&dev->roi, sizeof(dev->roi))` — a raw hash of the whole struct, which would have silently absorbed the members leaving it, so a stale cached frame rather than the compiler would have reported the next migration.

### Verification

Release, Debug (`-Werror`) and nofeatures build at every commit. `cycles 0` and `layering_violations 187` unchanged; conditional-includes, unused-includes, list-order, statelessness, module-boundaries and return-types all pass. Decoded-pixel export A/B (`--disable-opencl`, isolated `--configdir`) of a raw carrying a 57-node brush mask: **0 differing pixels on both the image page and the mask page**, re-run at each commit.

Not covered by any of that, so worth a GUI pass: darkroom zoom/pan, the navigation thumbnail, and drawing on an image with `retouch` or `drawlayer`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)