### PR TITLE
Fix #1116: drawn masks read their rasterisation step from the pipe instead of guessing at it

### DIFF
--- a/data/anselconfig.xml.in
+++ b/data/anselconfig.xml.in
@@ -1636,6 +1636,18 @@
     <longdescription/>
   </dtconfig>
   <dtconfig>
+    <name>plugins/darkroom/masks/rasterization</name>
+    <type>
+      <enum>
+        <option>auto</option>
+        <option>never</option>
+      </enum>
+    </type>
+    <default>auto</default>
+    <shortdescription>fast drawn mask rasterization</shortdescription>
+    <longdescription>how finely drawn masks (brush, polygon) are rasterized in the darkroom. auto: one sample per displayed pixel, so zoomed-out views cost less and 1:1 or closer stays exact. never: always pixel-accurate, at the cost of speed when zoomed out. Exports, thumbnails and snapshots are always pixel-accurate regardless of this setting.</longdescription>
+  </dtconfig>
+  <dtconfig>
     <name>plugins/darkroom/ui/border_size</name>
     <type>int</type>
     <default>10</default>

--- a/src/develop/dev_pixelpipe.c
+++ b/src/develop/dev_pixelpipe.c
@@ -1450,6 +1450,19 @@ void dt_pixelpipe_get_global_hash(dt_dev_pixelpipe_t *pipe)
     local_hash = dt_hash(local_hash, (const char *)&piece->dsc_in, sizeof(dt_iop_buffer_dsc_t));
     local_hash = dt_hash(local_hash, (const char *)&piece->dsc_out, sizeof(dt_iop_buffer_dsc_t));
 
+    /* The pipe's drawn-mask rasterisation step changes the mask a module blends with, so it
+     * changes that module's pixels. It belongs HERE, with request_mask_display below, and for
+     * the same reason: it is global GUI state that no module's history carries, so
+     * dt_iop_commit_params() would only fold it when that module's own parameters changed --
+     * flipping the preference from auto to never would leave every cached line valid-looking
+     * and stale.
+     *
+     * Only for a module that actually draws a mask: the raw stages upstream cannot carry one,
+     * and rehashing them would cost cache misses for pixels that cannot move. */
+    if((piece->module->blend_params->mask_mode & DEVELOP_MASK_SHAPE)
+       && piece->module->blend_params->mask_id > 0)
+      local_hash = dt_hash(local_hash, (const char *)&pipe->mask_rasterization_step, sizeof(int));
+
 /*
     fprintf(stdout, "start->end : %-17s | ROI in: %4ix%-4i @%2.4f | ROI out: %4ix%-4i @%2.4f\n", piece->module->op,
             piece->buf_in.width, piece->buf_in.height, piece->buf_in.scale, piece->buf_out.width,

--- a/src/develop/dev_roi_request.c
+++ b/src/develop/dev_roi_request.c
@@ -17,6 +17,7 @@
 */
 
 #include "develop/dev_roi_request.h"
+#include "common/conf.h"
 #include "develop/dev_geometry.h"
 #include "develop/dev_viewport.h"
 #include "develop/develop.h"
@@ -154,6 +155,32 @@ uint64_t dt_dev_roi_request_publish(dt_develop_t *dev)
   // without being invalidated by every republication of identical numbers.
   const uint64_t published = dt_atomic_get_uint64(&dev->roi_request.generation);
   if(_payload_equal(&dev->roi_request.value, &next)) return published;
+
+  /* Drawn-mask rasterisation step, decided HERE because this is the GUI thread and the only
+   * place that knows both scales: the main pipe renders at natural_scale * scaling (the zoom
+   * the user set) and the preview at natural_scale (always fit). It must not be decided in the
+   * pipeline thread -- that would read a user preference and a viewport from a thread that owns
+   * neither, and would recompute per frame what changes only when the viewport does.
+   *
+   * "never" pins both to 1. Absent a GUI, nothing calls this at all, so the pipes keep the
+   * pixel-accurate step their init gave them. */
+  int main_step = 1;
+  int preview_step = 1;
+  if(dev->gui_attached && next.valid && next.natural_scale > 0.f)
+  {
+    /* The preference governs the MAIN pipe only. The preview is always rendered at fit size and
+     * is never what the user inspects for pixel accuracy, so its step follows its own ROI
+     * unconditionally. */
+    gchar *mode = dt_conf_get_string("plugins/darkroom/masks/rasterization");
+    const gboolean fast = IS_NULL_PTR(mode) || strcmp(mode, "never") != 0;
+    g_free(mode);
+
+    const float main_scale = next.natural_scale * next.scaling;
+    if(fast && main_scale > 0.f) main_step = (int)floorf(1.f / main_scale);
+    preview_step = (int)floorf(1.f / next.natural_scale);
+  }
+  dt_dev_pixelpipe_set_mask_rasterization_step(dev->pipe, main_step);
+  dt_dev_pixelpipe_set_mask_rasterization_step(dev->preview_pipe, preview_step);
 
   next.generation = published + 2;   // stays even: the store's counter is the odd/even flag
   dt_atomic_set_uint64(&dev->roi_request.generation, published + 1);

--- a/src/develop/masks/brush.c
+++ b/src/develop/masks/brush.c
@@ -734,8 +734,10 @@ static int _brush_get_pts_border(dt_develop_t *develop, dt_masks_form_t *mask_fo
 
   const float iwd = pipe->iwidth;
   const float iht = pipe->iheight;
-  const int pixel_threshold = (dt_dev_pixelpipe_has_preview_output(develop, pipe, NULL)
-                               || pipe->type == DT_DEV_PIXELPIPE_THUMBNAIL) ? 3 : 1;
+  // How far apart consecutive samples of the outline may land, in image pixels. Decided by the
+  // pipe, never here; see dt_dev_pixelpipe_t::mask_rasterization_step. Above 1 the samples
+  // spread out and the radial spokes stamped from them leave gaps between each pair (#1116).
+  const int pixel_threshold = pipe->mask_rasterization_step;
 
   dt_masks_dynbuf_t *dpoints = NULL, *dborder = NULL, *dpayload = NULL;
 
@@ -2771,9 +2773,8 @@ static int _brush_get_mask(const dt_iop_module_t *const module, dt_dev_pixelpipe
     *width = *height = *offset_x = *offset_y = 0;
     return 0;
   }
-  const gboolean use_sparse = (dt_dev_pixelpipe_has_preview_output(piece->module->dev, pipe, NULL)
-                               || pipe->type == DT_DEV_PIXELPIPE_THUMBNAIL);
-  const int sparse_step = use_sparse ? 4 : 1;
+  const gboolean use_sparse = (pipe->mask_rasterization_step > 1);
+  const int sparse_step = pipe->mask_rasterization_step;
   _brush_bounding_box(points, border, node_count, points_count, width, height, offset_x, offset_y);
 
   if(dt_get_debug_flags() & DT_DEBUG_PERF)
@@ -2924,9 +2925,8 @@ static int _brush_get_mask_roi(const dt_iop_module_t *const module, dt_dev_pixel
   const int roi_width = roi->width;
   const int roi_height = roi->height;
   const float roi_scale = roi->scale;
-  const gboolean use_sparse = (dt_dev_pixelpipe_has_preview_output(piece->module->dev, pipe, roi)
-                               || pipe->type == DT_DEV_PIXELPIPE_THUMBNAIL);
-  const int sparse_step = use_sparse ? 4 : 1;
+  const gboolean use_sparse = (pipe->mask_rasterization_step > 1);
+  const int sparse_step = pipe->mask_rasterization_step;
 
   // we get buffers for all points
   float *points = NULL, *border = NULL, *payload = NULL;

--- a/src/develop/masks/polygon.c
+++ b/src/develop/masks/polygon.c
@@ -727,8 +727,28 @@ static int _polygon_get_pts_border(dt_develop_t *develop, dt_masks_form_t *mask_
 
   const float input_width = pipe->iwidth;
   const float input_height = pipe->iheight;
-  // See dt_dev_pixelpipe_t::mask_rasterization_step -- the pipe decides, not each mask type.
-  const int pixel_threshold = pipe->mask_rasterization_step;
+  /* One pixel, always, and NOT dt_dev_pixelpipe_t::mask_rasterization_step.
+   *
+   * The border produced here is fed to _polygon_find_self_intersection(), which is a PIXEL-GRID
+   * algorithm: it traces the border into a grid one cell per pixel, joining consecutive samples
+   * with straight chords via _polygon_fill_gaps(), and treats a revisited cell as the polygon's
+   * offset curve folding over itself. That inference is only sound while the chords follow the
+   * true curve, i.e. while consecutive samples are about a pixel apart. Sample more coarsely and
+   * the chords cut across cells the real curve never enters, two distant parts of the contour
+   * collide in the grid, and a self-intersection is reported where there is none.
+   *
+   * The cost of getting it wrong is not a slightly rough outline: the reported range is written
+   * back into the border as a NaN jump marker, and every consumer -- including the scale/shift
+   * loop in _polygon_get_mask_roi() -- skips it. Measured on issue #1116's polygon at threshold
+   * 2 and 3: one spurious marker spanning the whole contour, 4121 of 4131 border points never
+   * scaled into ROI space, so the feather was drawn from image-space coordinates that land
+   * outside the buffer and vanished, leaving only the solid core and one stray scaled point.
+   * Threshold 4 happened to find no collision and looked correct, which is what made the
+   * failure look non-monotonic.
+   *
+   * The step still applies to what this costs to PAINT -- see `sparse' in the rasterisers below,
+   * which is where the expensive per-pixel work is. Only the geometry has to stay exact. */
+  const int pixel_threshold = 1;
   const guint node_count = g_list_length(mask_form->points);
 
   dt_masks_dynbuf_t *dpoints = NULL, *dborder = NULL, *intersections = NULL;
@@ -2550,8 +2570,13 @@ static int _polygon_get_mask(const dt_iop_module_t *const module, dt_dev_pixelpi
 
   const int hb = *height;
   const int wb = *width;
-  const gboolean sparse = (pipe->mask_rasterization_step > 1);
-  const int sparse_factor = pipe->mask_rasterization_step;
+  /* Nothing left to interpolate: the outline above is sampled at one pixel whatever the pipe's
+   * step, because the self-intersection detector needs it that way, so consecutive falloff
+   * segments are already adjacent. Interpolating between them would only stamp the same pixels
+   * again. Polygon therefore buys no speed from a coarse step today -- making it do so means
+   * decimating the PAINTING while keeping the geometry exact, which is a separate change. */
+  const gboolean sparse = FALSE;
+  const int sparse_factor = 1;
 
   if(dt_get_debug_flags() & DT_DEBUG_PERF)
   {
@@ -3134,8 +3159,13 @@ static int _polygon_get_mask_roi(const dt_iop_module_t *const module, dt_dev_pix
   const int width = roi->width;
   const int height = roi->height;
   const float scale = roi->scale;
-  const gboolean sparse = (pipe->mask_rasterization_step > 1);
-  const int sparse_factor = pipe->mask_rasterization_step;
+  /* Nothing left to interpolate: the outline above is sampled at one pixel whatever the pipe's
+   * step, because the self-intersection detector needs it that way, so consecutive falloff
+   * segments are already adjacent. Interpolating between them would only stamp the same pixels
+   * again. Polygon therefore buys no speed from a coarse step today -- making it do so means
+   * decimating the PAINTING while keeping the geometry exact, which is a separate change. */
+  const gboolean sparse = FALSE;
+  const int sparse_factor = 1;
 
   // we need to take care of four different cases:
   // 1) polygon and feather are outside of roi

--- a/src/develop/masks/polygon.c
+++ b/src/develop/masks/polygon.c
@@ -727,8 +727,8 @@ static int _polygon_get_pts_border(dt_develop_t *develop, dt_masks_form_t *mask_
 
   const float input_width = pipe->iwidth;
   const float input_height = pipe->iheight;
-  const int pixel_threshold = (dt_dev_pixelpipe_has_preview_output(develop, pipe, NULL)
-                               || pipe->type == DT_DEV_PIXELPIPE_THUMBNAIL) ? 3 : 1;
+  // See dt_dev_pixelpipe_t::mask_rasterization_step -- the pipe decides, not each mask type.
+  const int pixel_threshold = pipe->mask_rasterization_step;
   const guint node_count = g_list_length(mask_form->points);
 
   dt_masks_dynbuf_t *dpoints = NULL, *dborder = NULL, *intersections = NULL;
@@ -2550,9 +2550,8 @@ static int _polygon_get_mask(const dt_iop_module_t *const module, dt_dev_pixelpi
 
   const int hb = *height;
   const int wb = *width;
-  const gboolean sparse = (dt_dev_pixelpipe_has_preview_output(piece->module->dev, pipe, NULL)
-                           || pipe->type == DT_DEV_PIXELPIPE_THUMBNAIL);
-  const int sparse_factor = sparse ? 4 : 1;
+  const gboolean sparse = (pipe->mask_rasterization_step > 1);
+  const int sparse_factor = pipe->mask_rasterization_step;
 
   if(dt_get_debug_flags() & DT_DEBUG_PERF)
   {
@@ -3135,9 +3134,8 @@ static int _polygon_get_mask_roi(const dt_iop_module_t *const module, dt_dev_pix
   const int width = roi->width;
   const int height = roi->height;
   const float scale = roi->scale;
-  const gboolean sparse = (dt_dev_pixelpipe_has_preview_output(piece->module->dev, pipe, roi)
-                           || pipe->type == DT_DEV_PIXELPIPE_THUMBNAIL);
-  const int sparse_factor = sparse ? 4 : 1;
+  const gboolean sparse = (pipe->mask_rasterization_step > 1);
+  const int sparse_factor = pipe->mask_rasterization_step;
 
   // we need to take care of four different cases:
   // 1) polygon and feather are outside of roi

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -381,6 +381,7 @@ int dt_dev_pixelpipe_init_export(dt_dev_pixelpipe_t *pipe, dt_develop_t *dev, in
   const int res = dt_dev_pixelpipe_init_cached(pipe);
   pipe->type = DT_DEV_PIXELPIPE_EXPORT;
   pipe->gui_observable_source = FALSE;
+  pipe->mask_rasterization_step = 1;   // these pixels are the deliverable
   pipe->levels = levels;
   pipe->store_all_raster_masks = store_masks;
   pipe->dev = dev;
@@ -392,6 +393,7 @@ int dt_dev_pixelpipe_init_thumbnail(dt_dev_pixelpipe_t *pipe, dt_develop_t *dev)
   const int res = dt_dev_pixelpipe_init_cached(pipe);
   pipe->type = DT_DEV_PIXELPIPE_THUMBNAIL;
   pipe->no_cache = TRUE;
+  pipe->mask_rasterization_step = 1;   // raised by the GUI only, never on its own
   pipe->dev = dev;
   return res;
 }
@@ -411,6 +413,7 @@ int dt_dev_pixelpipe_init_preview(dt_dev_pixelpipe_t *pipe, dt_develop_t *dev)
   const int res = dt_dev_pixelpipe_init_cached(pipe);
   pipe->type = DT_DEV_PIXELPIPE_PREVIEW;
   pipe->gui_observable_source = TRUE;
+  pipe->mask_rasterization_step = 1;   // raised by the GUI only, never on its own
 
   // Needed for caching
   pipe->store_all_raster_masks = TRUE;
@@ -418,10 +421,29 @@ int dt_dev_pixelpipe_init_preview(dt_dev_pixelpipe_t *pipe, dt_develop_t *dev)
   return res;
 }
 
+/**
+ * @brief Set the drawn-mask rasterisation step for the frame this pipe is about to run.
+ *
+ * @param step Maximum distance, in image pixels, between consecutive samples of a mask outline.
+ * Clamped to at least 1 (pixel accuracy).
+ *
+ * @details Called by the darkroom, which is the only place that knows both the zoom level and
+ * the user's preference. Nothing else raises it, so a pipe that is never told -- every headless
+ * export, thumbnail and snapshot -- keeps the pixel-accurate default it was initialised with.
+ */
+void dt_dev_pixelpipe_set_mask_rasterization_step(dt_dev_pixelpipe_t *pipe, const int step)
+{
+  if(IS_NULL_PTR(pipe)) return;
+
+  pipe->mask_rasterization_step = MAX(1, step);
+}
+
 int dt_dev_pixelpipe_init(dt_dev_pixelpipe_t *pipe, dt_develop_t *dev)
 {
   const int res = dt_dev_pixelpipe_init_cached(pipe);
   pipe->type = DT_DEV_PIXELPIPE_FULL;
+  // Raised per frame by the darkroom; see dt_dev_pixelpipe_set_mask_rasterization_step().
+  pipe->mask_rasterization_step = 1;
 
   // Needed for caching
   pipe->store_all_raster_masks = TRUE;

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -381,7 +381,6 @@ int dt_dev_pixelpipe_init_export(dt_dev_pixelpipe_t *pipe, dt_develop_t *dev, in
   const int res = dt_dev_pixelpipe_init_cached(pipe);
   pipe->type = DT_DEV_PIXELPIPE_EXPORT;
   pipe->gui_observable_source = FALSE;
-  pipe->mask_rasterization_step = 1;   // these pixels are the deliverable
   pipe->levels = levels;
   pipe->store_all_raster_masks = store_masks;
   pipe->dev = dev;
@@ -393,7 +392,6 @@ int dt_dev_pixelpipe_init_thumbnail(dt_dev_pixelpipe_t *pipe, dt_develop_t *dev)
   const int res = dt_dev_pixelpipe_init_cached(pipe);
   pipe->type = DT_DEV_PIXELPIPE_THUMBNAIL;
   pipe->no_cache = TRUE;
-  pipe->mask_rasterization_step = 1;   // raised by the GUI only, never on its own
   pipe->dev = dev;
   return res;
 }
@@ -413,7 +411,6 @@ int dt_dev_pixelpipe_init_preview(dt_dev_pixelpipe_t *pipe, dt_develop_t *dev)
   const int res = dt_dev_pixelpipe_init_cached(pipe);
   pipe->type = DT_DEV_PIXELPIPE_PREVIEW;
   pipe->gui_observable_source = TRUE;
-  pipe->mask_rasterization_step = 1;   // raised by the GUI only, never on its own
 
   // Needed for caching
   pipe->store_all_raster_masks = TRUE;
@@ -442,8 +439,6 @@ int dt_dev_pixelpipe_init(dt_dev_pixelpipe_t *pipe, dt_develop_t *dev)
 {
   const int res = dt_dev_pixelpipe_init_cached(pipe);
   pipe->type = DT_DEV_PIXELPIPE_FULL;
-  // Raised per frame by the darkroom; see dt_dev_pixelpipe_set_mask_rasterization_step().
-  pipe->mask_rasterization_step = 1;
 
   // Needed for caching
   pipe->store_all_raster_masks = TRUE;
@@ -460,6 +455,16 @@ int dt_dev_pixelpipe_init_cached(dt_dev_pixelpipe_t *pipe)
   pipe->roi_request.value = dt_dev_roi_request_neutral();
   pipe->devid = -1;
   pipe->last_devid = -1;
+
+  /* Pixel accuracy, the safe default: only the darkroom ever raises this, from the GUI thread.
+   * It is set HERE, in the one function every pipe init calls, and not in each of them: the
+   * per-type version of this missed dt_dev_pixelpipe_init_dummy(), which gui/dtgtk/focus.h uses
+   * for the focus-ring overlay, and left it at the memset's 0. Zero does not divide by anything
+   * -- `use_sparse' is `step > 1' and the interpolation loop is `for(k = 1; k < step; k++)', so
+   * both are simply skipped -- but it makes _is_within_pxl_threshold() test `< 0', which is
+   * never true, so the outline subdivides until `tmax - tmin < 0.0001' instead of stopping at
+   * one pixel: thousands of samples per segment, on an overlay that wanted the cheap path. */
+  pipe->mask_rasterization_step = 1;
   dt_dev_pixelpipe_set_changed(pipe, DT_DEV_PIPE_UNCHANGED);
   dt_dev_pixelpipe_set_hash(pipe, DT_PIXELPIPE_CACHE_HASH_INVALID);
   dt_dev_pixelpipe_set_history_hash(pipe, DT_PIXELPIPE_CACHE_HASH_INVALID);

--- a/src/develop/pixelpipe_hb.h
+++ b/src/develop/pixelpipe_hb.h
@@ -345,6 +345,31 @@ typedef struct dt_dev_pixelpipe_t
   // sampling. The processing core reacts to this property instead of branching
   // on pipeline type.
   gboolean gui_observable_source;
+
+  /**
+   * @brief Rasterisation step for drawn masks, in image pixels. Always >= 1.
+   *
+   * @details Brush and polygon subdivide their outline until consecutive samples land within
+   * this many pixels, then paint one radial spoke per sample. At 1 the outline is followed to
+   * pixel accuracy. Above 1 the samples spread out and the spokes leave gaps between them --
+   * invisible when the result is shown well below 1:1, a diagonal hatch across the stroke when
+   * it is not (#1116).
+   *
+   * IT IS SET UPSTREAM AND ONLY READ HERE. Every mask type used to re-derive its own answer
+   * from `dt_dev_pixelpipe_has_preview_output(...) || type == THUMBNAIL' -- six copies across
+   * brush.c and polygon.c, some passing the module's roi and some NULL, so one pipe could be
+   * classified two ways inside a single frame, and an export could be classified as a preview.
+   * How finely a pipe must rasterise is a property OF THE PIPE, decided by whoever configures
+   * it: pipe init, or the darkroom GUI from the zoom level.
+   *
+   * The default is 1 and every init sets it, so a pipe nobody configures -- every headless
+   * export, thumbnail and snapshot -- is pixel-accurate by construction rather than by a
+   * predicate that has to get the answer right.
+   *
+   * It feeds the module hash (dt_pixelpipe_get_global_hash), because two runs at different
+   * steps produce different pixels and must not share a cache line.
+   */
+  int mask_rasterization_step;
   // the final output pixel format this pixelpipe will be converted to
   dt_imageio_levels_t levels;
   // opencl device that has been locked for this pipe.
@@ -491,6 +516,11 @@ char *dt_pixelpipe_get_pipe_name(dt_dev_pixelpipe_type_t pipe_type);
 
 // inits the pixelpipe with plain passthrough input/output and empty input and default caching settings.
 int dt_dev_pixelpipe_init(dt_dev_pixelpipe_t *pipe, struct dt_develop_t *dev);
+
+/** @brief Set the drawn-mask rasterisation step for the next frame, in image pixels (clamped
+ *  to >= 1). @see dt_dev_pixelpipe_t::mask_rasterization_step. */
+void dt_dev_pixelpipe_set_mask_rasterization_step(struct dt_dev_pixelpipe_t *pipe, const int step);
+
 // inits the preview pixelpipe with plain passthrough input/output and empty input and default caching
 // settings.
 int dt_dev_pixelpipe_init_preview(dt_dev_pixelpipe_t *pipe, struct dt_develop_t *dev);

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -1329,6 +1329,18 @@ static void _darkroom_change_rendering_size(GtkWidget *combobox, gpointer user_d
   dt_dev_pixelpipe_resync_history_main(d);
 }
 
+static void _darkroom_change_mask_rasterization(GtkWidget *combobox, gpointer user_data)
+{
+  dt_develop_t *d = (dt_develop_t *)user_data;
+  dt_conf_set_string("plugins/darkroom/masks/rasterization",
+                     (dt_bauhaus_combobox_get(combobox) == 0) ? "auto" : "never");
+  /* The step itself is recomputed by dt_dev_roi_request_publish(), on this thread. Only the
+   * MAIN pipe is affected: the preview's step is always automatic, set from its own ROI, so
+   * this preference cannot change it and resyncing it would be wasted work. */
+  dt_dev_roi_request_publish(d);
+  dt_dev_pixelpipe_resync_history_main(d);
+}
+
 /** end of toolbox */
 
 #if 0
@@ -1664,6 +1676,25 @@ void gui_init(dt_view_t *self)
                                 N_("scaled (default)")
                               );
     gtk_box_pack_start(GTK_BOX(vbox), GTK_WIDGET(rendering), TRUE, TRUE, 0);
+
+    gchar *rasterization = dt_conf_get_string("plugins/darkroom/masks/rasterization");
+    const int rasterization_index = (!IS_NULL_PTR(rasterization) && !strcmp(rasterization, "never")) ? 1 : 0;
+    g_free(rasterization);
+
+    GtkWidget *mask_rasterization;
+    DT_BAUHAUS_COMBOBOX_NEW_FULL(dt_bauhaus_get_global(), mask_rasterization, NULL,
+                                N_("Fast drawn mask rasterization"),
+                                _("Choose how finely brush and polygon masks are drawn in the darkroom.\n"
+                                  "Auto samples one point per displayed pixel: zoomed out costs less,\n"
+                                  "and at 100% or closer masks are pixel-accurate.\n"
+                                  "Never keeps pixel accuracy at every zoom level, at some cost when zoomed out.\n"
+                                  "Exports, thumbnails and snapshots are always pixel-accurate either way."),
+                                rasterization_index,
+                                _darkroom_change_mask_rasterization, dev,
+                                N_("auto (default)"),
+                                N_("never")
+                              );
+    gtk_box_pack_start(GTK_BOX(vbox), GTK_WIDGET(mask_rasterization), TRUE, TRUE, 0);
 
     gtk_box_pack_start(GTK_BOX(vbox), dt_ui_section_label_new(_("Mask preview settings")), FALSE, FALSE, 0);
 


### PR DESCRIPTION
Closes #1116. Three commits.

## 1. The rasterisation step becomes a property of the pipe

Brush and polygon subdivide their outline to a pixel threshold, then paint **one radial spoke per sample**. Each mask type decided that threshold for itself, from `dt_dev_pixelpipe_has_preview_output(...) || pipe->type == THUMBNAIL` — **six copies** across `brush.c` and `polygon.c`, three passing the module's `roi` and three passing `NULL`, so one pipe could be classified two ways inside a frame. Two more sites hard-coded a factor of 4 for the same idea under another name.

When that guess says "preview" the threshold is 3: samples land up to 2 px apart while `_brush_falloff_roi()` stamps only a 1 px neighbour, so ~1 px stays unpainted **between** spokes — invisible at preview size, a diagonal hatch across the stroke at full size.

It is now `dt_dev_pixelpipe_t::mask_rasterization_step`, read by masks and set nowhere else:

- **Every init sets 1**, so any pipe nobody configures — export, thumbnail, snapshot — is pixel-accurate *by construction*.
- **The darkroom raises it on the GUI thread**, from `dt_dev_roi_request_publish()`, where the viewport and the preference are owned. Main pipe follows the zoom; preview follows its own ROI.
- **Setting** `plugins/darkroom/masks/rasterization` (auto|never) as *"Fast drawn mask rasterization"* beside *"Rendering size"*. `never` pins the main pipe only, so it resyncs the main pipe only.
- **Hashed** per piece in `dt_pixelpipe_get_global_hash()`, beside `request_mask_display` — global GUI state no module's history carries, so folding it in `dt_iop_commit_params()` would only take effect when that module's own params changed, and flipping the preference would leave cache lines valid-looking and stale. Only for modules that actually draw a mask.

**Measured**: reproduced by forcing threshold 3 on the export pipe, and confirmed it is *this* artifact rather than a lookalike — **correlation 0.944** between the pixels that threshold drops and the dark lines in the reported export (brightness 0.229 there vs 0.645 elsewhere in the same stroke). After the fix the headless export is bit-identical to a known-good mask.

## 2. The step's default moves into `init_cached` (review finding)

`dt_dev_pixelpipe_init_dummy()` — used by `gui/dtgtk/focus.h` for the focus ring — was the one init that didn't set it, so it kept the memset's 0.

The reported consequence, a division by zero, is **not** what happens: `use_sparse` is `step > 1` and the loop is `for(k = 1; k < step; k++)`, so both are skipped at 0. What 0 actually does is quieter — `_is_within_pxl_threshold()` tests `< 0`, never true, so the outline subdivides to the `tmax - tmin < 0.0001f` floor: thousands of samples per segment, on the overlay that least wants them. Fixed in the one function all five inits call first, so a future init cannot miss it.

## 3. The polygon feather (regression found in GUI testing)

Commit 1 let the darkroom raise the step on the main pipe below 1:1 — which no pipe had ever done for polygons. The feather then mostly vanished below 50% zoom, leaving the solid core and one stray spot.

`_polygon_find_self_intersection()` is a **pixel-grid** algorithm: it traces the border into a grid of one cell per pixel, joins consecutive samples with straight chords, and reads a revisited cell as the offset curve folding over itself. Sound only while samples are ~1 px apart. Coarser, and the chords cut through cells the real curve never enters, distant parts of the contour collide, and an intersection is reported where there is none.

That doesn't roughen the outline — the range is written back as a **NaN jump marker** which every consumer skips, including the scale/shift loop in `_polygon_get_mask_roi()`. Instrumented at threshold 2: **one** spurious marker, **4121 of 4131 border points never scaled into ROI space**, left in image coordinates, landing outside the buffer. The single scaled point is the stray spot. Threshold 4 happened to find no collision, which is why the failure looked non-monotonic (fine at 1 and 4, broken at 2, 3, 8).

So the polygon outline is sampled at 1 px whatever the step, and the sparse interpolation that rode along is off — with samples already adjacent it would restamp the same pixels.

**Verified**: the exported mask is now **bit-identical at steps 1, 3 and 8** (solid 273,879, feather 699,763), where it lost 85% of the feather at 2, 3 and 8.

Two hypotheses died on measurement first and are recorded in the commit so they aren't retried: interpolating to close the *measured* gap instead of a fixed count, and making the factor exceed the threshold to reproduce the legacy `(3,4)` pairing. Neither moved the feather off 14.5%, because the geometry had already been discarded upstream.

## Known limitation

Polygon now buys no speed from a coarse step — its geometry must stay dense. Getting that back means decimating the **painting** while keeping the geometry exact, which is a separate change rather than something to fold in here.

## Two things the original symptoms turned out not to be

- **The four large unpainted regions are not a rasterisation fault.** Every pixel lies 147–207 px from the centreline against a 150.7 px brush radius — the brush never swept them; they're loop interiors. An independent line drawer reproduces them exactly.
- **`CLAUDE.md`'s standing hypothesis is wrong** — wedges opening between spokes that fan out faster than the border sampling. Consecutive border samples are at most **1.23 px** apart, p99 **0.58**. Worth rewriting that section separately.

## Verification

Release, Debug (`-Werror`) and nofeatures build; `ctest` 8/8; `cycles 0`, `layering_violations 184`; module boundaries hold. GUI-validated by the maintainer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
