### PR TITLE
Develop T5: the cache-wait queue moves to the cache layer

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -196,6 +196,7 @@ FILE(GLOB SOURCE_FILES
   "develop/lightroom.c"
   "develop/pixelpipe.c"
   "caches/pixelpipe_cache.c"
+  "caches/pixelpipe_cache_wait.c"
   "develop/pixelpipe_cpu.c"
   "develop/pipeline_notify.c"
   "develop/pixelpipe_gpu.c"

--- a/src/caches/pixelpipe_cache_wait.c
+++ b/src/caches/pixelpipe_cache_wait.c
@@ -1,0 +1,224 @@
+/*
+    This file is part of Ansel.
+    Copyright (C) 2026 Aurélien Pierre.
+
+    Ansel is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Ansel is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Ansel.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "caches/pixelpipe_cache_wait.h"
+#include "caches/pixelpipe_cache.h"   // DT_PIXELPIPE_CACHE_HASH_INVALID
+#include "system/macros.h"            // IS_NULL_PTR
+#include "system/mem_alloc.h"         // dt_free
+
+#include <stdlib.h>                   // calloc
+
+/* The queue lives here and nothing else does. No control/, no gui/, no develop/: this file is
+ * layer 1 and stays that way, which is what lets tools/check_module_boundaries.sh keep its
+ * caches_upcall_baseline at 9.
+ */
+
+typedef struct dt_pixelpipe_cache_wait_record_t
+{
+  dt_pixelpipe_cache_wait_t *wait;
+  uint64_t request_id;
+  int64_t queued_at_us;
+} dt_pixelpipe_cache_wait_record_t;
+
+typedef struct dt_pixelpipe_cache_wait_queue_t
+{
+  dt_pthread_mutex_t lock;
+  GList *pending;
+  uint64_t next_request_id;
+  uint64_t queued_requests;
+  uint64_t served_requests;
+  uint64_t cancelled_requests;
+  uint64_t immediate_hits;
+  uint64_t misses;
+} dt_pixelpipe_cache_wait_queue_t;
+
+static dt_pixelpipe_cache_wait_queue_t _queue
+    = { .lock = { PTHREAD_MUTEX_INITIALIZER }, .pending = NULL, .next_request_id = 1,
+        .queued_requests = 0, .served_requests = 0, .cancelled_requests = 0,
+        .immediate_hits = 0, .misses = 0 };
+
+/** Unlink one record without touching the wait it points at. Caller holds the lock. */
+static void _unlink_locked(GList *link)
+{
+  dt_pixelpipe_cache_wait_record_t *record = link->data;
+  _queue.pending = g_list_delete_link(_queue.pending, link);
+  dt_free(record);
+}
+
+/** Find the record linking @p wait, or NULL. Caller holds the lock. */
+static GList *_find_locked(const dt_pixelpipe_cache_wait_t *wait)
+{
+  for(GList *iter = _queue.pending; iter; iter = g_list_next(iter))
+  {
+    const dt_pixelpipe_cache_wait_record_t *record = iter->data;
+    if(!IS_NULL_PTR(record) && record->wait == wait) return iter;
+  }
+  return NULL;
+}
+
+gboolean dt_pixelpipe_cache_wait_enqueue(dt_pixelpipe_cache_wait_t *wait)
+{
+  if(IS_NULL_PTR(wait)) return FALSE;
+
+  dt_pthread_mutex_lock(&_queue.lock);
+
+  const gboolean was_empty = IS_NULL_PTR(_queue.pending);
+
+  // Already queued for this exact target: nothing to add. The caller re-asks on every redraw,
+  // and each of those must not grow the queue.
+  if(wait->connected && !IS_NULL_PTR(_find_locked(wait)))
+  {
+    dt_pthread_mutex_unlock(&_queue.lock);
+    return FALSE;
+  }
+
+  dt_pixelpipe_cache_wait_record_t *record
+      = (dt_pixelpipe_cache_wait_record_t *)calloc(1, sizeof(dt_pixelpipe_cache_wait_record_t));
+  if(IS_NULL_PTR(record))
+  {
+    dt_pthread_mutex_unlock(&_queue.lock);
+    return FALSE;
+  }
+
+  wait->request_id = _queue.next_request_id++;
+  wait->connected = TRUE;
+  record->wait = wait;
+  record->request_id = wait->request_id;
+  record->queued_at_us = g_get_monotonic_time();
+  _queue.pending = g_list_prepend(_queue.pending, record);
+  _queue.queued_requests++;
+
+  dt_pthread_mutex_unlock(&_queue.lock);
+  return was_empty;
+}
+
+GList *dt_pixelpipe_cache_wait_take_matching(const uint64_t hash, const uint64_t producer_node_key,
+                                             gboolean *drained)
+{
+  GList *taken = NULL;
+  const gboolean node_key_valid
+      = producer_node_key != 0 && producer_node_key != DT_PIXELPIPE_CACHE_HASH_INVALID;
+
+  dt_pthread_mutex_lock(&_queue.lock);
+  for(GList *iter = _queue.pending; iter;)
+  {
+    GList *next = g_list_next(iter);
+    const dt_pixelpipe_cache_wait_record_t *record = iter->data;
+    dt_pixelpipe_cache_wait_t *wait = !IS_NULL_PTR(record) ? record->wait : NULL;
+
+    // Exact hash, or the node that produced it. The node match is what survives hash drift:
+    // the waiter registered the hash it predicted, the worker published a different one for
+    // the same module output, and the waiter still wants waking -- its restart re-reads the
+    // module's current output hash and hits.
+    const gboolean node_match
+        = node_key_valid && !IS_NULL_PTR(wait) && wait->target_node_key == producer_node_key;
+    if(!IS_NULL_PTR(wait) && wait->connected && (wait->hash == hash || node_match))
+    {
+      _unlink_locked(iter);
+      _queue.served_requests++;
+      wait->connected = FALSE;
+      taken = g_list_prepend(taken, wait);
+    }
+    iter = next;
+  }
+  if(!IS_NULL_PTR(drained)) *drained = IS_NULL_PTR(_queue.pending);
+  dt_pthread_mutex_unlock(&_queue.lock);
+
+  return taken;
+}
+
+gboolean dt_pixelpipe_cache_wait_cancel(dt_pixelpipe_cache_wait_t *wait, gboolean *drained)
+{
+  if(IS_NULL_PTR(wait)) return FALSE;
+
+  dt_pthread_mutex_lock(&_queue.lock);
+  GList *link = _find_locked(wait);
+  const gboolean was_queued = !IS_NULL_PTR(link);
+  if(was_queued)
+  {
+    _unlink_locked(link);
+    _queue.cancelled_requests++;
+  }
+  if(!IS_NULL_PTR(drained)) *drained = IS_NULL_PTR(_queue.pending);
+  dt_pthread_mutex_unlock(&_queue.lock);
+
+  wait->connected = FALSE;
+  return was_queued;
+}
+
+guint dt_pixelpipe_cache_wait_pending_count(void)
+{
+  dt_pthread_mutex_lock(&_queue.lock);
+  const guint count = g_list_length(_queue.pending);
+  dt_pthread_mutex_unlock(&_queue.lock);
+  return count;
+}
+
+void dt_pixelpipe_cache_wait_get_stats(uint64_t *queued, uint64_t *served, uint64_t *cancelled,
+                                       uint64_t *immediate_hits, uint64_t *misses)
+{
+  dt_pthread_mutex_lock(&_queue.lock);
+  if(!IS_NULL_PTR(queued)) *queued = _queue.queued_requests;
+  if(!IS_NULL_PTR(served)) *served = _queue.served_requests;
+  if(!IS_NULL_PTR(cancelled)) *cancelled = _queue.cancelled_requests;
+  if(!IS_NULL_PTR(immediate_hits)) *immediate_hits = _queue.immediate_hits;
+  if(!IS_NULL_PTR(misses)) *misses = _queue.misses;
+  dt_pthread_mutex_unlock(&_queue.lock);
+}
+
+void dt_pixelpipe_cache_wait_count_immediate_hit(void)
+{
+  // trylock, as the counter is diagnostic only: a consumer reopening an already-available
+  // cacheline must not block behind a queue operation to record it.
+  if(!dt_pthread_mutex_trylock(&_queue.lock))
+  {
+    _queue.immediate_hits++;
+    dt_pthread_mutex_unlock(&_queue.lock);
+  }
+}
+
+void dt_pixelpipe_cache_wait_count_miss(void)
+{
+  if(!dt_pthread_mutex_trylock(&_queue.lock))
+  {
+    _queue.misses++;
+    dt_pthread_mutex_unlock(&_queue.lock);
+  }
+}
+
+void dt_pixelpipe_cache_wait_foreach_pending(dt_pixelpipe_cache_wait_visitor_t callback,
+                                             gpointer user_data)
+{
+  if(IS_NULL_PTR(callback)) return;
+
+  const int64_t now = g_get_monotonic_time();
+  dt_pthread_mutex_lock(&_queue.lock);
+  for(const GList *iter = _queue.pending; iter; iter = g_list_next(iter))
+  {
+    const dt_pixelpipe_cache_wait_record_t *record = iter->data;
+    if(IS_NULL_PTR(record) || IS_NULL_PTR(record->wait)) continue;
+    callback(record->wait, now - record->queued_at_us, user_data);
+  }
+  dt_pthread_mutex_unlock(&_queue.lock);
+}
+
+// clang-format off
+// modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py
+// vim: shiftwidth=2 expandtab tabstop=2 cindent
+// kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;
+// clang-format on

--- a/src/caches/pixelpipe_cache_wait.h
+++ b/src/caches/pixelpipe_cache_wait.h
@@ -1,0 +1,147 @@
+/*
+    This file is part of Ansel.
+    Copyright (C) 2026 Aurélien Pierre.
+
+    Ansel is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Ansel is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Ansel.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+/** @file caches/pixelpipe_cache_wait.h
+ *
+ * @brief The queue of consumers waiting for a pixel cacheline that does not exist yet.
+ *
+ * @details A GUI consumer that asks the cache for an output the pipeline has not published
+ * yet -- a histogram, a colour picker, the darkroom surface, autoset -- leaves a request
+ * here and is called back when a matching cacheline appears. The queue, its lock, its
+ * counters and the rule for deciding which waiters a publication satisfies are cache state,
+ * and this is where they live.
+ *
+ * What is deliberately NOT here: how the "a cacheline became ready" fact travels, and what a
+ * pending queue looks like to the user. Those belong to whoever is running the cache.
+ * `develop/` still owns both, because the transport must stay ASYNCHRONOUS and that is not a
+ * style preference -- the ready fact is emitted from
+ * dt_dev_pixelpipe_cache_wrlock_entry(FALSE, ...), which _cache_try_rekey_reuse_locked()
+ * calls while holding the process-wide `cache->lock'. Restart callbacks re-enter the cache.
+ * Serving them inline would re-lock a non-recursive mutex on the same thread and hang the
+ * pipeline worker holding it, taking every other pipe with it.
+ *
+ * So this module hands back the list of waiters a publication satisfies and lets the caller
+ * run them, on whatever thread the caller has already arranged to be safe.
+ */
+
+#ifndef DT_CACHES_PIXELPIPE_CACHE_WAIT_H
+#define DT_CACHES_PIXELPIPE_CACHE_WAIT_H
+
+#include <glib.h>
+#include <stdint.h>
+
+#include "system/dtpthread.h"
+
+/** @brief Called when the awaited cacheline finally exists. Runs on the caller's thread. */
+typedef void (*dt_pixelpipe_cache_ready_callback_t)(gpointer user_data);
+
+/**
+ * @brief One consumer's outstanding request, owned by that consumer, not by the queue.
+ *
+ * @details Callers embed this (dt_develop_t holds two) or keep one per widget, and hand its
+ * address in. The queue only ever links it, matches it and hands it back.
+ */
+typedef struct dt_pixelpipe_cache_wait_t
+{
+  /* Identity only, never dereferenced: which pipe and which module this waiter is about, so a
+   * re-request can be recognised as the same one and a teardown can cancel by owner. The queue
+   * outlives neither object, which is why the labels below are copies rather than reads. */
+  const void *pipe;
+  const void *module;
+
+  /* Captured when the wait is queued, for debug traces and telemetry keys. */
+  char module_op[20];
+  int module_multi_priority;
+  int pipe_type;
+  int32_t pipe_imgid;
+
+  uint64_t hash;
+
+  /** Producer node identity of the awaited output. Lets a waiter be served when its target
+   *  module publishes, even if the exact awaited hash drifted before the publish -- the GUI
+   *  predicts a hash, the worker recomputes them all. INVALID for a backbuf target, which has
+   *  no single producing node and keeps to the exact-hash match. */
+  uint64_t target_node_key;
+
+  dt_pixelpipe_cache_ready_callback_t restart;
+  gpointer user_data;
+  const char *owner_tag;
+  gpointer owner_object;
+  uint64_t request_id;
+  gboolean connected;
+} dt_pixelpipe_cache_wait_t;
+
+/**
+ * @brief Queue @p wait, or refresh it in place if it is already queued for the same target.
+ *
+ * @return TRUE when the queue went from empty to non-empty, so the caller can raise whatever
+ * "the user is waiting" state it owns. FALSE otherwise, including when the wait was already
+ * queued unchanged.
+ */
+gboolean dt_pixelpipe_cache_wait_enqueue(dt_pixelpipe_cache_wait_t *wait);
+
+/**
+ * @brief Take every waiter satisfied by a publication of @p hash from node @p producer_node_key.
+ *
+ * @details Matches on the exact hash OR on the producing node, which is what makes the
+ * protocol survive hash drift. Removes them from the queue and marks them disconnected.
+ *
+ * @param drained Set to TRUE when this emptied the queue.
+ * @return A caller-owned GList of dt_pixelpipe_cache_wait_t*, to run and then free. Callbacks
+ * are deliberately NOT run here: see the file comment on why the caller owns that step.
+ */
+GList *dt_pixelpipe_cache_wait_take_matching(uint64_t hash, uint64_t producer_node_key,
+                                             gboolean *drained);
+
+/**
+ * @brief Remove @p wait from the queue if it is there, and reset it to an inert state.
+ *
+ * @param drained Set to TRUE when this emptied the queue.
+ * @return TRUE when the wait was actually queued and has now been removed.
+ */
+gboolean dt_pixelpipe_cache_wait_cancel(dt_pixelpipe_cache_wait_t *wait, gboolean *drained);
+
+/** @brief How many requests are outstanding. Diagnostics only. */
+guint dt_pixelpipe_cache_wait_pending_count(void);
+
+/** @brief Snapshot of the lifetime counters, for the dump. Any pointer may be NULL. */
+void dt_pixelpipe_cache_wait_get_stats(uint64_t *queued, uint64_t *served, uint64_t *cancelled,
+                                       uint64_t *immediate_hits, uint64_t *misses);
+
+/** @brief Count one cache hit that never needed to queue. */
+void dt_pixelpipe_cache_wait_count_immediate_hit(void);
+
+/** @brief Count one miss that is about to queue. */
+void dt_pixelpipe_cache_wait_count_miss(void);
+
+/**
+ * @brief Walk the outstanding requests. @p callback is invoked under the queue lock, so it
+ * must not re-enter this module or the cache.
+ */
+typedef void (*dt_pixelpipe_cache_wait_visitor_t)(const dt_pixelpipe_cache_wait_t *wait,
+                                                  int64_t age_us, gpointer user_data);
+void dt_pixelpipe_cache_wait_foreach_pending(dt_pixelpipe_cache_wait_visitor_t callback,
+                                             gpointer user_data);
+
+#endif // DT_CACHES_PIXELPIPE_CACHE_WAIT_H
+
+// clang-format off
+// modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py
+// vim: shiftwidth=2 expandtab tabstop=2 cindent
+// kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;
+// clang-format on

--- a/src/develop/dev_pixelpipe.c
+++ b/src/develop/dev_pixelpipe.c
@@ -50,32 +50,17 @@ static void _dt_dev_pixelpipe_cache_wait_ready_callback(gpointer instance, const
                                                         const guint64 producer_node_key,
                                                         gpointer user_data);
 
-typedef struct dt_dev_pixelpipe_cache_wait_record_t
-{
-  dt_dev_pixelpipe_cache_wait_t *wait;
-  uint64_t request_id;
-  int64_t queued_at_us;
-} dt_dev_pixelpipe_cache_wait_record_t;
-
-typedef struct dt_dev_pixelpipe_cache_wait_manager_t
-{
-  dt_pthread_mutex_t lock;
-  GList *pending;
-  gboolean connected;
-  gboolean wait_cursor_active;
-  uint64_t next_request_id;
-  uint64_t queued_requests;
-  uint64_t served_requests;
-  uint64_t cancelled_requests;
-  uint64_t immediate_hits;
-  uint64_t misses;
-} dt_dev_pixelpipe_cache_wait_manager_t;
-
-static dt_dev_pixelpipe_cache_wait_manager_t _cache_wait_manager
-    = { .lock = { PTHREAD_MUTEX_INITIALIZER }, .pending = NULL, .connected = FALSE,
-        .wait_cursor_active = FALSE,
-        .next_request_id = 1, .queued_requests = 0, .served_requests = 0,
-        .cancelled_requests = 0, .immediate_hits = 0, .misses = 0 };
+/* What stays here is the TRANSPORT and the PRESENTATION of the wait queue, not the queue:
+ * whether we are currently subscribed to the ready signal, and whether the busy cursor is up.
+ * The queue, its lock, its counters and its matching rule are cache state and live in
+ * caches/pixelpipe_cache_wait.{h,c}.
+ *
+ * Both flags are GUI-thread-only, like every accessor below: DT_SIGNAL_CACHELINE_READY is
+ * declared asynchronous (control/signal.c), so its handler is marshalled to the main loop, and
+ * every enqueue site is an expose, a widget callback or an idle. That asynchrony is load-bearing
+ * and must not be optimised away -- see the file comment in caches/pixelpipe_cache_wait.h. */
+static gboolean _cache_wait_connected = FALSE;
+static gboolean _cache_wait_cursor_active = FALSE;
 
 static gboolean _cache_wait_cursor_progress(gpointer user_data)
 {
@@ -96,60 +81,35 @@ static gboolean _cache_wait_cursor_restore(gpointer user_data)
   return G_SOURCE_REMOVE;
 }
 
-static dt_dev_pixelpipe_cache_wait_record_t *_cache_wait_manager_remove_wait_locked(dt_dev_pixelpipe_cache_wait_t *wait)
+static void _dump_one_pending(const dt_dev_pixelpipe_cache_wait_t *wait, const int64_t age_us,
+                              gpointer user_data)
 {
-  for(GList *iter = _cache_wait_manager.pending; iter; iter = g_list_next(iter))
-  {
-    dt_dev_pixelpipe_cache_wait_record_t *record = iter->data;
-    if(!IS_NULL_PTR(record) && record->wait == wait)
-    {
-      _cache_wait_manager.pending = g_list_delete_link(_cache_wait_manager.pending, iter);
-      return record;
-    }
-  }
-
-  return NULL;
+  (void)user_data;
+  dt_print(DT_DEBUG_PIPECACHE,
+           "[cache-wait] pending id=%" PRIu64 " owner=%s hash=%" PRIu64
+           " target=%s connected=%d age_ms=%" PRId64 "\n",
+           wait->request_id,
+           !IS_NULL_PTR(wait->owner_tag) ? wait->owner_tag : "(unknown)",
+           wait->hash,
+           !IS_NULL_PTR(wait->module) ? wait->module_op : "backbuf",
+           wait->connected,
+           MAX(age_us / 1000, 0));
 }
 
 void dt_dev_pixelpipe_cache_wait_dump_pending(const char *reason)
 {
   const char *context = !IS_NULL_PTR(reason) ? reason : "unspecified";
-  const int64_t now_us = g_get_monotonic_time();
 
-  // This is a diagnostic snapshot only. Skip it rather than stalling GUI teardown
-  // behind a cache-ready callback that is already updating the same wait list.
-  if(dt_pthread_mutex_trylock(&_cache_wait_manager.lock))
-  {
-    dt_print(DT_DEBUG_PIPECACHE, "[cache-wait] dump reason=%s skipped=lock-busy\n", context);
-    return;
-  }
+  uint64_t queued = 0, served = 0, cancelled = 0, immediate = 0, misses = 0;
+  dt_pixelpipe_cache_wait_get_stats(&queued, &served, &cancelled, &immediate, &misses);
 
-  const guint pending_count = g_list_length(_cache_wait_manager.pending);
   dt_print(DT_DEBUG_PIPECACHE,
            "[cache-wait] dump reason=%s pending=%u queued=%" PRIu64 " served=%" PRIu64
            " cancelled=%" PRIu64 " immediate=%" PRIu64 " misses=%" PRIu64 "\n",
-           context, pending_count, _cache_wait_manager.queued_requests,
-           _cache_wait_manager.served_requests, _cache_wait_manager.cancelled_requests,
-           _cache_wait_manager.immediate_hits, _cache_wait_manager.misses);
+           context, dt_pixelpipe_cache_wait_pending_count(), queued, served, cancelled,
+           immediate, misses);
 
-  for(GList *iter = _cache_wait_manager.pending; iter; iter = g_list_next(iter))
-  {
-    dt_dev_pixelpipe_cache_wait_record_t *record = iter->data;
-    dt_dev_pixelpipe_cache_wait_t *wait = !IS_NULL_PTR(record) ? record->wait : NULL;
-    if(IS_NULL_PTR(wait) || IS_NULL_PTR(record)) continue;
-
-    const int64_t age_ms = MAX((now_us - record->queued_at_us) / 1000, 0);
-    dt_print(DT_DEBUG_PIPECACHE,
-             "[cache-wait] pending id=%" PRIu64 " owner=%s hash=%" PRIu64
-             " target=%s connected=%d age_ms=%" PRId64 "\n",
-             wait->request_id,
-             !IS_NULL_PTR(wait->owner_tag) ? wait->owner_tag : "(unknown)",
-             wait->hash,
-             !IS_NULL_PTR(wait->module) ? wait->module_op : "backbuf",
-             wait->connected,
-             age_ms);
-  }
-  dt_pthread_mutex_unlock(&_cache_wait_manager.lock);
+  dt_pixelpipe_cache_wait_foreach_pending(_dump_one_pending, NULL);
 }
 
 static gboolean _module_requires_global_histogram_output_cache(const dt_dev_pixelpipe_t *pipe,
@@ -747,26 +707,14 @@ gboolean dt_dev_pixelpipe_cache_peek_gui(dt_dev_pixelpipe_t *pipe, const dt_dev_
      && dt_dev_pixelpipe_cache_peek(display_hash, &buffer, &entry, -1, NULL)
      &&  !IS_NULL_PTR(buffer) && !IS_NULL_PTR(entry))
   {
-    // These counters are only diagnostic; cache consumers should not wait for
-    // queue lifecycle updates before reopening an already available cacheline.
-    if(!dt_pthread_mutex_trylock(&_cache_wait_manager.lock))
-    {
-      _cache_wait_manager.immediate_hits++;
-      dt_pthread_mutex_unlock(&_cache_wait_manager.lock);
-    }
+    dt_pixelpipe_cache_wait_count_immediate_hit();
     dt_dev_pixelpipe_cache_wait_cleanup(wait, "peek-gui-immediate-hit");
     if(!IS_NULL_PTR(data)) *data = buffer;
     if(!IS_NULL_PTR(cache_entry)) *cache_entry = entry;
     return TRUE;
   }
 
-  // A missed GUI peek already requests cache publication below. The miss counter
-  // is diagnostic, so it must not block redraw/picker paths under contention.
-  if(!dt_pthread_mutex_trylock(&_cache_wait_manager.lock))
-  {
-    _cache_wait_manager.misses++;
-    dt_pthread_mutex_unlock(&_cache_wait_manager.lock);
-  }
+  dt_pixelpipe_cache_wait_count_miss();
 
   gboolean request_cacheline = TRUE;
   if(!IS_NULL_PTR(wait) && !IS_NULL_PTR(restart) && hash != DT_PIXELPIPE_CACHE_HASH_INVALID)
@@ -817,26 +765,24 @@ gboolean dt_dev_pixelpipe_cache_peek_gui(dt_dev_pixelpipe_t *pipe, const dt_dev_
         wait->owner_object = restart_data;
       wait->connected = TRUE;
 
-      dt_pthread_mutex_lock(&_cache_wait_manager.lock);
-      wait->request_id = _cache_wait_manager.next_request_id++;
-      _cache_wait_manager.queued_requests++;
-      dt_dev_pixelpipe_cache_wait_record_t *record = calloc(1, sizeof(*record));
-      record->wait = wait;
-      record->request_id = wait->request_id;
-      record->queued_at_us = g_get_monotonic_time();
-      _cache_wait_manager.pending = g_list_prepend(_cache_wait_manager.pending, record);
-      if(!_cache_wait_manager.connected)
+      // The queue assigns the request id and reports whether it just went from empty to
+      // non-empty; the subscription and the cursor are ours, and both hang off exactly that
+      // transition -- which is why they were one flag each in the old manager.
+      const gboolean queue_became_busy = dt_pixelpipe_cache_wait_enqueue(wait);
+      if(queue_became_busy)
       {
-        DT_DEBUG_CONTROL_SIGNAL_CONNECT(dt_control_signal_get_global(), DT_SIGNAL_CACHELINE_READY,
-                                        G_CALLBACK(_dt_dev_pixelpipe_cache_wait_ready_callback), NULL);
-        _cache_wait_manager.connected = TRUE;
+        if(!_cache_wait_connected)
+        {
+          DT_DEBUG_CONTROL_SIGNAL_CONNECT(dt_control_signal_get_global(), DT_SIGNAL_CACHELINE_READY,
+                                          G_CALLBACK(_dt_dev_pixelpipe_cache_wait_ready_callback), NULL);
+          _cache_wait_connected = TRUE;
+        }
+        if(!_cache_wait_cursor_active)
+        {
+          _cache_wait_cursor_active = TRUE;
+          activate_wait_cursor = TRUE;
+        }
       }
-      if(!_cache_wait_manager.wait_cursor_active)
-      {
-        _cache_wait_manager.wait_cursor_active = TRUE;
-        activate_wait_cursor = TRUE;
-      }
-      dt_pthread_mutex_unlock(&_cache_wait_manager.lock);
       if(activate_wait_cursor)
         g_main_context_invoke(NULL, _cache_wait_cursor_progress, NULL);
 
@@ -919,42 +865,25 @@ static void _dt_dev_pixelpipe_cache_wait_ready_callback(gpointer instance, const
                                                         const guint64 producer_node_key,
                                                         gpointer user_data)
 {
-  GList *to_restart = NULL;
   gboolean restore_wait_cursor = FALSE;
-  const gboolean node_key_valid
-      = producer_node_key != 0 && producer_node_key != DT_PIXELPIPE_CACHE_HASH_INVALID;
+  gboolean drained = FALSE;
 
-  dt_pthread_mutex_lock(&_cache_wait_manager.lock);
-  for(GList *iter = _cache_wait_manager.pending; iter; )
-  {
-    GList *next = g_list_next(iter);
-    dt_dev_pixelpipe_cache_wait_record_t *record = iter->data;
-    dt_dev_pixelpipe_cache_wait_t *wait = !IS_NULL_PTR(record) ? record->wait : NULL;
-    const gboolean node_match = node_key_valid && !IS_NULL_PTR(wait)
-                                && wait->target_node_key == producer_node_key;
-    if(!IS_NULL_PTR(wait) && wait->connected && (wait->hash == hash || node_match))
-    {
-      _cache_wait_manager.pending = g_list_delete_link(_cache_wait_manager.pending, iter);
-      _cache_wait_manager.served_requests++;
-      wait->connected = FALSE;
-      to_restart = g_list_prepend(to_restart, wait);
-      dt_free(record);
-    }
-    iter = next;
-  }
+  // The queue decides who this publication satisfies and hands them back; running their
+  // callbacks is ours, and stays OUTSIDE any queue lock, because a restart handler queues
+  // redraws and asks for new cachelines.
+  GList *to_restart = dt_pixelpipe_cache_wait_take_matching(hash, producer_node_key, &drained);
 
-  if(IS_NULL_PTR(_cache_wait_manager.pending) && _cache_wait_manager.connected)
+  if(drained && _cache_wait_connected)
   {
     DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(dt_control_signal_get_global(),
                                        G_CALLBACK(_dt_dev_pixelpipe_cache_wait_ready_callback), NULL);
-    _cache_wait_manager.connected = FALSE;
+    _cache_wait_connected = FALSE;
   }
-  if(IS_NULL_PTR(_cache_wait_manager.pending) && _cache_wait_manager.wait_cursor_active)
+  if(drained && _cache_wait_cursor_active)
   {
-    _cache_wait_manager.wait_cursor_active = FALSE;
+    _cache_wait_cursor_active = FALSE;
     restore_wait_cursor = TRUE;
   }
-  dt_pthread_mutex_unlock(&_cache_wait_manager.lock);
   if(restore_wait_cursor)
     g_main_context_invoke(NULL, _cache_wait_cursor_restore, NULL);
 
@@ -1002,7 +931,6 @@ void dt_dev_pixelpipe_cache_wait_cleanup(dt_dev_pixelpipe_cache_wait_t *wait, co
 {
   if(IS_NULL_PTR(wait) || !wait->connected) return;
   gboolean restore_wait_cursor = FALSE;
-  int64_t queued_at_us = 0;
   const uint64_t request_id = wait->request_id;
   const uint64_t hash = wait->hash;
   const char *owner_tag = wait->owner_tag;
@@ -1017,30 +945,26 @@ void dt_dev_pixelpipe_cache_wait_cleanup(dt_dev_pixelpipe_cache_wait_t *wait, co
   const int32_t cancel_pipe_imgid = wait->pipe_imgid;
   const char *cancel_reason = !IS_NULL_PTR(reason) ? reason : "unspecified";
 
-  dt_pthread_mutex_lock(&_cache_wait_manager.lock);
-  dt_dev_pixelpipe_cache_wait_record_t *record = _cache_wait_manager_remove_wait_locked(wait);
-  if(!IS_NULL_PTR(record))
-  {
-    queued_at_us = record->queued_at_us;
-    dt_free(record);
-  }
-  _cache_wait_manager.cancelled_requests++;
-  if(IS_NULL_PTR(_cache_wait_manager.pending) && _cache_wait_manager.connected)
+  gboolean drained = FALSE;
+  dt_pixelpipe_cache_wait_cancel(wait, &drained);
+
+  if(drained && _cache_wait_connected)
   {
     DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(dt_control_signal_get_global(),
                                        G_CALLBACK(_dt_dev_pixelpipe_cache_wait_ready_callback), NULL);
-    _cache_wait_manager.connected = FALSE;
+    _cache_wait_connected = FALSE;
   }
-  if(IS_NULL_PTR(_cache_wait_manager.pending) && _cache_wait_manager.wait_cursor_active)
+  if(drained && _cache_wait_cursor_active)
   {
-    _cache_wait_manager.wait_cursor_active = FALSE;
+    _cache_wait_cursor_active = FALSE;
     restore_wait_cursor = TRUE;
   }
-  dt_pthread_mutex_unlock(&_cache_wait_manager.lock);
   if(restore_wait_cursor)
     g_main_context_invoke(NULL, _cache_wait_cursor_restore, NULL);
 
-  const int64_t age_ms = queued_at_us > 0 ? MAX((g_get_monotonic_time() - queued_at_us) / 1000, 0) : -1;
+  // -1: the queue owns the enqueue timestamp, and a cancellation is not worth an extra query
+  // into it. The dump reports real ages for everything still pending.
+  const int64_t age_ms = -1;
   dt_print(DT_DEBUG_PIPECACHE,
            "[cache-wait] cancelled id=%" PRIu64 " owner=%s hash=%" PRIu64
            " target=%s age_ms=%" PRId64 " reason=%s\n",

--- a/src/develop/dev_pixelpipe.c
+++ b/src/develop/dev_pixelpipe.c
@@ -145,7 +145,7 @@ void dt_dev_pixelpipe_cache_wait_dump_pending(const char *reason)
              wait->request_id,
              !IS_NULL_PTR(wait->owner_tag) ? wait->owner_tag : "(unknown)",
              wait->hash,
-             !IS_NULL_PTR(wait->module) ? wait->module->op : "backbuf",
+             !IS_NULL_PTR(wait->module) ? wait->module_op : "backbuf",
              wait->connected,
              age_ms);
   }
@@ -782,6 +782,24 @@ gboolean dt_dev_pixelpipe_cache_peek_gui(dt_dev_pixelpipe_t *pipe, const dt_dev_
       dt_dev_pixelpipe_cache_wait_cleanup(wait, "peek-gui-target-changed");
       wait->pipe = pipe;
       wait->module = !IS_NULL_PTR(piece) ? piece->module : NULL;
+
+      // Copy the labels now, while both objects are certainly alive. The queue never reads
+      // through the two identity pointers above; everything it reports about a waiter comes
+      // from here.
+      const dt_iop_module_t *target_module = !IS_NULL_PTR(piece) ? piece->module : NULL;
+      if(!IS_NULL_PTR(target_module))
+      {
+        g_strlcpy(wait->module_op, target_module->op, sizeof(wait->module_op));
+        wait->module_multi_priority = target_module->multi_priority;
+      }
+      else
+      {
+        wait->module_op[0] = '\0';
+        wait->module_multi_priority = 0;
+      }
+      wait->pipe_type = (int)pipe->type;
+      wait->pipe_imgid = pipe->imgid;
+
       wait->hash = hash;
       // Record the producing node identity so CACHELINE_READY can serve this waiter by
       // its target module even if the exact awaited hash drifts before publish (§8). A
@@ -827,12 +845,12 @@ gboolean dt_dev_pixelpipe_cache_peek_gui(dt_dev_pixelpipe_t *pipe, const dt_dev_
                wait->request_id,
                !IS_NULL_PTR(wait->owner_tag) ? wait->owner_tag : "(unknown)",
                wait->hash,
-               !IS_NULL_PTR(wait->module) ? wait->module->op : "backbuf");
+               !IS_NULL_PTR(wait->module) ? wait->module_op : "backbuf");
 
       if(dt_supervisor_active())
         dt_supervisor_cache_wait(DT_SV_CREATE, wait->request_id, wait->hash, wait->owner_tag,
-                                 !IS_NULL_PTR(wait->module) ? wait->module->op : NULL,
-                                 !IS_NULL_PTR(wait->module) ? wait->module->multi_priority : 0,
+                                 !IS_NULL_PTR(wait->module) ? wait->module_op : NULL,
+                                 wait->module_multi_priority,
                                  (int)pipe->type, pipe->imgid, TRUE, NULL);
     }
     else
@@ -848,8 +866,8 @@ gboolean dt_dev_pixelpipe_cache_peek_gui(dt_dev_pixelpipe_t *pipe, const dt_dev_
        * finishes" signature. */
       if(dt_supervisor_active())
         dt_supervisor_cache_wait(DT_SV_READ, wait->request_id, wait->hash, wait->owner_tag,
-                                 !IS_NULL_PTR(wait->module) ? wait->module->op : NULL,
-                                 !IS_NULL_PTR(wait->module) ? wait->module->multi_priority : 0,
+                                 !IS_NULL_PTR(wait->module) ? wait->module_op : NULL,
+                                 wait->module_multi_priority,
                                  (int)pipe->type, pipe->imgid, FALSE, "dedup-poll");
     }
   }
@@ -956,15 +974,15 @@ static void _dt_dev_pixelpipe_cache_wait_ready_callback(gpointer instance, const
              wait->request_id,
              !IS_NULL_PTR(wait->owner_tag) ? wait->owner_tag : "(unknown)",
              wait->hash, hash,
-             !IS_NULL_PTR(wait->module) ? wait->module->op : "backbuf",
+             !IS_NULL_PTR(wait->module) ? wait->module_op : "backbuf",
              drift_serve ? " (drift: node-key)" : "");
 
     if(dt_supervisor_active())
       dt_supervisor_cache_wait(DT_SV_DELETE, wait->request_id, wait->hash, wait->owner_tag,
-                               !IS_NULL_PTR(wait->module) ? wait->module->op : NULL,
-                               !IS_NULL_PTR(wait->module) ? wait->module->multi_priority : 0,
-                               !IS_NULL_PTR(wait->pipe) ? (int)wait->pipe->type : -1,
-                               !IS_NULL_PTR(wait->pipe) ? wait->pipe->imgid : -1, FALSE,
+                               !IS_NULL_PTR(wait->module) ? wait->module_op : NULL,
+                               wait->module_multi_priority,
+                               !IS_NULL_PTR(wait->pipe) ? (int)wait->pipe_type : -1,
+                               !IS_NULL_PTR(wait->pipe) ? wait->pipe_imgid : -1, FALSE,
                                drift_serve ? "served (drift: node-key)" : "served");
 
     wait->pipe = NULL;
@@ -988,8 +1006,15 @@ void dt_dev_pixelpipe_cache_wait_cleanup(dt_dev_pixelpipe_cache_wait_t *wait, co
   const uint64_t request_id = wait->request_id;
   const uint64_t hash = wait->hash;
   const char *owner_tag = wait->owner_tag;
-  const dt_iop_module_t *module = wait->module;
-  const dt_dev_pixelpipe_t *cancel_pipe = wait->pipe;
+  // Snapshot the identity and its labels together, before the reset below clears them. Nothing
+  // here dereferences the module or the pipe: the labels were copied when the wait was queued,
+  // precisely because either object can be gone by the time a wait is cancelled.
+  const gboolean had_module = !IS_NULL_PTR(wait->module);
+  const gboolean had_pipe = !IS_NULL_PTR(wait->pipe);
+  const char *module_op = had_module ? wait->module_op : NULL;
+  const int module_multi_priority = wait->module_multi_priority;
+  const int cancel_pipe_type = wait->pipe_type;
+  const int32_t cancel_pipe_imgid = wait->pipe_imgid;
   const char *cancel_reason = !IS_NULL_PTR(reason) ? reason : "unspecified";
 
   dt_pthread_mutex_lock(&_cache_wait_manager.lock);
@@ -1022,7 +1047,7 @@ void dt_dev_pixelpipe_cache_wait_cleanup(dt_dev_pixelpipe_cache_wait_t *wait, co
            request_id,
            !IS_NULL_PTR(owner_tag) ? owner_tag : "(unknown)",
            hash,
-           !IS_NULL_PTR(module) ? module->op : "backbuf",
+           had_module ? module_op : "backbuf",
            age_ms,
            cancel_reason);
 
@@ -1031,10 +1056,9 @@ void dt_dev_pixelpipe_cache_wait_cleanup(dt_dev_pixelpipe_cache_wait_t *wait, co
     char note[64];
     g_snprintf(note, sizeof(note), "cancelled: %s", cancel_reason);
     dt_supervisor_cache_wait(DT_SV_DELETE, request_id, hash, owner_tag,
-                             !IS_NULL_PTR(module) ? module->op : NULL,
-                             !IS_NULL_PTR(module) ? module->multi_priority : 0,
-                             !IS_NULL_PTR(cancel_pipe) ? (int)cancel_pipe->type : -1,
-                             !IS_NULL_PTR(cancel_pipe) ? cancel_pipe->imgid : -1, FALSE, note);
+                             module_op, module_multi_priority,
+                             had_pipe ? cancel_pipe_type : -1,
+                             had_pipe ? cancel_pipe_imgid : -1, FALSE, note);
   }
 
   wait->pipe = NULL;

--- a/src/develop/dev_pixelpipe.h
+++ b/src/develop/dev_pixelpipe.h
@@ -154,8 +154,24 @@ typedef void (*dt_dev_pixelpipe_cache_ready_callback_t)(gpointer user_data);
 
 typedef struct dt_dev_pixelpipe_cache_wait_t
 {
-  struct dt_dev_pixelpipe_t *pipe;
-  const struct dt_iop_module_t *module;
+  /* Identity only, never dereferenced: these say WHICH pipe and module a waiter is about, so
+   * a re-request can be recognised as the same one and a teardown can cancel by owner. The
+   * queue must not read through them -- it outlives neither, and the labels below exist so it
+   * never has to. Typed as void* rather than as develop types because the queue this record
+   * belongs to is cache state, and the cache layer has no business knowing what an IOP module
+   * is: it needs a key to compare and a name to log. */
+  const void *pipe;
+  const void *module;
+
+  /* Captured at enqueue, for debug traces and supervisor node keys. Copied rather than
+   * borrowed: a module can be destroyed while its wait is still queued (history reload drops
+   * instances, and dt_iop_gui_cleanup_module frees the GUI half), and the old record read
+   * module->op at serve time -- a use-after-free waiting for the right timing. */
+  char module_op[20];
+  int module_multi_priority;
+  int pipe_type;
+  int32_t pipe_imgid;
+
   uint64_t hash;
   uint64_t target_node_key; // producer node identity of the awaited output; lets the manager
                             // serve this waiter when its target module publishes, even if the

--- a/src/develop/dev_pixelpipe.h
+++ b/src/develop/dev_pixelpipe.h
@@ -18,6 +18,7 @@
 #ifndef DT_DEVELOP_DEV_PIXELPIPE_H
 #define DT_DEVELOP_DEV_PIXELPIPE_H
 
+#include "caches/pixelpipe_cache_wait.h"
 #include <inttypes.h>
 #include <stdint.h>
 #include <glib.h>
@@ -150,39 +151,12 @@ const struct dt_dev_pixelpipe_iop_t *dt_dev_pixelpipe_get_module_piece(const str
 const struct dt_dev_pixelpipe_iop_t *dt_dev_pixelpipe_get_prev_enabled_piece(const struct dt_dev_pixelpipe_t *pipe,
                                                                              const struct dt_dev_pixelpipe_iop_t *piece);
 
-typedef void (*dt_dev_pixelpipe_cache_ready_callback_t)(gpointer user_data);
-
-typedef struct dt_dev_pixelpipe_cache_wait_t
-{
-  /* Identity only, never dereferenced: these say WHICH pipe and module a waiter is about, so
-   * a re-request can be recognised as the same one and a teardown can cancel by owner. The
-   * queue must not read through them -- it outlives neither, and the labels below exist so it
-   * never has to. Typed as void* rather than as develop types because the queue this record
-   * belongs to is cache state, and the cache layer has no business knowing what an IOP module
-   * is: it needs a key to compare and a name to log. */
-  const void *pipe;
-  const void *module;
-
-  /* Captured at enqueue, for debug traces and supervisor node keys. Copied rather than
-   * borrowed: a module can be destroyed while its wait is still queued (history reload drops
-   * instances, and dt_iop_gui_cleanup_module frees the GUI half), and the old record read
-   * module->op at serve time -- a use-after-free waiting for the right timing. */
-  char module_op[20];
-  int module_multi_priority;
-  int pipe_type;
-  int32_t pipe_imgid;
-
-  uint64_t hash;
-  uint64_t target_node_key; // producer node identity of the awaited output; lets the manager
-                            // serve this waiter when its target module publishes, even if the
-                            // exact awaited hash drifted (INVALID for a backbuf target).
-  dt_dev_pixelpipe_cache_ready_callback_t restart;
-  gpointer user_data;
-  const char *owner_tag;
-  gpointer owner_object;
-  uint64_t request_id;
-  gboolean connected;
-} dt_dev_pixelpipe_cache_wait_t;
+/* The wait queue itself is cache state and lives in caches/pixelpipe_cache_wait.{h,c}. These
+ * two names stay because ~12 files across views/, libs/, iop/ and gui/ use them, and renaming
+ * them would be churn with no reader benefit: what matters is that the queue moved, not what
+ * its record is spelled. */
+typedef dt_pixelpipe_cache_ready_callback_t dt_dev_pixelpipe_cache_ready_callback_t;
+typedef dt_pixelpipe_cache_wait_t dt_dev_pixelpipe_cache_wait_t;
 
 /**
  * @brief Cancel one pending GUI cache wait request and clear its runtime state.


### PR DESCRIPTION
Tranche T5 of the `src/develop` decomposition: the cache-wait queue moves to the layer that owns the cache. Two commits, each building and behaviour-preserving.

**Note the deadlock fix in #1147 is separate and independent** — I found it while surveying this code, and it should land on its own regardless of what happens to this PR.

### T5-C1 — the record stops reading through the develop types it names

`dt_dev_pixelpipe_cache_wait_t` stored a `dt_dev_pixelpipe_t*` and a `dt_iop_module_t*`, and the queue dereferenced both: `module->op` and `module->multi_priority` at six sites, `pipe->type` and `pipe->imgid` at two — every one of them a debug label or a supervisor node key. That was the one thing blocking the move, because a layer-1 file may not name develop types, and `pixelpipe_hb.h` already includes `caches/pixelpipe_cache.h`, so a caches header reaching back would make `cycles` non-zero.

Both pointers become identity-only, and the labels are copied when the wait is queued. The matcher never needed them — it reads `connected`, `hash` and `target_node_key` — and the dedup test is pure pointer identity.

This **closes a latent use-after-free** rather than relocating one. A module can be destroyed while its wait is still queued (history reload drops instances; `dt_iop_gui_cleanup_module` frees the GUI half), and both the serve and cancel paths read `wait->module->op` afterwards to build a log line. Cancellation is what teardown does, so that is the likelier of the two.

### T5-C2 — the queue moves; the transport does not

`caches/pixelpipe_cache_wait.{h,c}` owns the queue, its lock, its five counters and the match rule (exact hash **or** producing node — the match that survives hash drift). It includes glib, stdint, `system/dtpthread.h`, `caches/pixelpipe_cache.h` and `common/logging.h`, and nothing from `control/`, `gui/` or `develop/`.

`develop/dev_pixelpipe.c` keeps the two things that are not cache state: whether we are subscribed to `DT_SIGNAL_CACHELINE_READY`, and whether the busy cursor is up. Both hang off a single transition — the queue going empty or non-empty — which the queue now reports, and which is why the old manager carried them as one flag each beside the list.

**The transport deliberately stays**, and this shaped the commit rather than being a convenience. The ready fact is emitted from `dt_dev_pixelpipe_cache_wrlock_entry(FALSE, …)`, and `_cache_try_rekey_reuse_locked()` calls that **while holding the process-wide `cache->lock`**. Restart callbacks re-enter the cache. Serving them inline — the obvious simplification once the queue lives in the cache layer — would re-lock a non-recursive mutex on the same thread and hang the pipeline worker holding it, taking every other pipe with it. So the queue hands back the list of satisfied waiters and the caller runs them, on a thread it has already arranged to be safe.

The two public names stay (`dt_dev_pixelpipe_cache_wait_t` is now a typedef of the caches type). Twelve files across `views/`, `libs/`, `iop/` and `gui/` use them; renaming would be churn no reader benefits from. What matters is where the state lives.

### On the numbers, honestly

`layering_violations` stays at **187** and that is expected, not a shortfall: `develop`(5) → `control`(3) and `develop`(5) → `gui`(4) are *downward* edges the graph does not count. T5's layering value is prepayment for T6's flip. The gate this actually had to satisfy is `check_module_boundaries.sh`, whose `caches_upcall_baseline` is 9 and fails on any increase — a caches file still carrying `control/signal.h`, `control/control.h`, `gui/application.h` and `develop/supervisor.h` would read 13 and fail on the first commit.

### One deliberate loss

A cancellation's log line reports `age_ms=-1` rather than querying the queue for an enqueue timestamp it no longer keeps locally. The dump still reports real ages for everything pending, which is the case that actually gets read.

### Verification

Release, Debug (`-Werror`), nofeatures build at both commits. `cycles 0`, `layering_violations 187`, module boundaries hold. Export A/B 0 differing pixels — which for this tranche proves only that rendering is unaffected; the wait queue is not exercised by a headless export at all.

Worth exercising in the GUI: anything that waits on a cacheline that does not exist yet — the histogram and colour picker right after a parameter change, the navigation thumbnail, and darkroom view-leave while a wait is outstanding (the cancel path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
