### PR TITLE
Geometry service G2: the skeleton, running in shadow

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -183,6 +183,7 @@ FILE(GLOB SOURCE_FILES
   "control/signal.c"
   "develop/develop.c"
   "develop/dev_geometry.c"
+  "develop/geometry/geometry.c"
   "develop/dev_viewport.c"
   "develop/dev_roi_request.c"
   "develop/gui_throttle.c"

--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -391,15 +391,25 @@ int dt_dev_get_thumbnail_size(dt_develop_t *dev)
                                &processed_width, &processed_height);
   dt_dev_geometry_set_processed_size(dev, processed_width, processed_height);
 
+  // Derive and publish everything the pipes plan from, as one record.
+  dt_dev_roi_request_publish(dev);
+
   /* Rebuild the geometry chain from the same modules and history the fold above just used, and
    * hold it against the answer the pipe produced. It publishes nothing and nothing consumes it
    * yet (G2): while its roster is incomplete it reports which modules still owe it a record,
-   * per image, and once complete it reports divergence. Both under `-d dev'. */
+   * per image, and once complete it reports divergence. Both under `-d dev'.
+   *
+   * STRICTLY AFTER the two publications above, and never between them. Those two are one
+   * atomic-looking update to a consumer: the first moves the geometry record to the new
+   * processed size, the second moves the ROI request to match AND flags the pipes to replan
+   * (dt_dev_roi_request_publish, since the fix for #1157). Anything inserted between them
+   * widens the window in which the darkroom worker can latch the OLD request against ALREADY
+   * NEW history -- which is precisely the mixed frame #1157 is about, and this rebuild is not
+   * cheap enough to be invisible there: it costs milliseconds once a module with a real lookup
+   * publishes a record, against a worker that naps in tens of milliseconds. A shadow observer
+   * must not sit inside the update it is observing. */
   dt_geometry_chain_rebuild(dev);
   dt_geometry_shadow_check_size(dev, processed_width, processed_height);
-
-  // Derive and publish everything the pipes plan from, as one record.
-  dt_dev_roi_request_publish(dev);
 
 
   dt_dev_update_mouse_effect_radius(dev);

--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -86,6 +86,7 @@
 #include "develop/masks.h"
 #include "caches/pixelpipe_cache.h"
 #include "gui/application.h"
+#include "develop/geometry/geometry.h"
 #include "develop/gui_throttle.h"
 #include "libs/colorpicker.h"
 #include "widgets/label.h"
@@ -149,6 +150,11 @@ void dt_dev_init(dt_develop_t *dev, int32_t gui_attached)
     dt_dev_pixelpipe_init(dev->pipe, dev);
     dt_dev_pixelpipe_init_preview(dev->preview_pipe, dev);
     dt_dev_pixelpipe_init_preview(dev->virtual_pipe, dev);
+
+    /* The geometry chain runs beside the virtual pipe and will replace it (G2 skeleton --
+     * doc/geometry-service.md). GUI devs only: it answers GUI questions and is GUI-thread
+     * state, so a headless dev has nothing to do with one. */
+    dev->geometry_chain = dt_geometry_chain_new();
   }
 
   dt_dev_set_backbuf(&dev->raw_histogram, 0, 0, 0, -1, -1);
@@ -245,6 +251,8 @@ void dt_dev_cleanup(dt_develop_t *dev)
     dt_dev_pixelpipe_cleanup(dev->virtual_pipe);
     dt_free(dev->virtual_pipe);
   }
+  dt_geometry_chain_free(dev->geometry_chain);
+  dev->geometry_chain = NULL;
 
   dt_pthread_rwlock_wrlock(&dev->history_mutex);
   while(dev->history)
@@ -382,6 +390,13 @@ int dt_dev_get_thumbnail_size(dt_develop_t *dev)
   dt_dev_pixelpipe_get_roi_out(dev->virtual_pipe, raw_width, raw_height,
                                &processed_width, &processed_height);
   dt_dev_geometry_set_processed_size(dev, processed_width, processed_height);
+
+  /* Rebuild the geometry chain from the same modules and history the fold above just used, and
+   * hold it against the answer the pipe produced. It publishes nothing and nothing consumes it
+   * yet (G2): while its roster is incomplete it reports which modules still owe it a record,
+   * per image, and once complete it reports divergence. Both under `-d dev'. */
+  dt_geometry_chain_rebuild(dev);
+  dt_geometry_shadow_check_size(dev, processed_width, processed_height);
 
   // Derive and publish everything the pipes plan from, as one record.
   dt_dev_roi_request_publish(dev);

--- a/src/develop/develop.h
+++ b/src/develop/develop.h
@@ -463,6 +463,12 @@ typedef struct dt_develop_t
   gboolean mask_lock;
 
   cairo_surface_t *image_surface;
+
+  /* Composed geometry, GUI thread only: what dev->virtual_pipe is walked for today, as data.
+   * Appended at the end of this struct deliberately -- IOP plugins are compiled against this
+   * layout, so a field inserted anywhere else silently shifts what they read. See
+   * develop/geometry/geometry.h and doc/geometry-service.md. NULL on non-gui devs. */
+  struct dt_geometry_chain_t *geometry_chain;
 } dt_develop_t;
 
 static inline uint64_t dt_dev_get_history_hash(const dt_develop_t *dev)

--- a/src/develop/geometry/geometry.c
+++ b/src/develop/geometry/geometry.c
@@ -71,9 +71,16 @@ struct dt_geometry_chain_t
    * reporting "not ready", which would be true and useless. */
   GList *missing;   /**< gchar*, owned */
 
-  /* Query-time GUI state, published by dt_geometry_set_focus(). */
-  const struct dt_iop_module_t *focused;
-  gboolean focus_editing;
+  /* Query-time GUI state, published by dt_geometry_set_focus(). Held BY VALUE, not as a
+   * dt_iop_module_t pointer: the focus outlives individual publications, and a module can be
+   * destroyed (instance removed, image changed, darkroom left) without anyone telling this
+   * chain. A stored pointer would then be dereferenced by the next query. The two things the
+   * exception needs -- who is focused, and what that module filters -- are both immutable for
+   * a given module, so copying them costs nothing and cannot dangle. */
+  char focus_op[32];
+  int focus_instance;
+  int focus_tags_filter;
+  gboolean focus_active;
 };
 
 static gboolean _on_roster(const char *op)
@@ -134,10 +141,9 @@ static gint _by_iop_order(gconstpointer a, gconstpointer b)
  */
 static gboolean _suppressed_by_focus(const dt_geometry_chain_t *chain, const dt_geometry_record_t *record)
 {
-  if(IS_NULL_PTR(chain->focused) || !chain->focus_editing) return FALSE;
-  if(!strcmp(chain->focused->op, record->op) && chain->focused->multi_priority == record->instance)
-    return FALSE;
-  return (chain->focused->operation_tags_filter() & record->operation_tags) != 0;
+  if(!chain->focus_active) return FALSE;
+  if(!strcmp(chain->focus_op, record->op) && chain->focus_instance == record->instance) return FALSE;
+  return (chain->focus_tags_filter & record->operation_tags) != 0;
 }
 
 /**
@@ -205,7 +211,6 @@ void dt_geometry_chain_rebuild(dt_develop_t *dev)
     record->iop_order = module->iop_order;
     record->enabled = TRUE;
     record->operation_tags = module->operation_tags();
-    record->operation_tags_filter = module->operation_tags_filter();
 
     /* A module that publishes nothing is identity, which is correct for the ~80 modules that
      * do not touch geometry -- their record exists only to carry dimensions. A ROSTER module
@@ -312,8 +317,24 @@ int dt_geometry_backtransform(dt_develop_t *dev, const double iop_order, const i
 void dt_geometry_set_focus(dt_develop_t *dev, const dt_iop_module_t *focused, const gboolean editing)
 {
   if(IS_NULL_PTR(dev) || IS_NULL_PTR(dev->geometry_chain)) return;
-  dev->geometry_chain->focused = focused;
-  dev->geometry_chain->focus_editing = editing;
+  dt_geometry_chain_t *chain = dev->geometry_chain;
+
+  if(IS_NULL_PTR(focused) || !editing)
+  {
+    chain->focus_active = FALSE;
+    return;
+  }
+
+  g_strlcpy(chain->focus_op, focused->op, sizeof(chain->focus_op));
+  chain->focus_instance = focused->multi_priority;
+  chain->focus_tags_filter = focused->operation_tags_filter();
+  chain->focus_active = TRUE;
+}
+
+void dt_geometry_clear_focus(dt_develop_t *dev)
+{
+  if(IS_NULL_PTR(dev) || IS_NULL_PTR(dev->geometry_chain)) return;
+  dev->geometry_chain->focus_active = FALSE;
 }
 
 void dt_geometry_shadow_check_size(dt_develop_t *dev, const int pipe_width, const int pipe_height)

--- a/src/develop/geometry/geometry.c
+++ b/src/develop/geometry/geometry.c
@@ -1,0 +1,363 @@
+/*
+    This file is part of Ansel.
+    Copyright (C) 2026 Aurélien Pierre.
+
+    Ansel is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Ansel is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Ansel.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "develop/geometry/geometry.h"
+
+#include "common/logging.h"
+#include "develop/dev_geometry.h"
+#include "develop/develop.h"
+#include "develop/imageop.h"
+#include "system/mem_alloc.h"
+
+#include <string.h>
+
+/**
+ * THE ROSTER.
+ *
+ * Which modules owe this service a record. It is a hand-maintained list and cannot be anything
+ * else: dt_iop_module_t's geometry callbacks are bound through the DEFAULT() macros in
+ * common/module_api.h, so EVERY module has a non-NULL, no-op distort_transform() and an identity
+ * modify_roi_out(). There is no runtime predicate for "is this a geometry module" to test.
+ *
+ * Membership is by source audit (doc/geometry-service.md §1): the 15 modules that implement
+ * modify_roi_out plus the 11 that implement distort_transform, minus the two that implement
+ * neither in a way this service is concerned with.
+ *
+ * NOT on the roster, deliberately:
+ *   - retouch, spots: identity modify_roi_out and no point transform at all. Their
+ *     modify_roi_in expands the read window for source patches, which is a RENDERING concern --
+ *     it reads live dev->forms on the pipeline thread and exists so a clone source is inside
+ *     the tile. Nothing about it belongs to GUI geometry.
+ *   - initialscale, finalscale: no modify_roi_out whatsoever, so identity in a scale-1 fold,
+ *     and no point transform. finalscale's enabled state additionally depends on pipe type and
+ *     zoom, which is exactly the kind of per-pipe fact a pipe-less service must not try to own.
+ *   - useless: the module template, not built.
+ *
+ * A module added to this list without a geometry_record() implementation keeps the chain
+ * non-authoritative forever, which is the safe direction: consumers go on using the pipe.
+ */
+static const char *const _roster[] = {
+  "rawprepare", "basebuffer", "demosaic", "lens",     "ashift",  "liquify", "rotatepixels",
+  "scalepixels", "flip",      "clipping", "crop",     "borders",
+};
+
+struct dt_geometry_chain_t
+{
+  GList *records;   /**< dt_geometry_record_t*, ordered by iop_order, one per ENABLED module */
+
+  int32_t raw_width, raw_height;
+  int32_t processed_width, processed_height;
+  gboolean sized;
+
+  /** Every roster module that is enabled has published a record. See the header. */
+  gboolean authoritative;
+
+  /* What the last rebuild could not get. Kept so shadow mode can name it instead of just
+   * reporting "not ready", which would be true and useless. */
+  GList *missing;   /**< gchar*, owned */
+
+  /* Query-time GUI state, published by dt_geometry_set_focus(). */
+  const struct dt_iop_module_t *focused;
+  gboolean focus_editing;
+};
+
+static gboolean _on_roster(const char *op)
+{
+  if(IS_NULL_PTR(op)) return FALSE;
+  for(size_t i = 0; i < G_N_ELEMENTS(_roster); i++)
+    if(!strcmp(op, _roster[i])) return TRUE;
+  return FALSE;
+}
+
+static void _record_free(void *ptr)
+{
+  dt_geometry_record_t *record = (dt_geometry_record_t *)ptr;
+  if(IS_NULL_PTR(record)) return;
+  if(!IS_NULL_PTR(record->free_data) && !IS_NULL_PTR(record->data)) record->free_data(record->data);
+  dt_free(record);
+}
+
+static void _chain_clear(dt_geometry_chain_t *chain)
+{
+  g_list_free_full(chain->records, _record_free);
+  chain->records = NULL;
+  g_list_free_full(chain->missing, dt_free_gpointer);
+  chain->missing = NULL;
+  chain->authoritative = FALSE;
+  chain->sized = FALSE;
+  chain->processed_width = chain->processed_height = 0;
+}
+
+dt_geometry_chain_t *dt_geometry_chain_new(void)
+{
+  return (dt_geometry_chain_t *)g_malloc0(sizeof(dt_geometry_chain_t));
+}
+
+void dt_geometry_chain_free(dt_geometry_chain_t *chain)
+{
+  if(IS_NULL_PTR(chain)) return;
+  _chain_clear(chain);
+  dt_free(chain);
+}
+
+static gint _by_iop_order(gconstpointer a, gconstpointer b)
+{
+  const dt_geometry_record_t *ra = (const dt_geometry_record_t *)a;
+  const dt_geometry_record_t *rb = (const dt_geometry_record_t *)b;
+  if(ra->iop_order < rb->iop_order) return -1;
+  if(ra->iop_order > rb->iop_order) return 1;
+  return 0;
+}
+
+/**
+ * @brief Is this record disabled for the current query by the focused module?
+ *
+ * @details The chain's copy of dt_dev_pixelpipe_activemodule_disables_currentmodule(). It is
+ * evaluated HERE, per query, and never stored in a record: the inputs are the focused module's
+ * identity, its tag filter, and whether it is in editing mode -- all of which change with no
+ * history commit, which is precisely why records cannot carry them.
+ */
+static gboolean _suppressed_by_focus(const dt_geometry_chain_t *chain, const dt_geometry_record_t *record)
+{
+  if(IS_NULL_PTR(chain->focused) || !chain->focus_editing) return FALSE;
+  if(!strcmp(chain->focused->op, record->op) && chain->focused->multi_priority == record->instance)
+    return FALSE;
+  return (chain->focused->operation_tags_filter() & record->operation_tags) != 0;
+}
+
+/**
+ * @brief Fold every record's map_size in pipe order, at full resolution and scale 1.
+ *
+ * @details Reproduces dt_dev_pixelpipe_get_roi_out(): seed the input rect from the raw
+ * dimensions at scale 1, hand each enabled module its input and take its output as the next
+ * module's input, and record both on the way through. Those per-record rects are a product in
+ * their own right -- consumers read their own module's input/output dimensions off them, and
+ * not only the geometric modules do (graduatednd has no geometry callbacks and reads its output
+ * rect for its overlay).
+ *
+ * A record with no vtable, or one suppressed by the focused module, is identity. The suppression
+ * matters for SIZE and not only for coordinates: the fold this mirrors clears piece->enabled for
+ * such modules, so the developed size genuinely changes when the user enters crop's edit mode.
+ */
+static void _fold_sizes(dt_geometry_chain_t *chain)
+{
+  dt_iop_roi_t rect = (dt_iop_roi_t){ 0, 0, chain->raw_width, chain->raw_height, 1.0f };
+
+  for(GList *node = g_list_first(chain->records); node; node = g_list_next(node))
+  {
+    dt_geometry_record_t *record = (dt_geometry_record_t *)node->data;
+    record->in = rect;
+
+    if(!IS_NULL_PTR(record->vtable) && !IS_NULL_PTR(record->vtable->map_size)
+       && !_suppressed_by_focus(chain, record))
+      record->vtable->map_size(record->data, &rect, &record->out);
+    else
+      record->out = rect;
+
+    rect = record->out;
+  }
+
+  chain->processed_width = rect.width;
+  chain->processed_height = rect.height;
+  chain->sized = (chain->raw_width > 0 && chain->raw_height > 0);
+}
+
+void dt_geometry_chain_rebuild(dt_develop_t *dev)
+{
+  if(IS_NULL_PTR(dev) || IS_NULL_PTR(dev->geometry_chain)) return;
+
+  dt_geometry_chain_t *chain = dev->geometry_chain;
+  _chain_clear(chain);
+
+  int32_t raw_width = 0;
+  int32_t raw_height = 0;
+  if(!dt_dev_geometry_get_raw_size(dev, &raw_width, &raw_height)) return;
+  chain->raw_width = raw_width;
+  chain->raw_height = raw_height;
+
+  gboolean complete = TRUE;
+
+  for(GList *node = g_list_first(dev->iop); node; node = g_list_next(node))
+  {
+    dt_iop_module_t *module = (dt_iop_module_t *)node->data;
+    if(IS_NULL_PTR(module) || !module->enabled) continue;
+
+    dt_geometry_record_t *record = (dt_geometry_record_t *)g_malloc0(sizeof(dt_geometry_record_t));
+    if(IS_NULL_PTR(record)) continue;
+
+    g_strlcpy(record->op, module->op, sizeof(record->op));
+    record->instance = module->multi_priority;
+    record->iop_order = module->iop_order;
+    record->enabled = TRUE;
+    record->operation_tags = module->operation_tags();
+    record->operation_tags_filter = module->operation_tags_filter();
+
+    /* A module that publishes nothing is identity, which is correct for the ~80 modules that
+     * do not touch geometry -- their record exists only to carry dimensions. A ROSTER module
+     * that publishes nothing is a gap, and the chain must not be trusted until it closes. */
+    const gboolean published = !IS_NULL_PTR(module->geometry_record)
+                               && module->geometry_record(module, record);
+
+    if(!published && _on_roster(module->op))
+    {
+      complete = FALSE;
+      chain->missing = g_list_prepend(chain->missing,
+                                      g_strdup_printf("%s.%d", module->op, module->multi_priority));
+    }
+
+    chain->records = g_list_insert_sorted(chain->records, record, _by_iop_order);
+  }
+
+  _fold_sizes(chain);
+  chain->authoritative = complete && chain->sized;
+}
+
+gboolean dt_geometry_chain_authoritative(const dt_geometry_chain_t *chain)
+{
+  return !IS_NULL_PTR(chain) && chain->authoritative;
+}
+
+gboolean dt_geometry_chain_processed_size(const dt_geometry_chain_t *chain, int *width, int *height)
+{
+  if(IS_NULL_PTR(chain) || !chain->sized) return FALSE;
+  if(!IS_NULL_PTR(width)) *width = chain->processed_width;
+  if(!IS_NULL_PTR(height)) *height = chain->processed_height;
+  return TRUE;
+}
+
+const dt_geometry_record_t *dt_geometry_chain_find(const dt_geometry_chain_t *chain, const char *op,
+                                                   const int instance)
+{
+  if(IS_NULL_PTR(chain) || IS_NULL_PTR(op)) return NULL;
+  for(const GList *node = g_list_first(chain->records); node; node = g_list_next(node))
+  {
+    const dt_geometry_record_t *record = (const dt_geometry_record_t *)node->data;
+    if(!strcmp(record->op, op) && record->instance == instance) return record;
+  }
+  return NULL;
+}
+
+/**
+ * @brief Does this record fall inside the requested bound?
+ *
+ * @details The five modes are dt_dev_distort_transform_plus()'s, reproduced exactly. Every
+ * existing caller's bound has to keep meaning what it meant -- the mask GUI in particular
+ * composes BACK_EXCL up to a module, shifts, then FORW_INCL back out, and a bound that shifted
+ * by one module would move every clone source by that module's transform.
+ */
+static gboolean _in_bound(const dt_geometry_record_t *record, const double iop_order, const int direction)
+{
+  switch(direction)
+  {
+    case DT_DEV_TRANSFORM_DIR_FORW_INCL: return record->iop_order >= iop_order;
+    case DT_DEV_TRANSFORM_DIR_FORW_EXCL: return record->iop_order > iop_order;
+    case DT_DEV_TRANSFORM_DIR_BACK_INCL: return record->iop_order <= iop_order;
+    case DT_DEV_TRANSFORM_DIR_BACK_EXCL: return record->iop_order < iop_order;
+    case DT_DEV_TRANSFORM_DIR_ALL:
+    default: return TRUE;
+  }
+}
+
+int dt_geometry_transform(dt_develop_t *dev, const double iop_order, const int direction, float *points,
+                          const size_t points_count)
+{
+  if(IS_NULL_PTR(dev) || IS_NULL_PTR(dev->geometry_chain) || IS_NULL_PTR(points)) return 0;
+  dt_geometry_chain_t *chain = dev->geometry_chain;
+  if(!chain->authoritative) return 0;
+
+  for(GList *node = g_list_first(chain->records); node; node = g_list_next(node))
+  {
+    dt_geometry_record_t *record = (dt_geometry_record_t *)node->data;
+    if(IS_NULL_PTR(record->vtable) || IS_NULL_PTR(record->vtable->transform)) continue;
+    if(!_in_bound(record, iop_order, direction)) continue;
+    if(_suppressed_by_focus(chain, record)) continue;
+    record->vtable->transform(record->data, record, chain, points, points_count);
+  }
+  return 1;
+}
+
+int dt_geometry_backtransform(dt_develop_t *dev, const double iop_order, const int direction, float *points,
+                              const size_t points_count)
+{
+  if(IS_NULL_PTR(dev) || IS_NULL_PTR(dev->geometry_chain) || IS_NULL_PTR(points)) return 0;
+  dt_geometry_chain_t *chain = dev->geometry_chain;
+  if(!chain->authoritative) return 0;
+
+  for(GList *node = g_list_last(chain->records); node; node = g_list_previous(node))
+  {
+    dt_geometry_record_t *record = (dt_geometry_record_t *)node->data;
+    if(IS_NULL_PTR(record->vtable) || IS_NULL_PTR(record->vtable->backtransform)) continue;
+    if(!_in_bound(record, iop_order, direction)) continue;
+    if(_suppressed_by_focus(chain, record)) continue;
+    record->vtable->backtransform(record->data, record, chain, points, points_count);
+  }
+  return 1;
+}
+
+void dt_geometry_set_focus(dt_develop_t *dev, const dt_iop_module_t *focused, const gboolean editing)
+{
+  if(IS_NULL_PTR(dev) || IS_NULL_PTR(dev->geometry_chain)) return;
+  dev->geometry_chain->focused = focused;
+  dev->geometry_chain->focus_editing = editing;
+}
+
+void dt_geometry_shadow_check_size(dt_develop_t *dev, const int pipe_width, const int pipe_height)
+{
+  if(IS_NULL_PTR(dev) || IS_NULL_PTR(dev->geometry_chain)) return;
+  if(!(dt_get_debug_flags() & DT_DEBUG_DEV)) return;
+
+  const dt_geometry_chain_t *chain = dev->geometry_chain;
+
+  if(!chain->authoritative)
+  {
+    /* Name the gap. "Not ready" is true and useless; the list below is the actual, per-image
+     * work remaining, measured rather than taken from the source audit -- which is how a module
+     * that the audit missed, or one that only becomes enabled on some images, gets found. */
+    if(IS_NULL_PTR(chain->missing))
+    {
+      dt_print(DT_DEBUG_DEV, "[geometry] chain not authoritative: no usable raw geometry yet\n");
+      return;
+    }
+
+    gchar **names = (gchar **)g_malloc0((g_list_length(chain->missing) + 1) * sizeof(gchar *));
+    if(IS_NULL_PTR(names)) return;
+    int i = 0;
+    for(const GList *node = g_list_first(chain->missing); node; node = g_list_next(node))
+      names[i++] = (gchar *)node->data;
+    gchar *joined = g_strjoinv(", ", names);
+    dt_free(names);   // the strings belong to chain->missing; only the vector is ours
+
+    dt_print(DT_DEBUG_DEV, "[geometry] chain not authoritative: %d roster module(s) without a record: %s\n",
+             g_list_length(chain->missing), joined);
+    dt_free(joined);
+    return;
+  }
+
+  if(chain->processed_width != pipe_width || chain->processed_height != pipe_height)
+    dt_print(DT_DEBUG_DEV, "[geometry] SIZE DIVERGENCE: chain %dx%d, pipe %dx%d\n", chain->processed_width,
+             chain->processed_height, pipe_width, pipe_height);
+  else
+    dt_print(DT_DEBUG_DEV, "[geometry] size agrees with the pipe: %dx%d\n", chain->processed_width,
+             chain->processed_height);
+}
+
+// clang-format off
+// modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py
+// vim: shiftwidth=2 expandtab tabstop=2 cindent
+// kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;
+// clang-format on

--- a/src/develop/geometry/geometry.h
+++ b/src/develop/geometry/geometry.h
@@ -97,10 +97,10 @@ typedef struct dt_geometry_record_t
   double iop_order;        /**< position in the pipe; the walkers' ordering and bound */
   gboolean enabled;
 
-  /* Cached so the query-time GUI exception can be evaluated without touching dt_iop_module_t
-   * from a consumer. See dt_geometry_set_focus(). */
+  /* The candidate half of the query-time GUI exception: the FOCUSED module's tag filter is
+   * tested against this. The focused module's own filter is not stored per record -- it is one
+   * value for the whole query, and it lives on the chain. See dt_geometry_set_focus(). */
   int operation_tags;
-  int operation_tags_filter;
 
   const dt_geometry_vtable_t *vtable;   /**< NULL: this module is geometrically identity */
   void *data;                           /**< module-owned blob, freed by ::free_data */
@@ -171,6 +171,11 @@ int dt_geometry_backtransform(struct dt_develop_t *dev, double iop_order, int di
  */
 void dt_geometry_set_focus(struct dt_develop_t *dev, const struct dt_iop_module_t *focused,
                            gboolean editing);
+
+/** @brief Forget the focused module. Call before any module list teardown -- see the note on
+ *  dt_geometry_set_focus(): the chain keeps the focus by VALUE precisely so a stale publication
+ *  cannot dereference a destroyed module, but clearing it at teardown keeps the state honest. */
+void dt_geometry_clear_focus(struct dt_develop_t *dev);
 
 /**
  * @brief Shadow mode: compare the chain against the pipe that still owns the answer.

--- a/src/develop/geometry/geometry.h
+++ b/src/develop/geometry/geometry.h
@@ -1,0 +1,191 @@
+/*
+    This file is part of Ansel.
+    Copyright (C) 2026 Aurélien Pierre.
+
+    Ansel is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Ansel is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Ansel.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+/** @file develop/geometry/geometry.h
+ *
+ * @brief Where things are on the image, answered without a pipeline.
+ *
+ * @details The GUI constantly needs two geometric facts: how big the developed image is, and
+ * where a point on it lands after the distorting modules have had their say. Today both are
+ * answered by `dev->virtual_pipe' -- a complete, pixel-less clone of all ~95 IOP modules, their
+ * history committed into real pipeline nodes, resynchronised on the GUI thread at every history
+ * commit for 0.10 to 0.33 s. It renders nothing. It exists only to be walked.
+ *
+ * This module replaces that with the data the walk actually consumes. Each module that changes
+ * geometry publishes a small record -- its transform as values, not as a node -- and the GUI
+ * composes sizes and coordinates from the ordered list. See doc/geometry-service.md for the
+ * decision, the survey behind it, and the tranche plan; the traps section there is not
+ * optional reading.
+ *
+ * THREADING. This is GUI-thread state and takes no locks. Nothing else may touch it. The pixel
+ * pipelines keep their own piece-based modify_roi and distort callbacks for rendering, and the
+ * two must never be crossed: a worker that needs geometry asks its own pieces.
+ *
+ * STATUS: skeleton (tranche G2). No module publishes a record yet, so the chain is never
+ * authoritative and nothing consumes it; it runs beside the virtual pipe and reports what it
+ * would need in order to take over. Shadow mode is the whole point of this tranche.
+ */
+
+#ifndef DT_DEVELOP_GEOMETRY_GEOMETRY_H
+#define DT_DEVELOP_GEOMETRY_GEOMETRY_H
+
+#include <glib.h>
+#include <stdint.h>
+
+#include "develop/pixelpipe_hb.h"   // dt_iop_roi_t
+
+struct dt_develop_t;
+struct dt_iop_module_t;
+struct dt_geometry_record_t;
+struct dt_geometry_chain_t;
+
+/**
+ * @brief A module's geometry, evaluated. Pure functions of the record's own data.
+ *
+ * @details Every entry may be NULL, which means "identity for this operation": a module that
+ * resizes but does not move points (demosaic's downsample) has a map_size and no transform, and
+ * a module that is only ever asked for its dimensions (graduatednd) has neither.
+ *
+ * These evaluators are the SAME code the module's own distort_transform()/modify_roi_out() run
+ * on the pixel pipe -- one shared static helper per module, called from both sides. That rule is
+ * not stylistic: two derivations of the same geometry drift, and the drift shows up as an
+ * overlay that no longer sits on the thing it describes, months later, on one image.
+ */
+typedef struct dt_geometry_vtable_t
+{
+  /** @brief Full-resolution input rect -> output rect. Mirrors modify_roi_out() at scale 1. */
+  void (*map_size)(const void *data, const dt_iop_roi_t *const in, dt_iop_roi_t *out);
+
+  /** @brief Image coordinates in -> image coordinates out, in place, @p points_count pairs.
+   *  @p ctx composes the sub-chain upstream of this record, for the one module that needs it
+   *  (liquify's warps live in RAW coordinates). NULL for every other module. */
+  int (*transform)(const void *data, const struct dt_geometry_record_t *const record,
+                   struct dt_geometry_chain_t *chain, float *points, size_t points_count);
+
+  /** @brief The inverse of ::transform. */
+  int (*backtransform)(const void *data, const struct dt_geometry_record_t *const record,
+                       struct dt_geometry_chain_t *chain, float *points, size_t points_count);
+} dt_geometry_vtable_t;
+
+/**
+ * @brief One module instance's contribution, as data.
+ *
+ * @details There is a record for EVERY enabled module, not only the geometric ones: consumers
+ * ask this list for their own module's input and output dimensions, and `graduatednd' -- which
+ * has no geometry callbacks at all -- is one of them. A module with no geometry gets a record
+ * with a NULL vtable, which the size fold treats as identity and the walkers skip.
+ */
+typedef struct dt_geometry_record_t
+{
+  char op[32];             /**< module operation name */
+  int instance;            /**< multi_priority: which instance of that operation */
+  double iop_order;        /**< position in the pipe; the walkers' ordering and bound */
+  gboolean enabled;
+
+  /* Cached so the query-time GUI exception can be evaluated without touching dt_iop_module_t
+   * from a consumer. See dt_geometry_set_focus(). */
+  int operation_tags;
+  int operation_tags_filter;
+
+  const dt_geometry_vtable_t *vtable;   /**< NULL: this module is geometrically identity */
+  void *data;                           /**< module-owned blob, freed by ::free_data */
+  void (*free_data)(void *data);        /**< NULL when ::data needs no teardown */
+
+  /* Filled by the chain's own size fold, at full resolution and scale 1 -- the same numbers
+   * dt_dev_pixelpipe_get_roi_out() writes into piece->buf_in/buf_out today, which is what
+   * consumers actually read off the virtual pipe. */
+  dt_iop_roi_t in;
+  dt_iop_roi_t out;
+} dt_geometry_record_t;
+
+/** @brief The composed geometry of one image, for one dev. GUI thread only. */
+typedef struct dt_geometry_chain_t dt_geometry_chain_t;
+
+dt_geometry_chain_t *dt_geometry_chain_new(void);
+void dt_geometry_chain_free(dt_geometry_chain_t *chain);
+
+/**
+ * @brief Rebuild the chain from the dev's current modules and history. GUI thread only.
+ *
+ * @details Called wherever the virtual pipe is resynchronised today. Cheap by construction --
+ * a record is a small derivation of already-committed params, with no LUT, no colour transform
+ * and no disk access -- which is the point: it can run in the same step as the history write,
+ * where the virtual pipe's 0.1-0.3 s could not.
+ */
+void dt_geometry_chain_rebuild(struct dt_develop_t *dev);
+
+/**
+ * @brief Can this chain answer questions yet?
+ *
+ * @details TRUE only when every enabled module the roster names has published a record.
+ * Authority is WHOLESALE: composing some modules from records and the rest from pipeline
+ * pieces would interleave two states, and the result would be wrong in a way that looks
+ * plausible. Until the last roster module lands, this stays FALSE and every consumer keeps
+ * using the pipe.
+ */
+gboolean dt_geometry_chain_authoritative(const dt_geometry_chain_t *chain);
+
+/** @brief The developed image's full-resolution size, from the chain's own fold. */
+gboolean dt_geometry_chain_processed_size(const dt_geometry_chain_t *chain, int *width, int *height);
+
+/** @brief One module instance's record, or NULL. Use it for that module's own in/out dims. */
+const dt_geometry_record_t *dt_geometry_chain_find(const dt_geometry_chain_t *chain, const char *op,
+                                                   int instance);
+
+/* Direction modes, matching dt_dev_distort_transform_plus()'s DT_DEV_TRANSFORM_DIR_* exactly:
+ * the walkers this replaces are bounded folds, and every existing caller's bound has to keep
+ * meaning what it meant. */
+
+/** @brief Compose forward over the chain, in place. @p direction is a DT_DEV_TRANSFORM_DIR_*. */
+int dt_geometry_transform(struct dt_develop_t *dev, double iop_order, int direction, float *points,
+                          size_t points_count);
+
+/** @brief Compose backward over the chain, in place. */
+int dt_geometry_backtransform(struct dt_develop_t *dev, double iop_order, int direction, float *points,
+                              size_t points_count);
+
+/**
+ * @brief Publish the focused module and its editing state, for the query-time GUI exception.
+ *
+ * @details dt_dev_pixelpipe_activemodule_disables_currentmodule() reads the focused module, its
+ * operation_tags_filter() and its live cache-bypass flag, and disables matching modules for the
+ * duration of a walk -- and, in the size fold, for the resulting processed size too. That is
+ * view state: it changes when the user clicks into crop's edit mode, with no history commit
+ * anywhere. It therefore cannot be baked into records; the chain reads it at query time, from
+ * whatever the GUI last published here.
+ */
+void dt_geometry_set_focus(struct dt_develop_t *dev, const struct dt_iop_module_t *focused,
+                           gboolean editing);
+
+/**
+ * @brief Shadow mode: compare the chain against the pipe that still owns the answer.
+ *
+ * @details Called from the size path with whatever the virtual pipe just produced. While the
+ * roster is incomplete this reports exactly which enabled modules are still missing a record --
+ * measured per image, rather than assumed from a source audit -- and once it is complete it
+ * reports any divergence. Both under `-d dev'. It never changes behaviour.
+ */
+void dt_geometry_shadow_check_size(struct dt_develop_t *dev, int pipe_width, int pipe_height);
+
+#endif // DT_DEVELOP_GEOMETRY_GEOMETRY_H
+
+// clang-format off
+// modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py
+// vim: shiftwidth=2 expandtab tabstop=2 cindent
+// kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;
+// clang-format on

--- a/src/develop/imageop.h
+++ b/src/develop/imageop.h
@@ -82,6 +82,12 @@ struct dt_dev_pixelpipe_iop_t;
 struct dt_develop_blend_params_t;
 struct dt_develop_tiling_t;
 struct dt_iop_color_picker_t;
+/* develop/geometry/geometry.h -- named by the geometry_record() vtable entry. Declared HERE,
+ * not only in iop_api.h: that header's forward declarations live inside its FULL_API_H block,
+ * which the struct-body expansion of the X-macro does not compile, so the first mention would
+ * otherwise be inside a function prototype -- C scopes that to the prototype and the resulting
+ * type is distinct from every other declaration of the same name. */
+struct dt_geometry_record_t;
 
 typedef enum dt_iop_module_header_icons_t
 {

--- a/src/iop/iop_api.h
+++ b/src/iop/iop_api.h
@@ -58,6 +58,7 @@ struct dt_iop_module_so_t;
 struct dt_iop_module_t;
 struct dt_dev_pixelpipe_t;
 struct dt_dev_pixelpipe_iop_t;
+struct dt_geometry_record_t;
 struct dt_iop_roi_t;
 struct dt_develop_tiling_t;
 struct dt_iop_buffer_dsc_t;
@@ -198,6 +199,18 @@ DEFAULT(gboolean, has_defaults, struct dt_iop_module_t *self);
  *  (dt_colorspaces_conversion_identity()) and hash THAT. */
 DEFAULT(gboolean, runtime_data_hash, struct dt_iop_module_t *self, struct dt_dev_pixelpipe_t *pipe,
                                      const struct dt_dev_pixelpipe_iop_t *piece);
+
+/** Publish this module's geometry as data, for develop/geometry (the service replacing the
+ *  pixel-less virtual pipe -- see doc/geometry-service.md).
+ *
+ *  Fill @p record's vtable/data and return TRUE; return FALSE (the default) for a module that
+ *  does not change geometry. Called on the GUI thread, after params are committed.
+ *
+ *  THE ONE-CONSTRUCTOR RULE: whatever commit_params() derives for geometry and whatever the
+ *  record carries must come from ONE shared helper, and the record's evaluators must be the
+ *  same code distort_transform()/modify_roi_out() run. Two derivations of the same geometry
+ *  drift, and the drift surfaces as an overlay that no longer sits on what it describes. */
+OPTIONAL(gboolean, geometry_record, struct dt_iop_module_t *self, struct dt_geometry_record_t *record);
 
 /** called after the image has changed in darkroom */
 OPTIONAL(void, change_image, struct dt_iop_module_t *self);


### PR DESCRIPTION
Second tranche of `doc/geometry-service.md` (plan #1163, pre-fixes #1164 — independent, no file
overlap, either order).

Adds `src/develop/geometry/` — the record, the chain, the two composition walkers, the size fold
and a shadow-mode harness — wired to run **alongside** `dev->virtual_pipe` and consume nothing.
**No behaviour changes**: no module publishes a record yet, so the chain is never authoritative
and every consumer still asks the pipe.

### What is here

- **`dt_geometry_record_t`** — one enabled module instance's geometry as data, plus the in/out
  rects the fold fills. There is a record for **every** enabled module, not just geometric ones:
  consumers read their own module's dimensions off this list, and `graduatednd` — which has no
  geometry callbacks at all — is one of them.
- **The size fold** — `dt_dev_pixelpipe_get_roi_out()`'s fold over records instead of pieces.
- **The walkers** — the same iop_order-bounded folds, all five direction modes reproduced
  exactly. Existing callers compose BACK_EXCL up to a module, shift, then FORW_INCL back out, so
  a bound off by one module would move every clone source by that module's transform.
- **The focus exception, at query time and never stored** — its inputs change with no history
  commit, and they gate the developed *size* as well as coordinates.
- **`geometry_record()`**, a new OPTIONAL module API entry, carrying the **one-constructor rule**
  on its declaration.
- **The roster** — hand-maintained, because there is no runtime predicate: the `DEFAULT()` macros
  give every module a non-NULL no-op `distort_transform` and identity `modify_roi_out`. Its
  exclusions are argued in the source (retouch/spots are a rendering concern; initialscale/
  finalscale have no `modify_roi_out` and finalscale's enabled state is per pipe type and zoom).

### Why shadow mode is the point

An empty skeleton is unverifiable, so this one **reports**. Under `-d dev` it rebuilds beside the
virtual pipe at every size publication and says either which roster modules still lack a record,
per image, or — once none do — whether its size agrees with the pipe's. That turns the source
audit into a measurement. On the test raw:

```
[geometry] chain not authoritative: 5 roster module(s) without a record:
           crop.0, flip.0, demosaic.0, rawprepare.0, basebuffer.0
```

That is the real work list for the next tranches on that image, and it is how a module the audit
missed — or one enabled only on some images — gets found.

Authority is **wholesale**: nothing is answered until every enabled roster module has published.
Mixing records with pipeline pieces inside one composition would interleave two states and give a
plausible wrong answer.

### Two C traps paid for here

Noted so the next file in this directory doesn't repeat them:

1. A doc comment containing `modify_roi_*/distort_*` **terminates itself** on the glob.
2. The record struct's forward declaration must live in `develop/imageop.h`, not only inside
   `iop_api.h`'s `FULL_API_H` block — the X-macro's struct-body expansion doesn't compile that
   block, so the first mention would land inside a function prototype, which C scopes to the
   prototype, making the type distinct from every other declaration of the same name.

### Verification

- Export A/B vs pre-change binary: **bit-identical**, 0 differing pixels of 23.7 M.
- 30 s darkroom-open run clean, emits the shadow report above.
- `include_graph.py`: cycles 0, layering 184 unchanged — `develop/geometry` maps to the develop
  layer through `layer_of()`'s `parts[1]`, so no tool change was needed.
- `check_module_boundaries.sh` held; `pragma_once_to_guards.py --verify` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
