### PR TITLE
Develop T5b+T5c: the host-cache seal becomes a pure decision with sampled inputs

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -292,6 +292,5 @@ xyz1001
 zhaowq32
 
 * Sub-module samples contributors (at least 1 commit):
-Guillaume Stutin
 
 And all those of you that made previous releases possible

--- a/doc/develop-split.md
+++ b/doc/develop-split.md
@@ -161,6 +161,13 @@ mechanical with the surveys in hand; T4+ need design.
 * **T5 — the cache-wait ownership move** + progress/backbuf taps: cache layer owns the
   notifier; `_seal_opencl_cache_policy` reads pipe-owned flags. Gate with the
   pipeline-cache regression discipline (issue #817, #1069 lineage).
+  **Half of that last clause is blocked on T6 and was measured, not guessed.** The seal's two
+  GUI-owned inputs are `dev->gui_module` and `dev->color_picker.module`. Having the GUI
+  *publish* them — the T4b viewport shape — means `gui/`(4) calling into `develop/`(5), and
+  `tools/check_layering.sh` fails that (+1, 187 → 188) because today the pipeline sits ABOVE
+  the GUI. The publication is legal only once T6 inverts the table, and is then the natural
+  first use of it. What T5 can do meanwhile is sample both facts ONCE per seal instead of
+  per node, and bring the predicates that read them home from `gui/`.
 * **T6 — re-stratify**: flip the layer table (pipeline + params engine below gui), then
   the IOP question — each IOP is operator + panel in one file; the X-macro API already
   separates the hook groups (survey classified all ~60 hooks into the three axes), so an

--- a/src/develop/dev_pixelpipe.c
+++ b/src/develop/dev_pixelpipe.c
@@ -33,7 +33,6 @@
 #include "caches/pixelpipe_cache.h"
 #include "develop/supervisor.h"
 #include "develop/blend.h"
-#include "gui/color_picker_proxy.h"
 #include "control/control.h"
 #include "control/signal.h"
 #include <stdint.h>
@@ -133,6 +132,31 @@ static gboolean _module_requires_global_histogram_input_cache(const dt_dev_pixel
   if(!pipe->gui_observable_source) return FALSE;
 
   return !strcmp(module->op, "gamma");
+}
+
+/**
+ * @brief Is @p module the one a picker samples, or the one feeding it?
+ *
+ * @details A picker reads its module's OUTPUT and the output of the enabled module before it
+ * (its own input), so both must keep a host copy. @p picker_module is the identity the caller
+ * sampled once for the whole walk, not the live dev field -- and it is only ever compared here,
+ * never followed, so a module torn down since the sample cannot be dereferenced through it.
+ *
+ * This was dt_iop_color_picker_force_cache() in gui/color_picker_proxy.c, which read
+ * pipe->dev->color_picker.module itself. Nothing about it was GUI code: it walks pipe nodes and
+ * compares module identities, and the seal was its only caller.
+ */
+static gboolean _module_feeds_color_picker(const dt_dev_pixelpipe_t *pipe,
+                                           const dt_iop_module_t *module,
+                                           const dt_iop_module_t *picker_module)
+{
+  if(IS_NULL_PTR(picker_module) || IS_NULL_PTR(module)) return FALSE;
+  if(module == picker_module) return TRUE;
+
+  const dt_dev_pixelpipe_iop_t *const piece = dt_dev_pixelpipe_get_module_piece(pipe, picker_module);
+  const dt_dev_pixelpipe_iop_t *const previous_piece = dt_dev_pixelpipe_get_prev_enabled_piece(pipe, piece);
+
+  return !IS_NULL_PTR(previous_piece) && previous_piece->module == module;
 }
 
 static gchar *_get_debug_pipe_name(const dt_dev_pixelpipe_t *pipe, const dt_develop_t *dev)
@@ -308,6 +332,15 @@ static void _seal_opencl_cache_policy(dt_dev_pixelpipe_t *pipe)
   // realtime drawing, where it is pure overhead.
   const gboolean realtime = dt_dev_pixelpipe_get_realtime(pipe);
 
+  // ONE read each, for the whole walk. Both belong to the GUI thread, and both were read LIVE at
+  // every node: a focus change or a picker toggle landing mid-walk gave the early nodes one
+  // answer and the later nodes another, so the sealed pipe described no single moment. Sampling
+  // them here does not make the pipeline the owner of these facts -- having the GUI publish them
+  // instead needs the layer flip, since gui/ may not reach up into develop/ today -- but it does
+  // make one resync describe one moment.
+  const dt_iop_module_t *const focused_module = pipe->dev->gui_module;
+  const dt_iop_module_t *const picker_module = pipe->dev->color_picker.module;
+
   gboolean current_output_must_cache_host = TRUE;
 
   for(GList *pieces = g_list_last(pipe->nodes); pieces; pieces = g_list_previous(pieces))
@@ -329,7 +362,7 @@ static void _seal_opencl_cache_policy(dt_dev_pixelpipe_t *pipe)
     const gboolean user_requested_cache = dt_conf_get_bool(string);
     dt_free(string);
 
-    const gboolean color_picker_on = dt_iop_color_picker_force_cache(pipe, module);
+    const gboolean color_picker_on = _module_feeds_color_picker(pipe, module, picker_module);
     const gboolean global_hist_output_on
         = !realtime && _module_requires_global_histogram_output_cache(pipe, module);
     const gboolean global_hist_input_on
@@ -342,7 +375,7 @@ static void _seal_opencl_cache_policy(dt_dev_pixelpipe_t *pipe)
            && (piece->request_histogram & DT_REQUEST_ON));
     const gboolean active_in_gui
         = (pipe->type == DT_DEV_PIXELPIPE_FULL || pipe->type == DT_DEV_PIXELPIPE_PREVIEW)
-           && pipe->dev->gui_module == module;
+           && focused_module == module;
 
     const gboolean has_autoset = pipe->autoset && !IS_NULL_PTR(module->autoset);
 

--- a/src/develop/dev_pixelpipe.c
+++ b/src/develop/dev_pixelpipe.c
@@ -20,6 +20,7 @@
 #include "widgets/widget_settings.h"
 #include "common/conf.h"
 #include "system/macros.h"
+#include "develop/pipe_cache_policy.h"
 #include "system/mem_alloc.h"
 #include "common/hash.h"
 #include "common/logging.h"
@@ -345,21 +346,22 @@ static void _seal_opencl_cache_policy(dt_dev_pixelpipe_t *pipe)
 
     const gboolean has_autoset = pipe->autoset && !IS_NULL_PTR(module->autoset);
 
-    const gboolean previous_output_must_cache_host
-        = !supports_opencl || active_in_gui || module_hist_on || global_hist_input_on || has_autoset;
+    // The decision is a pure function of these nine facts (develop/pipe_cache_policy.h), pinned
+    // by src/tests/unittests/test_pipe_cache_policy.c. What stays here is GATHERING them, which
+    // is the part that needs a pipe and a dev to look at.
+    const dt_dev_pipe_cache_policy_inputs_t inputs = { .authored_cache = authored_cache,
+                                                       .user_requested_cache = user_requested_cache,
+                                                       .supports_opencl = supports_opencl,
+                                                       .color_picker_on = color_picker_on,
+                                                       .global_hist_output_on = global_hist_output_on,
+                                                       .global_hist_input_on = global_hist_input_on,
+                                                       .module_hist_on = module_hist_on,
+                                                       .active_in_gui = active_in_gui,
+                                                       .has_autoset = has_autoset };
 
     piece->cache_output_on_ram
-        = authored_cache || user_requested_cache || color_picker_on
-          || global_hist_output_on
-          || current_output_must_cache_host;
-
-    // A GPU-capable module that itself needs no host copy of its input must not erase a host
-    // requirement inherited from further downstream (e.g. a CPU-only module reached through it,
-    // or through a module that is disabled right now but was enabled a moment ago and left a
-    // stale host-less cacheline behind). Once established, the requirement has to keep
-    // propagating upstream, module after module, or an intermediate GPU module silently resets
-    // it and the module before it skips the readback that a later, non-adjacent consumer needs.
-    current_output_must_cache_host = previous_output_must_cache_host || current_output_must_cache_host;
+        = dt_dev_pipe_cache_policy_decide(&inputs, current_output_must_cache_host,
+                                          &current_output_must_cache_host);
   }
 }
 

--- a/src/develop/pipe_cache_policy.h
+++ b/src/develop/pipe_cache_policy.h
@@ -1,0 +1,106 @@
+/*
+    This file is part of Ansel.
+    Copyright (C) 2026 Aurélien Pierre.
+
+    Ansel is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Ansel is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Ansel.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+/** @file develop/pipe_cache_policy.h
+ *
+ * @brief Whether one pipeline node must keep a host-RAM copy of its output.
+ *
+ * @details Split out of _seal_opencl_cache_policy() so the decision is a pure function of
+ * named inputs. That is not tidiness: the outcome it computes -- per-piece
+ * cache_output_on_ram -- is invisible to every check this project runs. It changes no pixel
+ * in an export (the export path drives the pipe directly and never reaches the seal), it
+ * changes no hash, and it produces no log unless someone is already looking. The one time it
+ * was wrong, the symptom was a downstream module silently reading stale host bytes from a
+ * rekeyed cacheline, and it was found by dumping OpenCL buffers, not by a test.
+ *
+ * A pure function can be pinned by one, which is what src/tests/unittests/test_pipe_cache_policy.c
+ * does. Gathering the inputs -- which of them come from the GUI, which from the pipe -- stays
+ * in dev_pixelpipe.c, where it can see those things.
+ */
+
+#ifndef DT_DEVELOP_PIPE_CACHE_POLICY_H
+#define DT_DEVELOP_PIPE_CACHE_POLICY_H
+
+#include <glib.h>
+
+#include "system/macros.h"   // IS_NULL_PTR
+
+/** @brief Everything the decision depends on, named. */
+typedef struct dt_dev_pipe_cache_policy_inputs_t
+{
+  /** The module authored this itself (piece->cache_output_on_ram before the seal). */
+  gboolean authored_cache;
+  /** The user pinned it through /plugins/<op>/cache. */
+  gboolean user_requested_cache;
+  /** This node can run on the GPU at all: OpenCL inited, the piece is CL-ready, the module
+   *  has a process_cl. A node that cannot is by definition producing host data. */
+  gboolean supports_opencl;
+  /** A colour picker is sampling this module's output. */
+  gboolean color_picker_on;
+  /** The global histogram reads this module's OUTPUT. */
+  gboolean global_hist_output_on;
+  /** The global histogram reads this module's INPUT, so the module BEFORE it must publish. */
+  gboolean global_hist_input_on;
+  /** The module computes its own histogram from its input. */
+  gboolean module_hist_on;
+  /** This is the module the darkroom currently has focused. */
+  gboolean active_in_gui;
+  /** An autoset pass wants this module's input. */
+  gboolean has_autoset;
+} dt_dev_pipe_cache_policy_inputs_t;
+
+/**
+ * @brief Decide one node's host-cache requirement, walking the pipe from the end backwards.
+ *
+ * @param in The node's own inputs.
+ * @param inherited_requirement What the nodes downstream of this one already established.
+ * @param[out] upstream_requirement What to hand the node before this one. Never smaller than
+ * @p inherited_requirement -- see the note below, it is the whole reason this is a function
+ * and not an expression.
+ *
+ * @return TRUE when this node must keep its output in host RAM.
+ */
+static inline gboolean dt_dev_pipe_cache_policy_decide(const dt_dev_pipe_cache_policy_inputs_t *in,
+                                                       const gboolean inherited_requirement,
+                                                       gboolean *upstream_requirement)
+{
+  // What THIS node needs from the node before it.
+  const gboolean own_input_requirement
+      = !in->supports_opencl || in->active_in_gui || in->module_hist_on
+        || in->global_hist_input_on || in->has_autoset;
+
+  // A GPU-capable node that needs no host input of its own must not ERASE a requirement
+  // inherited from further downstream -- a CPU-only module reached through it, or one that is
+  // disabled right now but was enabled a moment ago and left a stale host-less cacheline
+  // behind. This was an `=' once, and an intermediate GPU module silently reset the flag; the
+  // module before it then skipped a readback that a later, non-adjacent consumer needed, and
+  // read the previous life of a rekeyed cacheline. Only reproducible with OpenCL enabled.
+  if(!IS_NULL_PTR(upstream_requirement))
+    *upstream_requirement = own_input_requirement || inherited_requirement;
+
+  return in->authored_cache || in->user_requested_cache || in->color_picker_on
+         || in->global_hist_output_on || inherited_requirement;
+}
+
+#endif // DT_DEVELOP_PIPE_CACHE_POLICY_H
+
+// clang-format off
+// modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py
+// vim: shiftwidth=2 expandtab tabstop=2 cindent
+// kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;
+// clang-format on

--- a/src/gui/color_picker_proxy.c
+++ b/src/gui/color_picker_proxy.c
@@ -894,16 +894,6 @@ void dt_iop_color_picker_request_update(void)
   _queue_refresh_active_picker(dev);
 }
 
-gboolean dt_iop_color_picker_force_cache(const dt_dev_pixelpipe_t *pipe,
-                                         const dt_iop_module_t *module)
-{
-  const dt_dev_pixelpipe_iop_t *const piece = dt_dev_pixelpipe_get_module_piece((dt_dev_pixelpipe_t *)pipe,
-                                                                                 pipe->dev->color_picker.module);
-  const dt_dev_pixelpipe_iop_t *const previous_piece = dt_dev_pixelpipe_get_prev_enabled_piece(pipe, piece);
-
-  return module == pipe->dev->color_picker.module || (previous_piece && previous_piece->module == module);
-}
-
 static void _track_active_picker_hashes(dt_develop_t *dev)
 {
   if(IS_NULL_PTR(dev))

--- a/src/gui/color_picker_proxy.h
+++ b/src/gui/color_picker_proxy.h
@@ -123,22 +123,6 @@ int dt_iop_color_picker_get_ready_data(const dt_iop_module_t *module, GtkWidget 
                                        struct dt_dev_pixelpipe_t **pipe,
                                        const struct dt_dev_pixelpipe_iop_t **piece);
 
-/**
- * @brief Tell whether the active picker requires host-cache retention on one module output.
- *
- * @details
- * Picker sampling reopens the active module cacheline directly from the preview cache on the GUI thread.
- * To make that possible when OpenCL is active, the producing module must keep a host-visible cacheline.
- * The pixelpipe asks that question during `_set_opencl_cache()`, while the picker code asks it again
- * when deciding whether a cache miss should trigger a preview recompute.
- *
- * @param module Candidate module in the preview pipe.
- *
- * @return TRUE if the active picker captures @p module and therefore needs its output cached on host.
- */
-gboolean dt_iop_color_picker_force_cache(const struct dt_dev_pixelpipe_t *pipe,
-                                         const dt_iop_module_t *module);
-
 /* global init: link signal */
 void dt_iop_color_picker_init();
 

--- a/src/tests/unittests/CMakeLists.txt
+++ b/src/tests/unittests/CMakeLists.txt
@@ -12,6 +12,9 @@ set(DATABASE_UNIT_TESTS
   test_preset_repository
   test_tag_selection_metadata
   test_metadata_notify
+  # Not a database test, but it wants the same standalone-binary-linking-lib_ansel treatment,
+  # and splitting the list to say so would be more ceremony than it is worth.
+  test_pipe_cache_policy
 )
 
 foreach(test ${DATABASE_UNIT_TESTS})

--- a/src/tests/unittests/test_pipe_cache_policy.c
+++ b/src/tests/unittests/test_pipe_cache_policy.c
@@ -1,0 +1,173 @@
+/*
+    This file is part of Ansel,
+    Copyright (C) 2026 Aurélien PIERRE.
+
+    Ansel is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Ansel is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Ansel.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+/** Which pipeline nodes must keep a host-RAM copy of their output.
+ *
+ * These tests exist because nothing else can see this. The per-piece cache_output_on_ram flag
+ * changes no exported pixel -- the export path drives the pipe directly and never reaches the
+ * seal that computes it -- changes no hash, and produces no log unless someone is already
+ * looking. When it was wrong, the symptom was a downstream module reading stale host bytes
+ * from a rekeyed cacheline, only with OpenCL enabled, and it was found by dumping GPU buffers.
+ *
+ * The propagation test below is that bug, pinned.
+ */
+
+#include "develop/pipe_cache_policy.h"
+
+#include <stdarg.h>
+#include <stddef.h>
+// cmocka.h declares `extern jmp_buf global_expect_assert_env' at file scope without including
+// <setjmp.h> itself. Same suppression as test_metadata_notify.c, and for the same reason.
+#include <setjmp.h>  // NOLINT(misc-include-cleaner)
+#include <stdint.h>
+#include <cmocka.h>
+
+/** A GPU-capable node with no reason of its own to want host data. */
+static dt_dev_pipe_cache_policy_inputs_t _gpu_node_with_no_needs(void)
+{
+  dt_dev_pipe_cache_policy_inputs_t in = { 0 };
+  in.supports_opencl = TRUE;
+  return in;
+}
+
+/** A node that cannot run on the GPU at all: it produces host data by construction. */
+static void _cpu_only_node_needs_its_input_on_host(void **state)
+{
+  (void)state;
+  dt_dev_pipe_cache_policy_inputs_t in = { 0 };
+  in.supports_opencl = FALSE;
+
+  gboolean upstream = FALSE;
+  const gboolean own = dt_dev_pipe_cache_policy_decide(&in, FALSE, &upstream);
+
+  // It requires nothing of its OWN output -- nobody downstream asked for it ...
+  assert_false(own);
+  // ... but the node before it must publish to host, because this one reads on the CPU.
+  assert_true(upstream);
+}
+
+static void _gpu_node_requires_nothing_on_its_own(void **state)
+{
+  (void)state;
+  dt_dev_pipe_cache_policy_inputs_t in = _gpu_node_with_no_needs();
+
+  gboolean upstream = TRUE;
+  const gboolean own = dt_dev_pipe_cache_policy_decide(&in, FALSE, &upstream);
+
+  assert_false(own);
+  assert_false(upstream);
+}
+
+/**
+ * THE REGRESSION. An enabled, GPU-capable node that needs no host input of its own must PASS
+ * THROUGH a requirement inherited from further downstream, not replace it.
+ *
+ * This was an `=' rather than an `||'. Toggling on a GPU module with no host needs of its own
+ * (iop/rawoverexposed.c: NO_HISTORY_STACK, GPU-capable, no GUI or histogram reason) erased the
+ * TRUE that a CPU-only module further downstream (dither) had correctly established. colorout
+ * then skipped its GPU-to-host readback, and dither read the stale bytes left in the cacheline's
+ * previous life -- every hash and ROI in the chain individually correct.
+ */
+static void _gpu_node_propagates_an_inherited_requirement(void **state)
+{
+  (void)state;
+  dt_dev_pipe_cache_policy_inputs_t in = _gpu_node_with_no_needs();
+
+  gboolean upstream = FALSE;
+  const gboolean own = dt_dev_pipe_cache_policy_decide(&in, TRUE, &upstream);
+
+  // The inherited requirement reaches this node's own output ...
+  assert_true(own);
+  // ... AND keeps travelling to the node before it. An `=' here would make this FALSE.
+  assert_true(upstream);
+}
+
+/** Each of the five own-input reasons must raise the upstream requirement by itself. */
+static void _each_own_input_reason_raises_upstream(void **state)
+{
+  (void)state;
+  const size_t offsets[] = {
+    offsetof(dt_dev_pipe_cache_policy_inputs_t, active_in_gui),
+    offsetof(dt_dev_pipe_cache_policy_inputs_t, module_hist_on),
+    offsetof(dt_dev_pipe_cache_policy_inputs_t, global_hist_input_on),
+    offsetof(dt_dev_pipe_cache_policy_inputs_t, has_autoset),
+  };
+
+  for(size_t i = 0; i < sizeof(offsets) / sizeof(offsets[0]); i++)
+  {
+    dt_dev_pipe_cache_policy_inputs_t in = _gpu_node_with_no_needs();
+    *(gboolean *)((char *)&in + offsets[i]) = TRUE;
+
+    gboolean upstream = FALSE;
+    dt_dev_pipe_cache_policy_decide(&in, FALSE, &upstream);
+    assert_true(upstream);
+  }
+}
+
+/** Each of the four own-output reasons must raise this node's own requirement by itself. */
+static void _each_own_output_reason_raises_own(void **state)
+{
+  (void)state;
+  const size_t offsets[] = {
+    offsetof(dt_dev_pipe_cache_policy_inputs_t, authored_cache),
+    offsetof(dt_dev_pipe_cache_policy_inputs_t, user_requested_cache),
+    offsetof(dt_dev_pipe_cache_policy_inputs_t, color_picker_on),
+    offsetof(dt_dev_pipe_cache_policy_inputs_t, global_hist_output_on),
+  };
+
+  for(size_t i = 0; i < sizeof(offsets) / sizeof(offsets[0]); i++)
+  {
+    dt_dev_pipe_cache_policy_inputs_t in = _gpu_node_with_no_needs();
+    *(gboolean *)((char *)&in + offsets[i]) = TRUE;
+
+    gboolean upstream = FALSE;
+    assert_true(dt_dev_pipe_cache_policy_decide(&in, FALSE, &upstream));
+    // None of these four says anything about what the node BEFORE this one must do.
+    assert_false(upstream);
+  }
+}
+
+/** A NULL out-param is allowed: the last node in the walk has nobody upstream to tell. */
+static void _null_upstream_pointer_is_allowed(void **state)
+{
+  (void)state;
+  dt_dev_pipe_cache_policy_inputs_t in = _gpu_node_with_no_needs();
+  in.color_picker_on = TRUE;
+
+  assert_true(dt_dev_pipe_cache_policy_decide(&in, FALSE, NULL));
+}
+
+int main(void)
+{
+  const struct CMUnitTest tests[] = {
+    cmocka_unit_test(_cpu_only_node_needs_its_input_on_host),
+    cmocka_unit_test(_gpu_node_requires_nothing_on_its_own),
+    cmocka_unit_test(_gpu_node_propagates_an_inherited_requirement),
+    cmocka_unit_test(_each_own_input_reason_raises_upstream),
+    cmocka_unit_test(_each_own_output_reason_raises_own),
+    cmocka_unit_test(_null_upstream_pointer_is_allowed),
+  };
+
+  return cmocka_run_group_tests(tests, NULL, NULL);
+}
+
+// clang-format off
+// modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py
+// vim: shiftwidth=2 expandtab tabstop=2 cindent
+// kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;
+// clang-format on


### PR DESCRIPTION
The rest of the T5 tranche line ("`_seal_opencl_cache_policy` reads pipe-owned flags"), in two commits. `_seal_opencl_cache_policy()` walks a pipe backwards and decides, per node, whether that node must keep a host-RAM copy of its output.

### T5b — the decision becomes a pure function, and a test pins it

It gathered nine facts and decided in four lines. The decision moves to `develop/pipe_cache_policy.h` as a pure function of those nine named inputs; gathering them stays in `dev_pixelpipe.c`, which is the part that needs a pipe and a dev to look at. Same inputs, same boolean algebra, same order.

**Why, which is not tidiness.** The tranche plan requires preserving the per-piece `cache_output_on_ram` outcomes, and **nothing this project runs can observe them**: it changes no exported pixel (the export path drives the pipe directly, `imageio_core.c`, and never reaches the seal), changes no hash, and logs nothing unless someone is already looking. When it was last wrong, the symptom was a downstream module silently reading stale host bytes from a rekeyed cacheline, only with OpenCL enabled, found by dumping GPU buffers.

A pure function can be pinned by a test. That is the whole argument for the shape.

`src/tests/unittests/test_pipe_cache_policy.c` states the truth table. The important case is `_gpu_node_propagates_an_inherited_requirement` — **the bug that shipped**: an `=` rather than an `||`, so toggling on a GPU module with no host needs of its own (`rawoverexposed`) erased the `TRUE` a CPU-only module further downstream (`dither`) had correctly established; `colorout` then skipped its readback and `dither` read the cacheline's previous life, with every hash and ROI in the chain individually correct. **I checked the test catches it** rather than assuming: reintroducing the `=` fails that test and only that test.

### T5c — the seal samples the GUI's two facts once, and the picker predicate comes home

`dev->gui_module` and `dev->color_picker.module` were read **live, once per node**, from the worker thread. A focus change or picker toggle landing mid-walk gave the early nodes one answer and the later nodes another, so the sealed pipe described no single moment. Both are now sampled once, before the walk.

`dt_iop_color_picker_force_cache()` leaves `gui/color_picker_proxy.c` and becomes `_module_feeds_color_picker()` beside its only caller. Nothing about it was GUI code — it walks pipe nodes and compares module identities — and the seal reaching down into `gui/` for it is a call the T6 flip turns into a violation. Its doc comment claimed a second caller "when deciding whether a cache miss should trigger a preview recompute"; no such caller exists.

Equivalent by construction, not inspection: the added NULL early-out matches the old expression exactly, because `dt_dev_pixelpipe_get_module_piece()` returns NULL for a NULL module and `dt_dev_pixelpipe_get_prev_enabled_piece()` returns NULL for a NULL piece — so the old form already yielded FALSE for every non-NULL module when no picker was active.

### What is deliberately NOT here, and why it is measured

Having the GUI **publish** those two facts — the T4b viewport shape — is the other half of the tranche line, and it is blocked on T6. I wrote it (a seqlock record, publishers at all 13 writers) and `tools/check_layering.sh` rejected it: **+1, 187 → 188**, because `gui/` is layer 4 and `develop/` is layer 5, so today the pipeline may read the GUI but not the reverse. It becomes legal — and is then the natural first use of the flipped table — only after T6. Recorded against the T5 bullet in `doc/develop-split.md` so the next pass does not rediscover it.

### Verification

Release, Debug (`-Werror`), nofeatures build. `ctest` 8/8. `cycles 0`, `layering_violations 187` (baseline), module boundaries hold.

**No pixel A/B, and that is a statement rather than an omission**: the seal is not reached by the export path, and headlessly both sampled fields are NULL, so an A/B cannot execute the changed code at all. It would print 0 differing pixels and mean nothing — the same calibration T4b produced, where the harness printed 0 through all five real defects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
