### PR TITLE
Develop T4b (part 4): each pipe plans from the viewport it latched

### DIFF
--- a/src/develop/dev_pixelpipe.c
+++ b/src/develop/dev_pixelpipe.c
@@ -1445,6 +1445,22 @@ void dt_pixelpipe_get_global_hash(dt_dev_pixelpipe_t *pipe)
 
     // Panning and zooming change the ROI. Some GUI modes (crop in editing mode) too.
     // dt_dev_get_roi_in() should have run before
+    //
+    // These two folds are ALSO how the darkroom viewport reaches this hash, which is why the
+    // pipe's latched dt_dev_roi_request_t (pixelpipe_hb.h) deliberately does NOT contribute its
+    // generation here. Every field of that record reaches the ROI by construction, in
+    // _update_darkroom_roi(): zoom and the fit scale become roi.scale (their product), the
+    // centre becomes roi.x/roi.y, the box and the processed size become roi.width/height. Even
+    // finalscale's piece->enabled -- the one consumer that reads the record rather than the ROI
+    // -- is a function of that same product, and a disabled piece is skipped above, so a toggle
+    // changes the chain anyway.
+    //
+    // Folding the generation on top would therefore add no discriminating power and would only
+    // over-invalidate: a republication that advances the generation while producing identical
+    // ROIs (a sub-pixel pan that rounds to the same roi.x, a box change the fminf clamp absorbs)
+    // would rekey the whole FULL-pipe cache chain for pixels that are bit-identical. Content,
+    // not version, is the right key here -- unlike mask_preview_settings_revision below, which
+    // hashes a revision precisely because its state reaches no ROI at all.
     local_hash = dt_hash(local_hash, (const char *)&piece->roi_in, sizeof(dt_iop_roi_t));
     local_hash = dt_hash(local_hash, (const char *)&piece->roi_out, sizeof(dt_iop_roi_t));
 

--- a/src/develop/dev_roi_request.c
+++ b/src/develop/dev_roi_request.c
@@ -56,15 +56,22 @@ static inline gboolean _payload_equal(const dt_dev_roi_request_t *a, const dt_de
          && a->valid == b->valid;
 }
 
+dt_dev_roi_request_t dt_dev_roi_request_neutral(void)
+{
+  dt_dev_roi_request_t request;
+  memset(&request, 0, sizeof(request));
+  request.natural_scale = -1.f;
+  request.scaling = 1.f;
+  request.center_x = 0.5f;
+  request.center_y = 0.5f;
+  return request;
+}
+
 void dt_dev_roi_request_init(dt_develop_t *dev)
 {
   if(IS_NULL_PTR(dev)) return;
 
-  memset(&dev->roi_request.value, 0, sizeof(dev->roi_request.value));
-  dev->roi_request.value.natural_scale = -1.f;
-  dev->roi_request.value.scaling = 1.f;
-  dev->roi_request.value.center_x = 0.5f;
-  dev->roi_request.value.center_y = 0.5f;
+  dev->roi_request.value = dt_dev_roi_request_neutral();
   dt_atomic_set_uint64(&dev->roi_request.generation, 0);
 }
 

--- a/src/develop/dev_roi_request.c
+++ b/src/develop/dev_roi_request.c
@@ -20,6 +20,7 @@
 #include "develop/dev_geometry.h"
 #include "develop/dev_viewport.h"
 #include "develop/develop.h"
+#include "develop/pixelpipe_hb.h"
 
 #include <string.h>
 
@@ -160,6 +161,35 @@ uint64_t dt_dev_roi_request_publish(dt_develop_t *dev)
   dt_atomic_set_uint64(&dev->roi_request.generation, published + 2);
 
   return next.generation;
+}
+
+void dt_dev_roi_request_latch(dt_dev_pixelpipe_t *pipe, const dt_dev_roi_request_t *request)
+{
+  if(IS_NULL_PTR(pipe) || IS_NULL_PTR(request)) return;
+
+  const uint64_t published = dt_atomic_get_uint64(&pipe->roi_request.generation);
+  dt_atomic_set_uint64(&pipe->roi_request.generation, published + 1);
+  pipe->roi_request.value = *request;
+  dt_atomic_set_uint64(&pipe->roi_request.generation, published + 2);
+}
+
+dt_dev_roi_request_t dt_dev_roi_request_of_pipe(const dt_dev_pixelpipe_t *pipe)
+{
+  dt_dev_roi_request_t request = dt_dev_roi_request_neutral();
+  if(IS_NULL_PTR(pipe)) return request;
+
+  for(;;)
+  {
+    const uint64_t before = dt_atomic_get_uint64(&pipe->roi_request.generation);
+    if(before & 1) continue;
+
+    request = pipe->roi_request.value;
+
+    const uint64_t after = dt_atomic_get_uint64(&pipe->roi_request.generation);
+    if(before == after) break;
+  }
+
+  return request;
 }
 
 int32_t dt_dev_roi_request_preview_width(const dt_develop_t *dev)

--- a/src/develop/dev_roi_request.h
+++ b/src/develop/dev_roi_request.h
@@ -26,6 +26,7 @@
 #include "system/atomic.h"
 
 struct dt_develop_t;
+struct dt_dev_pixelpipe_t;
 
 /**
  * @brief The coherent set of numbers a darkroom pipe plans its ROI from.
@@ -121,6 +122,21 @@ uint64_t dt_dev_roi_request_publish(struct dt_develop_t *dev);
 /** Coherent copy (seqlock read). The returned record is zeroed with valid == FALSE when nothing
  *  usable has been published. */
 dt_dev_roi_request_t dt_dev_roi_request_get(const struct dt_develop_t *dev);
+
+/**
+ * @brief Publish onto a pipe the request its next run is planned from. Darkroom worker only.
+ *
+ * @details Same seqlock as the dev-level store, and for the same reason: the worker writes this
+ * once per loop iteration while the GUI thread can read it at any moment --
+ * dt_dev_pipelines_share_preview_output() does exactly that from the darkroom expose path, and
+ * every dt_dev_pixelpipe_has_preview_output() call from an IOP GUI callback does too. A plain
+ * struct assignment across those threads is a torn read of the same shape this record exists to
+ * prevent.
+ */
+void dt_dev_roi_request_latch(struct dt_dev_pixelpipe_t *pipe, const dt_dev_roi_request_t *request);
+
+/** Coherent copy of what a pipe was last latched with. Safe from any thread. */
+dt_dev_roi_request_t dt_dev_roi_request_of_pipe(const struct dt_dev_pixelpipe_t *pipe);
 
 /* Single-field readers, one line each. Use dt_dev_roi_request_get() wherever more than one is
  * needed: the whole point of the record is that its members are consumed as a product. */

--- a/src/develop/dev_roi_request.h
+++ b/src/develop/dev_roi_request.h
@@ -94,6 +94,17 @@ static inline float dt_dev_roi_natural_scale(const int32_t box_width, const int3
                1.f);
 }
 
+/**
+ * @brief The value a pipe carries before the worker has latched anything.
+ *
+ * @details NOT a zeroed record. scaling = 1 and natural_scale = -1 are what dt_dev_reset_roi()
+ * left on every dev, headless ones included, before this record existed -- and iop/finalscale.c
+ * multiplies exactly those two to decide whether it enables itself. Seeding zeros there would
+ * change piece->enabled on any pipe that never gets latched, which is every export, thumbnail
+ * and snapshot pipe.
+ */
+dt_dev_roi_request_t dt_dev_roi_request_neutral(void);
+
 /** Seed the store. Call once, from dt_dev_init(). */
 void dt_dev_roi_request_init(struct dt_develop_t *dev);
 

--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -402,13 +402,16 @@ int dt_dev_get_thumbnail_size(dt_develop_t *dev)
 gboolean dt_dev_pixelpipe_has_preview_output(const dt_develop_t *dev, const dt_dev_pixelpipe_t *pipe,
                                              const dt_iop_roi_t *roi)
 {
-  if(IS_NULL_PTR(dev) || IS_NULL_PTR(pipe) || !dev->gui_attached || !dt_dev_roi_request_valid(dev)) return FALSE;
+  // Pipeline thread: compare against what this pipe was planned from, not what the GUI has
+  // published since.
+  const dt_dev_roi_request_t request = pipe->roi_request;
+  if(IS_NULL_PTR(dev) || IS_NULL_PTR(pipe) || !dev->gui_attached || !request.valid) return FALSE;
 
   int x = 0;
   int y = 0;
   int width = 0;
   int height = 0;
-  float scale = dt_dev_roi_request_natural_scale(dev);
+  float scale = request.natural_scale;
 
   if(!IS_NULL_PTR(roi))
   {
@@ -440,10 +443,10 @@ gboolean dt_dev_pixelpipe_has_preview_output(const dt_develop_t *dev, const dt_d
   // strictly greater than natural_scale, so loosening the size match cannot misclassify those.
   const int tol = 2;
   const gboolean dims_match
-      = (abs(width - dt_dev_roi_request_preview_width(dev)) <= tol && abs(height - dt_dev_roi_request_preview_height(dev)) <= tol)
-        || (abs(width - dt_dev_roi_request_preview_height(dev)) <= tol && abs(height - dt_dev_roi_request_preview_width(dev)) <= tol);
+      = (abs(width - request.preview_width) <= tol && abs(height - request.preview_height) <= tol)
+        || (abs(width - request.preview_height) <= tol && abs(height - request.preview_width) <= tol);
   if(!dims_match) return FALSE;
-  return x == 0 && y == 0 && fabsf(scale - dt_dev_roi_request_natural_scale(dev)) < 1e-4f;
+  return x == 0 && y == 0 && fabsf(scale - request.natural_scale) < 1e-4f;
 }
 
 
@@ -451,7 +454,10 @@ gboolean dt_dev_pixelpipe_has_preview_output(const dt_develop_t *dev, const dt_d
 static gboolean _update_darkroom_roi(dt_develop_t *dev, dt_dev_pixelpipe_t *pipe, int *x, int *y, int *wd, int *ht,
                                      float *scale)
 {  
-  if(!dt_dev_roi_request_valid(dev)) return 1;
+  // The latched snapshot, not the live record: this runs on the worker, and the frame must be
+  // planned from the same numbers the rest of this iteration uses.
+  const dt_dev_roi_request_t request = pipe->roi_request;
+  if(!request.valid) return 1;
 
   // Store previous values
   int x_old = *x;
@@ -462,20 +468,18 @@ static gboolean _update_darkroom_roi(dt_develop_t *dev, dt_dev_pixelpipe_t *pipe
 
   // roi->scale is the pipeline sampling ratio against the processed image and
   // therefore excludes the GUI backing-store density.
-  *scale = dt_dev_roi_request_natural_scale(dev);
+  *scale = request.natural_scale;
   const gboolean preview_pipe = (pipe == dev->preview_pipe);
-  if(!preview_pipe) *scale *= dt_dev_viewport_scaling(dev);
+  if(!preview_pipe) *scale *= request.scaling;
 
   // Width, height, x and y are already expressed in raster pixels, so they
-  // must follow the same raster-space sampling ratio as roi->scale.
-  const dt_dev_image_geometry_t geometry = dt_dev_geometry_snapshot(dev);
-  const int32_t processed_width = geometry.processed_width;
-  const int32_t processed_height = geometry.processed_height;
-
-  int roi_width = roundf(*scale * processed_width);
-  int roi_height = roundf(*scale * processed_height);
-  int widget_wd = dt_dev_viewport_box_width(dev);
-  int widget_ht = dt_dev_viewport_box_height(dev);
+  // must follow the same raster-space sampling ratio as roi->scale. All of it comes from the
+  // latched record: mixing one live read into this arithmetic is exactly how a frame ends up
+  // describing a viewport that never existed.
+  int roi_width = roundf(*scale * request.processed_width);
+  int roi_height = roundf(*scale * request.processed_height);
+  int widget_wd = request.box_width;
+  int widget_ht = request.box_height;
 
   *wd = roundf(fminf(roi_width, widget_wd));
   *ht = roundf(fminf(roi_height, widget_ht));
@@ -483,8 +487,8 @@ static gboolean _update_darkroom_roi(dt_develop_t *dev, dt_dev_pixelpipe_t *pipe
   // dt_dev_viewport_center_x(dev),y are the relative coordinates of the ROI center.
   // in preview pipe, we always render a full image, so x,y = 0,0 
   // otherwise, x,y here are the top-left corner. Translate:
-  *x = preview_pipe ? 0 : roundf(dt_dev_viewport_center_x(dev) * roi_width - *wd * .5f);
-  *y = preview_pipe ? 0 : roundf(dt_dev_viewport_center_y(dev) * roi_height - *ht * .5f);
+  *x = preview_pipe ? 0 : roundf(request.center_x * roi_width - *wd * .5f);
+  *y = preview_pipe ? 0 : roundf(request.center_y * roi_height - *ht * .5f);
 
 /*  fprintf (stderr, "_update_darkroom_roi: dev %.2f %.2f  type %s  xy %d %d  dim %d %d"
                    "   ppd:%.4f scale:%.4f nat_scale:%.4f * scaling:%.4f\n",
@@ -616,6 +620,15 @@ void dt_dev_darkroom_pipeline(dt_develop_t *dev)
       dt_iop_nap(50000); // wait 50 ms until GUI/image sizes are initialized
       continue;
     }
+
+    // Latch the viewport request ONCE for this iteration, before anything reads it. Everything
+    // downstream -- the ROI planner, the resync, every module callback -- then works from one
+    // snapshot for the whole frame, however many times the GUI thread republishes meanwhile.
+    // Reading it live at each consumer is what let a single frame be planned from two different
+    // viewport states.
+    const dt_dev_roi_request_t latched = dt_dev_roi_request_get(dev);
+    for(size_t i = 0; i < G_N_ELEMENTS(pipes); i++)
+      pipes[i]->roi_request = latched;
 
     // This is cheap to run, keep it in sync always.
     const dt_dev_image_geometry_t geometry = dt_dev_geometry_snapshot(dev);

--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -402,10 +402,14 @@ int dt_dev_get_thumbnail_size(dt_develop_t *dev)
 gboolean dt_dev_pixelpipe_has_preview_output(const dt_develop_t *dev, const dt_dev_pixelpipe_t *pipe,
                                              const dt_iop_roi_t *roi)
 {
-  // Pipeline thread: compare against what this pipe was planned from, not what the GUI has
-  // published since.
-  const dt_dev_roi_request_t request = pipe->roi_request;
-  if(IS_NULL_PTR(dev) || IS_NULL_PTR(pipe) || !dev->gui_attached || !request.valid) return FALSE;
+  // The NULL checks come FIRST: this is called with dev->preview_pipe, which is allocated only
+  // for a gui_attached dev (dt_dev_init) and is therefore NULL on every export and thumbnail
+  // dev -- iop/denoiseprofile.c passes exactly that.
+  if(IS_NULL_PTR(dev) || IS_NULL_PTR(pipe) || !dev->gui_attached) return FALSE;
+
+  // Compare against what this pipe was planned from, not what the GUI has published since.
+  const dt_dev_roi_request_t request = dt_dev_roi_request_of_pipe(pipe);
+  if(!request.valid) return FALSE;
 
   int x = 0;
   int y = 0;
@@ -456,7 +460,7 @@ static gboolean _update_darkroom_roi(dt_develop_t *dev, dt_dev_pixelpipe_t *pipe
 {  
   // The latched snapshot, not the live record: this runs on the worker, and the frame must be
   // planned from the same numbers the rest of this iteration uses.
-  const dt_dev_roi_request_t request = pipe->roi_request;
+  const dt_dev_roi_request_t request = dt_dev_roi_request_of_pipe(pipe);
   if(!request.valid) return 1;
 
   // Store previous values
@@ -628,7 +632,7 @@ void dt_dev_darkroom_pipeline(dt_develop_t *dev)
     // viewport states.
     const dt_dev_roi_request_t latched = dt_dev_roi_request_get(dev);
     for(size_t i = 0; i < G_N_ELEMENTS(pipes); i++)
-      pipes[i]->roi_request = latched;
+      dt_dev_roi_request_latch(pipes[i], &latched);
 
     // This is cheap to run, keep it in sync always.
     const dt_dev_image_geometry_t geometry = dt_dev_geometry_snapshot(dev);

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -435,6 +435,7 @@ int dt_dev_pixelpipe_init_cached(dt_dev_pixelpipe_t *pipe)
   memset(pipe, 0, sizeof(dt_dev_pixelpipe_t));
 
   // Set only the stuff that doesn't take 0 as default
+  pipe->roi_request = dt_dev_roi_request_neutral();
   pipe->devid = -1;
   pipe->last_devid = -1;
   dt_dev_pixelpipe_set_changed(pipe, DT_DEV_PIPE_UNCHANGED);

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -435,7 +435,7 @@ int dt_dev_pixelpipe_init_cached(dt_dev_pixelpipe_t *pipe)
   memset(pipe, 0, sizeof(dt_dev_pixelpipe_t));
 
   // Set only the stuff that doesn't take 0 as default
-  pipe->roi_request = dt_dev_roi_request_neutral();
+  pipe->roi_request.value = dt_dev_roi_request_neutral();
   pipe->devid = -1;
   pipe->last_devid = -1;
   dt_dev_pixelpipe_set_changed(pipe, DT_DEV_PIPE_UNCHANGED);

--- a/src/develop/pixelpipe_hb.h
+++ b/src/develop/pixelpipe_hb.h
@@ -306,7 +306,7 @@ typedef struct dt_dev_pixelpipe_t
    * dt_dev_pixelpipe_init_cached() gives it: scaling 1, natural_scale -1, which is what those
    * pipes have always read off a headless dev. See develop/dev_roi_request.h.
    */
-  dt_dev_roi_request_t roi_request;
+  dt_dev_roi_request_store_t roi_request;
 
   // processing is true when actual pixel computations are ongoing
   int processing;

--- a/src/develop/pixelpipe_hb.h
+++ b/src/develop/pixelpipe_hb.h
@@ -40,6 +40,7 @@
  * the concrete types needed by value (dt_iop_roi_t, dt_iop_buffer_dsc_t) live in
  * develop/format.h. */
 #include "pixel/format.h"
+#include "develop/dev_roi_request.h"
 #include "develop/pixelpipe.h"
 #include "caches/pixelpipe_cache.h"
 
@@ -293,6 +294,20 @@ typedef struct dt_dev_pixelpipe_t
   GArray *raster_mask_hashes;
 
   int output_imgid;
+  /**
+   * @brief The viewport snapshot this run was planned from.
+   *
+   * @details Latched once per darkroom worker iteration, before any resync, and read by
+   * everything that runs on the pipeline thread for the rest of that run -- so a module
+   * callback and the ROI planner cannot disagree about the zoom, however many times the GUI
+   * thread republishes while the frame is being computed.
+   *
+   * A pipe nobody latches (export, thumbnail, snapshot) keeps the neutral seed
+   * dt_dev_pixelpipe_init_cached() gives it: scaling 1, natural_scale -1, which is what those
+   * pipes have always read off a headless dev. See develop/dev_roi_request.h.
+   */
+  dt_dev_roi_request_t roi_request;
+
   // processing is true when actual pixel computations are ongoing
   int processing;
   // running is true when the pipe thread is running, computing or idle.

--- a/src/iop/finalscale.c
+++ b/src/iop/finalscale.c
@@ -179,7 +179,8 @@ void commit_params(dt_iop_module_t *self, dt_iop_params_t *params, dt_dev_pixelp
   // This is important for consistency with exports.
   // The pipe's latched snapshot, not a live read off dev: this runs on the pipeline thread, and
   // piece->enabled must agree with the ROI the same iteration planned.
-  const float darkroom_zoom = pipe->roi_request.scaling * pipe->roi_request.natural_scale;
+  const dt_dev_roi_request_t request = dt_dev_roi_request_of_pipe(pipe);
+  const float darkroom_zoom = request.scaling * request.natural_scale;
   piece->enabled = (darkroom_zoom > 1.f)
     || (dt_conf_get_int("darkroom/render_size") != 1 && darkroom_zoom != 1.f);
 }

--- a/src/iop/finalscale.c
+++ b/src/iop/finalscale.c
@@ -177,7 +177,9 @@ void commit_params(dt_iop_module_t *self, dt_iop_params_t *params, dt_dev_pixelp
   // Darkroom pipes only. Depending on ROI zoom level, we may need to enable finalscale so
   // the pipeline runs at most at 100%, for pixel-level accuracy, and we upscale at the end.
   // This is important for consistency with exports.
-  const float darkroom_zoom = dt_dev_viewport_scaling(pipe->dev) * dt_dev_roi_request_natural_scale(pipe->dev);
+  // The pipe's latched snapshot, not a live read off dev: this runs on the pipeline thread, and
+  // piece->enabled must agree with the ROI the same iteration planned.
+  const float darkroom_zoom = pipe->roi_request.scaling * pipe->roi_request.natural_scale;
   piece->enabled = (darkroom_zoom > 1.f)
     || (dt_conf_get_int("darkroom/render_size") != 1 && darkroom_zoom != 1.f);
 }


### PR DESCRIPTION
Fourth step of the `dev->roi` division, on top of #1140, #1141 and #1143.

The darkroom worker now latches `dt_dev_roi_request_get()` **once per loop iteration** and copies it into every pipe, before any resync or planning. Everything downstream on the pipeline thread works from that one snapshot for the whole frame: `_update_darkroom_roi()` plans from it, `dt_dev_pixelpipe_has_preview_output()` compares against it, and `finalscale`'s `commit_params()` decides `piece->enabled` from it.

### Why the record alone wasn't enough

C3 made a single *read* coherent. It could not stop a frame being planned from two **different** reads — and the GUI thread republishes exactly when the user zooms, pans or resizes, which is precisely while a frame is being computed.

The planner alone made four separate reads: `natural_scale`, then `scaling`, then the processed size, then the box and the centre. A zoom landing between the first and the last produced a frame whose geometry never existed at any instant — internally consistent, correctly hashed, and therefore undetectable downstream. That is the same class as the torn `x`/`y` pair #1141 fixed, one level up: not a torn *field* but a torn *sequence of reads*.

### The neutral seed is load-bearing

A pipe nobody latches — export, thumbnail, snapshot — keeps what `dt_dev_pixelpipe_init_cached()` seeds, and that seed is deliberately **not** zeroed: `scaling = 1` and `natural_scale = -1` are what those pipes read off a headless dev before this record existed, and `finalscale` multiplies exactly those two to decide whether it enables itself. Zeros there would flip `piece->enabled` on every export.

### Verification

Release, Debug (`-Werror`), nofeatures build. `cycles 0`, `layering_violations 187`, all gates pass. Export A/B against the pre-tranche baseline: 0 differing pixels on both pages — though for *this* commit that only proves the neutral seed is right, since export pipes never latch.

The behaviour this commit exists for is not reachable from a headless export at all. **Worth exercising in the GUI: zooming and panning during a slow recompute** (a large raw, or a heavy module like diffuse), which is the case the latch is for.

### Next

C5 folds the generation into the FULL pipe hash. That is the one with real risk in this tranche: a wrong change-gate silently invalidates the pipeline cache chain on every history commit, and neither the export A/B nor any static gate can see it, because export pipes hash zero there. I'll measure how often the generation actually advances during an editing session rather than relying on the usual checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)