### PR TITLE
Control PR2: the redraw raisers leave the god-header

### DIFF
--- a/src/control/control.h
+++ b/src/control/control.h
@@ -53,6 +53,7 @@
 
 #include "control/jobs.h"
 #include "control/user_message.h"   // the message API moved out; still supplied here
+#include "control/redraw.h"         // the redraw raisers moved out; still supplied here
 #include "control/progress.h"
 #include "libs/lib.h"
 #include <gtk/gtk.h>
@@ -160,39 +161,11 @@ void dt_control_save_xmp(const int32_t imgid);
 void dt_control_save_xmps(const GList *imgids, const gboolean check_history);
 void dt_control_delete_images();
 
-/** \brief request redraw of the workspace.
-    This redraws the whole workspace within a gdk critical
-    section to prevent several threads to carry out a redraw
-    which will end up in crashes.
- */
-void dt_control_queue_redraw();
-
-/** \brief request redraw of center window.
-    This redraws the center view within a gdk critical section
-    to prevent several threads to carry out the redraw.
-*/
-void dt_control_queue_redraw_center();
-
 /** \brief threadsafe request of redraw of specific widget.
     Use this function if you need to redraw a specific widget
     if your current thread context is not gtk main thread.
 */
 void dt_control_queue_redraw_widget(GtkWidget *widget);
-
-/** \brief request redraw of the navigation widget.
-    This redraws the wiget of the navigation module.
- */
-void dt_control_navigation_redraw();
-
-/** \brief request redraw of the log widget.
-    This redraws the message label.
- */
-void dt_control_log_redraw();
-
-/** \brief request redraw of the toast widget.
-    This redraws the message label.
- */
-void dt_control_toast_redraw();
 
 void dt_ctl_switch_mode_to(const char *mode);
 void dt_ctl_switch_mode_to_by_view(const dt_view_t *view);

--- a/src/control/redraw.h
+++ b/src/control/redraw.h
@@ -1,0 +1,71 @@
+/*
+    This file is part of Ansel.
+    Copyright (C) 2026 Aurélien Pierre.
+
+    Ansel is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Ansel is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Ansel.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+/** @file control/redraw.h
+ *
+ * @brief Asking the interface to repaint itself.
+ *
+ * @details Five one-line signal raisers, split out of control/control.h for the same reason
+ * control/user_message.h was: a caller that only wants the screen refreshed should not compile
+ * libs/lib.h and views/view.h to say so. Nine files use these and nothing else from control.h.
+ *
+ * Each is a DT_DEBUG_CONTROL_SIGNAL_RAISE and nothing more, so none of them needs a toolkit
+ * type and this header includes nothing. The sixth raiser, dt_control_queue_redraw_widget(),
+ * takes a GtkWidget* and therefore stays in control.h -- putting it here would drag GTK into
+ * every includer and defeat the point.
+ *
+ * They are safe to call from any thread: the raise is what crosses back to the GUI thread.
+ */
+
+#ifndef DT_CONTROL_REDRAW_H
+#define DT_CONTROL_REDRAW_H
+
+/* C linkage: these are defined in a C translation unit and reachable from C++ ones. The header
+ * this came from wraps its declarations the same way, so without this a C++ caller emits a
+ * mangled reference. Linux does not catch it -- a plugin .so may keep undefined symbols and
+ * fail at dlopen() instead -- but macOS and Windows fail the link. See control/user_message.h. */
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** @brief Request a redraw of the whole workspace. */
+void dt_control_queue_redraw();
+
+/** @brief Request a redraw of the centre view. */
+void dt_control_queue_redraw_center();
+
+/** @brief Request a redraw of the navigation module's widget. */
+void dt_control_navigation_redraw();
+
+/** @brief Request a redraw of the log message label. */
+void dt_control_log_redraw();
+
+/** @brief Request a redraw of the toast message label. */
+void dt_control_toast_redraw();
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // DT_CONTROL_REDRAW_H
+
+// clang-format off
+// modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py
+// vim: shiftwidth=2 expandtab tabstop=2 cindent
+// kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;
+// clang-format on

--- a/src/gui/actions/image.c
+++ b/src/gui/actions/image.c
@@ -25,7 +25,7 @@
 #include "common/grouping.h"
 #include "metadata/colorlabels.h"
 #include "metadata/ratings.h"
-#include "control/control.h"
+#include "control/redraw.h"
 #include "common/collection.h"
 
 static gboolean rotate_counterclockwise_callback(GtkAccelGroup *group, GObject *acceleratable, guint keyval, GdkModifierType mods, gpointer user_data)

--- a/src/gui/color_picker_proxy.c
+++ b/src/gui/color_picker_proxy.c
@@ -34,7 +34,7 @@
 #include "widgets/bauhaus.h"
 #include "common/color_picker.h"
 #include "control/signal.h"
-#include "control/control.h"
+#include "control/redraw.h"
 #include "develop/dev_pixelpipe.h"
 #include "caches/pixelpipe_cache.h"
 #include "libs/colorpicker.h"

--- a/src/gui/common/history_actions_gui.c
+++ b/src/gui/common/history_actions_gui.c
@@ -33,7 +33,7 @@
 #include "common/conf.h"
 #include "common/history_actions.h"
 #include "system/macros.h"
-#include "control/control.h"
+#include "control/redraw.h"
 #include "develop/develop.h"
 #include "develop/dev_history.h"
 #include "gui/actions/menu.h"

--- a/src/gui/guides.c
+++ b/src/gui/guides.c
@@ -36,7 +36,7 @@
 #include "common/utility.h"
 #include "gui/guides.h"
 #include "widgets/draw.h"
-#include "control/control.h"
+#include "control/redraw.h"
 #include "develop/develop.h"
 #include "widgets/widget_style.h"
 

--- a/src/iop/graduatednd.c
+++ b/src/iop/graduatednd.c
@@ -72,7 +72,7 @@
 #include "colorprofiles/colorspaces.h"
 #include "math/math.h"
 #include "common/opencl.h"
-#include "control/control.h"
+#include "control/redraw.h"
 #include "develop/develop.h"
 #include "develop/imageop.h"
 #include "develop/imageop_math.h"

--- a/src/libs/masks.c
+++ b/src/libs/masks.c
@@ -44,7 +44,7 @@
 #include "common/logging.h"
 #include "system/macros.h"
 #include "common/module_versioning.h"
-#include "control/control.h"
+#include "control/redraw.h"
 #include "develop/blend.h"
 #include "develop/blend_gui.h"
 #include "develop/develop.h"

--- a/src/views/dev_backbuf.c
+++ b/src/views/dev_backbuf.c
@@ -28,7 +28,7 @@
 #include "system/macros.h"
 #include "system/simd.h"
 #include "gui/application.h"
-#include "control/control.h"
+#include "control/redraw.h"
 #include "develop/develop.h"
 #include "caches/pixelpipe_cache.h"
 #include "develop/pixelpipe_hb.h"

--- a/src/views/dev_toolbox.c
+++ b/src/views/dev_toolbox.c
@@ -20,7 +20,7 @@
 #include "common/file_location.h"
 #include "common/usermanual_url.h"
 #include "common/conf.h"
-#include "control/control.h"
+#include "control/redraw.h"
 #include "control/signal.h"
 #include "develop/develop.h"
 #include "develop/dev_pixelpipe.h"


### PR DESCRIPTION
PR2 of [`doc/control-split.md`](doc/control-split.md). Independent of #1154 — both edit `control.h`, but in different regions.

Five one-line signal raisers — `dt_control_queue_redraw()`, `_redraw_center()`, `_navigation_redraw()`, `_log_redraw()`, `_toast_redraw()` — move to `control/redraw.h`. Each is a `DT_DEBUG_CONTROL_SIGNAL_RAISE` and nothing else, so **the header includes nothing at all**. `control.h` includes it, so the other includers are untouched.

`dt_control_queue_redraw_widget()` stays behind: it takes a `GtkWidget*`, and moving it here would drag GTK into every includer and defeat the point.

**8 files repointed.** They wanted the screen refreshed and were compiling `libs/lib.h` and `views/view.h` to ask for it.

### This corrects the plan's numbers

The doc predicts *"55 touchers, 18 exclusive"*. Counting direct includers of `control.h` that name a raiser: **43 touchers, 9 exclusive**, plus 4 more that use only raisers + the message API and become repointable once #1154 lands. The doc's figures came from another branch and a different counting rule; these are from this tree.

**One of the 9 was not repointed.** `iop/basicadj.c` reaches `dt_action_button_new()` through `control.h`, which `libs/lib.h` declares — `iop → libs` is upward, so an explicit include would raise the ratchet. Same disposition as `gui/presets.c` and `iop/lut3d.c` in PR1: it keeps `control.h` until the `libs/lib.h` edge itself goes.

### A measurement worth having for PR5

I probed the plan's big win — deleting `control.h:56 #include "libs/lib.h"` — by actually removing it and building. **12 files break**, and `control.h` itself accounts for 84 of the errors, since it uses `dt_view_t` in `dt_ctl_switch_mode_to_by_view()` (the function the plan already identifies as having zero callers).

The rest need `views/view.h` explicitly: `common/folder_survey.c` (layer 1), `control/jobs/control_jobs.c` (3), `develop/develop.c` (5), `gui/actions/edit.c` and `views.c` (4) — **every one upward**. Those dependencies exist today, hidden behind a single counted edge; making them explicit turns 1 violation into ~5.

So PR5 cannot be pulled forward as a mechanical change, and the plan is right to sequence the inversions first. Useful to know before someone tries it, since on the surface it looks like a one-line deletion.

### Verification

Release, Debug (`-Werror`) and nofeatures build; `ctest` 8/8; Δ`layering_violations` = 0 (184); boundaries hold.

C linkage guards are in the new header **from the start**, per the macOS/Windows failure #1154 hit — on Linux a plugin `.so` can keep an undefined mangled symbol and fail at `dlopen()` rather than at build. Swept every built plugin afterwards: no mangled `dt_` references.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
