### PR TITLE
Develop T4b (part 2): the darkroom viewport becomes an object

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -183,6 +183,7 @@ FILE(GLOB SOURCE_FILES
   "control/signal.c"
   "develop/develop.c"
   "develop/dev_geometry.c"
+  "develop/dev_viewport.c"
   "develop/gui_throttle.c"
   "develop/dev_history.c"
   "develop/dev_history_gui.c"

--- a/src/develop/dev_snapshot.c
+++ b/src/develop/dev_snapshot.c
@@ -153,17 +153,17 @@ gboolean dt_dev_snapshot_is_valid(const dt_dev_snapshot_t *snap)
 static gboolean _compute_main_roi(const dt_develop_t *dev, const dt_dev_pixelpipe_t *pipe, dt_iop_roi_t *roi)
 {
   if(IS_NULL_PTR(dev) || IS_NULL_PTR(pipe) || IS_NULL_PTR(roi)) return FALSE;
-  if(!dev->roi.output_inited || dev->roi.width <= 0 || dev->roi.height <= 0) return FALSE;
+  if(!dev->roi.output_inited || dt_dev_viewport_box_width(dev) <= 0 || dt_dev_viewport_box_height(dev) <= 0) return FALSE;
   if(pipe->processed_width <= 0 || pipe->processed_height <= 0) return FALSE;
 
-  const float scale = dev->roi.natural_scale * dev->roi.scaling;
+  const float scale = dev->roi.natural_scale * dt_dev_viewport_scaling(dev);
   const int roi_width = (int)roundf(scale * pipe->processed_width);
   const int roi_height = (int)roundf(scale * pipe->processed_height);
 
-  roi->width = MAX(1, MIN(roi_width, dev->roi.width));
-  roi->height = MAX(1, MIN(roi_height, dev->roi.height));
-  roi->x = (int)roundf(dev->roi.x * roi_width - roi->width * .5f);
-  roi->y = (int)roundf(dev->roi.y * roi_height - roi->height * .5f);
+  roi->width = MAX(1, MIN(roi_width, dt_dev_viewport_box_width(dev)));
+  roi->height = MAX(1, MIN(roi_height, dt_dev_viewport_box_height(dev)));
+  roi->x = (int)roundf(dt_dev_viewport_center_x(dev) * roi_width - roi->width * .5f);
+  roi->y = (int)roundf(dt_dev_viewport_center_y(dev) * roi_height - roi->height * .5f);
   roi->scale = scale;
   return TRUE;
 }
@@ -322,9 +322,9 @@ static void _draw_preview_fallback(dt_dev_snapshot_engine_t *engine, dt_develop_
   const float ppd = dt_gui_get_global()->ppd;
   const float preview_wd = engine->preview_locked.width / ppd;
   const float preview_ht = engine->preview_locked.height / ppd;
-  const float preview_scale = dev->roi.scaling;
-  const float tx = 0.5f * width - dev->roi.x * preview_wd * preview_scale;
-  const float ty = 0.5f * height - dev->roi.y * preview_ht * preview_scale;
+  const float preview_scale = dt_dev_viewport_scaling(dev);
+  const float tx = 0.5f * width - dt_dev_viewport_center_x(dev) * preview_wd * preview_scale;
+  const float ty = 0.5f * height - dt_dev_viewport_center_y(dev) * preview_ht * preview_scale;
 
   dt_dev_pixelpipe_cache_rdlock_entry(TRUE, engine->preview_locked.entry);
   cairo_surface_set_device_scale(engine->preview_locked.surface, ppd, ppd);
@@ -560,7 +560,7 @@ void dt_dev_snapshot_draw(dt_dev_snapshot_t *snap, cairo_t *cri, struct dt_devel
   {
     if(dt_dev_lock_pipe_surface(dev, engine->pipe, &engine->locked, &engine->wait, "snapshot", FALSE)
        && !IS_NULL_PTR(engine->locked.surface))
-      dt_dev_render_locked_surface(cri, dev, &engine->locked, width, height, dev->roi.border_size, bg_color);
+      dt_dev_render_locked_surface(cri, dev, &engine->locked, width, height, dt_dev_viewport_border_size(dev), bg_color);
   }
   else
   {

--- a/src/develop/dev_viewport.c
+++ b/src/develop/dev_viewport.c
@@ -1,0 +1,185 @@
+/*
+    This file is part of Ansel.
+    Copyright (C) 2026 Aurélien Pierre.
+
+    Ansel is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Ansel is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Ansel.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "develop/dev_viewport.h"
+#include "develop/develop.h"
+
+#include <string.h>
+
+/* The publication protocol is the geometry record's, for the same reason: the GUI thread is
+ * the only writer, while the darkroom worker and drawlayer's paint thread read. A mutator
+ * builds the whole next state in a local, compares it, and publishes it in one bracketed
+ * store -- so "half the old pan and half the new" is not a state a reader can observe.
+ */
+
+static inline void _publish(dt_dev_viewport_t *viewport, const dt_dev_viewport_state_t *next)
+{
+  dt_atomic_set_uint64(&viewport->generation, dt_atomic_get_uint64(&viewport->generation) + 1);
+  viewport->state = *next;
+  dt_atomic_set_uint64(&viewport->generation, dt_atomic_get_uint64(&viewport->generation) + 1);
+}
+
+dt_dev_viewport_state_t dt_dev_viewport_neutral(void)
+{
+  // Not a zeroed struct: these are the values dt_dev_reset_roi() left on every dev, including
+  // headless ones, before the viewport was an object. A dev with no viewport must keep reading
+  // them, or every consumer of the product (scaling * natural_scale) changes answer.
+  dt_dev_viewport_state_t state;
+  memset(&state, 0, sizeof(state));
+  state.scaling = 1.f;
+  state.center_x = 0.5f;
+  state.center_y = 0.5f;
+  return state;
+}
+
+dt_dev_viewport_t *dt_dev_viewport_new(void)
+{
+  dt_dev_viewport_t *viewport = (dt_dev_viewport_t *)calloc(1, sizeof(dt_dev_viewport_t));
+  if(IS_NULL_PTR(viewport)) return NULL;
+
+  viewport->state = dt_dev_viewport_neutral();
+  dt_atomic_set_uint64(&viewport->generation, 0);
+  return viewport;
+}
+
+void dt_dev_viewport_free(dt_dev_viewport_t *viewport)
+{
+  dt_free(viewport);
+}
+
+gboolean dt_dev_viewport_exists(const dt_develop_t *dev)
+{
+  return !IS_NULL_PTR(dev) && !IS_NULL_PTR(dev->viewport);
+}
+
+dt_dev_viewport_state_t dt_dev_viewport_get(const dt_develop_t *dev)
+{
+  if(!dt_dev_viewport_exists(dev)) return dt_dev_viewport_neutral();
+
+  const dt_dev_viewport_t *viewport = dev->viewport;
+  dt_dev_viewport_state_t state;
+
+  // Seqlock read: copy, then check nothing was published while we copied.
+  for(;;)
+  {
+    const uint64_t before = dt_atomic_get_uint64(&viewport->generation);
+    if(before & 1) continue;
+
+    state = viewport->state;
+
+    const uint64_t after = dt_atomic_get_uint64(&viewport->generation);
+    if(before == after) break;
+  }
+
+  return state;
+}
+
+float dt_dev_viewport_scaling(const dt_develop_t *dev) { return dt_dev_viewport_get(dev).scaling; }
+float dt_dev_viewport_center_x(const dt_develop_t *dev) { return dt_dev_viewport_get(dev).center_x; }
+float dt_dev_viewport_center_y(const dt_develop_t *dev) { return dt_dev_viewport_get(dev).center_y; }
+int32_t dt_dev_viewport_box_width(const dt_develop_t *dev) { return dt_dev_viewport_get(dev).box_width; }
+int32_t dt_dev_viewport_box_height(const dt_develop_t *dev) { return dt_dev_viewport_get(dev).box_height; }
+int32_t dt_dev_viewport_widget_width(const dt_develop_t *dev) { return dt_dev_viewport_get(dev).widget_width; }
+int32_t dt_dev_viewport_widget_height(const dt_develop_t *dev) { return dt_dev_viewport_get(dev).widget_height; }
+int32_t dt_dev_viewport_border_size(const dt_develop_t *dev) { return dt_dev_viewport_get(dev).border_size; }
+gboolean dt_dev_viewport_configured(const dt_develop_t *dev) { return dt_dev_viewport_get(dev).configured; }
+
+gboolean dt_dev_viewport_set_widget_size(dt_develop_t *dev, const int32_t widget_width,
+                                         const int32_t widget_height)
+{
+  if(!dt_dev_viewport_exists(dev)) return FALSE;
+
+  dt_dev_viewport_state_t next = dt_dev_viewport_get(dev);
+  if(next.widget_width == widget_width && next.widget_height == widget_height) return FALSE;
+
+  next.widget_width = widget_width;
+  next.widget_height = widget_height;
+  _publish(dev->viewport, &next);
+  return TRUE;
+}
+
+gboolean dt_dev_viewport_set_border(dt_develop_t *dev, const int32_t border_size)
+{
+  if(!dt_dev_viewport_exists(dev)) return FALSE;
+
+  dt_dev_viewport_state_t next = dt_dev_viewport_get(dev);
+  if(next.border_size == border_size) return FALSE;
+
+  next.border_size = border_size;
+  _publish(dev->viewport, &next);
+  return TRUE;
+}
+
+gboolean dt_dev_viewport_set_box(dt_develop_t *dev, const int32_t box_width, const int32_t box_height)
+{
+  if(!dt_dev_viewport_exists(dev)) return FALSE;
+
+  dt_dev_viewport_state_t next = dt_dev_viewport_get(dev);
+  if(next.box_width == box_width && next.box_height == box_height && next.configured) return FALSE;
+
+  next.box_width = box_width;
+  next.box_height = box_height;
+  next.configured = TRUE;
+  _publish(dev->viewport, &next);
+  return TRUE;
+}
+
+gboolean dt_dev_viewport_set_center(dt_develop_t *dev, const float center_x, const float center_y)
+{
+  if(!dt_dev_viewport_exists(dev)) return FALSE;
+
+  dt_dev_viewport_state_t next = dt_dev_viewport_get(dev);
+  if(next.center_x == center_x && next.center_y == center_y) return FALSE;
+
+  // The pair is published together, which is the whole point: the two coordinates were eight
+  // independent stores before, and the worker read them as two independent loads.
+  next.center_x = center_x;
+  next.center_y = center_y;
+  _publish(dev->viewport, &next);
+  return TRUE;
+}
+
+gboolean dt_dev_viewport_set_scaling(dt_develop_t *dev, const float scaling)
+{
+  if(!dt_dev_viewport_exists(dev)) return FALSE;
+
+  dt_dev_viewport_state_t next = dt_dev_viewport_get(dev);
+  if(next.scaling == scaling) return FALSE;
+
+  next.scaling = scaling;
+  _publish(dev->viewport, &next);
+  return TRUE;
+}
+
+void dt_dev_viewport_reset(dt_develop_t *dev)
+{
+  if(!dt_dev_viewport_exists(dev)) return;
+
+  const dt_dev_viewport_state_t neutral = dt_dev_viewport_neutral();
+  dt_dev_viewport_state_t next = dt_dev_viewport_get(dev);
+  next.scaling = neutral.scaling;
+  next.center_x = neutral.center_x;
+  next.center_y = neutral.center_y;
+  _publish(dev->viewport, &next);
+}
+
+// clang-format off
+// modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py
+// vim: shiftwidth=2 expandtab tabstop=2 cindent
+// kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;
+// clang-format on

--- a/src/develop/dev_viewport.h
+++ b/src/develop/dev_viewport.h
@@ -1,0 +1,150 @@
+/*
+    This file is part of Ansel.
+    Copyright (C) 2026 Aurélien Pierre.
+
+    Ansel is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Ansel is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Ansel.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef DT_DEVELOP_DEV_VIEWPORT_H
+#define DT_DEVELOP_DEV_VIEWPORT_H
+
+#include <glib.h>
+#include <stdint.h>
+
+#include "system/atomic.h"
+
+struct dt_develop_t;
+
+/**
+ * @brief What the darkroom view asks the pipeline to show: the window onto the image.
+ *
+ * @details Meaningless without a GUI, and therefore absent without one -- dt_develop_t owns a
+ * pointer that is allocated only for a gui_attached dev and NULL otherwise. That NULL IS the
+ * flag: it replaces roi.gui_inited, and for this half of the object it replaces
+ * dev->gui_attached too.
+ *
+ * Two devs can hold one at the same time (the darkroom's and studio capture's), and studio
+ * capture swaps which one is global. Nothing here resolves dt_dev_get_global() internally;
+ * every entry point takes the dev whose viewport it means.
+ */
+typedef struct dt_dev_viewport_state_t
+{
+  /** Darkroom main widget size in GUI logical coordinates, as allocated by Gtk from the window
+   *  minus all panels. NOT the size of the backbuffer. (was roi.orig_width/orig_height) */
+  int32_t widget_width, widget_height;
+
+  /** ISO 12646 borders, or user-defined borders, in GUI logical pixels. */
+  int32_t border_size;
+
+  /** (widget size - 2 * border_size) converted to raster pixels through the GUI ppd factor:
+   *  the surface an image backbuffer actually covers. Derived here, never set from outside.
+   *  (was roi.width/roi.height) */
+  int32_t box_width, box_height;
+
+  /** User zoom, applied on top of the natural (fit-to-box) scale. */
+  float scaling;
+
+  /** Relative coordinates of the centre of the ROI within the whole image. Written and read as
+   *  a pair -- a frame planned from half the old pan and half the new is the failure this
+   *  object exists to make unrepresentable. (was roi.x/roi.y) */
+  float center_x, center_y;
+
+  /** TRUE once a widget allocation has been handed in. (was roi.gui_inited) */
+  gboolean configured;
+} dt_dev_viewport_state_t;
+
+typedef struct dt_dev_viewport_t
+{
+  /** Single-writer seqlock, same contract as dt_dev_geometry_store_t: the GUI thread is the
+   *  only writer, while the darkroom worker and drawlayer's "draw-back" thread both read. */
+  dt_atomic_uint64 generation;
+  dt_dev_viewport_state_t state;
+} dt_dev_viewport_t;
+
+/** Allocate/free. dt_dev_init() creates one only for a gui_attached dev. */
+dt_dev_viewport_t *dt_dev_viewport_new(void);
+void dt_dev_viewport_free(dt_dev_viewport_t *viewport);
+
+/**
+ * @brief Coherent copy of the viewport state, by value -- the ordinary way to read it:
+ *
+ *    const dt_dev_viewport_state_t viewport = dt_dev_viewport_get(dev);
+ *
+ * @details A dev with no viewport yields the NEUTRAL state, which is not zeroed: scaling is
+ * 1.0 and the centre is (0.5, 0.5), reproducing exactly what dt_dev_reset_roi() left on a
+ * headless dev before this object existed. Callers that need to distinguish "no viewport" from
+ * "viewport at defaults" ask dt_dev_viewport_exists().
+ */
+dt_dev_viewport_state_t dt_dev_viewport_get(const struct dt_develop_t *dev);
+
+/** The neutral state a dev without a viewport reads as. */
+dt_dev_viewport_state_t dt_dev_viewport_neutral(void);
+
+gboolean dt_dev_viewport_exists(const struct dt_develop_t *dev);
+
+/* Single-field readers, one line each, for the sites that want one number. */
+float dt_dev_viewport_scaling(const struct dt_develop_t *dev);
+float dt_dev_viewport_center_x(const struct dt_develop_t *dev);
+float dt_dev_viewport_center_y(const struct dt_develop_t *dev);
+int32_t dt_dev_viewport_box_width(const struct dt_develop_t *dev);
+int32_t dt_dev_viewport_box_height(const struct dt_develop_t *dev);
+int32_t dt_dev_viewport_widget_width(const struct dt_develop_t *dev);
+int32_t dt_dev_viewport_widget_height(const struct dt_develop_t *dev);
+int32_t dt_dev_viewport_border_size(const struct dt_develop_t *dev);
+gboolean dt_dev_viewport_configured(const struct dt_develop_t *dev);
+
+/* ---- mutators ----
+ *
+ * GUI thread only. Each returns TRUE when the published state actually changed, so a caller
+ * can decide whether to trigger a recompute without comparing fields itself. Each publishes
+ * once, as a whole state, so no reader can observe a half-applied change; and each applies its
+ * own clamps BEFORE publishing, so no value the clamp would take back is ever visible.
+ *
+ * A dev with no viewport accepts every call and does nothing.
+ */
+
+/** The Gtk allocation of the darkroom centre widget, in logical pixels. */
+gboolean dt_dev_viewport_set_widget_size(struct dt_develop_t *dev, int32_t widget_width,
+                                         int32_t widget_height);
+
+/** Border policy (ISO 12646 toggle, preference), in logical pixels. */
+gboolean dt_dev_viewport_set_border(struct dt_develop_t *dev, int32_t border_size);
+
+/** The raster-pixel box an image backbuffer covers, and the "a size has been handed in" flag.
+ *
+ *  Takes the box already converted to raster pixels, because that is what its one caller
+ *  computes today (dt_dev_configure_real, through dt_dev_convert_roi) and because the border
+ *  subtraction that precedes it lives at ITS callers (views/dev_toolbox.c). Folding both into
+ *  this object is the right end state and a behaviour change to argue separately; this tranche
+ *  relocates state, it does not redistribute arithmetic. */
+gboolean dt_dev_viewport_set_box(struct dt_develop_t *dev, int32_t box_width, int32_t box_height);
+
+/** Absolute pan, in normalized image coordinates. The caller clamps: the clamp needs the
+ *  processed size and the zoom level, which belong to the ROI request, not here. */
+gboolean dt_dev_viewport_set_center(struct dt_develop_t *dev, float center_x, float center_y);
+
+/** User zoom, applied on top of the natural (fit-to-box) scale. Clamped by the caller, for the
+ *  same reason as the centre. */
+gboolean dt_dev_viewport_set_scaling(struct dt_develop_t *dev, float scaling);
+
+/** Reset to the neutral zoom and centre, without touching the allocation or border. */
+void dt_dev_viewport_reset(struct dt_develop_t *dev);
+
+#endif // DT_DEVELOP_DEV_VIEWPORT_H
+
+// clang-format off
+// modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py
+// vim: shiftwidth=2 expandtab tabstop=2 cindent
+// kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;
+// clang-format on

--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -135,8 +135,7 @@ void dt_dev_init(dt_develop_t *dev, int32_t gui_attached)
   dt_pthread_mutex_init(&dev->transient_params_mutex, NULL);
 
   dev->gui_attached = gui_attached;
-  dev->roi.width = -1;
-  dev->roi.height = -1;
+  if(gui_attached) dev->viewport = dt_dev_viewport_new();
 
   dt_image_init(&dev->image_storage);
 
@@ -223,6 +222,9 @@ void dt_dev_cleanup(dt_develop_t *dev)
 
   dt_gui_throttle_cancel(dev);
   dt_dev_history_drop_pending_commits(dev);
+
+  dt_dev_viewport_free(dev->viewport);
+  dev->viewport = NULL;
 
   dev->proxy.chroma_adaptation = NULL;
   dev->proxy.wb_coeffs[0] = 0.f;
@@ -331,8 +333,8 @@ static gboolean _darkroom_pipeline_inputs_ready(const dt_develop_t *dev)
   dt_dev_geometry_get(dev, &geometry);
 
   return dev->image_storage.id > 0
-         && dev->roi.width >= 32
-         && dev->roi.height >= 32
+         && dt_dev_viewport_box_width(dev) >= 32
+         && dt_dev_viewport_box_height(dev) >= 32
          && geometry.raw_width >= 32
          && geometry.raw_height >= 32
          && geometry.processed_width >= 32
@@ -343,7 +345,7 @@ static gboolean _darkroom_pipeline_inputs_ready(const dt_develop_t *dev)
 
 int dt_dev_get_thumbnail_size(dt_develop_t *dev)
 {
-  if(!dt_dev_geometry_raw_inited(dev) || !dev->roi.gui_inited) return 1;
+  if(!dt_dev_geometry_raw_inited(dev) || !dt_dev_viewport_configured(dev)) return 1;
 
   // Keep the virtual pipe synced so ROI computations on the GUI thread
   // always use up-to-date history and input sizes.
@@ -473,7 +475,7 @@ static gboolean _update_darkroom_roi(dt_develop_t *dev, dt_dev_pixelpipe_t *pipe
   // therefore excludes the GUI backing-store density.
   *scale = dev->roi.natural_scale;
   const gboolean preview_pipe = (pipe == dev->preview_pipe);
-  if(!preview_pipe) *scale *= dev->roi.scaling;
+  if(!preview_pipe) *scale *= dt_dev_viewport_scaling(dev);
 
   // Width, height, x and y are already expressed in raster pixels, so they
   // must follow the same raster-space sampling ratio as roi->scale.
@@ -483,21 +485,21 @@ static gboolean _update_darkroom_roi(dt_develop_t *dev, dt_dev_pixelpipe_t *pipe
 
   int roi_width = roundf(*scale * processed_width);
   int roi_height = roundf(*scale * processed_height);
-  int widget_wd = dev->roi.width;
-  int widget_ht = dev->roi.height;
+  int widget_wd = dt_dev_viewport_box_width(dev);
+  int widget_ht = dt_dev_viewport_box_height(dev);
 
   *wd = roundf(fminf(roi_width, widget_wd));
   *ht = roundf(fminf(roi_height, widget_ht));
 
-  // dev->roi.x,y are the relative coordinates of the ROI center.
+  // dt_dev_viewport_center_x(dev),y are the relative coordinates of the ROI center.
   // in preview pipe, we always render a full image, so x,y = 0,0 
   // otherwise, x,y here are the top-left corner. Translate:
-  *x = preview_pipe ? 0 : roundf(dev->roi.x * roi_width - *wd * .5f);
-  *y = preview_pipe ? 0 : roundf(dev->roi.y * roi_height - *ht * .5f);
+  *x = preview_pipe ? 0 : roundf(dt_dev_viewport_center_x(dev) * roi_width - *wd * .5f);
+  *y = preview_pipe ? 0 : roundf(dt_dev_viewport_center_y(dev) * roi_height - *ht * .5f);
 
 /*  fprintf (stderr, "_update_darkroom_roi: dev %.2f %.2f  type %s  xy %d %d  dim %d %d"
                    "   ppd:%.4f scale:%.4f nat_scale:%.4f * scaling:%.4f\n",
-            dev->roi.x, dev->roi.y, dt_pipe_type_to_str(pipe->type), *x, *y, *wd, *ht, dt_gui_get_global()->ppd, *scale, dev->roi.natural_scale, dev->roi.scaling);
+            dt_dev_viewport_center_x(dev), dt_dev_viewport_center_y(dev), dt_pipe_type_to_str(pipe->type), *x, *y, *wd, *ht, dt_gui_get_global()->ppd, *scale, dev->roi.natural_scale, dt_dev_viewport_scaling(dev));
 */
   return x_old != *x || y_old != *y || wd_old != *wd || ht_old != *ht || old_scale != *scale;
 }
@@ -962,7 +964,7 @@ float dt_dev_get_zoom_scale(const dt_develop_t *dev, const gboolean preview)
 
   const float w = preview ? processed_width : dev->pipe->processed_width;
   const float h = preview ? processed_height : dev->pipe->processed_height;
-  return fminf(dev->roi.width / w, dev->roi.height / h);
+  return fminf(dt_dev_viewport_box_width(dev) / w, dt_dev_viewport_box_height(dev) / h);
 }
 
 dt_dev_image_storage_t dt_dev_load_image(dt_develop_t *dev, const int32_t imgid)
@@ -1008,18 +1010,35 @@ void dt_dev_configure_real(dt_develop_t *dev, int wd, int ht)
   const dt_iop_roi_t gui_roi = { .x = 0, .y = 0, .width = wd, .height = ht, .scale = 1.0f };
   dt_iop_roi_t pipe_roi = { 0 };
   dt_dev_convert_roi(dev, &gui_roi, &pipe_roi, DT_DEV_ROI_GUI_LOGICAL, DT_DEV_ROI_PIPELINE);
-  dev->roi.width = pipe_roi.width;
-  dev->roi.height = pipe_roi.height;
-  dev->roi.gui_inited = TRUE;
+  dt_dev_viewport_set_box(dev, pipe_roi.width, pipe_roi.height);
 
   dt_print(DT_DEBUG_DEV,
            "[pixelpipe] Darkroom requested a %i×%i px widget -> %i×%i px raster preview\n",
-           wd, ht, dev->roi.width, dev->roi.height);
+           wd, ht, dt_dev_viewport_box_width(dev), dt_dev_viewport_box_height(dev));
 
   dt_dev_get_thumbnail_size(dev);
   dt_dev_pixelpipe_update_zoom_main(dev);
   dt_dev_pixelpipe_update_zoom_preview(dev);
   dt_control_queue_redraw();
+}
+
+/**
+ * @brief Clamp the viewport centre against the box currently visible at this zoom.
+ *
+ * @details Four call sites used to hand dt_dev_check_zoom_pos_bounds() the addresses of the
+ * centre fields and let it write through them. Nothing may hold a pointer into the viewport
+ * now -- it publishes whole states -- so the read/clamp/publish round trip lives here once
+ * instead of being spelled out at each site.
+ *
+ * @return TRUE when the clamp actually moved the centre.
+ */
+gboolean dt_dev_clamp_viewport_center(dt_develop_t *dev)
+{
+  const dt_dev_viewport_state_t viewport = dt_dev_viewport_get(dev);
+  float center_x = viewport.center_x;
+  float center_y = viewport.center_y;
+  dt_dev_check_zoom_pos_bounds(dev, &center_x, &center_y, NULL, NULL);
+  return dt_dev_viewport_set_center(dev, center_x, center_y);
 }
 
 void dt_dev_check_zoom_pos_bounds(dt_develop_t *dev, float *dev_x, float *dev_y, float *box_w, float *box_h)
@@ -1033,16 +1052,16 @@ void dt_dev_check_zoom_pos_bounds(dt_develop_t *dev, float *dev_x, float *dev_y,
   const float scale = dt_dev_get_zoom_level(dev);
 
   // find the box size
-  const float bw = dev->roi.width / (proc_w * scale);
-  const float bh = dev->roi.height / (proc_h * scale);
+  const float bw = dt_dev_viewport_box_width(dev) / (proc_w * scale);
+  const float bh = dt_dev_viewport_box_height(dev) / (proc_h * scale);
 
   // calculate half-dimensions once
   const float half_bw = bw * 0.5f;
   const float half_bh = bh * 0.5f;
 
   // clamp position using pre-calculated values
-  *dev_x = (bw > 1.0f || dev->roi.scaling <= 1.0f) ? 0.5f : CLAMPF(*dev_x, half_bw, 1.0f - half_bw);
-  *dev_y = (bh > 1.0f || dev->roi.scaling <= 1.0f) ? 0.5f : CLAMPF(*dev_y, half_bh, 1.0f - half_bh);
+  *dev_x = (bw > 1.0f || dt_dev_viewport_scaling(dev) <= 1.0f) ? 0.5f : CLAMPF(*dev_x, half_bw, 1.0f - half_bw);
+  *dev_y = (bh > 1.0f || dt_dev_viewport_scaling(dev) <= 1.0f) ? 0.5f : CLAMPF(*dev_y, half_bh, 1.0f - half_bh);
   // return box size
   if(!IS_NULL_PTR(box_w)) *box_w = bw;
   if(!IS_NULL_PTR(box_h)) *box_h = bh;
@@ -1096,10 +1115,10 @@ void dt_dev_coordinates_widget_to_image_norm(dt_develop_t *dev, float *points, s
   // zoom lives in raster pixels. Convert back to the same GUI-space zoom used
   // by dt_dev_rescale_roi() so event hit-testing and overlay drawing stay aligned.
   const float scale = dt_dev_get_zoom_level(dev) / dt_gui_get_global()->ppd;
-  const float roi_x = (float)dev->roi.x;
-  const float roi_y = (float)dev->roi.y;
-  const float center_x = 0.5f * (float)dev->roi.orig_width;
-  const float center_y = 0.5f * (float)dev->roi.orig_height;
+  const float roi_x = (float)dt_dev_viewport_center_x(dev);
+  const float roi_y = (float)dt_dev_viewport_center_y(dev);
+  const float center_x = 0.5f * (float)dt_dev_viewport_widget_width(dev);
+  const float center_y = 0.5f * (float)dt_dev_viewport_widget_height(dev);
   const float inv_scaled_width = 1.0f / (processed_width * scale);
   const float inv_scaled_height = 1.0f / (processed_height * scale);
 
@@ -1124,12 +1143,12 @@ void dt_dev_coordinates_image_norm_to_widget(dt_develop_t *dev, float *points, s
   // GUI overlays are drawn in logical widget coordinates, so use the same
   // GUI-space zoom that the Cairo darkroom transform applies.
   const float scale = dt_dev_get_zoom_level(dev) / dt_gui_get_global()->ppd;
-  const float roi_x = (float)dev->roi.x;
-  const float roi_y = (float)dev->roi.y;
+  const float roi_x = (float)dt_dev_viewport_center_x(dev);
+  const float roi_y = (float)dt_dev_viewport_center_y(dev);
   const float scaled_width = processed_width * scale;
   const float scaled_height = processed_height * scale;
-  const float center_x = 0.5f * (float)dev->roi.orig_width;
-  const float center_y = 0.5f * (float)dev->roi.orig_height;
+  const float center_x = 0.5f * (float)dt_dev_viewport_widget_width(dev);
+  const float center_y = 0.5f * (float)dt_dev_viewport_widget_height(dev);
 
   for(size_t i = 0; i < num_points; ++i)
   {
@@ -1806,17 +1825,17 @@ void dt_dev_masks_update_hash(dt_develop_t *dev)
 
 float dt_dev_get_natural_scale(dt_develop_t *dev)
 {
-  if(!dev->roi.gui_inited || !dt_dev_geometry_raw_inited(dev)) return -1.f;
+  if(!dt_dev_viewport_configured(dev) || !dt_dev_geometry_raw_inited(dev)) return -1.f;
 
-  return fminf(fminf((float)dev->roi.width / (float)dt_dev_geometry_processed_width(dev),
-                      (float)dev->roi.height / (float)dt_dev_geometry_processed_height(dev)),
+  return fminf(fminf((float)dt_dev_viewport_box_width(dev) / (float)dt_dev_geometry_processed_width(dev),
+                      (float)dt_dev_viewport_box_height(dev) / (float)dt_dev_geometry_processed_height(dev)),
                 1.f);
 }
 
 float dt_dev_get_fit_scale(dt_develop_t *dev)
 {
   if(IS_NULL_PTR(dev)) return 1.0f;
-  return dev->roi.scaling / dt_gui_get_global()->ppd;
+  return dt_dev_viewport_scaling(dev) / dt_gui_get_global()->ppd;
 }
 
 float dt_dev_get_overlay_scale(dt_develop_t *dev)
@@ -1833,18 +1852,18 @@ float dt_dev_get_widget_zoom_scale(const dt_develop_t *dev, const float scaling)
 void dt_dev_get_widget_center(const dt_develop_t *dev, float *point)
 {
   if(IS_NULL_PTR(dev) || IS_NULL_PTR(point)) return;
-  point[0] = 0.5f * dev->roi.orig_width;
-  point[1] = 0.5f * dev->roi.orig_height;
+  point[0] = 0.5f * dt_dev_viewport_widget_width(dev);
+  point[1] = 0.5f * dt_dev_viewport_widget_height(dev);
 }
 
 void dt_dev_get_image_box_in_widget(const dt_develop_t *dev, const int32_t width, const int32_t height, float *box)
 {
   if(IS_NULL_PTR(dev) || IS_NULL_PTR(box)) return;
 
-  const float scale = dev->roi.scaling / dt_gui_get_global()->ppd;
+  const float scale = dt_dev_viewport_scaling(dev) / dt_gui_get_global()->ppd;
   const float roi_width = fminf(width, dev->roi.preview_width * scale);
   const float roi_height = fminf(height, dev->roi.preview_height * scale);
-  const float border = dev->roi.border_size;
+  const float border = dt_dev_viewport_border_size(dev);
 
   box[0] = fmaxf(border, 0.5f * (width - roi_width));
   box[1] = fmaxf(border, 0.5f * (height - roi_height));
@@ -1855,15 +1874,13 @@ void dt_dev_get_image_box_in_widget(const dt_develop_t *dev, const int32_t width
 float dt_dev_get_zoom_level(const dt_develop_t *dev)
 {
   if(IS_NULL_PTR(dev)) return 1.f;
-  return dev->roi.scaling * dev->roi.natural_scale;
+  return dt_dev_viewport_scaling(dev) * dev->roi.natural_scale;
 }
 
 void dt_dev_reset_roi(dt_develop_t *dev)
 {
   dev->roi.natural_scale = -1.f;
-  dev->roi.scaling = 1.f;
-  dev->roi.x = 0.5f;
-  dev->roi.y = 0.5f;
+  dt_dev_viewport_reset(dev);
 }
 
 void dt_dev_convert_roi(const dt_develop_t *dev, const dt_iop_roi_t *roi_in, dt_iop_roi_t *roi_out,
@@ -1897,7 +1914,7 @@ gboolean dt_dev_clip_roi(dt_develop_t *dev, cairo_t *cr, int32_t width, int32_t 
   if(wd == 0.f || ht == 0.f) return TRUE;
 
   const float zoom_scale = dt_dev_get_overlay_scale(dev);
-  const int32_t border = dev->roi.border_size;
+  const int32_t border = dt_dev_viewport_border_size(dev);
   const float roi_width = fminf(width, wd * zoom_scale);
   const float roi_height = fminf(height, ht * zoom_scale);
 
@@ -1923,8 +1940,8 @@ static gboolean _dev_translate_roi(dt_develop_t *dev, cairo_t *cr, int32_t width
 
   // Get image's origin position and scale
   const float zoom_scale = dt_dev_get_zoom_level(dev) / dt_gui_get_global()->ppd;
-  const float tx = 0.5f * width - dev->roi.x * proc_wd * zoom_scale;
-  const float ty = 0.5f * height - dev->roi.y * proc_ht * zoom_scale;
+  const float tx = 0.5f * width - dt_dev_viewport_center_x(dev) * proc_wd * zoom_scale;
+  const float ty = 0.5f * height - dt_dev_viewport_center_y(dev) * proc_ht * zoom_scale;
 
   cairo_translate(cr, tx, ty);
   
@@ -1954,23 +1971,24 @@ gboolean dt_dev_rescale_roi_to_input(dt_develop_t *dev, cairo_t *cr, int32_t wid
 gboolean dt_dev_check_zoom_scale_bounds(dt_develop_t *dev)
 {
   const float natural_scale = dev->roi.natural_scale;
+  const float scaling = dt_dev_viewport_scaling(dev);
 
   // Limit zoom in to 16x the size of an apparent pixel on screen
-  const float pixel_actual_size = natural_scale * dev->roi.scaling;
+  const float pixel_actual_size = natural_scale * scaling;
   const float pixel_max_size = 16.f;
-  
+
   if(pixel_actual_size >= pixel_max_size)
   {
     // Restore old scaling (caller should handle this)
-    dev->roi.scaling = pixel_max_size / natural_scale;
+    dt_dev_viewport_set_scaling(dev, pixel_max_size / natural_scale);
     return TRUE;
   }
-  
+
   // Limit zoom out to 1/3rd of the fit-to-window size
   const float min_scaling = 0.33f;
-  if(dev->roi.scaling < min_scaling)
+  if(scaling < min_scaling)
   {
-    dev->roi.scaling = min_scaling;
+    dt_dev_viewport_set_scaling(dev, min_scaling);
     return TRUE;
   }
   return FALSE;

--- a/src/develop/develop.h
+++ b/src/develop/develop.h
@@ -60,6 +60,7 @@
 #include "develop/imageop.h"
 #include "develop/pixelpipe_hb.h"
 #include "develop/dev_geometry.h"
+#include "develop/dev_viewport.h"
 #include "develop/dev_history.h"
 #include "develop/dev_pixelpipe.h"
 
@@ -188,35 +189,22 @@ typedef struct dt_develop_t
    */
   dt_dev_geometry_store_t geometry;
 
+  /**
+   * @brief The darkroom view's window onto the image: widget allocation, borders, zoom, pan.
+   *
+   * @details Allocated only for a gui_attached dev and NULL otherwise -- its absence IS
+   * "this dev has no viewport", replacing roi.gui_inited. Read it through
+   * dt_dev_viewport_get(), which yields the neutral state for a dev that has none, so a
+   * headless caller needs no special case. See develop/dev_viewport.h.
+   */
+  dt_dev_viewport_t *viewport;
+
   // The roi structure is used in darkroom GUI only.
   // It defines the output size of the image backbuffer fitting
   // into the darkroom center widget. This is critically used for all
   // GUI <-> RAW pixel coordinates conversions. It should be recomputed
   // ASAP when widget size changes.
   struct {
-    // width = orig_width - 2 * border_size,
-    // height = orig_height - 2 * border_size,
-    // converted to raster pixels through the GUI ppd factor.
-    // This is the surface actually covered by an image backbuffer (ROI)
-    // and it is set by `dt_dev_configure()`.
-    int32_t width, height;
-
-    // User-defined scaling factor, related to GUI zoom.
-    // Applies on top of natural scale
-    float scaling;
-
-    // Relative coordinates of the center of the ROI, expressed with
-    // regard to the complete image.
-    float x, y;
-
-    // darkroom border size: ISO 12646 borders or user-defined borders
-    int32_t border_size;
-
-    // Those are the darkroom main widget size in GUI coordinates, aka max
-    // paintable area. This size is allocated by Gtk from the window size
-    // minus all panels. It is NOT the size of the backbuffer/ROI.
-    int32_t orig_width, orig_height;
-
     // Dimensions of the preview backbuffer, depending on the
     // darkroom main widget size and DPI factor.
     // These are computed early, before we have the actual buffer.
@@ -228,9 +216,6 @@ typedef struct dt_develop_t
     // natural scaling = MIN(dev->width / dt_dev_geometry_processed_width(dev), dev->height / dt_dev_geometry_processed_height(dev))
     // aka ensure that image fits into widget minus margins/borders.
     float natural_scale;
-
-    // Conveniency state to check if all widget sizes are inited
-    gboolean gui_inited;
 
     // Conveniency state to check if all output (backbuffer) sizes are inited
     gboolean output_inited;
@@ -601,6 +586,10 @@ void dt_dev_configure_real(dt_develop_t *dev, int wd, int ht);
  * @param box_h the height of navigation's box
  */
 void dt_dev_check_zoom_pos_bounds(dt_develop_t *dev, float *dev_x, float *dev_y, float *box_w, float *box_h);
+
+/** Clamp the viewport centre against the box visible at the current zoom. Returns TRUE when
+ *  the centre moved. */
+gboolean dt_dev_clamp_viewport_center(dt_develop_t *dev);
 
 /*
  * modulegroups helpers

--- a/src/develop/masks/masks_gui.c
+++ b/src/develop/masks/masks_gui.c
@@ -3640,7 +3640,7 @@ gboolean dt_masks_form_get_gravity_center(dt_develop_t *dev, const dt_masks_form
  * @brief Center the darkroom ROI on a mask form gravity center.
  *
  * @details Mask forms store their gravity center in normalized RAW coordinates,
- * while `dev->roi.x` and `dev->roi.y` address the processed image. Transforming
+ * while `dt_dev_viewport_center_x(dev)` and `dt_dev_viewport_center_y(dev)` address the processed image. Transforming
  * through absolute RAW and processed-image coordinates keeps the center aligned
  * with the final image after distortion modules, then the ROI clamp preserves
  * the same bounds used by manual panning.
@@ -3659,9 +3659,8 @@ int dt_masks_center_view_on_form(dt_develop_t *dev, const dt_masks_form_t *mask_
   if(!dt_dev_coordinates_raw_abs_to_image_abs(dev, center, 1)) return 1;
   dt_dev_coordinates_image_abs_to_image_norm(dev, center, 1);
 
-  dev->roi.x = center[0];
-  dev->roi.y = center[1];
-  dt_dev_check_zoom_pos_bounds(dev, &dev->roi.x, &dev->roi.y, NULL, NULL);
+  dt_dev_viewport_set_center(dev, center[0], center[1]);
+  dt_dev_clamp_viewport_center(dev);
   dt_dev_pixelpipe_change_zoom_main(dev);
 
   return 0;

--- a/src/gui/dtgtk/focus.h
+++ b/src/gui/dtgtk/focus.h
@@ -285,7 +285,12 @@ static void dt_focus_draw_clusters(cairo_t *cr, int width, int height, int32_t i
     dt_dev_cleanup(&dev);
   }
 
-  const int32_t tb = dt_dev_get_global()->roi.border_size;
+  // Reads the DARKROOM's border size from a lighttable thumbnail render job, on a control-job
+  // thread, through the global dev. Wrong on two axes -- a view that is not darkroom, a thread
+  // that is not the GUI's -- and flagged as such in doc/develop-split.md; kept behaviour-
+  // identical here because changing which border a thumbnail overlay uses is a visual change,
+  // not a relocation.
+  const int32_t tb = dt_dev_viewport_border_size(dt_dev_get_global());
   const float scale = fminf((width - 2 * tb) / (float)wd, (height - 2 * tb) / (float)ht) * full_zoom;
   cairo_scale(cr, scale, scale);
   float fx = 0.0f;

--- a/src/iop/basicadj.c
+++ b/src/iop/basicadj.c
@@ -443,7 +443,7 @@ void gui_post_expose(struct dt_iop_module_t *self, cairo_t *cr, int32_t width, i
 
   //cairo_translate(cr, width / 2.0, height / 2.0f);
   //cairo_scale(cr, zoom_scale, zoom_scale);
-  //cairo_translate(cr, -.5f * wd - dev->roi.x * wd, -.5f * ht - dev->roi.y * ht);
+  //cairo_translate(cr, -.5f * wd - dt_dev_viewport_center_x(dev) * wd, -.5f * ht - dt_dev_viewport_center_y(dev) * ht);
   dt_dev_rescale_roi(dev, cr, width, height);
 
   cairo_set_line_cap(cr, CAIRO_LINE_CAP_ROUND);

--- a/src/iop/clipping.c
+++ b/src/iop/clipping.c
@@ -2659,7 +2659,7 @@ int mouse_moved(struct dt_iop_module_t *self, double x, double y, double pressur
 
   const float wd = self->dev->roi.preview_width;
   const float ht = self->dev->roi.preview_height;
-  const float zoom_scale = dev->roi.scaling;
+  const float zoom_scale = dt_dev_viewport_scaling(dev);
   float pzxpy[2] = { (float)x, (float)y };
   dt_dev_coordinates_widget_to_image_norm(self->dev, pzxpy, 1);
   float pzx = pzxpy[0];
@@ -3117,7 +3117,7 @@ int button_pressed(struct dt_iop_module_t *self, double x, double y, double pres
         g->k_drag = TRUE; // if a keystone point is selected then we start to drag it
       else // if we click to the apply button
       {
-        const float zoom_scale = dev->roi.scaling;
+        const float zoom_scale = dt_dev_viewport_scaling(dev);
         float pzxpy[2] = { (float)x, (float)y };
         dt_dev_coordinates_widget_to_image_norm(dev, pzxpy, 1);
         float pzx = pzxpy[0];

--- a/src/iop/drawlayer.c
+++ b/src/iop/drawlayer.c
@@ -2913,9 +2913,9 @@ void gui_init(dt_iop_module_t *self)
   g->session.last_view_scale = 1.0f;
   if(self->dev)
   {
-    g->session.last_view_x = self->dev->roi.x;
-    g->session.last_view_y = self->dev->roi.y;
-    g->session.last_view_scale = self->dev->roi.scaling;
+    g->session.last_view_x = dt_dev_viewport_center_x(self->dev);
+    g->session.last_view_y = dt_dev_viewport_center_y(self->dev);
+    g->session.last_view_scale = dt_dev_viewport_scaling(self->dev);
   }
 
   self->gui->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_GUI_BOX_SPACING);

--- a/src/iop/drawlayer/coordinates.c
+++ b/src/iop/drawlayer/coordinates.c
@@ -169,14 +169,14 @@ gboolean dt_drawlayer_compute_view_patch(dt_iop_module_t *self, const float padd
   int layer_height = 0;
   if(!_virtual_piece_layer_geometry(self, &layer_width, &layer_height)) return FALSE;
 
-  const float widget_w = (float)self->dev->roi.orig_width;
-  const float widget_h = (float)self->dev->roi.orig_height;
+  const float widget_w = (float)dt_dev_viewport_widget_width(self->dev);
+  const float widget_h = (float)dt_dev_viewport_widget_height(self->dev);
   const float preview_w = self->dev->roi.preview_width;
   const float preview_h = self->dev->roi.preview_height;
   if(widget_w <= 0.0f || widget_h <= 0.0f || preview_w <= 0.0f || preview_h <= 0.0f) return FALSE;
 
   const float zoom_scale = dt_dev_get_overlay_scale(self->dev);
-  const float border = (float)self->dev->roi.border_size;
+  const float border = (float)dt_dev_viewport_border_size(self->dev);
   const float roi_w = fminf(widget_w, preview_w * zoom_scale);
   const float roi_h = fminf(widget_h, preview_h * zoom_scale);
   const float rec_x = fmaxf(border, 0.5f * (widget_w - roi_w));

--- a/src/iop/drawlayer/layers.c
+++ b/src/iop/drawlayer/layers.c
@@ -431,9 +431,9 @@ static gboolean _ensure_widget_cache(dt_iop_module_t *self)
 
   if(same_view)
   {
-    g->session.last_view_x = self->dev->roi.x;
-    g->session.last_view_y = self->dev->roi.y;
-    g->session.last_view_scale = self->dev->roi.scaling;
+    g->session.last_view_x = dt_dev_viewport_center_x(self->dev);
+    g->session.last_view_y = dt_dev_viewport_center_y(self->dev);
+    g->session.last_view_scale = dt_dev_viewport_scaling(self->dev);
     return TRUE;
   }
 
@@ -442,9 +442,9 @@ static gboolean _ensure_widget_cache(dt_iop_module_t *self)
   g->session.preview_rect = preview_rect;
 
   dt_drawlayer_worker_reset_backend_path(g->stroke.worker);
-  g->session.last_view_x = self->dev->roi.x;
-  g->session.last_view_y = self->dev->roi.y;
-  g->session.last_view_scale = self->dev->roi.scaling;
+  g->session.last_view_x = dt_dev_viewport_center_x(self->dev);
+  g->session.last_view_y = dt_dev_viewport_center_y(self->dev);
+  g->session.last_view_scale = dt_dev_viewport_scaling(self->dev);
   return TRUE;
 }
 

--- a/src/iop/drawlayer/runtime.c
+++ b/src/iop/drawlayer/runtime.c
@@ -180,9 +180,9 @@ static void _fill_runtime_inputs(const dt_drawlayer_runtime_context_t *runtime,
     .have_valid_output_roi = request->roi_out && request->roi_out->width > 0 && request->roi_out->height > 0,
     .use_opencl = request->use_opencl,
     .view_changed = g && self && self->dev
-                    && (fabsf(g->session.last_view_x - self->dev->roi.x) > 1e-6f
-                        || fabsf(g->session.last_view_y - self->dev->roi.y) > 1e-6f
-                        || fabsf(g->session.last_view_scale - self->dev->roi.scaling) > 1e-6f),
+                    && (fabsf(g->session.last_view_x - dt_dev_viewport_center_x(self->dev)) > 1e-6f
+                        || fabsf(g->session.last_view_y - dt_dev_viewport_center_y(self->dev)) > 1e-6f
+                        || fabsf(g->session.last_view_scale - dt_dev_viewport_scaling(self->dev)) > 1e-6f),
     .padding_changed = g && self && fabsf(g->session.live_padding - dt_drawlayer_current_live_padding(self)) > 1e-6f,
   };
 }

--- a/src/iop/finalscale.c
+++ b/src/iop/finalscale.c
@@ -177,7 +177,7 @@ void commit_params(dt_iop_module_t *self, dt_iop_params_t *params, dt_dev_pixelp
   // Darkroom pipes only. Depending on ROI zoom level, we may need to enable finalscale so
   // the pipeline runs at most at 100%, for pixel-level accuracy, and we upscale at the end.
   // This is important for consistency with exports.
-  const float darkroom_zoom = pipe->dev->roi.scaling * pipe->dev->roi.natural_scale;
+  const float darkroom_zoom = dt_dev_viewport_scaling(pipe->dev) * pipe->dev->roi.natural_scale;
   piece->enabled = (darkroom_zoom > 1.f)
     || (dt_conf_get_int("darkroom/render_size") != 1 && darkroom_zoom != 1.f);
 }

--- a/src/iop/graduatednd.c
+++ b/src/iop/graduatednd.c
@@ -446,7 +446,7 @@ void gui_post_expose(struct dt_iop_module_t *self, cairo_t *cr, int32_t width, i
   dt_iop_graduatednd_params_t *p = (dt_iop_graduatednd_params_t *)self->params;
   if(IS_NULL_PTR(g) || IS_NULL_PTR(p)) return;
 
-  const float zoom_scale = dev->roi.scaling;
+  const float zoom_scale = dt_dev_viewport_scaling(dev);
   dt_dev_rescale_roi(dev, cr, width, height);
 
   // we get the extremities of the line

--- a/src/iop/liquify.c
+++ b/src/iop/liquify.c
@@ -2866,7 +2866,7 @@ void gui_post_expose(struct dt_iop_module_t *module,
   _distort_paths(module, &d_params, &copy_params);
 
   // You're not supposed to understand this
-  const float zoom_scale = get_zoom_scale(develop) * develop->roi.scaling;
+  const float zoom_scale = get_zoom_scale(develop) * dt_dev_viewport_scaling(develop);
 
   if(dt_dev_rescale_roi_to_input(develop, cr, width, height))
     return;
@@ -3387,7 +3387,7 @@ static void _start_new_shape(dt_iop_module_t *module)
   //  create initial shape at the center
   float complex pt = 0.0f;
   float scale = 1.0f;
-  get_point_scale(module, 0.5f * module->dev->roi.width, 0.5f * module->dev->roi.height, &pt, &scale);
+  get_point_scale(module, 0.5f * dt_dev_viewport_box_width(module->dev), 0.5f * dt_dev_viewport_box_height(module->dev), &pt, &scale);
   float radius = 0.0f, r = 1.0f, phi = 0.0f;
   get_stamp_params(module, &radius, &r, &phi);
   //  start a new path

--- a/src/iop/vignette.c
+++ b/src/iop/vignette.c
@@ -478,7 +478,7 @@ int mouse_moved(struct dt_iop_module_t *self, double x, double y, double pressur
     smaller_side = wd;
   }
 
-  const float zoom_scale = dev->roi.scaling;
+  const float zoom_scale = dt_dev_viewport_scaling(dev);
   float pzxpy[2] = { (float)x, (float)y };
   dt_dev_coordinates_widget_to_image_norm(self->dev, pzxpy, 1);
   const float pzx = pzxpy[0];

--- a/src/libs/navigation.c
+++ b/src/libs/navigation.c
@@ -324,7 +324,7 @@ static gboolean _lib_navigation_draw_callback(GtkWidget *widget, cairo_t *crf, g
   }
 
   // draw box where we are
-  if(dev->roi.scaling > 1.f)
+  if(dt_dev_viewport_scaling(dev) > 1.f)
   {
     // Add a dark overlay on the picture to make it fade
     cairo_rectangle(cr, 0, 0, wd, ht);
@@ -332,11 +332,17 @@ static gboolean _lib_navigation_draw_callback(GtkWidget *widget, cairo_t *crf, g
 
     // clip dimensions to navigation area
     float boxw = 1, boxh = 1;
-    dt_dev_check_zoom_pos_bounds(dev, &(dev->roi.x), &(dev->roi.y), &boxw, &boxh);
+    // Reads the box; the centre clamp it also performed is kept, because removing a
+    // mutation from a paint handler is a behaviour change that belongs with the setter work,
+    // not with the relocation.
+    float clamped_x = dt_dev_viewport_center_x(dev);
+    float clamped_y = dt_dev_viewport_center_y(dev);
+    dt_dev_check_zoom_pos_bounds(dev, &clamped_x, &clamped_y, &boxw, &boxh);
+    dt_dev_viewport_set_center(dev, clamped_x, clamped_y);
     const float roi_w = MIN(boxw * wd, wd);
     const float roi_h = MIN(boxh * ht, ht);
-    const float roi_x = dev->roi.x * wd - roi_w * 0.5f;
-    const float roi_y = dev->roi.y * ht - roi_h * 0.5f;
+    const float roi_x = dt_dev_viewport_center_x(dev) * wd - roi_w * 0.5f;
+    const float roi_y = dt_dev_viewport_center_y(dev) * ht - roi_h * 0.5f;
     cairo_rectangle(cr, roi_x - 1, roi_y - 1, roi_w + 2, roi_h + 2);
 
     /* Use even–odd rule to punch the hole */
@@ -384,10 +390,10 @@ static gboolean _lib_navigation_draw_callback(GtkWidget *widget, cairo_t *crf, g
   gchar *zoomline;
   {
     gchar *fit = NULL;
-    if(dev->roi.scaling == 1.f)
+    if(dt_dev_viewport_scaling(dev) == 1.f)
       fit = g_strdup(_("Fit"));
   
-    zoomline = g_strdup_printf("%s %.0f%%", fit ? fit : "", dev->roi.scaling * dev->roi.natural_scale * 100);
+    zoomline = g_strdup_printf("%s %.0f%%", fit ? fit : "", dt_dev_viewport_scaling(dev) * dev->roi.natural_scale * 100);
     if(fit)
     {
       dt_free(fit);
@@ -446,7 +452,7 @@ static void _lib_navigation_set_position(dt_lib_module_t *self, double x, double
 {
   dt_develop_t *dev = dt_dev_get_global();
   const dt_lib_navigation_t *d = (const dt_lib_navigation_t *)self->data;
-  if(!(dev && d->dragging && dev->roi.scaling > 1.f)) return;
+  if(!(dev && d->dragging && dt_dev_viewport_scaling(dev) > 1.f)) return;
 
   // Compute size of navigation ROI in widget coordinates
   int proc_wd, proc_ht;
@@ -465,8 +471,7 @@ static void _lib_navigation_set_position(dt_lib_module_t *self, double x, double
   fy /= (float)nav_img_h;
   dt_dev_check_zoom_pos_bounds(dev, &fx, &fy, NULL, NULL);
 
-  dev->roi.x = fx;
-  dev->roi.y = fy;
+  dt_dev_viewport_set_center(dev, fx, fy);
 
   /* redraw myself */
   gtk_widget_queue_draw(d->area);
@@ -493,45 +498,45 @@ static void _zoom_preset_change(dt_lib_zoom_t zoom)
   switch(zoom)
   {
     default:
-      dev->roi.scaling = dev->roi.natural_scale;
+      dt_dev_viewport_set_scaling(dev, dev->roi.natural_scale);
       break;
     case LIB_ZOOM_SMALL:
-      dev->roi.scaling = dev->roi.natural_scale * 0.33;
+      dt_dev_viewport_set_scaling(dev, dev->roi.natural_scale * 0.33);
       break;
     case LIB_ZOOM_FIT:
-      dev->roi.scaling = dev->roi.natural_scale;
+      dt_dev_viewport_set_scaling(dev, dev->roi.natural_scale);
       break;
     case LIB_ZOOM_25:
-      dev->roi.scaling = 0.25;
+      dt_dev_viewport_set_scaling(dev, 0.25);
       break;
     case LIB_ZOOM_33:
-      dev->roi.scaling = 0.33;
+      dt_dev_viewport_set_scaling(dev, 0.33);
       break;
     case LIB_ZOOM_50:
-      dev->roi.scaling = 0.50;
+      dt_dev_viewport_set_scaling(dev, 0.50);
       break;
     case LIB_ZOOM_100:
-      dev->roi.scaling = 1.;
+      dt_dev_viewport_set_scaling(dev, 1.);
       break;
     case LIB_ZOOM_200:
-      dev->roi.scaling = 2.;
+      dt_dev_viewport_set_scaling(dev, 2.);
       break;
     case LIB_ZOOM_400:
-      dev->roi.scaling = 4.;
+      dt_dev_viewport_set_scaling(dev, 4.);
       break;
     case LIB_ZOOM_800:
-      dev->roi.scaling = 8.;
+      dt_dev_viewport_set_scaling(dev, 8.);
       break;
     case LIB_ZOOM_1600:
-      dev->roi.scaling = 16.;
+      dt_dev_viewport_set_scaling(dev, 16.);
       break;
   }
 
-  // Actual pixelpipe scaling is dev->roi.scaling * dev->roi.natural_scale,
+  // Actual pixelpipe scaling is dt_dev_viewport_scaling(dev) * dev->roi.natural_scale,
   // where dev->roi.natural_scale ensures the image fits within the viewport.
-  dev->roi.scaling /= dev->roi.natural_scale;
+  dt_dev_viewport_set_scaling(dev, dt_dev_viewport_scaling(dev) / dev->roi.natural_scale);
 
-  dt_dev_check_zoom_pos_bounds(dev, &dev->roi.x, &dev->roi.y, NULL, NULL);
+  dt_dev_clamp_viewport_center(dev);
   dt_dev_pixelpipe_change_zoom_main(dev);
 }
 

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -627,7 +627,7 @@ static gboolean _build_preview_fallback_surface(dt_develop_t *dev, const int wid
   const float ppd = dt_gui_get_global()->ppd;
   const float preview_wd = wd / ppd;
   const float preview_ht = ht / ppd;
-  const float preview_scale = dev->roi.scaling;
+  const float preview_scale = dt_dev_viewport_scaling(dev);
   float image_box[4] = { 0.0f };
   dt_dev_get_image_box_in_widget(dev, width, height, image_box);
 
@@ -659,8 +659,8 @@ static gboolean _build_preview_fallback_surface(dt_develop_t *dev, const int wid
   cairo_rectangle(cr, rec_x, rec_y, rec_w, rec_h);
   cairo_clip(cr);
 
-  const float tx = 0.5f * width - dev->roi.x * preview_wd * preview_scale;
-  const float ty = 0.5f * height - dev->roi.y * preview_ht * preview_scale;
+  const float tx = 0.5f * width - dt_dev_viewport_center_x(dev) * preview_wd * preview_scale;
+  const float ty = 0.5f * height - dt_dev_viewport_center_y(dev) * preview_ht * preview_scale;
   cairo_translate(cr, tx, ty);
   cairo_scale(cr, preview_scale, preview_scale);
   cairo_rectangle(cr, 0, 0, preview_wd, preview_ht);
@@ -735,25 +735,19 @@ static inline gboolean _darkroom_preview_fallback_valid(const dt_develop_t *dev,
 static uint64_t _darkroom_zoom_hash(const dt_develop_t *dev)
 {
   uint64_t hash = 5381;
-  hash = dt_hash(hash, (const char *)&dev->roi.width, sizeof(dev->roi.width));
-  hash = dt_hash(hash, (const char *)&dev->roi.height, sizeof(dev->roi.height));
-  hash = dt_hash(hash, (const char *)&dev->roi.scaling, sizeof(dev->roi.scaling));
-  hash = dt_hash(hash, (const char *)&dev->roi.x, sizeof(dev->roi.x));
-  hash = dt_hash(hash, (const char *)&dev->roi.y, sizeof(dev->roi.y));
-  hash = dt_hash(hash, (const char *)&dev->roi.border_size, sizeof(dev->roi.border_size));
-  hash = dt_hash(hash, (const char *)&dev->roi.orig_width, sizeof(dev->roi.orig_width));
-  hash = dt_hash(hash, (const char *)&dev->roi.orig_height, sizeof(dev->roi.orig_height));
+
+  // Three coherent reads, hashed as the three records they are. Hashing field by field through
+  // accessors would let a publication land between two of them and key the cached surface to a
+  // viewport that never existed -- which is the same tearing the objects were built to remove.
+  const dt_dev_viewport_state_t viewport = dt_dev_viewport_get(dev);
+  hash = dt_hash(hash, (const char *)&viewport, sizeof(viewport));
+
+  const dt_dev_image_geometry_t geometry = dt_dev_geometry_snapshot(dev);
+  hash = dt_hash(hash, (const char *)&geometry, sizeof(geometry));
+
   hash = dt_hash(hash, (const char *)&dev->roi.preview_width, sizeof(dev->roi.preview_width));
   hash = dt_hash(hash, (const char *)&dev->roi.preview_height, sizeof(dev->roi.preview_height));
   hash = dt_hash(hash, (const char *)&dev->roi.natural_scale, sizeof(dev->roi.natural_scale));
-  hash = dt_hash(hash, (const char *)&dev->roi.gui_inited, sizeof(dev->roi.gui_inited));
-
-  // One coherent read of the image geometry, hashed as the record it is: hashing the four
-  // numbers through four separate accessor calls would let a publication land between two of
-  // them and produce a key for a geometry that never existed.
-  dt_dev_image_geometry_t geometry;
-  dt_dev_geometry_get(dev, &geometry);
-  hash = dt_hash(hash, (const char *)&geometry, sizeof(geometry));
   hash = dt_hash(hash, (const char *)&dev->roi.output_inited, sizeof(dev->roi.output_inited));
   return hash;
 }
@@ -819,7 +813,7 @@ void expose(
 
   dt_develop_t *dev = (dt_develop_t *)self->data;
 
-  const int32_t border = dev->roi.border_size;
+  const int32_t border = dt_dev_viewport_border_size(dev);
 
 #if DARKROOM_EXPOSE_DUMB_DEBUG
   dt_aligned_pixel_t bg_color_dbg;
@@ -1798,7 +1792,7 @@ void gui_init(dt_view_t *self)
 
   dt_view_manager_get_global()->proxy.darkroom.get_layout = _lib_darkroom_get_layout;
   dt_view_manager_get_global()->proxy.darkroom.set_default_cursor = _darkroom_set_default_cursor;
-  dev->roi.border_size = DT_PIXEL_APPLY_DPI(dt_conf_get_int("plugins/darkroom/ui/border_size"));
+  dt_dev_viewport_set_border(dev, DT_PIXEL_APPLY_DPI(dt_conf_get_int("plugins/darkroom/ui/border_size")));
 }
 
 static gboolean _is_scroll_captured_by_widget()
@@ -2286,7 +2280,7 @@ static void _darkroom_edge_pan_update_state(dt_view_t *self,
 
   if(!gui->pan_edge.enabled
      || dt_view_manager_get_current_view(dt_view_manager_get_global()) != self
-     || dev->roi.scaling <= 1.0f)
+     || dt_dev_viewport_scaling(dev) <= 1.0f)
     return;
 
   float image_box[4] = { 0.0f };
@@ -2380,18 +2374,17 @@ static gboolean _darkroom_edge_pan_apply(dt_view_t *self,
   dt_develop_t *dev = edge.dev;
   dt_dev_coordinates_widget_delta_to_image_delta(dev, delta, 1);
 
-  float roi[2] = { dev->roi.x + delta[0] / (float)dt_dev_geometry_processed_width(dev),
-                   dev->roi.y + delta[1] / (float)dt_dev_geometry_processed_height(dev)
+  float roi[2] = { dt_dev_viewport_center_x(dev) + delta[0] / (float)dt_dev_geometry_processed_width(dev),
+                   dt_dev_viewport_center_y(dev) + delta[1] / (float)dt_dev_geometry_processed_height(dev)
                  };
   dt_dev_check_zoom_pos_bounds(dev, &roi[0], &roi[1], NULL, NULL);
 
   ctl->button_x = pointer_x;
   ctl->button_y = pointer_y;
 
-  if(dev->roi.x != roi[0] || dev->roi.y != roi[1])
+  if(dt_dev_viewport_center_x(dev) != roi[0] || dt_dev_viewport_center_y(dev) != roi[1])
   {
-    dev->roi.x = roi[0];
-    dev->roi.y = roi[1];
+    dt_dev_viewport_set_center(dev, roi[0], roi[1]);
     // Updating ctl->button_x/y changes the cursor position, which is the same as a mouse move event.
     mouse_moved(self, pointer_x, pointer_y, 1.0, 0);
     //dt_control_queue_redraw_center();
@@ -2564,17 +2557,16 @@ void mouse_moved(dt_view_t *self, double x, double y, double pressure, int which
   dt_control_commit_cursor();
 
   if(_darkroom_center_pan_drag && dt_control_get_global()->button_down
-     && dt_control_get_global()->button_down_which == 1 && dev->roi.scaling > 1)
+     && dt_control_get_global()->button_down_which == 1 && dt_dev_viewport_scaling(dev) > 1)
   {
     float delta[2] = { x - ctl->button_x, y - ctl->button_y };
     dt_dev_coordinates_widget_delta_to_image_delta(dev, delta, 1);
 
-    float roi[2] = { dev->roi.x - (delta[0] / dt_dev_geometry_processed_width(dev)),
-                     dev->roi.y - (delta[1] / dt_dev_geometry_processed_height(dev)) };
+    float roi[2] = { dt_dev_viewport_center_x(dev) - (delta[0] / dt_dev_geometry_processed_width(dev)),
+                     dt_dev_viewport_center_y(dev) - (delta[1] / dt_dev_geometry_processed_height(dev)) };
     dt_dev_check_zoom_pos_bounds(dev, &roi[0], &roi[1], NULL, NULL);
 
-    dev->roi.x = roi[0];
-    dev->roi.y = roi[1];
+    dt_dev_viewport_set_center(dev, roi[0], roi[1]);
     ctl->button_x = x;
     ctl->button_y = y;
 
@@ -2597,18 +2589,17 @@ void mouse_moved(dt_view_t *self, double x, double y, double pressure, int which
   }
 
   // panning with left mouse button
-  if(dt_control_get_global()->button_down && dt_control_get_global()->button_down_which == 1 && dev->roi.scaling > 1)
+  if(dt_control_get_global()->button_down && dt_control_get_global()->button_down_which == 1 && dt_dev_viewport_scaling(dev) > 1)
   {
     float delta[2] = { x - ctl->button_x, y - ctl->button_y };
     dt_dev_coordinates_widget_delta_to_image_delta(dev, delta, 1);
 
     // new roi position in full image scale
-    float roi[2] = { dev->roi.x - (delta[0] / dt_dev_geometry_processed_width(dev)),
-                     dev->roi.y - (delta[1] / dt_dev_geometry_processed_height(dev)) };
+    float roi[2] = { dt_dev_viewport_center_x(dev) - (delta[0] / dt_dev_geometry_processed_width(dev)),
+                     dt_dev_viewport_center_y(dev) - (delta[1] / dt_dev_geometry_processed_height(dev)) };
     dt_dev_check_zoom_pos_bounds(dev, &roi[0], &roi[1], NULL, NULL);
 
-    dev->roi.x = roi[0];
-    dev->roi.y = roi[1];
+    dt_dev_viewport_set_center(dev, roi[0], roi[1]);
 
     // update clicked position
     ctl->button_x = x;
@@ -2829,7 +2820,7 @@ int button_pressed(dt_view_t *self, double x, double y, double pressure, int whi
     return 1;
   }
 
-  if(which == 1 && dev->roi.scaling > 1.0f && mouse_in_imagearea(self, x, y))
+  if(which == 1 && dt_dev_viewport_scaling(dev) > 1.0f && mouse_in_imagearea(self, x, y))
     _darkroom_center_pan_drag = TRUE;
 
   if(which == 2)
@@ -2837,12 +2828,12 @@ int button_pressed(dt_view_t *self, double x, double y, double pressure, int whi
     // Incremental zoom-in on middle button click, from fit to 800% 
     // by power of 2 increments (100%, 200%, 400%, 800%).
     float new_scale = 1.f;
-    if(dev->roi.scaling < 1.f || dev->roi.scaling > 7.f / dev->roi.natural_scale)
+    if(dt_dev_viewport_scaling(dev) < 1.f || dt_dev_viewport_scaling(dev) > 7.f / dev->roi.natural_scale)
       new_scale = 1.f; // zoom to fit
-    else if(dev->roi.scaling * dev->roi.natural_scale < 1.f)
+    else if(dt_dev_viewport_scaling(dev) * dev->roi.natural_scale < 1.f)
       new_scale = 1.f / dev->roi.natural_scale; // 100 %
     else
-      new_scale = floorf(dev->roi.scaling * dev->roi.natural_scale) * 2.f / dev->roi.natural_scale;
+      new_scale = floorf(dt_dev_viewport_scaling(dev) * dev->roi.natural_scale) * 2.f / dev->roi.natural_scale;
 
     const float point[2] = { x, y };
     return _change_scaling(dev, point, new_scale);
@@ -2853,14 +2844,14 @@ int button_pressed(dt_view_t *self, double x, double y, double pressure, int whi
 
 static int _change_scaling(dt_develop_t *dev, const float point[2], const float new_scaling)
 {
-  const float old_scaling = dev->roi.scaling;
+  const float old_scaling = dt_dev_viewport_scaling(dev);
 
   // Round scaling to 1.0 (fit) if close enough
   const float epsilon = fabsf(old_scaling - new_scaling);
   if(fabsf(new_scaling - 1.0f) < epsilon)
-    dev->roi.scaling = 1.0f;
+    dt_dev_viewport_set_scaling(dev, 1.0f);
   else
-    dev->roi.scaling = new_scaling;
+    dt_dev_viewport_set_scaling(dev, new_scaling);
 
   if(!dt_dev_check_zoom_scale_bounds(dev))
   { 
@@ -2875,27 +2866,29 @@ static int _change_scaling(dt_develop_t *dev, const float point[2], const float 
     // Keep the image point under the mouse fixed in widget coordinates while
     // the pipeline zoom stays DPI-invariant.
     const float old_zoom = dt_dev_get_widget_zoom_scale(dev, old_scaling);
-    const float new_zoom = dt_dev_get_widget_zoom_scale(dev, dev->roi.scaling);
+    const float new_zoom = dt_dev_get_widget_zoom_scale(dev, dt_dev_viewport_scaling(dev));
     if(old_zoom <= 1e-6f || new_zoom <= 1e-6f)
     {
-      dev->roi.scaling = old_scaling;
+      dt_dev_viewport_set_scaling(dev, old_scaling);
       return 0;
     }
 
     // Adjust the center to compensate for the scale change
     int proc_w = 0.f, proc_h = 0.f;
     dt_dev_get_processed_size(dev, &proc_w, &proc_h);
-    dev->roi.x += mouse_offset[0] * (1.f / old_zoom - 1.f / new_zoom) / proc_w;
-    dev->roi.y += mouse_offset[1] * (1.f / old_zoom - 1.f / new_zoom) / proc_h;
+    const dt_dev_viewport_state_t anchored = dt_dev_viewport_get(dev);
+    dt_dev_viewport_set_center(dev,
+                               anchored.center_x + mouse_offset[0] * (1.f / old_zoom - 1.f / new_zoom) / proc_w,
+                               anchored.center_y + mouse_offset[1] * (1.f / old_zoom - 1.f / new_zoom) / proc_h);
     
-    dt_dev_check_zoom_pos_bounds(dev, &dev->roi.x, &dev->roi.y, NULL, NULL);
+    dt_dev_clamp_viewport_center(dev);
     dt_dev_pixelpipe_change_zoom_main(dev);
     return 1;
   }
   else
   {
     // Invalid zoom level, keep previous value
-    dev->roi.scaling = old_scaling;
+    dt_dev_viewport_set_scaling(dev, old_scaling);
     return 0;
   }
 }
@@ -2906,7 +2899,7 @@ static gboolean _center_view_free_zoom(dt_view_t *self, double x, double y, int 
 
   // Commit the new scaling
   const float step = 1.02f;
-  const float new_scaling = dev->roi.scaling * powf(step, (float)-flow);
+  const float new_scaling = dt_dev_viewport_scaling(dev) * powf(step, (float)-flow);
   const float point[2] = { x, y };
   return _change_scaling(dev, point, new_scaling);
 }
@@ -2949,7 +2942,7 @@ int scrolled(dt_view_t *self, double x, double y, int up, int state, int delta_y
 
 static void _key_scroll(dt_develop_t *dev)
 {
-  dt_dev_check_zoom_pos_bounds(dev, &dev->roi.x, &dev->roi.y, NULL, NULL);
+  dt_dev_clamp_viewport_center(dev);
   dt_control_queue_redraw_center();
   dt_dev_pixelpipe_change_zoom_main(dev);
 }
@@ -2990,9 +2983,9 @@ int key_pressed(dt_view_t *self, GdkEventKey *event)
     switch(key)
     {
       case GDK_KEY_plus:
-        return _change_scaling(dev, center, dev->roi.scaling * zoom_step);
+        return _change_scaling(dev, center, dt_dev_viewport_scaling(dev) * zoom_step);
       case GDK_KEY_minus:
-        return _change_scaling(dev, center, dev->roi.scaling / zoom_step);
+        return _change_scaling(dev, center, dt_dev_viewport_scaling(dev) / zoom_step);
     }
   }
 
@@ -3007,25 +3000,33 @@ int key_pressed(dt_view_t *self, GdkEventKey *event)
   {
     case GDK_KEY_Up:
     {
-      dev->roi.y -= delta[1] / (float)dt_dev_geometry_processed_height(dev);
+      dt_dev_viewport_set_center(dev, dt_dev_viewport_center_x(dev),
+                                 dt_dev_viewport_center_y(dev)
+                                     - delta[1] / (float)dt_dev_geometry_processed_height(dev));
       _key_scroll(dev);
       return 1;
     }
     case GDK_KEY_Down:
     {
-      dev->roi.y += delta[1] / (float)dt_dev_geometry_processed_height(dev);
+      dt_dev_viewport_set_center(dev, dt_dev_viewport_center_x(dev),
+                                 dt_dev_viewport_center_y(dev)
+                                     + delta[1] / (float)dt_dev_geometry_processed_height(dev));
       _key_scroll(dev);
       return 1;
     }
     case GDK_KEY_Left:
     {
-      dev->roi.x -= delta[0] / (float)dt_dev_geometry_processed_width(dev);
+      dt_dev_viewport_set_center(dev, dt_dev_viewport_center_x(dev)
+                                     - delta[0] / (float)dt_dev_geometry_processed_width(dev),
+                                 dt_dev_viewport_center_y(dev));
       _key_scroll(dev);
       return 1;
     }
     case GDK_KEY_Right:
     {
-      dev->roi.x += delta[0] / (float)dt_dev_geometry_processed_width(dev);
+      dt_dev_viewport_set_center(dev, dt_dev_viewport_center_x(dev)
+                                     + delta[0] / (float)dt_dev_geometry_processed_width(dev),
+                                 dt_dev_viewport_center_y(dev));
       _key_scroll(dev);
       return 1;
     }
@@ -3057,8 +3058,7 @@ void configure(dt_view_t *self, int wd, int ht)
   if(dt_view_manager_get_current_view(dt_view_manager_get_global()) == self)
   {
     // Reference dimensions before ISO 12646 mode
-    dev->roi.orig_height = ht;
-    dev->roi.orig_width = wd;
+    dt_dev_viewport_set_widget_size(dev, wd, ht);
     dt_dev_toolbox_apply_iso_12646_size(dev);
   }
 }

--- a/src/views/dev_toolbox.c
+++ b/src/views/dev_toolbox.c
@@ -43,15 +43,15 @@ void dt_dev_toolbox_apply_iso_12646_size(dt_develop_t *dev)
     // no matter the size of the widget. Meaning we force them to fit a square
     // of length matching the smaller widget dimension. The goal is to leave
     // a consistent perceptual impression between pictures, independent from orientation.
-    const int main_dim = MIN(dev->roi.orig_width, dev->roi.orig_height);
-    dev->roi.border_size = 0.125 * main_dim;
+    const int main_dim = MIN(dt_dev_viewport_widget_width(dev), dt_dev_viewport_widget_height(dev));
+    dt_dev_viewport_set_border(dev, 0.125 * main_dim);
   }
   else
   {
-    dev->roi.border_size = DT_PIXEL_APPLY_DPI(dt_conf_get_int("plugins/darkroom/ui/border_size"));
+    dt_dev_viewport_set_border(dev, DT_PIXEL_APPLY_DPI(dt_conf_get_int("plugins/darkroom/ui/border_size")));
   }
 
-  dt_dev_configure(dev, dev->roi.orig_width - 2 * dev->roi.border_size, dev->roi.orig_height - 2 * dev->roi.border_size);
+  dt_dev_configure(dev, dt_dev_viewport_widget_width(dev) - 2 * dt_dev_viewport_border_size(dev), dt_dev_viewport_widget_height(dev) - 2 * dt_dev_viewport_border_size(dev));
 }
 
 /*

--- a/src/views/dev_toolbox.h
+++ b/src/views/dev_toolbox.h
@@ -83,7 +83,7 @@ gboolean dt_dev_toolbox_activate_accel(GtkAccelGroup *accel_group, GObject *acce
 gboolean dt_dev_toolbox_focus_accel(GtkAccelGroup *accel_group, GObject *accelerable, guint keyval,
                                     GdkModifierType modifier, gpointer data);
 
-/** Re-apply dev->roi.border_size from dev->iso_12646.enabled and the
+/** Re-apply dt_dev_viewport_border_size(dev) from dev->iso_12646.enabled and the
  * "plugins/darkroom/ui/border_size" conf key, then dt_dev_configure() the
  * result. Called by the ISO 12646 toggle, and by any view that needs to
  * resize on iso_12646 changes from its own configure()/resize handling. */

--- a/src/views/studio_capture.c
+++ b/src/views/studio_capture.c
@@ -224,8 +224,7 @@ int try_enter(dt_view_t *self)
  */
 static void _studio_configure_dev_roi(dt_studio_capture_t *d, int width, int height)
 {
-  d->dev->roi.orig_width = width;
-  d->dev->roi.orig_height = height;
+  dt_dev_viewport_set_widget_size(d->dev, width, height);
   dt_dev_toolbox_apply_iso_12646_size(d->dev);
 }
 
@@ -896,7 +895,7 @@ void expose(dt_view_t *self, cairo_t *cr, int32_t width, int32_t height, int32_t
     // must not leak past this call.
     cairo_save(cr);
     drew_live = dt_dev_render_locked_surface(cr, d->dev, &d->main_locked, width, height,
-                                             d->dev->roi.border_size, bg_color);
+                                             dt_dev_viewport_border_size(d->dev), bg_color);
     cairo_restore(cr);
   }
 
@@ -905,7 +904,7 @@ void expose(dt_view_t *self, cairo_t *cr, int32_t width, int32_t height, int32_t
     cairo_save(cr);
     cairo_translate(cr, tr_x, tr_y);
     if(d->zoom == DT_THUMBTABLE_ZOOM_FIT && d->dev->iso_12646.enabled)
-      dt_dev_draw_iso12646_border(cr, logical_width, logical_height, d->dev->roi.border_size);
+      dt_dev_draw_iso12646_border(cr, logical_width, logical_height, dt_dev_viewport_border_size(d->dev));
     cairo_set_source_surface(cr, d->surface, 0, 0);
     cairo_pattern_set_filter(cairo_get_source(cr), dt_widget_image_filter());
     cairo_rectangle(cr, 0, 0, logical_width, logical_height);


### PR DESCRIPTION
Stacked on #1140 — review that one first; this PR's diff against it is the viewport object alone.

Second artifact of the `dev->roi` division. The nine GUI members — `scaling`, `x`, `y`, `border_size`, `orig_width`, `orig_height`, `gui_inited`, `width`, `height` — become `dt_dev_viewport_t`, owned by `dt_develop_t` as a pointer that exists only for a `gui_attached` dev.

### Why an object, not nine relocated fields

The survey established that five of them are read by threads that do not write them: the darkroom worker plans every frame's ROI from `scaling`/`x`/`y`/`width`/`height`, and drawlayer's "draw-back" pthread reads `x`/`y`/`orig_*` once per emitted dab. And `x`/`y` were written as two independent statements at all eight write sites and read as two — so a frame could be planned from **half the old pan and half the new**, internally consistent and correctly hashed, therefore undetectable downstream.

The viewport publishes whole states under the same single-writer seqlock as the geometry record in #1140. That state is now unrepresentable rather than merely unlikely.

The NULL pointer is the flag: it replaces `roi.gui_inited`, and `dt_dev_viewport_get()` answers a dev without one with the **neutral** state — `scaling = 1`, centre `(0.5, 0.5)` — which is exactly what `dt_dev_reset_roi()` left on a headless dev before, so no consumer of the `scaling * natural_scale` product changes answer.

### Scope

45 write sites become setter calls, 135 reads become accessors (enumerated by the compiler, not by grep). Four sites that clamped in place by handing `dt_dev_check_zoom_pos_bounds()` the *addresses* of the centre fields now call `dt_dev_clamp_viewport_center()` — nothing may hold a pointer into an object that publishes whole states.

**Deliberately not done here**, each a behaviour change rather than a relocation, and each better argued on its own:
- `_change_scaling` keeps its bounds/revert arithmetic instead of being absorbed into a `set_zoom()` with an anchor;
- the navigation draw handler keeps the centre clamp it performs as a paint-path side effect;
- `dev_toolbox` keeps the `orig - 2*border` arithmetic the viewport should own;
- `focus.h` still reads the *darkroom's* border from a lighttable thumbnail job on a control-job thread — wrong on two axes, now commented as such, and a visual change to fix.

### Verification

Release, Debug (`-Werror`), nofeatures build. `cycles 0`, `layering_violations 187`. Export A/B: 0 differing pixels on both the image and mask pages.

This one genuinely needs a GUI pass — zoom, pan, arrow-key panning, the navigation zoom presets, ISO 12646 borders, window resize and panel toggles — since none of it is reachable from a headless export.

🤖 Generated with [Claude Code](https://claude.com/claude-code)