### PR TITLE
Fix #1145: colorout keyed the pipeline cache on a heap address

### DIFF
--- a/src/colorprofiles/colorspaces.c
+++ b/src/colorprofiles/colorspaces.c
@@ -161,6 +161,9 @@ cmsCIEXYZTRIPLE Rec709_Primaries_Prequantized;
  * notification is dropped -- correct for a headless run, where nothing is watching a monitor. */
 static dt_colorspaces_profile_changed_handler_t _profile_changed_handler = NULL;
 
+/* Defined next to the counter it advances, in the settings block below. */
+static void _advance_settings_generation(void);
+
 void dt_colorspaces_set_profile_changed_handler(dt_colorspaces_profile_changed_handler_t handler)
 {
   _profile_changed_handler = handler;
@@ -173,6 +176,15 @@ static void _notify_profile_changed(void)
    * monitor's matrices and tone curves indefinitely -- silently, since every hash and ROI
    * in the chain stayed consistent. */
   dt_colorspaces_invalidate_display_profile_memo();
+
+  /* The DISPLAY entry's identity -- DT_COLORSPACE_DISPLAY, no filename -- is exactly what it
+   * was a moment ago; only the bytes behind that name changed. So a consumer keyed on the
+   * profile's NAME cannot tell that anything happened, and would go on serving pixels rendered
+   * through the previous monitor's profile. The generation is the one thing that can say
+   * "same name, different profile", which is why a prepared conversion folds it into its
+   * identity (colorprofiles/conversion.c) and why the counter is advanced here and not only
+   * by the setters. */
+  _advance_settings_generation();
 
   if(_profile_changed_handler) _profile_changed_handler();
 }
@@ -1263,6 +1275,15 @@ static dt_colorspaces_t *dt_colorspaces_get_global(void)
 
 static pthread_rwlock_t _settings_lock = PTHREAD_RWLOCK_INITIALIZER;
 static uint64_t _settings_generation = 0;
+
+/* Both callers of _notify_profile_changed() release _transforms_lock before calling it, so this
+ * takes no lock but its own -- and the settings lock is the INNER one either way. */
+static void _advance_settings_generation(void)
+{
+  pthread_rwlock_wrlock(&_settings_lock);
+  _settings_generation++;
+  pthread_rwlock_unlock(&_settings_lock);
+}
 
 void dt_colorprofiles_get_settings(dt_colorprofiles_settings_t *const out)
 {

--- a/src/colorprofiles/conversion.c
+++ b/src/colorprofiles/conversion.c
@@ -21,6 +21,7 @@
 #include "colorprofiles/iop_profile.h"
 
 #include "common/colorspaces_inline_conversions.h"
+#include "common/hash.h"
 #include "common/logging.h"
 #include "system/macros.h"
 #include "system/mem_alloc.h"
@@ -80,6 +81,9 @@ struct dt_colorspaces_conversion_t
    * practice is the quantised soft-proof copy. */
   cmsHPROFILE owned[1];
   int n_owned;
+
+  /* What this conversion IS, as a number: see dt_colorspaces_conversion_identity(). */
+  uint64_t identity;
 };
 
 /* Some built-in profiles carry a parametric TRC, which lcms2 reproduces exactly: a round trip
@@ -124,6 +128,35 @@ static cmsHPROFILE _resolve_endpoint(const dt_colorspaces_endpoint_t *const endp
 
   *entry = found;
   return found->profile;
+}
+
+/* Fold one endpoint's identity into a running hash.
+ *
+ * `entry' is the registered profile the endpoint resolved to, or NULL when the caller supplied
+ * an already-resolved, image-owned profile (dt_colorspaces_endpoint_t::resolved) -- in that case
+ * the endpoint's own type/filename is the only name that profile has. Such a profile belongs to
+ * ONE image, so two images' embedded profiles share a name here; that is harmless because the
+ * rest of a pipeline's cache key already separates two images, and it is the caller's business
+ * either way. */
+static uint64_t _hash_endpoint(uint64_t hash, const dt_colorspaces_endpoint_t *const endpoint,
+                               const dt_colorspaces_color_profile_t *const entry)
+{
+  dt_colorspaces_color_profile_type_t type = DT_COLORSPACE_NONE;
+  const char *filename = "";
+
+  if(!IS_NULL_PTR(entry))
+  {
+    type = entry->type;
+    filename = entry->filename;
+  }
+  else if(!IS_NULL_PTR(endpoint))
+  {
+    type = endpoint->type;
+    if(!IS_NULL_PTR(endpoint->filename)) filename = endpoint->filename;
+  }
+
+  hash = dt_hash(hash, (const char *)&type, sizeof(type));
+  return dt_hash(hash, filename, strlen(filename));
 }
 
 /* lcms2 pixel format for a handle. colorin used to derive this from cmsGetColorSpace() and
@@ -181,6 +214,12 @@ dt_colorspaces_conversion_t *dt_colorspaces_prepare_conversion(const dt_colorspa
 
   dt_colorspaces_conversion_t *conversion = calloc(1, sizeof(dt_colorspaces_conversion_t));
   if(IS_NULL_PTR(conversion)) return NULL;
+
+  /* Read before any profile entry lock is taken, so this never nests the settings lock inside
+   * one. It is folded into the identity below: it is the only thing that distinguishes two
+   * monitor profiles, which share the name DT_COLORSPACE_DISPLAY and differ only in content. */
+  dt_colorprofiles_settings_t settings;
+  dt_colorprofiles_get_settings(&settings);
 
   conversion->from_type = from->type;
   conversion->to_type = to->type;
@@ -357,6 +396,54 @@ dt_colorspaces_conversion_t *dt_colorspaces_prepare_conversion(const dt_colorspa
     if(IS_NULL_PTR(conversion->xform)) goto give_up;
   }
 
+  /* The identity of what was actually built -- see dt_colorspaces_conversion_identity(). It is
+   * computed HERE, from the finished object, rather than from the arguments: the branches above
+   * drop proofing when quantising fails and fall back from the matrix path to lcms2, so what the
+   * caller asked for and what it gets are not always the same thing, and it is what it GETS that
+   * decides the pixels.
+   *
+   * The curve LUTs are deliberately not hashed. They run to DT_CONVERSION_LUT_SAMPLES entries
+   * per channel -- 1.5 MB across both stages, on a path that runs once per pipeline resync --
+   * and they are a pure function of the profiles named just above, whose every mutation is
+   * either a new name or a new generation. The matrices are hashed because they are small and
+   * because doing so costs nothing. */
+  {
+    uint64_t identity = 5381;
+    identity = _hash_endpoint(identity, from, from_entry);
+    identity = _hash_endpoint(identity, to, to_entry);
+    identity = _hash_endpoint(identity, clip, clip_entry);
+    identity = _hash_endpoint(identity, proof, proof_entry);
+    identity = dt_hash(identity, (const char *)&intent, sizeof(intent));
+    identity = dt_hash(identity, (const char *)&flags, sizeof(flags));
+    identity = dt_hash(identity, (const char *)&settings.generation, sizeof(settings.generation));
+
+    identity = dt_hash(identity, (const char *)&conversion->is_matrix, sizeof(conversion->is_matrix));
+    identity = dt_hash(identity, (const char *)&conversion->has_clipping, sizeof(conversion->has_clipping));
+    identity = dt_hash(identity, (const char *)&conversion->gamutcheck, sizeof(conversion->gamutcheck));
+    identity = dt_hash(identity, (const char *)&conversion->have_source_matrix,
+                       sizeof(conversion->have_source_matrix));
+    identity = dt_hash(identity, (const char *)conversion->matrix, sizeof(conversion->matrix));
+    identity = dt_hash(identity, (const char *)conversion->clip_matrix, sizeof(conversion->clip_matrix));
+    identity = dt_hash(identity, (const char *)conversion->source_matrix, sizeof(conversion->source_matrix));
+    identity = dt_hash(identity, (const char *)&conversion->nonlinear_source,
+                       sizeof(conversion->nonlinear_source));
+    identity = dt_hash(identity, (const char *)&conversion->nonlinear_target,
+                       sizeof(conversion->nonlinear_target));
+    identity = dt_hash(identity, (const char *)conversion->coeffs_source, sizeof(conversion->coeffs_source));
+    identity = dt_hash(identity, (const char *)conversion->coeffs_target, sizeof(conversion->coeffs_target));
+
+    /* Whether a curve stage exists at all is structure, not content. */
+    for(int c = 0; c < 3; c++)
+    {
+      const gboolean has_source = !IS_NULL_PTR(conversion->lut_source[c]);
+      const gboolean has_target = !IS_NULL_PTR(conversion->lut_target[c]);
+      identity = dt_hash(identity, (const char *)&has_source, sizeof(has_source));
+      identity = dt_hash(identity, (const char *)&has_target, sizeof(has_target));
+    }
+
+    conversion->identity = identity;
+  }
+
   dt_colorspaces_unlock_profile(proof_entry);
   dt_colorspaces_unlock_profile(clip_entry);
   dt_colorspaces_unlock_profile(to_entry);
@@ -372,6 +459,11 @@ give_up:
   dt_colorspaces_unlock_profile(from_entry);
   dt_colorspaces_free_conversion(&conversion);
   return NULL;
+}
+
+uint64_t dt_colorspaces_conversion_identity(const dt_colorspaces_conversion_t *const conversion)
+{
+  return IS_NULL_PTR(conversion) ? 0 : conversion->identity;
 }
 
 void dt_colorspaces_free_conversion(dt_colorspaces_conversion_t **conversion)

--- a/src/colorprofiles/conversion.h
+++ b/src/colorprofiles/conversion.h
@@ -56,6 +56,7 @@
 
 #include <glib.h>
 #include <stddef.h>
+#include <stdint.h>
 
 #include "colorprofiles/profile_types.h"
 #include "math/matrices.h"
@@ -229,6 +230,28 @@ void dt_colorspaces_apply_conversion_hooked(const dt_colorspaces_conversion_t *c
  * apply on the host. A caller that finds itself running a matrix multiply from
  * dt_colorspaces_conversion_matrix() on the CPU has taken the wrong entry point.
  */
+
+/**
+ * @brief What this conversion IS, as a number: equal for two conversions that render the same
+ * pixels, different otherwise.
+ *
+ * @details For a caller that folds its rendering state into a pipeline cache key. The prepared
+ * conversion is opaque and lives on the heap, so a caller holding one has nothing else to
+ * offer a hash but its ADDRESS -- and an address describes no pixels. It both MISSES (the
+ * allocator hands back a different address for an identical conversion, re-keying the whole
+ * downstream chain to recompute pixels that cannot have moved) and, worse, HITS FALSELY (it
+ * hands back the SAME address for a conversion built from a different profile or intent, and
+ * the cache serves the previous one's pixels under the new key).
+ *
+ * This is the fix for both: it names the profiles the conversion resolved to, the intent and
+ * flags it was built with, the shape it settled on, its matrices, and the colour-management
+ * settings generation -- which is what separates two monitor profiles, since both are called
+ * DT_COLORSPACE_DISPLAY and differ only in their bytes.
+ *
+ * @return 0 for a NULL conversion, which is a legitimate state (a nop module) and must key
+ *         differently from any prepared one.
+ */
+uint64_t dt_colorspaces_conversion_identity(const dt_colorspaces_conversion_t *const conversion);
 
 /**
  * @brief Whether the conversion reduced to matrices and curves, and can therefore be run by a

--- a/src/iop/colorout.c
+++ b/src/iop/colorout.c
@@ -95,6 +95,15 @@ typedef struct dt_iop_colorout_data_t
 {
   dt_colorspaces_color_profile_type_t type;
   dt_colorspaces_color_mode_t mode;
+  /* Identity of the conversion below, and the only thing in this struct that describes it.
+   * runtime_data_hash() folds this prefix into the pipeline cache key, and the conversion is
+   * opaque heap state whose address says nothing about the pixels it produces -- so the
+   * address is deliberately kept OUT of the hashed prefix and its identity carried here
+   * instead. See dt_colorspaces_conversion_identity(). */
+  uint64_t conversion_id;
+
+  /* --- runtime pointers, deliberately after the hashed prefix (see init_pipe) --- */
+
   /* The whole of "how do we get from the pipeline's working space to the output space" --
    * matrices, tone curves, extrapolation fits, or an lcms2 proofing transform. Built by
    * colorprofiles/conversion.c, which is where the lifetime and locking rules for the
@@ -414,6 +423,10 @@ void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pix
   dt_iop_set_cache_bypass(self, (d->mode != DT_PROFILE_NORMAL));
 
   dt_colorspaces_free_conversion(&d->conversion);
+  /* Cleared here rather than beside each prepare below, so that every path which returns
+   * without building a conversion -- the virtual pipe, a Lab output -- leaves a hashed prefix
+   * that says so. */
+  d->conversion_id = 0;
   piece->process_cl_ready = 1;
 
   /* if we are exporting then check and set usage of override profile */
@@ -577,6 +590,9 @@ void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pix
                                                       softproofing ? &proof : NULL, out_intent, flags);
   }
 
+  /* After BOTH prepare attempts: what the sRGB fallback built is what will render. */
+  d->conversion_id = dt_colorspaces_conversion_identity(d->conversion);
+
   dt_colorspaces_free_image_profile(image_output);
 
   /* Only the vectorised branch has a kernel. The lcms2 one is host-only, and saying so here
@@ -598,7 +614,8 @@ gboolean runtime_data_hash(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pip
 void init_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
 {
   piece->data = dt_calloc_align(sizeof(dt_iop_colorout_data_t));
-  piece->data_size = sizeof(dt_iop_colorout_data_t);
+  // Hash the rendering contract, stopping before the runtime pointer.
+  piece->data_size = G_STRUCT_OFFSET(dt_iop_colorout_data_t, conversion);
 }
 
 void cleanup_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)

--- a/src/iop/iop_api.h
+++ b/src/iop/iop_api.h
@@ -180,7 +180,22 @@ OPTIONAL(void, reload_defaults, struct dt_iop_module_t *self);
  */
 DEFAULT(gboolean, has_defaults, struct dt_iop_module_t *self);
 
-/** whether commit_params() seals extra effective runtime state into piece->data that must be part of the cache hash */
+/** whether commit_params() seals extra effective runtime state into piece->data that must be part of the cache hash.
+ *
+ *  Returning TRUE makes dt_iop_commit_params() hash the first piece->data_size bytes of
+ *  piece->data BLINDLY. Those bytes must therefore be CONTENT, and piece->data_size must stop
+ *  before the first pointer in the struct -- keep runtime pointers last and set
+ *  `piece->data_size = G_STRUCT_OFFSET(<data_t>, <first pointer>)` in init_pipe(), as
+ *  iop/colorbalancergb.c and iop/colorout.c both do.
+ *
+ *  A pointer in the hashed prefix is wrong in both directions, and the second one is silent: a
+ *  re-allocation gives a new address for identical state, re-keying the whole downstream chain
+ *  to recompute pixels that cannot have moved; and the allocator handing the SAME address back
+ *  for different state makes the cache serve the previous state's pixels under the new key.
+ *  That is issue #1145: colorout's rendering state moved behind an opaque pointer, its hashed
+ *  prefix became an address, and every darkroom pipeline resync recomputed colorout, dither and
+ *  gamma. A module whose state is opaque must have its owner publish an identity for it
+ *  (dt_colorspaces_conversion_identity()) and hash THAT. */
 DEFAULT(gboolean, runtime_data_hash, struct dt_iop_module_t *self, struct dt_dev_pixelpipe_t *pipe,
                                      const struct dt_dev_pixelpipe_iop_t *piece);
 


### PR DESCRIPTION
Fixes #1145.

## The symptom

Opening an image that has a history recomputes the last modules of the preview pipe several
times over, once per pipeline resync, for pixels that cannot have changed.

## What was measured

Reproduced with an isolated configdir and `-d params -d perf`. On every resync, each module
committed a **byte-identical** hash — `basebuffer`, `initialscale`, `finalscale`, `overexposed`,
`rawoverexposed`, `gamma` — except `colorout`, which produced a different one every time:

```
97516629256517333 → 14115426125678199689 → 15753924393425185388 → 5348125940775127469 → …
```

The correlation with the reprocessing is 1:1. When the hash happened to repeat, the pipe served
the cacheline and printed **no processing line at all**; when it changed, colorout, dither and
gamma all ran again. The resyncs themselves are ordinary startup churn and are free when the
hash is stable.

## Root cause

`runtime_data_hash()` returning TRUE makes `dt_iop_commit_params()` hash the first `data_size`
bytes of `piece->data` **blindly**, so those bytes have to be content. They were: the struct
held the LUTs, the matrix and the extrapolation coefficients inline.

Moving the module onto a prepared conversion (0f687c2ccd, 2026-08-09 — hence "since a couple of
days") reduced it to `{ type, mode, conversion* }`. For the preview pipe `mode` is pinned to
`NORMAL` and `type` is the display profile, so the only thing left varying in the hashed bytes
was the address of a `calloc()` the module frees and rebuilds on every commit.

## Why this is not only a performance bug

An address is wrong in both directions, and the second way is silent:

- a **new** address for identical state re-keys the whole downstream chain — the reported symptom;
- the allocator handing back the **same** address for state built from a different profile or
  intent makes the cache serve the previous conversion's pixels under the new key.

The churn is what has been hiding that second half. Fixing only the churn would have exposed it,
which is why both are addressed here.

## The fix

`colorout` now follows the convention `iop/colorbalancergb.c` already documents: runtime pointers
last, `piece->data_size` stopping before them via `G_STRUCT_OFFSET`, and the conversion
represented in the hashed prefix by its **identity** rather than its address.

`dt_colorspaces_conversion_identity()` is new: the conversion is opaque, so only the module that
owns it can say what it is. It names the profiles the conversion actually resolved to, the intent
and flags, the shape it settled on, and its matrices — computed from the *finished* object, since
preparation drops proofing when quantising fails and falls back from the matrix path to lcms2.
The curve LUTs are deliberately excluded: 1.5 MB across both stages on a per-resync path, and a
pure function of the profiles already named.

That exclusion needed one thing to be true which was not. `DT_COLORSPACE_DISPLAY` is the only
handle in the profile list replaced at runtime, and a monitor change swaps it **in place** under
an unchanged name. `_notify_profile_changed()` now advances the settings generation — the one
thing that can say "same name, different profile" — and the identity folds it in.

The rule is written on the `runtime_data_hash()` declaration so the next module that grows a
pointer has somewhere to have read it.

## Verification

- Darkroom entry on `_DSC9410.NEF`: **six** colorout-only recomputes after the initial render →
  **zero**. The repeats that remain each begin at `initialscale` — real ROI changes as the window
  settles, present before this change too.
- Export A/B against the pre-fix build, `--disable-opencl`, pixel arrays compared (not bytes):
  **0 differing pixels of 72,480,768**, max delta 0.
- `pragma_once_to_guards.py --verify` clean; `include_graph.py --summary` cycles 0, layering
  violations 184 (unchanged); `check_module_boundaries.sh` all ratchets held.

## Note for review

The remaining two colorout runs per darkroom entry are ROI changes during window layout, not
this bug. They are visible in the before-log too and are out of scope here.

