### PR TITLE
Develop T6a: widgets/ moves to its real layer, and toolkit-freedom gets its own gate

### DIFF
--- a/doc/develop-split.md
+++ b/doc/develop-split.md
@@ -299,3 +299,63 @@ effect; `dev_toolbox` keeps the `orig - 2*border` arithmetic the viewport should
 still reads the darkroom's border from a lighttable job; and the geometry setters do not publish
 the request themselves, which is what would close the stale-`processed_*` window for producers
 other than the darkroom's own path.
+
+## T6 field survey: the flip is not blocked by the IOP split, and never was
+
+The tranche list says "flip the layer table, **then** the IOP question". Measurement inverts it.
+
+Pricing the flip first (`develop` 5→3.4, `iop`/`imageio` 6→3.6), before `widgets/` moved:
+**187 → 580, +393 new violations**, of which `iop→widgets` 231, `iop→gui` 102, `develop→widgets`
+50, `imageio→widgets` 26, `develop→gui` 18, `imageio→gui` 3 — 393 edges over 113 files, median 3
+each, and 84 of `src/iop`'s 95 top-level `.c`/`.cc` touching `gui/` or `widgets/`. That is the
+number behind "78% of the cost is IOPs", and it is an artifact of where `widgets/` sat.
+
+`widgets/` was at layer 4 beside `gui/` on the assumption that "GTK" and "the application's GUI"
+are one layer. Its own includes reach only `system/`, `common/`, `metadata/` and `pixel/`
+(`focus_peaking.c` → `pixel/eigf.h`), so it is a leaf library written against GTK. Moving it to
+**2.5** — above `pixel/`, below `control/` — creates ZERO new violations and removes three
+(`control/ → widgets/`): **187 → 184**. At 1.5 it costs one, because `pixel/` would then be above
+it. The four `widgets/ → osx/osx.h` edges never counted either way: `osx` is absent from `LAYERS`,
+so `layer_of()` returns `None` and the edge is skipped in both directions.
+
+That one line retires 307 of the 393. What remains is **123 edges, and 96 of them land in four
+headers**: `gui/presets.h` 35, `gui/color_picker_proxy.h` 33, `gui/screen_metrics.h` 25,
+`gui/application.h` 19. So what the flip needs is not "split 84 IOPs" but "stop operator code
+reaching four headers", three of which are misfiled by their own `#include` lines.
+
+**The knife edge.** Flip with no relocation: **+86** (184 → 270). Flip with all three of
+`presets`, `color_picker_proxy`, `screen_metrics` re-homed: **185**, i.e. free. Drop any one and
+it is +25 minimum — measured `presets`+`screen_metrics` 214, `presets`+`picker` 210,
+`picker`+`screen_metrics` 216. There is no partial credit and no "flip now, tidy later".
+
+**Do not bank the `develop` flip early.** `develop`→3.4 *alone* measures **166** — a fall of 18
+for one table line, the cheapest-looking commit on the board. It then makes the `iop`/`imageio`
+flip a **+19 rise** against that new baseline, which the ratchet refuses. One flip, after the
+relocations.
+
+**Only one of the three relocations is honest on its own terms.** `gui/screen_metrics.{h,c}`
+contains zero GTK references and includes only `system/surface_scaling.h`: genuinely misfiled.
+`gui/presets.c` has 179 GTK references and its header 8; `gui/color_picker_proxy.h` has 5. Moving
+those two *down* would drag GTK below `develop/` to make a number fall — the same trade the
+`widgets/` move makes, and the reason the toolkit ratchet below exists. They are relocations of
+*declarations*, not of GTK code.
+
+**Dependency order and toolkit-freedom are different properties, and only the first was gated.**
+Making 307 edges downward moves no GTK out of the pixel engine. A metric improving while the
+thing it stood for does not is worse than no metric, so `tools/check_module_boundaries.sh` gained
+a fourth rule counting files that *name* `GtkWidget`, `GdkEvent`, `cairo_t`, a `GTK_`/`GDK_`
+macro, or a toolkit header: `develop` 20/73, `iop` 97/164, `imageio` 13/55, with `pixel` 0/39,
+`caches` 0/11, `database` 0/31 pinned at zero. Comments are stripped first — this tree's doc
+comments discuss GTK constantly — and the gate is mutation-tested both ways.
+
+That gate has a stated blind spot: `src/iop/CMakeLists.txt:5-6` force-includes `iop/iop_api.h`
+into every IOP translation unit and `iop_api.h:44-45` includes `<cairo/cairo.h>` and
+`<gtk/gtk.h>`, so **no file partition yields a toolkit-free IOP object** until that is dealt
+with. `include_graph.py` cannot see it either: `INCLUDE_RE` matches the quote form only, so
+angle-bracket includes are outside the graph entirely.
+
+**A live defect found while surveying, unrelated to T6.** `iop/toneequal.c:621` `sanity_check()`
+is reached from `process()` via `toneeq_process()` — the pipeline thread — and there writes
+`self->enabled`, calls `dt_dev_add_history_item()`, and calls `gtk_toggle_button_set_active()` on
+`self->gui->off`. A GTK call off the GUI thread plus a history write from the pipeline, against
+the rule in CLAUDE.md that history is the only thread-safe interface between the two.

--- a/tools/check_module_boundaries.sh
+++ b/tools/check_module_boundaries.sh
@@ -372,6 +372,16 @@ fi
 #
 # Files, not occurrences: the file is the unit that gets split, and one GtkWidget in a header
 # is as disqualifying as forty in a callback.
+#
+# KNOWN BLIND SPOT, stated here so this number is not read as more than it is: every src/iop
+# translation unit is compiled with GTK already in scope, because src/iop/CMakeLists.txt:5-6
+# does `add_definitions(-include iop/iop_api.h)` and develop/iop_api.h:44-45 includes
+# <cairo/cairo.h> and <gtk/gtk.h> under FULL_API_H. No file partition produces a genuinely
+# toolkit-free IOP object file until that force-include is dealt with, and tools/include_graph.py
+# cannot see it either -- its INCLUDE_RE (:24) matches the quote form only, so angle-bracket
+# system includes are outside the graph entirely. So `toolkit: iop/ 0' would mean "no IOP file
+# NAMES a toolkit symbol", not "IOP objects no longer link against GTK". Both are worth having;
+# they are not the same claim.
 toolkit_develop_baseline=20
 toolkit_iop_baseline=97
 toolkit_imageio_baseline=13

--- a/tools/check_module_boundaries.sh
+++ b/tools/check_module_boundaries.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 #
-# Three module boundaries this tree relies on, made checkable rather than remembered.
-# The third is a ratchet on a migration in progress rather than a settled rule.
+# Four module boundaries this tree relies on, made checkable rather than remembered.
+# The third and fourth are ratchets on migrations in progress rather than settled rules.
 #
 #   1. src/system must include nothing that could bring state with it.
 #
@@ -17,11 +17,15 @@
 #   2. src/widgets must not include anything from gui/.
 #
 # That is what makes widgets/ a separate build target and, per the GTK->Qt goal, what makes a
-# port sizeable: the widget set has to be movable without the application coming with it. The
-# layering checker is structurally blind to this one -- tools/include_graph.py puts gui and
-# widgets on the same layer (4), so a widgets->gui edge is not an upward include and does not
-# register. It went unnoticed once already: gui/screen_metrics.h reached widgets/draw.h through
-# two helpers that turned out to have no callers at all, and only an adversarial read caught it.
+# port sizeable: the widget set has to be movable without the application coming with it. It
+# went unnoticed once already: gui/screen_metrics.h reached widgets/draw.h through two helpers
+# that turned out to have no callers at all, and only an adversarial read caught it.
+#
+# The layering checker used to be structurally blind to this -- it put gui/ and widgets/ on the
+# same layer (4), so a widgets->gui edge was not an upward include and did not register. Since
+# widgets/ moved to 2.5, where its own dependencies already put it, that edge IS an upward
+# include and tools/include_graph.py catches it too. This check stays: it is the one that names
+# the rule, and it is cheaper to read than a violation count.
 #
 # What each module may HOLD, rather than include, is a different question and is not answered
 # here: see tools/check_statelessness.sh, which measures it from the compiled objects. A
@@ -344,9 +348,85 @@ if [ "${history_upcalls_now}" -gt "${history_upcalls_baseline}" ]; then
   findings=$((findings + 1))
 fi
 
+# ---------------------------------------------------------------------------------------
+# 4. How much of the pixel engine still names a toolkit -- the GTK->Qt door.
+#
+# This measures a DIFFERENT property from tools/check_layering.sh, and the difference is the
+# whole reason it exists. That one measures dependency ORDER: who may include whom. This one
+# measures toolkit-FREEDOM: whether a translation unit names GtkWidget, GdkEvent, cairo_t or
+# their headers at all.
+#
+# They came apart when widgets/ moved from layer 4 to 2.5. That move is correct on the order
+# axis -- widgets/ depends only on system/, common/, metadata/ and pixel/, so it is a leaf
+# library that happens to be written against GTK, and the move costs zero new violations. But
+# it also makes develop/ -> widgets/ a DOWNWARD include, so 50 edges that the layering ratchet
+# used to count stopped counting, without one line of GTK leaving the pixel engine. Left alone
+# that is a metric improving while the thing it stood for does not, which is worse than no
+# metric. So the property those 50 edges were standing in for gets its own gate here.
+#
+# It is a ratchet because the tranche that lowers it is the IOP operator/panel split: an IOP is
+# currently one file holding both the pixel math and its GTK panel, and 97 of src/iop's 164
+# files name a toolkit type. Each split module lowers the iop count by one. src/pixel (0/39),
+# src/caches (0/11) and src/database (0/31) are already free and are pinned at zero so they
+# stay that way.
+#
+# Files, not occurrences: the file is the unit that gets split, and one GtkWidget in a header
+# is as disqualifying as forty in a callback.
+toolkit_develop_baseline=20
+toolkit_iop_baseline=97
+toolkit_imageio_baseline=13
+toolkit_pixel_baseline=0
+toolkit_caches_baseline=0
+toolkit_database_baseline=0
+
+# Comments are stripped first: a file that only MENTIONS GTK in prose is toolkit-free, and the
+# doc comments in this tree talk about GTK constantly.
+count_toolkit() {
+  ${PYTHON:-python3} - "$1" <<'PYEOF'
+import os, re, sys
+ident = re.compile(r'\b(?:Gtk[A-Z]\w*|Gdk[A-Z]\w*|GTK_[A-Z]\w*|GDK_[A-Z]\w*|cairo_[a-z]\w*|PangoLayout\w*)\b')
+inc = re.compile(r'^\s*#\s*include\s*[<"](?:gtk/|gdk/|cairo|pango)', re.M)
+hits = 0
+for root, _, names in os.walk(sys.argv[1]):
+    parts = root.split(os.sep)
+    if 'external' in parts or 'attic' in parts:
+        continue
+    for n in names:
+        if not n.endswith(('.c', '.h', '.cc', '.cpp', '.hpp')):
+            continue
+        try:
+            text = open(os.path.join(root, n), encoding='utf-8', errors='replace').read()
+        except OSError:
+            continue
+        text = re.sub(r'/\*.*?\*/', '', text, flags=re.S)
+        text = re.sub(r'//[^\n]*', '', text)
+        if ident.search(text) or inc.search(text):
+            hits += 1
+print(hits)
+PYEOF
+}
+
+toolkit_findings=0
+for module in develop iop imageio pixel caches database; do
+  now=$(count_toolkit "src/${module}")
+  eval "base=\${toolkit_${module}_baseline}"
+  printf 'toolkit:       %-9s %3d files name a toolkit type (baseline %d).\n' "${module}/" "${now}" "${base}"
+  if [ "${now}" -gt "${base}" ]; then
+    echo "toolkit: ${module}/ gained a file that names GTK, GDK, cairo or pango. The pixel engine"
+    echo "         and the params engine must be portable to another toolkit; put the widget code"
+    echo "         in the panel half and keep the operator half free of it."
+    toolkit_findings=$((toolkit_findings + 1))
+  elif [ "${now}" -lt "${base}" ]; then
+    echo "toolkit: ${module}/ fell ${base} -> ${now}. Lower toolkit_${module}_baseline in this"
+    echo "         script, in the same commit, so the gain is locked in."
+    toolkit_findings=$((toolkit_findings + 1))
+  fi
+done
+findings=$((findings + toolkit_findings))
+
 if [ "${findings}" -gt 0 ]; then
   exit 1
 fi
 
-echo "OK: src/system is closed, src/widgets does not reach into gui/; colorprofiles, opencl, caches, database, metadata and history held."
+echo "OK: src/system is closed, src/widgets does not reach into gui/; colorprofiles, opencl, caches, database, metadata and history held; the pixel engine's toolkit surface did not grow."
 exit 0

--- a/tools/forward_decl_audit.py
+++ b/tools/forward_decl_audit.py
@@ -25,27 +25,24 @@ Usage:
 import collections
 import json
 import os
+import importlib.util
 import re
 import sys
 
 REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 SRC = os.path.join(REPO, "src")
 
-# Kept in step with tools/include_graph.py deliberately: a second, disagreeing copy of the
-# layer order would be worse than none.
-LAYERS = [
-    ('external', 0), ('win', 0), ('system', 0),
-    ('common', 1), ('math', 1), ('colorprofiles', 1),
-    ('pixel', 2),
-    ('control', 3),
-    ('gui', 4), ('widgets', 4),
-    ('develop', 5),
-    ('iop', 6), ('imageio', 6),
-    ('libs', 7), ('views', 7), ('chart', 7),
-    ('apps', 10),
-    ('app', 9),
-]
-LAYER = dict(LAYERS)
+# IMPORTED from tools/include_graph.py, not copied. This used to be a second copy carrying a
+# comment that said it was "kept in step deliberately: a second, disagreeing copy of the layer
+# order would be worse than none" -- and it had already drifted, missing caches/, database/,
+# metadata/ and history/ entirely and holding widgets/ at the layer it left. The comment was
+# right about the hazard and wrong that a copy could avoid it.
+_ig_spec = importlib.util.spec_from_file_location(
+    "_include_graph", os.path.join(os.path.dirname(os.path.abspath(__file__)), "include_graph.py"))
+_ig = importlib.util.module_from_spec(_ig_spec)
+_ig_spec.loader.exec_module(_ig)   # module level is definitions only; main() is under __main__
+LAYERS = _ig.LAYERS
+LAYER = _ig.LAYER
 
 FWD = re.compile(r'^\s*(?:struct|union|enum)\s+([A-Za-z_]\w*)\s*;\s*$')
 # `} name;` closes a struct/union/enum definition; `struct name {` opens one.

--- a/tools/include_baseline.txt
+++ b/tools/include_baseline.txt
@@ -1,4 +1,4 @@
 # Include-graph ratchet baseline. Regenerate with tools/check_layering.sh --update.
 # Lower these by fixing includes; never raise them to make CI pass.
 cycles 0
-layering_violations 187
+layering_violations 184

--- a/tools/include_graph.py
+++ b/tools/include_graph.py
@@ -37,8 +37,20 @@ LAYERS = [
     # violations, because its consumers (common/, caches/) sit at 1.
     ('caches', 1), ('database', 1), ('metadata', 1), ('history', 1),
     ('pixel', 2),
+    # widgets/: reusable GTK widgets that hold no application state. It was at 4, beside gui/,
+    # on the assumption that "GTK" and "the application's GUI" are one layer. They are not:
+    # widgets/ depends only on system/, common/, metadata/ and pixel/ (focus_peaking.c reads
+    # pixel/eigf.h), so it is a leaf library that happens to be written against GTK, and 2.5 --
+    # above pixel/, below control/ -- is where its own dependencies already put it. Measured,
+    # not assumed: the move creates ZERO new violations and removes three (control/ -> widgets/),
+    # 187 -> 184. At 1.5 it would cost one, because pixel/ would then be above it.
+    #
+    # It does NOT follow that a lower layer may now use GTK freely. Dependency order and
+    # toolkit-freedom are different properties and this table measures only the first; the
+    # second is what the Qt port needs and belongs in its own gate.
+    ('widgets', 2.5),
     ('control', 3),
-    ('gui', 4), ('widgets', 4),   # widgets/ = reusable GTK widgets, no app state
+    ('gui', 4),
     ('develop', 5),
     ('iop', 6), ('imageio', 6),
     ('libs', 7), ('views', 7), ('chart', 7),


### PR DESCRIPTION
First step of T6, and a correction to how T6 was priced. **Tools only — no source file changes.**

### `widgets/` moves from layer 4 to 2.5

It sat beside `gui/` on the assumption that "GTK" and "the application's GUI" are one layer. They are not. `widgets/` depends only on `system/`, `common/`, `metadata/` and `pixel/` (`focus_peaking.c` reads `pixel/eigf.h`), holds no application state, and is already a separate build target. It is a leaf library that happens to be written against GTK, and 2.5 — above `pixel/`, below `control/` — is where its own includes already put it.

**Measured, not assumed**: zero new violations, three removed (`control/` → `widgets/`). **187 → 184.** At 1.5 it would cost one, because `pixel/` would then sit above it. The four `widgets/` → `osx/osx.h` edges never counted either way — `osx` is absent from `LAYERS`, so `layer_of()` returns `None` and the edge is skipped.

It also **un-blinds an existing check**. `check_module_boundaries.sh` rule 2 carried a note that the layering checker was structurally blind to `widgets/` → `gui/`, because the two shared a layer so the edge was not upward. At 2.5 it is upward and registers. The hand-written rule stays — it names the rule — but is no longer the only thing holding it.

### Why the second half exists — the part worth reviewing

I priced the T6 flip before writing anything, and the plan's assumption did not survive it:

| scenario | violations |
|---|---|
| today | 187 |
| flip alone (`develop` → 3.4, `iop`/`imageio` → 3.6) | **580** (+393) |
| flip, after this commit | 245 |
| …plus re-homing `gui/screen_metrics.{h,c}` (zero GTK in either) | 245 → the residual is 98 edges |

The +393 is 231 `iop/`→`widgets/`, 102 `iop/`→`gui/`, 50 `develop/`→`widgets/`, 26 `imageio/`→`widgets/`, 18 `develop/`→`gui/`, 3 `imageio/`→`gui/`. This commit removes 281 of them by making those includes downward.

**But not one line of GTK leaves the pixel engine when that happens.** A metric improving while the thing it stood for does not is worse than no metric. So the property those 281 edges were standing in for is now stated directly, as a fourth boundary:

> **toolkit**: how many files under a directory name `GtkWidget`, `GdkEvent`, `cairo_t`, a `GTK_`/`GDK_` macro, or a gtk/gdk/cairo/pango header at all.

Baselines at today's counts — `develop` 20/73, `iop` 97/164, `imageio` 13/55 — with `pixel` 0/39, `caches` 0/11, `database` 0/31 pinned at zero so they stay free. Files rather than occurrences: the file is the unit that gets split, and one `GtkWidget` in a header disqualifies as thoroughly as forty in a callback. Comments are stripped before matching, because this tree's doc comments discuss GTK constantly and a gate that cries wolf gets switched off.

**Mutation-tested rather than assumed correct**: appending a `GtkWidget` declaration to a `src/pixel` file fails the gate; appending the same names inside `/* */` and `//` comments does not.

This is the ratchet the IOP operator/panel split lowers, one module at a time.

### What this reorders in the plan

`doc/develop-split.md` has T6 as "flip the layer table, **then** the IOP question". The measurement says the two are not sequential in that direction and not as coupled as assumed: after this commit the flip's residual is 98 edges, of which `iop/`→`gui/` is 78 — and 68 of those 78 are just two headers, `gui/presets.h` (35) and `gui/color_picker_proxy.h` (33). So what the flip needs is not "split all 84 IOPs" but "stop IOP operator code calling two APIs". I have a design pass running on the split itself and will propose the doc update separately.

### Verification

`cycles 0`, `layering_violations 184` (baseline lowered in the same commit, per the rule). All four module boundaries hold. No source file is touched, so no build or pixel behaviour can change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
