### PR TITLE
Fix header_consumers.py silently blanking 79% of a file when a string contains "//"

### DIFF
--- a/tools/header_consumers.py
+++ b/tools/header_consumers.py
@@ -71,9 +71,55 @@ NOISE = {
 
 
 def strip_noise(text):
-    text = COMMENT_BLOCK.sub(" ", text)
-    text = COMMENT_LINE.sub(" ", text)
-    return STRING_LIT.sub('""', text)
+    """Blank comments and string literals, in ONE pass.
+
+    Three regexes applied in sequence cannot do this, in either order, because each construct
+    can contain the others' delimiters. Comments-first blanks from the `//` of a URL to the end
+    of the line, taking the string's closing quote with it; the surviving opening quote then
+    pairs with the next quote further down the file and swallows everything between. Measured on
+    src/gui/actions/help.c: 7550 of 9491 characters gone, and its three dt_control_log() calls
+    with them -- the file was reported as using NOTHING from control.h while calling it three
+    times. 129 files in this tree contain `//` inside a string literal.
+
+    Strings-first fails symmetrically: a lone `"` inside a comment (`// don't use "foo.h" here`
+    is fine, an unbalanced one is not) starts a literal that eats real code.
+
+    So: scan once, tracking which construct we are inside. Newlines are preserved so line
+    numbers stay meaningful; everything else becomes a space, and a string literal becomes the
+    empty pair the callers already expect.
+    """
+    out = []
+    i, n = 0, len(text)
+    while i < n:
+        c = text[i]
+        if c == '/' and i + 1 < n and text[i + 1] == '*':
+            j = text.find('*/', i + 2)
+            j = n if j < 0 else j + 2
+            out.append("".join(ch if ch == '\n' else ' ' for ch in text[i:j]))
+            i = j
+        elif c == '/' and i + 1 < n and text[i + 1] == '/':
+            j = text.find('\n', i)
+            j = n if j < 0 else j
+            out.append(' ' * (j - i))
+            i = j
+        elif c == '"' or c == "'":
+            quote, j = c, i + 1
+            while j < n:
+                if text[j] == '\\':
+                    j += 2
+                    continue
+                if text[j] == quote or text[j] == '\n':   # newline: unterminated, stop there
+                    break
+                j += 1
+            if j < n and text[j] == quote:
+                j += 1
+            out.append('""' if quote == '"' else "''")
+            out.append("".join(ch if ch == '\n' else '' for ch in text[i:j]))
+            i = j
+        else:
+            out.append(c)
+            i += 1
+    return "".join(out)
 
 
 def read(path):


### PR DESCRIPTION
`strip_noise()` applied three regexes in sequence — block comments, then line comments, then string literals. **No ordering of three independent substitutions can be correct here**, because each construct may contain the others' delimiters.

Comments-first — what it did — blanks from the `//` of a URL to the end of the line, taking the string's **closing quote** with it. The surviving opening quote then pairs with the next quote further down the file, and `STRING_LIT` replaces everything between with `""`.

Measured on [`src/gui/actions/help.c`](src/gui/actions/help.c): **7550 of 9491 characters gone (79%)**, and its three `dt_control_log()` calls with them. **129 files** in this tree contain `//` inside a string literal, including `src/darktable.h` and `src/views/darkroom.c`.

Strings-first fails symmetrically: an unbalanced `"` inside a comment starts a literal that eats real code. So this is a scanner, not a reordering.

### Why this bucket is the dangerous one

CLAUDE.md is explicit that *"files using nothing from it"* does **not** mean the include can be dropped — those files reach the symbols through some other include and, under this tree's rule, need the include added **explicitly**. A **false** entry there invites deleting an include the file genuinely needs — precisely the failure that broke `build-nofeatures` when `colorprofiles/colorspaces.h` was split.

Two false entries were being reported:

| header | falsely "uses nothing" | what it actually calls |
|---|---|---|
| `control/control.h` | `src/gui/actions/help.c` | `dt_control_log` ×3 |
| `gui/application.h` | `src/gui/privacy_consent.c` | `dt_gui_get_global`, `dt_gui_get_ui`, `dt_gui_main_window` |

Both hidden by a URL in a string literal.

### The fix

One pass that tracks which construct it is inside. Newlines preserved, so line numbers stay meaningful.

**Verified on eight adversarial inputs**, each of which must keep the code after it and drop the noise: URL in a string, a quote inside a line comment, `//` and a quote inside a block comment, an escaped quote, a quoted apostrophe in a char literal, an apostrophe in a comment, an unterminated string, and `/*` inside a string. All eight pass — before the fix, the first alone swallowed the rest of the file.

Before/after on real headers (`buggy → fixed` count of the "using nothing" bucket): `control/control.h` 1 → 0, `gui/application.h` 1 → 0, and `control/signal.h` 7 → 7, `develop/imageop.h` 4 → 4, `common/image.h` 1 → 1 unchanged — the genuine ones stay put.

Found while acting on `doc/control-split.md` (#1152), whose PR1 depends on this tool telling the truth about `control.h`'s 125 includers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
