### PR TITLE
Fix #1157: a stale viewport latch could plan the terminal frame

### DIFF
--- a/doc/gui-sizing.md
+++ b/doc/gui-sizing.md
@@ -1,0 +1,110 @@
+# GUI sizing without a full pixel-less pipeline — analysis and plan
+
+Written while fixing #1157, whose root cause is entangled with the virtual pipe's cost.
+Status: analysis + recommendation. Nothing here is implemented except where noted.
+
+## What the virtual pipe is, and what it costs
+
+`dev->virtual_pipe` is a full clone of the module stack — every one of the ~95 IOPs gets a
+node, params committed from history — that never processes a pixel. It exists so the GUI
+thread can answer two questions synchronously, without waiting for a worker pipe:
+
+1. **"How big is the processed image?"** — `dt_dev_get_thumbnail_size()` resyncs it and folds
+   `modify_roi_out` over its nodes (`dt_dev_pixelpipe_get_roi_out`), publishing the result to
+   the geometry record and the ROI request.
+2. **"Where is this image point on screen?"** (and back) — `dt_dev_distort_transform_plus()` /
+   `_backtransform_plus()` walk its pieces calling each distorting module's transform, for
+   every overlay: mask outlines, crop handles, ashift lines, liquify widgets, the pointer.
+
+Measured on a darkroom open of a 6016×4016 NEF (`-d perf`, isolated configdir):
+
+- first virtual resync: **0.329 s (2.06 s CPU)** on the GUI thread;
+- steady-state resync (per history commit, inside the throttled drain): **0.10–0.20 s**;
+- of the steady-state 0.10 s, **≈73 ms is two modules building pixel state the virtual pipe
+  can never read**: `colorequal`'s CLUT (55–86 ms) and `colorprimaries`' CLUT (17–22 ms).
+  `lut3d`'s `commit_params` reads its LUT **from disk**. All of that is paid on the GUI
+  thread, per commit, for a pipe that renders nothing.
+
+## What actually consumes it (audited)
+
+- `dt_dev_get_thumbnail_size()` — the ROI fold. Needs `piece->enabled` plus committed params
+  for the **15 of 95** modules that implement `modify_roi_out` (crop, clipping, ashift, lens,
+  flip, liquify, borders, rotatepixels, scalepixels, spots, retouch, demosaic, rawprepare,
+  basebuffer, and the template).
+- The transform walkers — need committed params for modules with `distort_transform`, a
+  subset of the same 15.
+- Module GUIs asking for **their own piece** (`dt_dev_distort_get_iop_pipe(virtual, self)`:
+  graduatednd, ashift, crop, clipping, …) — every audited site reads only **dimensions**
+  (`buf_in`/`buf_out`, `iwidth`/`iheight`), which come from the ROI fold, never
+  `piece->data`. `graduatednd` is the reason a *node-filtered* pipe is wrong: it is not a
+  geometry module, but its overlay needs its piece's dims, so every module must keep a node.
+- `dev_history.c`'s `last_history_item` bookkeeping — pointer identity only.
+
+**Nobody reads pixel state from the virtual pipe.** `iop/colorout.c` already encodes this as
+a per-module early-out: on the virtual pipe it commits `d->type = DT_COLORSPACE_LAB` and
+returns before building any LCMS transform.
+
+## Why this is #1157's accomplice
+
+The throttled history drain runs, on the GUI thread: shutdown → history write → pipe flags →
+**virtual resync (0.1–0.3 s)** → publish of the matching ROI request. Everything between the
+history write and the publish is a window in which the worker can sync the new history while
+still holding a latch on the old geometry. The fix for #1157 (publish re-arms the pipes; the
+worker re-checks its latch) makes a mixed frame transient instead of terminal — but the
+window itself IS the virtual resync's duration. Shrink or remove it and the residual
+one-frame flash goes with it.
+
+## Options
+
+### A. Keep the pipe, stop paying for pixels (small, incremental, recommended first)
+
+Apply the `colorout` pattern to the measured offenders: `commit_params` early-outs on
+`pipe == dev->virtual_pipe` for `colorequal`, `colorprimaries`, `lut3d` (and any module a
+`-d perf` pass shows building derived pixel state). Each early-out must still commit the
+fields its own `output_format()`/contract logic reads — that is why this is per-module and
+audited, not a blanket skip: a blanket "skip commit_params for non-geometry modules" leaves
+`piece->data` zeroed, and `dt_dev_pixelpipe_propagate_formats()` then reads garbage contracts
+and can disable different modules on the virtual pipe than on the real ones — silent geometry
+divergence.
+
+Expected: steady-state virtual resync 0.10–0.20 s → **~0.03–0.05 s**. The #1157 residual
+window shrinks proportionally. No consumer can notice: none reads what is skipped.
+
+### B. Worker-authoritative sizes (the structural fix; next tranche)
+
+The worker already computes the processed size at the end of **every** resync
+(`dt_dev_pixelpipe_get_roi_out` at the tail of `dt_dev_pixelpipe_change()`); the virtual pipe
+recomputes the same number on the GUI thread so it is available *immediately*. Invert the
+authority:
+
+- the worker publishes `(history_hash, processed_width, processed_height)` as one seqlock
+  record after each resync — history and its geometry become **atomic**, which is the
+  invariant #1157 was missing;
+- `dt_dev_get_thumbnail_size()` stops resyncing the virtual pipe for sizes and shrinks to
+  "derive and publish the request from the latest worker geometry";
+- the drain's flag→publish gap collapses to microseconds;
+- the virtual pipe remains only for transforms and own-piece dims, resynced **outside** the
+  commit path (lazily on first overlay use, or where the drain does it today — but no longer
+  blocking the publish).
+
+Cost: the fit scale for a geometry commit is derived one worker-resync later (~0.15 s). With
+the #1157 flags this is invisible — the worker re-plans as soon as the publish lands, which
+is exactly what happens today anyway for the *pixels*; only the number arrives with them
+instead of before them. Risk: every consumer of "processed size" must tolerate reading a
+value one commit older than `dev->history` for that window — the audit of those consumers is
+the real work of this tranche.
+
+### C. A geometry service instead of a pipe (Qt-horizon)
+
+Transforms as data: each of the 15 geometry modules publishes, at commit time, a serialized
+transform (crop rect, homography, lens polynomial, …) into a per-image list; the GUI composes
+transforms and sizes from the list with no pipe, no pieces, no nodes. Kills the virtual pipe
+entirely and makes overlay math backend-independent — the shape a Qt frontend wants. This is
+a refactor of all 15 modules plus the mask/overlay call sites; not a bug-fix-adjacent change.
+
+## Recommendation
+
+A now (three audited early-outs, verifiable from one `-d perf` run), B as its own tranche
+with the consumer audit, C when the frontend split gets there. A and B compose: A makes the
+remaining GUI-thread resync cheap for the transforms that stay, B removes it from the sizing
+path where it does the #1157-class damage.

--- a/src/develop/dev_roi_request.c
+++ b/src/develop/dev_roi_request.c
@@ -182,10 +182,58 @@ uint64_t dt_dev_roi_request_publish(dt_develop_t *dev)
   dt_dev_pixelpipe_set_mask_rasterization_step(dev->pipe, main_step);
   dt_dev_pixelpipe_set_mask_rasterization_step(dev->preview_pipe, preview_step);
 
+  /* Which pipes' PLANS does this change invalidate? Decided from the old payload while we still
+   * hold it. The preview plans from (natural_scale, processed, box) only -- _update_darkroom_roi()
+   * ignores scaling and centre for it -- so a zoom or pan tick must not cost a preview run. The
+   * main pipe plans from all of it. `valid' flipping is a plan change for both: the first usable
+   * record is what lets a pipe plan at all. */
+  const dt_dev_roi_request_t previous = dev->roi_request.value;
+  const gboolean preview_plan_changed = previous.processed_width != next.processed_width
+                                        || previous.processed_height != next.processed_height
+                                        || previous.box_width != next.box_width
+                                        || previous.box_height != next.box_height
+                                        || previous.natural_scale != next.natural_scale
+                                        || previous.valid != next.valid;
+
   next.generation = published + 2;   // stays even: the store's counter is the odd/even flag
   dt_atomic_set_uint64(&dev->roi_request.generation, published + 1);
   dev->roi_request.value = next;
   dt_atomic_set_uint64(&dev->roi_request.generation, published + 2);
+
+  /* A record nobody replans from is a lie waiting to be displayed. This is the fix for #1157:
+   * the darkroom worker latches this record ONCE per iteration, and its history resync loop
+   * spans 100-400 ms -- so a history commit whose SYNCH flag lands inside that loop gets its
+   * flag consumed by a run still planned from the PREVIOUS latch. The killswitch raised with
+   * the flag does not save that run either: the worker resets it when processing starts. The
+   * run then renders the new history into the old geometry -- the border-clamped smear of
+   * issue #1157 -- publishes it, and, since this function used to flag nothing, NOTHING forced
+   * a corrective render: the frame was terminal until the user zoomed.
+   *
+   * So the publisher re-arms the pipes itself, which also makes the viewport setters' callers'
+   * manual flagging (dt_dev_pixelpipe_change_zoom_main, dt_dev_configure_real) a guarantee
+   * instead of a convention.
+   *
+   * ORDER MATTERS: the flags are raised AFTER the seqlock store above completes. A worker woken
+   * by the flag re-latches, and must not be able to re-latch the old record -- flag observed
+   * implies store visible. Raising them before the store would recreate the bug one level down.
+   *
+   * The shutdown is the same killswitch _change_pipe() raises: an in-flight run planned from
+   * the previous record is superseded and should stop wasting the device. */
+  if(dev->gui_attached)
+  {
+    if(preview_plan_changed && !IS_NULL_PTR(dev->preview_pipe))
+    {
+      dt_dev_pixelpipe_or_changed(dev->preview_pipe, DT_DEV_PIPE_ZOOMED);
+      dt_atomic_set_int(&dev->preview_pipe->shutdown, TRUE);
+    }
+    /* Any payload change alters the main plan: _payload_equal() already returned FALSE, and
+     * every field it compares is either a main-plan input or derived from one. */
+    if(!IS_NULL_PTR(dev->pipe))
+    {
+      dt_dev_pixelpipe_or_changed(dev->pipe, DT_DEV_PIPE_ZOOMED);
+      dt_atomic_set_int(&dev->pipe->shutdown, TRUE);
+    }
+  }
 
   return next.generation;
 }

--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -680,19 +680,41 @@ void dt_dev_darkroom_pipeline(dt_develop_t *dev)
       // The resync stage above synchronized history, planned the ROI and advertised the matching
       // final global hash. We process the exact state it committed, using pipe_roi[i]: that is what
       // dt_dev_pixelpipe_process() recomputes its hash from, so the cacheline it publishes always
-      // carries the hash already announced to GUI consumers. A change that landed after the resync
-      // (zoom/pan, a fresh history commit) does NOT invalidate this run — it always also raised the
-      // killswitch (`_change_pipe()` sets shutdown together with the changed flag), so the run below
-      // aborts cleanly and the next loop iteration resyncs, re-advertises and reprocesses the new
-      // state. We must NOT skip on a set changed flag here: every darkroom configure-event flags the
-      // preview pipe ZOOMED, so on an image switch (which re-lays-out the view) skipping would starve
-      // the preview and leave navigation/scopes blank.
+      // carries the hash already announced to GUI consumers. A change that lands after this point
+      // raises the killswitch together with its changed flag (`_change_pipe()`, and
+      // dt_dev_roi_request_publish() does the same on a payload change), so the run below aborts
+      // and the next loop iteration resyncs, re-advertises and reprocesses the new state. We must
+      // NOT skip on a set changed flag here: every darkroom configure-event flags the preview pipe
+      // ZOOMED, so on an image switch (which re-lays-out the view) skipping would starve the
+      // preview and leave navigation/scopes blank.
+      //
+      // A change that landed BETWEEN this iteration's latch and this point is another matter, and
+      // the check below is the second half of the #1157 fix. The resync's while(changed) loop
+      // spans 100-400 ms and consumes whatever flags land inside it, syncing their history -- but
+      // the ROI was then planned from THIS ITERATION'S latch, taken before any of it. Their
+      // killswitch does not save the run either, since the reset a few lines down would swallow
+      // it. Rendering the consumed history into the stale latched geometry is how a crop Apply
+      // produced a border-clamped smear that nothing ever corrected. So: if the published record
+      // has moved past the latch, this plan is dead. Re-flag (the flag may have been consumed) and
+      // skip the run; the next iteration re-latches and replans from the current record. This
+      // cannot starve: the generation only advances when a GUI publish actually changed the
+      // payload, so a quiet viewport lets the very next iteration through.
+      const dt_dev_roi_request_t current_request = dt_dev_roi_request_get(dev);
+      if(current_request.generation != latched.generation)
+      {
+        dt_dev_pixelpipe_or_changed(pipe, DT_DEV_PIPE_ZOOMED);
+        continue;
+      }
+
       dt_print(DT_DEBUG_PIPE | DT_DEBUG_DEV, "PIPE %s needs update\n", pipe->type == DT_DEV_PIXELPIPE_FULL ? "full" : "preview");
 
       dt_pthread_mutex_lock(&pipe->busy_mutex);
       pipe->processing = 1;
 
-      // We are starting fresh, reset the killswitch signal.
+      // We are starting fresh, reset the killswitch signal. Safe only because the staleness
+      // check above ran after the resync: any killswitch this discards belonged to a change
+      // whose flag either survives (raised after the resync loop exited) or whose publish
+      // moved the generation (caught above). Do not move this reset earlier.
       dt_atomic_set_int(&pipe->shutdown, FALSE);
 
       /**


### PR DESCRIPTION
Fixes #1157.

## Symptom

Crop Apply (and occasionally Edit entry) intermittently leaves the centre view smeared until the
user zooms. The screenshot's artifact is diagnostic: the right band is the last valid **column**
replicated (horizontal streaks), the bottom band the last valid **row** (vertical streaks) — a
resampler clamping at the edge of its valid source. No display-path scaling produces that
signature (`dt_dev_render_locked_surface` draws 1:1; the preview fallback uses one uniform
`cairo_scale`; the only `EXTEND_PAD` in the tree, `dt_cairo_rescale_surface`, has no callers).
The published backbuf itself contains the smear: its **content** and its **plan** came from two
different states.

## The interleaving

The throttled history drain (`dt_dev_history_commit_item_now`, GUI thread — `processing/timeout`
defaults to 200 ms, so all of this runs after the Apply click returns) does, in order:

1. shutdown both pipes;
2. write history + hash;
3. flag the pipes — which also **synchronously resyncs the virtual pipe on the GUI thread,
   100–300 ms**;
4. only then publish the matching ROI request (`_commit_gui` → `dt_dev_get_thumbnail_size`).

The worker latches the request **once per iteration**, and its `while(changed)` resync loop spans
100–400 ms. When step 3 lands inside that loop, the loop's re-check consumes the flag and syncs
the **new** history — while `_update_darkroom_roi` then plans from the latch taken before any of
it: the **old** geometry. Step 1's killswitch does not save the run: the worker resets
`pipe->shutdown` at process start. The mixed frame publishes — new-crop content clamped into an
uncropped plan. And since `dt_dev_roi_request_publish` flagged **nothing**, step 4 left no pipe
dirty: the frame was **terminal** until zoom raised `DT_DEV_PIPE_ZOOMED`. Exactly the report,
including "rectifies by simply zooming".

## The fix

1. **`dt_dev_roi_request_publish` re-arms the pipes itself** when the payload changed — ZOOMED +
   killswitch, raised **after** the seqlock store completes so a worker woken by the flag can
   only re-latch the new record. Per-plan, not blanket: the preview plans from
   `(natural_scale, processed, box)` only, so zoom/pan ticks still cost no preview run. This also
   turns the manual flagging conventions (`dt_dev_pixelpipe_change_zoom_main`,
   `dt_dev_configure_real`) into a guarantee.
2. **The worker re-checks the latch generation immediately before each pipe's process** (and
   before the killswitch reset). Stale → re-flag and skip; next iteration re-latches and replans.
   Cannot starve: the generation only advances when a publish actually changed the payload.

## Known residual, by construction

A run that starts *and finishes* inside the drain's step 2→4 gap (the GUI-thread virtual-pipe
resync) still publishes one mixed frame — now corrected about one iteration later by the
publish's flag, instead of standing forever. Closing even that requires removing the virtual-pipe
resync from between the two publications — the GUI-sizing redesign discussed in the issue, not a
patch.

## Verification

- 40 s darkroom-open runs (isolated configdir), fixed vs pre-fix binary: **no new resyncs or
  processes** — the idle-time resync bursts exist in both logs and are larger in the pre-fix run;
  the new flags fire only on generation advances (no storm, activity settles).
- The race itself is timing-dependent (reporter: 1-in-12); the mechanism is established from the
  code with every step cited above. A deterministic GUI-automation repro (Xvfb + xdotool) is
  possible if wanted — those tools aren't installed here.
- `include_graph.py`: cycles 0, layering 184 (unchanged); `check_module_boundaries.sh` all held;
  `pragma_once_to_guards.py --verify` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
