### PR TITLE
Geometry service G3: the first five records, and the chain answers for the first time

### DIFF
--- a/src/develop/geometry/geometry.c
+++ b/src/develop/geometry/geometry.c
@@ -24,6 +24,7 @@
 #include "develop/imageop.h"
 #include "system/mem_alloc.h"
 
+#include <math.h>
 #include <string.h>
 
 /**
@@ -370,11 +371,51 @@ void dt_geometry_shadow_check_size(dt_develop_t *dev, const int pipe_width, cons
   }
 
   if(chain->processed_width != pipe_width || chain->processed_height != pipe_height)
+  {
     dt_print(DT_DEBUG_DEV, "[geometry] SIZE DIVERGENCE: chain %dx%d, pipe %dx%d\n", chain->processed_width,
              chain->processed_height, pipe_width, pipe_height);
+    return;
+  }
+
+  /* The size fold only exercises map_size. Probe the point transforms too, or the evaluators
+   * that actually move overlays would go unverified until a consumer switched over and a user
+   * noticed a mask sitting in the wrong place.
+   *
+   * Five points spanning the raw frame, forward through everything (iop_order 0, DIR_ALL --
+   * what dt_dev_coordinates_raw_abs_to_image_abs() asks for), then the same through the pipe.
+   * The tolerance is half a pixel: both sides do the same arithmetic in the same order, so they
+   * should agree exactly, but the fold's rects reach the evaluators as ints on one side and
+   * through piece->buf_in on the other, and a rounding difference of that size is not a defect
+   * worth failing on. Anything larger is a real divergence and is printed with the point. */
+  const float w = (float)chain->raw_width;
+  const float h = (float)chain->raw_height;
+  float chain_points[10] = { 0.f, 0.f, w, 0.f, 0.f, h, w, h, 0.5f * w, 0.5f * h };
+  float pipe_points[10];
+  memcpy(pipe_points, chain_points, sizeof(pipe_points));
+
+  if(!dt_geometry_transform(dev, 0.0, DT_DEV_TRANSFORM_DIR_ALL, chain_points, 5)) return;
+  if(IS_NULL_PTR(dev->virtual_pipe)) return;
+  dt_dev_distort_transform_plus(dev->virtual_pipe, 0.0, DT_DEV_TRANSFORM_DIR_ALL, pipe_points, 5);
+
+  int diverged = 0;
+  for(int i = 0; i < 5; i++)
+  {
+    if(fabsf(chain_points[2 * i] - pipe_points[2 * i]) > 0.5f
+       || fabsf(chain_points[2 * i + 1] - pipe_points[2 * i + 1]) > 0.5f)
+    {
+      dt_print(DT_DEBUG_DEV,
+               "[geometry] TRANSFORM DIVERGENCE at probe %d: chain (%.2f, %.2f), pipe (%.2f, %.2f)\n", i,
+               chain_points[2 * i], chain_points[2 * i + 1], pipe_points[2 * i], pipe_points[2 * i + 1]);
+      diverged++;
+    }
+  }
+
+  if(diverged)
+    dt_print(DT_DEBUG_DEV, "[geometry] size agrees (%dx%d) but %d/5 transform probes diverge\n",
+             chain->processed_width, chain->processed_height, diverged);
   else
-    dt_print(DT_DEBUG_DEV, "[geometry] size agrees with the pipe: %dx%d\n", chain->processed_width,
-             chain->processed_height);
+    dt_print(DT_DEBUG_DEV, "[geometry] agrees with the pipe: size %dx%d, all 5 transform probes\n",
+             chain->processed_width, chain->processed_height);
 }
 
 // clang-format off

--- a/src/develop/geometry/geometry.c
+++ b/src/develop/geometry/geometry.c
@@ -410,11 +410,42 @@ void dt_geometry_shadow_check_size(dt_develop_t *dev, const int pipe_width, cons
     }
   }
 
-  if(diverged)
-    dt_print(DT_DEBUG_DEV, "[geometry] size agrees (%dx%d) but %d/5 transform probes diverge\n",
-             chain->processed_width, chain->processed_height, diverged);
+  /* And the inverse. Comparing forward against the pipe leaves every backtransform evaluator
+   * unverified -- they are only ever exercised by GUI consumers that have not switched over yet
+   * -- so round-trip the same probes through the chain and require the identity back.
+   *
+   * This is the check that decides a real question about flip, whose forward flips against the
+   * input dimensions and THEN swaps the axes. Its inverse un-swaps and unflips against those
+   * same dimensions, in the pre-swap frame where they are the right ones; swapping the
+   * dimensions as well -- which the neighbouring modify_roi_in helper legitimately does, in its
+   * own rectangle-mapping convention -- would break exactly the 90-degree orientations this
+   * probe covers. Composed here rather than argued. */
+  float roundtrip[10] = { 0.f, 0.f, w, 0.f, 0.f, h, w, h, 0.5f * w, 0.5f * h };
+  const float origin[10] = { 0.f, 0.f, w, 0.f, 0.f, h, w, h, 0.5f * w, 0.5f * h };
+
+  dt_geometry_transform(dev, 0.0, DT_DEV_TRANSFORM_DIR_ALL, roundtrip, 5);
+  dt_geometry_backtransform(dev, 0.0, DT_DEV_TRANSFORM_DIR_ALL, roundtrip, 5);
+
+  int not_identity = 0;
+  for(int i = 0; i < 5; i++)
+  {
+    if(fabsf(roundtrip[2 * i] - origin[2 * i]) > 0.5f
+       || fabsf(roundtrip[2 * i + 1] - origin[2 * i + 1]) > 0.5f)
+    {
+      dt_print(DT_DEBUG_DEV,
+               "[geometry] ROUND-TRIP DIVERGENCE at probe %d: (%.2f, %.2f) came back as (%.2f, %.2f)\n", i,
+               origin[2 * i], origin[2 * i + 1], roundtrip[2 * i], roundtrip[2 * i + 1]);
+      not_identity++;
+    }
+  }
+
+  if(diverged || not_identity)
+    dt_print(DT_DEBUG_DEV,
+             "[geometry] size agrees (%dx%d) but %d/5 forward probes and %d/5 round-trips diverge\n",
+             chain->processed_width, chain->processed_height, diverged, not_identity);
   else
-    dt_print(DT_DEBUG_DEV, "[geometry] agrees with the pipe: size %dx%d, all 5 transform probes\n",
+    dt_print(DT_DEBUG_DEV,
+             "[geometry] agrees with the pipe: size %dx%d, 5/5 forward probes, 5/5 round-trips\n",
              chain->processed_width, chain->processed_height);
 }
 

--- a/src/iop/basebuffer.c
+++ b/src/iop/basebuffer.c
@@ -27,6 +27,7 @@
 #include "common/module_versioning.h"
 #include "caches/mipmap_cache.h"
 #include "develop/develop.h"
+#include "develop/geometry/geometry.h"
 #include "develop/imageop.h"
 #include "iop/iop_api.h"
 
@@ -72,6 +73,31 @@ void modify_roi_out(dt_iop_module_t *self, const dt_dev_pixelpipe_t *pipe, dt_de
                     dt_iop_roi_t *roi_out, const dt_iop_roi_t *const roi_in)
 {
   *roi_out = (dt_iop_roi_t){ 0, 0, pipe->iwidth, pipe->iheight, 1.f };
+}
+
+/* --- the geometry service's view of this module (develop/geometry/geometry.h) ---------
+ *
+ * basebuffer is the first module in the pipe and asserts the full sensor frame at scale 1,
+ * ignoring whatever roi_in it is handed. The geometry chain seeds its fold with exactly that
+ * -- the raw dimensions at scale 1 -- so re-asserting the input rect here reproduces the
+ * callback above for every position this module can occupy. It moves no points.
+ */
+
+static void _basebuffer_geometry_map_size(const void *data, const dt_iop_roi_t *const in, dt_iop_roi_t *out)
+{
+  *out = (dt_iop_roi_t){ 0, 0, in->width, in->height, 1.f };
+}
+
+static const dt_geometry_vtable_t _basebuffer_geometry_vtable = {
+  .map_size = _basebuffer_geometry_map_size,
+  .transform = NULL,
+  .backtransform = NULL,
+};
+
+gboolean geometry_record(dt_iop_module_t *self, dt_geometry_record_t *record)
+{
+  record->vtable = &_basebuffer_geometry_vtable;
+  return TRUE;
 }
 
 

--- a/src/iop/crop.c
+++ b/src/iop/crop.c
@@ -46,6 +46,7 @@
 #include "control/input.h"
 #include "control/control.h"
 #include "develop/develop.h"
+#include "develop/geometry/geometry.h"
 #include "develop/imageop.h"
 #include "develop/imageop_gui.h"
 
@@ -293,13 +294,71 @@ static gboolean _set_max_clip(dt_dev_pixelpipe_t *pipe, struct dt_iop_module_t *
   return TRUE;
 }
 
+/* --- the shared geometry core ----------------------------------------------------------
+ *
+ * These three are the ONLY place crop's geometry is expressed. commit_params() and the
+ * pipeline's distort/roi callbacks call them, and so does geometry_record() for the pixel-less
+ * geometry service (develop/geometry/geometry.h). One constructor and one evaluator per fact:
+ * a second derivation of the same crop would drift from this one, and the drift would show up
+ * as the crop overlay sitting somewhere the cropped image is not.
+ */
+
+/** @brief Resolve the effective crop rectangle. THE constructor -- see the note above. */
+static void _crop_resolve(dt_iop_module_t *self, const dt_iop_crop_params_t *const p,
+                          dt_iop_crop_data_t *out)
+{
+  const dt_iop_crop_gui_data_t *g = (dt_iop_crop_gui_data_t *)dt_iop_gui_data(self);
+
+  if(!IS_NULL_PTR(g) && g->editing)
+  {
+    // In editing mode, we need to see the full uncropped image to setup the frame.
+    out->cx = 0.0f;
+    out->cy = 0.0f;
+    out->cw = 1.0f;
+    out->ch = 1.0f;
+  }
+  else
+  {
+    out->cx = CLAMPF(p->cx, 0.0f, 0.9f);
+    out->cy = CLAMPF(p->cy, 0.0f, 0.9f);
+    out->cw = CLAMPF(p->cw, 0.1f, 1.0f);
+    out->ch = CLAMPF(p->ch, 0.1f, 1.0f);
+  }
+}
+
+/** @brief Input rect -> output rect. THE size evaluator. */
+static void _crop_map_size(const dt_iop_crop_data_t *const d, const dt_iop_roi_t *const roi_in,
+                           dt_iop_roi_t *roi_out)
+{
+  *roi_out = *roi_in;
+
+  roi_out->width = roi_in->width * (d->cw - d->cx);
+  roi_out->height = roi_in->height * (d->ch - d->cy);
+  roi_out->x = roi_in->width * d->cx;
+  roi_out->y = roi_in->height * d->cy;
+
+  // sanity check.
+  if(roi_out->x < 0) roi_out->x = 0;
+  if(roi_out->y < 0) roi_out->y = 0;
+  if(roi_out->width < 5) roi_out->width = 5;
+  if(roi_out->height < 5) roi_out->height = 5;
+}
+
+/** @brief The translation the crop applies, in the input rect's own pixels. */
+static void _crop_offset(const dt_iop_crop_data_t *const d, const dt_iop_roi_t *const roi_in, float *left,
+                         float *top)
+{
+  *left = roi_in->width * d->cx;
+  *top = roi_in->height * d->cy;
+}
+
 int distort_transform(dt_iop_module_t *self, const dt_dev_pixelpipe_t *pipe, const dt_dev_pixelpipe_iop_t *piece,
                       float *const restrict points, size_t points_count)
 {
   dt_iop_crop_data_t *d = (dt_iop_crop_data_t *)piece->data;
 
-  const float crop_top = piece->buf_in.height * d->cy;
-  const float crop_left = piece->buf_in.width * d->cx;
+  float crop_left = 0.f, crop_top = 0.f;
+  _crop_offset(d, &piece->buf_in, &crop_left, &crop_top);
 
   // nothing to be done if parameters are set to neutral values (no top/left border)
   if(crop_top == 0 && crop_left == 0) return 1;
@@ -318,8 +377,8 @@ int distort_backtransform(dt_iop_module_t *self, const dt_dev_pixelpipe_t *pipe,
 {
   dt_iop_crop_data_t *d = (dt_iop_crop_data_t *)piece->data;
 
-  const float crop_top = piece->buf_in.height * d->cy;
-  const float crop_left = piece->buf_in.width * d->cx;
+  float crop_left = 0.f, crop_top = 0.f;
+  _crop_offset(d, &piece->buf_in, &crop_left, &crop_top);
 
   // nothing to be done if parameters are set to neutral values (no top/left border)
   if(crop_top == 0 && crop_left == 0) return 1;
@@ -349,19 +408,7 @@ void modify_roi_out(struct dt_iop_module_t *self, const struct dt_dev_pixelpipe_
                     struct dt_dev_pixelpipe_iop_t *piece, dt_iop_roi_t *roi_out,
                     const dt_iop_roi_t *roi_in)
 {
-  *roi_out = *roi_in;
-  dt_iop_crop_data_t *d = (dt_iop_crop_data_t *)piece->data;
-
-  roi_out->width = roi_in->width * (d->cw - d->cx);
-  roi_out->height = roi_in->height * (d->ch - d->cy);
-  roi_out->x = roi_in->width * d->cx;
-  roi_out->y = roi_in->height * d->cy;
-
-  // sanity check.
-  if(roi_out->x < 0) roi_out->x = 0;
-  if(roi_out->y < 0) roi_out->y = 0;
-  if(roi_out->width < 5) roi_out->width = 5;
-  if(roi_out->height < 5) roi_out->height = 5;
+  _crop_map_size((dt_iop_crop_data_t *)piece->data, roi_in, roi_out);
 }
 
 // 2nd pass: which roi would this operation need as input to fill the given output region?
@@ -412,26 +459,64 @@ error:
 void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pixelpipe_t *pipe,
                    dt_dev_pixelpipe_iop_t *piece)
 {
-  dt_iop_crop_params_t *p = (dt_iop_crop_params_t *)p1;
-  dt_iop_crop_data_t *d = (dt_iop_crop_data_t *)piece->data;
-  dt_iop_crop_gui_data_t *g = (dt_iop_crop_gui_data_t *)dt_iop_gui_data(self);
+  _crop_resolve(self, (dt_iop_crop_params_t *)p1, (dt_iop_crop_data_t *)piece->data);
+}
 
-  if(!IS_NULL_PTR(g) && g->editing)
+/* --- the geometry service's view of this module (develop/geometry/geometry.h) --------- */
+
+static void _crop_geometry_map_size(const void *data, const dt_iop_roi_t *const in, dt_iop_roi_t *out)
+{
+  _crop_map_size((const dt_iop_crop_data_t *)data, in, out);
+}
+
+static int _crop_geometry_transform(const void *data, const dt_geometry_record_t *const record,
+                                    dt_geometry_chain_t *chain, float *points, size_t points_count)
+{
+  float left = 0.f, top = 0.f;
+  _crop_offset((const dt_iop_crop_data_t *)data, &record->in, &left, &top);
+  if(left == 0.f && top == 0.f) return 1;
+  for(size_t i = 0; i < points_count * 2; i += 2)
   {
-    // In editing mode, we need to see the full uncropped image
-    // to setup the frame.
-    d->cx = 0.0f;
-    d->cy = 0.0f;
-    d->cw = 1.0f;
-    d->ch = 1.0f;
+    points[i] -= left;
+    points[i + 1] -= top;
   }
-  else
+  return 1;
+}
+
+static int _crop_geometry_backtransform(const void *data, const dt_geometry_record_t *const record,
+                                        dt_geometry_chain_t *chain, float *points, size_t points_count)
+{
+  float left = 0.f, top = 0.f;
+  _crop_offset((const dt_iop_crop_data_t *)data, &record->in, &left, &top);
+  if(left == 0.f && top == 0.f) return 1;
+  for(size_t i = 0; i < points_count * 2; i += 2)
   {
-    d->cx = CLAMPF(p->cx, 0.0f, 0.9f);
-    d->cy = CLAMPF(p->cy, 0.0f, 0.9f);
-    d->cw = CLAMPF(p->cw, 0.1f, 1.0f);
-    d->ch = CLAMPF(p->ch, 0.1f, 1.0f);
+    points[i] += left;
+    points[i + 1] += top;
   }
+  return 1;
+}
+
+static const dt_geometry_vtable_t _crop_geometry_vtable = {
+  .map_size = _crop_geometry_map_size,
+  .transform = _crop_geometry_transform,
+  .backtransform = _crop_geometry_backtransform,
+};
+
+gboolean geometry_record(dt_iop_module_t *self, dt_geometry_record_t *record)
+{
+  /* Same constructor commit_params() uses, including the edit-mode neutralisation: while the
+   * crop GUI is in editing mode the pipe renders the full uncropped frame, and the overlays
+   * have to be told the same story or they would sit on a crop nobody is displaying. */
+  dt_iop_crop_data_t *data = (dt_iop_crop_data_t *)g_malloc0(sizeof(dt_iop_crop_data_t));
+  if(IS_NULL_PTR(data)) return FALSE;
+
+  _crop_resolve(self, (const dt_iop_crop_params_t *)self->params, data);
+
+  record->data = data;
+  record->free_data = dt_free_gpointer;
+  record->vtable = &_crop_geometry_vtable;
+  return TRUE;
 }
 
 gboolean runtime_data_hash(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe,

--- a/src/iop/demosaic.c
+++ b/src/iop/demosaic.c
@@ -77,6 +77,7 @@
 #include "develop/blend.h"
 #include "develop/develop.h"
 #include "pixel/format.h"
+#include "develop/geometry/geometry.h"
 #include "develop/imageop.h"
 #include "develop/imageop_math.h"
 #include "develop/imageop_gui.h"
@@ -933,14 +934,14 @@ void distort_mask(struct dt_iop_module_t *self, const struct dt_dev_pixelpipe_t 
   dt_interpolation_resample_roi_1c(itor, out, roi_out, in, roi_in);
 }
 
-void modify_roi_out(struct dt_iop_module_t *self, const struct dt_dev_pixelpipe_t *pipe,
-                    struct dt_dev_pixelpipe_iop_t *piece, dt_iop_roi_t *roi_out,
-                    const dt_iop_roi_t *const roi_in)
+/** @brief Input rect -> output rect. THE size evaluator: modify_roi_out() below and the
+ *  geometry service's record (develop/geometry/geometry.h) are its only two callers. */
+static void _demosaic_map_size(const gboolean downsamples, const dt_iop_roi_t *const roi_in,
+                               dt_iop_roi_t *roi_out)
 {
   *roi_out = *roi_in;
 
-  dt_iop_demosaic_data_t *data = (dt_iop_demosaic_data_t *)piece->data;
-  if(_is_downsample_method(data->demosaicing_method))
+  if(downsamples)
   {
     roi_out->width = (roi_in->width + 1) / 2;
     roi_out->height = (roi_in->height + 1) / 2;
@@ -949,6 +950,53 @@ void modify_roi_out(struct dt_iop_module_t *self, const struct dt_dev_pixelpipe_
   // snap to start of mosaic block:
   roi_out->x = 0; // MAX(0, roi_out->x & ~1);
   roi_out->y = 0; // MAX(0, roi_out->y & ~1);
+}
+
+void modify_roi_out(struct dt_iop_module_t *self, const struct dt_dev_pixelpipe_t *pipe,
+                    struct dt_dev_pixelpipe_iop_t *piece, dt_iop_roi_t *roi_out,
+                    const dt_iop_roi_t *const roi_in)
+{
+  dt_iop_demosaic_data_t *data = (dt_iop_demosaic_data_t *)piece->data;
+  _demosaic_map_size(_is_downsample_method(data->demosaicing_method), roi_in, roi_out);
+}
+
+/* --- the geometry service's view of this module (develop/geometry/geometry.h) ---------
+ *
+ * Demosaic is on the roster for its SIZE only: the downsampling methods halve the frame, and
+ * nothing downstream would otherwise know. It publishes no point transform because it has none
+ * -- consumers of coordinates work in the post-demosaic frame and normalise against the
+ * per-module dimensions the chain's fold records.
+ */
+
+typedef struct dt_iop_demosaic_geometry_t
+{
+  gboolean downsamples;
+} dt_iop_demosaic_geometry_t;
+
+static void _demosaic_geometry_map_size(const void *data, const dt_iop_roi_t *const in, dt_iop_roi_t *out)
+{
+  _demosaic_map_size(((const dt_iop_demosaic_geometry_t *)data)->downsamples, in, out);
+}
+
+static const dt_geometry_vtable_t _demosaic_geometry_vtable = {
+  .map_size = _demosaic_geometry_map_size,
+  .transform = NULL,
+  .backtransform = NULL,
+};
+
+gboolean geometry_record(dt_iop_module_t *self, dt_geometry_record_t *record)
+{
+  const dt_iop_demosaic_params_t *const p = (const dt_iop_demosaic_params_t *)self->params;
+
+  dt_iop_demosaic_geometry_t *data
+      = (dt_iop_demosaic_geometry_t *)g_malloc0(sizeof(dt_iop_demosaic_geometry_t));
+  if(IS_NULL_PTR(data)) return FALSE;
+  data->downsamples = _is_downsample_method(p->demosaicing_method);
+
+  record->data = data;
+  record->free_data = dt_free_gpointer;
+  record->vtable = &_demosaic_geometry_vtable;
+  return TRUE;
 }
 
 // which roi input is needed to process to this output?

--- a/src/iop/flip.c
+++ b/src/iop/flip.c
@@ -61,6 +61,7 @@
 #include "imageio/imageio_core.h"
 #include "common/opencl.h"
 #include "develop/develop.h"
+#include "develop/geometry/geometry.h"
 #include "develop/imageop.h"
 #include "develop/imageop_gui.h"
 #include "develop/imageop_gui.h"
@@ -225,6 +226,40 @@ static void backtransform(const int32_t *x, int32_t *o, const dt_image_orientati
   }
 }
 
+/* --- the shared geometry core ----------------------------------------------------------
+ *
+ * The ONE place flip's orientation is resolved and the ONE place its size map is expressed.
+ * commit_params() and modify_roi_out() use them, and so does geometry_record() for the
+ * pixel-less geometry service (develop/geometry/geometry.h).
+ */
+
+/**
+ * @brief The orientation this module will actually apply.
+ *
+ * @details ORIENTATION_NULL means "whatever the file says", which is resolved from the image's
+ * EXIF here rather than stored in params -- so the resolution has to happen identically wherever
+ * the orientation is consumed, or a record would describe a rotation the pipe is not doing.
+ */
+static dt_image_orientation_t _flip_resolve(dt_iop_module_t *self, const dt_iop_flip_params_t *const p)
+{
+  if(p->orientation == ORIENTATION_NULL) return dt_image_orientation(&self->dev->image_storage);
+  return p->orientation;
+}
+
+/** @brief Input rect -> output rect: a swap, or nothing. */
+static void _flip_map_size(const dt_image_orientation_t orientation, const dt_iop_roi_t *const roi_in,
+                           dt_iop_roi_t *roi_out)
+{
+  *roi_out = *roi_in;
+
+  // transform whole buffer roi
+  if(orientation & ORIENTATION_SWAP_XY)
+  {
+    roi_out->width = roi_in->height;
+    roi_out->height = roi_in->width;
+  }
+}
+
 int distort_transform(dt_iop_module_t *self, const dt_dev_pixelpipe_t *pipe, const dt_dev_pixelpipe_iop_t *piece,
                       float *const restrict points, size_t points_count)
 {
@@ -305,14 +340,7 @@ void modify_roi_out(struct dt_iop_module_t *self, const struct dt_dev_pixelpipe_
                     const dt_iop_roi_t *roi_in)
 {
   const dt_iop_flip_data_t *d = (dt_iop_flip_data_t *)piece->data;
-  *roi_out = *roi_in;
-
-  // transform whole buffer roi
-  if(d->orientation & ORIENTATION_SWAP_XY)
-  {
-    roi_out->width = roi_in->height;
-    roi_out->height = roi_in->width;
-  }
+  _flip_map_size(d->orientation, roi_in, roi_out);
 }
 
 // 2nd pass: which roi would this operation need as input to fill the given output region?
@@ -423,12 +451,92 @@ void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pix
   const dt_iop_flip_params_t *p = (dt_iop_flip_params_t *)p1;
   dt_iop_flip_data_t *d = (dt_iop_flip_data_t *)piece->data;
 
-  if(p->orientation == ORIENTATION_NULL)
-    d->orientation = dt_image_orientation(&self->dev->image_storage);
-  else
-    d->orientation = p->orientation;
+  d->orientation = _flip_resolve(self, p);
 
   if(d->orientation == ORIENTATION_NONE) piece->enabled = 0;
+}
+
+/* --- the geometry service's view of this module (develop/geometry/geometry.h) --------- */
+
+typedef struct dt_iop_flip_geometry_t
+{
+  dt_image_orientation_t orientation;
+} dt_iop_flip_geometry_t;
+
+static void _flip_geometry_map_size(const void *data, const dt_iop_roi_t *const in, dt_iop_roi_t *out)
+{
+  _flip_map_size(((const dt_iop_flip_geometry_t *)data)->orientation, in, out);
+}
+
+static int _flip_geometry_transform(const void *data, const dt_geometry_record_t *const record,
+                                    dt_geometry_chain_t *chain, float *points, size_t points_count)
+{
+  const dt_image_orientation_t orientation = ((const dt_iop_flip_geometry_t *)data)->orientation;
+  for(size_t i = 0; i < points_count * 2; i += 2)
+  {
+    float x = points[i];
+    float y = points[i + 1];
+    if(orientation & ORIENTATION_FLIP_X) x = record->in.width - points[i];
+    if(orientation & ORIENTATION_FLIP_Y) y = record->in.height - points[i + 1];
+    if(orientation & ORIENTATION_SWAP_XY)
+    {
+      const float yy = y;
+      y = x;
+      x = yy;
+    }
+    points[i] = x;
+    points[i + 1] = y;
+  }
+  return 1;
+}
+
+static int _flip_geometry_backtransform(const void *data, const dt_geometry_record_t *const record,
+                                        dt_geometry_chain_t *chain, float *points, size_t points_count)
+{
+  const dt_image_orientation_t orientation = ((const dt_iop_flip_geometry_t *)data)->orientation;
+  for(size_t i = 0; i < points_count * 2; i += 2)
+  {
+    float x = points[i];
+    float y = points[i + 1];
+    if(orientation & ORIENTATION_SWAP_XY)
+    {
+      const float yy = y;
+      y = x;
+      x = yy;
+    }
+    if(orientation & ORIENTATION_FLIP_X) x = record->in.width - x;
+    if(orientation & ORIENTATION_FLIP_Y) y = record->in.height - y;
+    points[i] = x;
+    points[i + 1] = y;
+  }
+  return 1;
+}
+
+static const dt_geometry_vtable_t _flip_geometry_vtable = {
+  .map_size = _flip_geometry_map_size,
+  .transform = _flip_geometry_transform,
+  .backtransform = _flip_geometry_backtransform,
+};
+
+gboolean geometry_record(dt_iop_module_t *self, dt_geometry_record_t *record)
+{
+  const dt_image_orientation_t orientation
+      = _flip_resolve(self, (const dt_iop_flip_params_t *)self->params);
+
+  /* ORIENTATION_NONE is how commit_params() clears piece->enabled: an enabled flip module whose
+   * resolved orientation is a no-op contributes nothing to the pipe, and must contribute nothing
+   * here either. Published (so the roster is satisfied) with no vtable, which the chain reads as
+   * identity -- the same thing a disabled piece is. */
+  if(orientation == ORIENTATION_NONE) return TRUE;
+
+  dt_iop_flip_geometry_t *data = (dt_iop_flip_geometry_t *)g_malloc0(sizeof(dt_iop_flip_geometry_t));
+  if(IS_NULL_PTR(data)) return FALSE;
+  data->orientation = orientation;
+
+  record->data = data;
+  record->free_data = dt_free_gpointer;
+  record->vtable = &_flip_geometry_vtable;
+  return TRUE;
 }
 
 void init_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)

--- a/src/iop/rawprepare.c
+++ b/src/iop/rawprepare.c
@@ -49,6 +49,7 @@
 #include "common/opencl.h"
 #include "common/imagebuf.h"
 #include "common/image.h"
+#include "develop/geometry/geometry.h"
 #include "develop/imageop.h"
 #include "develop/imageop_gui.h"
 #include "caches/image_cache.h"
@@ -268,6 +269,40 @@ static void _update_output_cfa_descriptor(const dt_dev_pixelpipe_t *pipe,
   }
 }
 
+/* --- the shared geometry core ----------------------------------------------------------
+ *
+ * rawprepare's geometry is the fixed sensor border trim: a translation by the top/left margin,
+ * and an output shrunk by the total margin. Expressed once here for the pipeline callbacks and
+ * for geometry_record() (develop/geometry/geometry.h) alike.
+ */
+
+typedef struct dt_iop_rawprepare_geometry_t
+{
+  int32_t x, y, width, height;   /**< the four crop fields, verbatim from params */
+} dt_iop_rawprepare_geometry_t;
+
+/** @brief The translation the trim applies, at @p scale. */
+static void _rawprepare_offset(const int32_t crop_x, const int32_t crop_y, const double scale, double *dx,
+                               double *dy)
+{
+  *dx = (double)crop_x * scale;
+  *dy = (double)crop_y * scale;
+}
+
+/** @brief Input rect -> output rect, shrunk by the total margin at the input's own scale. */
+static void _rawprepare_map_size(const dt_iop_rawprepare_geometry_t *const g,
+                                 const dt_iop_roi_t *const roi_in, dt_iop_roi_t *roi_out)
+{
+  *roi_out = *roi_in;
+  roi_out->x = roi_out->y = 0;
+
+  const double x = g->x + g->width;
+  const double y = g->y + g->height;
+  const double scale = roi_in->scale;
+  roi_out->width = (int)round((double)roi_out->width - x * scale);
+  roi_out->height = (int)round((double)roi_out->height - y * scale);
+}
+
 int distort_transform(dt_iop_module_t *self, const dt_dev_pixelpipe_t *pipe, const dt_dev_pixelpipe_iop_t *piece,
                       float *const restrict points, size_t points_count)
 {
@@ -278,9 +313,8 @@ int distort_transform(dt_iop_module_t *self, const dt_dev_pixelpipe_t *pipe, con
   // nothing to be done if parameters are set to neutral values (no top/left crop)
   if (d->x == 0 && d->y == 0) return 1;
 
-  const double scale = piece->buf_in.scale;
-  const double x = (double)d->x * scale;
-  const double y = (double)d->y * scale;
+  double x = 0.0, y = 0.0;
+  _rawprepare_offset(d->x, d->y, piece->buf_in.scale, &x, &y);
   __OMP_PARALLEL_FOR_SIMD__(aligned(points:64) if(points_count > 100))
   for(size_t i = 0; i < points_count * 2; i += 2)
   {
@@ -302,9 +336,8 @@ int distort_backtransform(dt_iop_module_t *self, const dt_dev_pixelpipe_t *pipe,
   // nothing to be done if parameters are set to neutral values (no top/left crop)
   if (d->x == 0 && d->y == 0) return 1;
 
-  const double scale = piece->buf_in.scale;
-  const double x = (double)d->x * scale;
-  const double y = (double)d->y * scale;
+  double x = 0.0, y = 0.0;
+  _rawprepare_offset(d->x, d->y, piece->buf_in.scale, &x, &y);
   __OMP_PARALLEL_FOR_SIMD__(aligned(points:64) if(points_count > 100))
   for(size_t i = 0; i < points_count * 2; i += 2)
   {
@@ -332,16 +365,10 @@ void modify_roi_out(dt_iop_module_t *self, const dt_dev_pixelpipe_t *pipe, dt_de
                     dt_iop_roi_t *roi_out,
                     const dt_iop_roi_t *const roi_in)
 {
-  *roi_out = *roi_in;
   dt_iop_rawprepare_data_t *d = (dt_iop_rawprepare_data_t *)piece->data;
 
-  roi_out->x = roi_out->y = 0;
-
-  const double x = d->x + d->width;
-  const double y = d->y + d->height;
-  const double scale = roi_in->scale;
-  roi_out->width = (int)round((double)roi_out->width - x * scale);
-  roi_out->height = (int)round((double)roi_out->height - y * scale);
+  const dt_iop_rawprepare_geometry_t geo = { d->x, d->y, d->width, d->height };
+  _rawprepare_map_size(&geo, roi_in, roi_out);
 
   /* Rawprepare changes the CFA phase according to the effective crop on the current ROI scale.
    * That contract cannot be authored at history resync time because `piece->roi_in` is not known yet.
@@ -924,6 +951,71 @@ void init_pipe(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe
 {
   piece->data = dt_calloc_align(sizeof(dt_iop_rawprepare_data_t));
   piece->data_size = sizeof(dt_iop_rawprepare_data_t);
+}
+
+/* --- the geometry service's view of this module (develop/geometry/geometry.h) --------- */
+
+static void _rawprepare_geometry_map_size(const void *data, const dt_iop_roi_t *const in, dt_iop_roi_t *out)
+{
+  _rawprepare_map_size((const dt_iop_rawprepare_geometry_t *)data, in, out);
+}
+
+static int _rawprepare_geometry_transform(const void *data, const dt_geometry_record_t *const record,
+                                          dt_geometry_chain_t *chain, float *points, size_t points_count)
+{
+  const dt_iop_rawprepare_geometry_t *const g = (const dt_iop_rawprepare_geometry_t *)data;
+  if(g->x == 0 && g->y == 0) return 1;
+
+  double x = 0.0, y = 0.0;
+  _rawprepare_offset(g->x, g->y, record->in.scale, &x, &y);
+  for(size_t i = 0; i < points_count * 2; i += 2)
+  {
+    points[i] -= x;
+    points[i + 1] -= y;
+  }
+  return 1;
+}
+
+static int _rawprepare_geometry_backtransform(const void *data, const dt_geometry_record_t *const record,
+                                              dt_geometry_chain_t *chain, float *points, size_t points_count)
+{
+  const dt_iop_rawprepare_geometry_t *const g = (const dt_iop_rawprepare_geometry_t *)data;
+  if(g->x == 0 && g->y == 0) return 1;
+
+  double x = 0.0, y = 0.0;
+  _rawprepare_offset(g->x, g->y, record->in.scale, &x, &y);
+  for(size_t i = 0; i < points_count * 2; i += 2)
+  {
+    points[i] += x;
+    points[i + 1] += y;
+  }
+  return 1;
+}
+
+static const dt_geometry_vtable_t _rawprepare_geometry_vtable = {
+  .map_size = _rawprepare_geometry_map_size,
+  .transform = _rawprepare_geometry_transform,
+  .backtransform = _rawprepare_geometry_backtransform,
+};
+
+gboolean geometry_record(dt_iop_module_t *self, dt_geometry_record_t *record)
+{
+  const dt_iop_rawprepare_params_t *const p = (const dt_iop_rawprepare_params_t *)self->params;
+
+  dt_iop_rawprepare_geometry_t *data
+      = (dt_iop_rawprepare_geometry_t *)g_malloc0(sizeof(dt_iop_rawprepare_geometry_t));
+  if(IS_NULL_PTR(data)) return FALSE;
+
+  /* commit_params() copies these four verbatim; nothing else about them is derived. */
+  data->x = p->x;
+  data->y = p->y;
+  data->width = p->width;
+  data->height = p->height;
+
+  record->data = data;
+  record->free_data = dt_free_gpointer;
+  record->vtable = &_rawprepare_geometry_vtable;
+  return TRUE;
 }
 
 void cleanup_pipe(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)


### PR DESCRIPTION
Third tranche of `doc/geometry-service.md`. **Stacked on #1165** (base is `geometry/g2-skeleton`);
it needs the chain that PR adds. Rebase to master once #1165 lands.

Five modules publish records — enough for the chain to become **authoritative** on a real image,
so shadow mode starts comparing answers instead of listing gaps.

### Which five, and why those

**Not the five the plan named.** G2's harness was built to report which roster modules gate a
given image, and on the test raw it named `crop, flip, demosaic, rawprepare, basebuffer` — three
of which are always-enabled infrastructure the plan had scattered across two later tranches.
Nothing can *ever* become authoritative without those three, so they came first, with the two
simple ones that complete that image. The harness earned its keep on its first run.

### The one-constructor rule, applied

Each module's geometry is now expressed exactly once and consumed from both sides — the pipeline
callbacks and the record:

| module | shared core | note |
|---|---|---|
| crop | `_crop_resolve` / `_crop_map_size` / `_crop_offset` | the resolve carries the **edit-mode neutralisation**: while the crop GUI is editing, the pipe renders the full uncropped frame, and a record that disagreed would put overlays on a crop nobody is displaying |
| flip | `_flip_resolve` / `_flip_map_size` | `ORIENTATION_NULL` resolves from EXIF; a resolved `ORIENTATION_NONE` is how `commit_params` clears `piece->enabled`, reproduced by publishing with no vtable = identity |
| rawprepare | `_rawprepare_offset` / `_rawprepare_map_size` | `modify_roi_out` keeps its CFA-descriptor side effect — rendering state, no business of this service |
| demosaic | `_demosaic_map_size` | on the roster for **size only**; the downsample methods halve the frame and nothing downstream would otherwise know |
| basebuffer | asserts the full sensor frame at scale 1 | which is what the chain seeds its fold with |

### Shadow mode now checks transforms, not just sizes

The size fold only exercises `map_size`, so the evaluators that actually move overlays would have
gone unverified until a consumer switched over and a user noticed a mask in the wrong place.
Shadow mode now also pushes five points spanning the raw frame through both the chain and the
virtual pipe at iop_order 0 / `DIR_ALL` — what `dt_dev_coordinates_raw_abs_to_image_abs()` asks
for — and reports any disagreeing by more than half a pixel, with the point.

### Measured

```
_DSC9410.NEF   [geometry] agrees with the pipe: size 2464x3213, all 5 transform probes
20181020.RAF   [geometry] agrees with the pipe: size 6032x4032, all 5 transform probes
```

The NEF is not a trivial pass: raw 6016×4016 → flip swaps → 4016×6016 → crop → 2464×3213, so
both modules are doing real work in that chain.

**The breadth run reorders what comes next.** Across CR2, ARW and DNG from the test collection,
the only remaining gate is **`lens.0`, on every one of them**. Lens buys more than borders,
rotatepixels, scalepixels and clipping combined — none of which has gated anything measured so
far. I'd take lens next rather than following the plan's G4 order; the doc update recording that
goes on the plan branch (#1163), which doesn't exist in this tree.

- Export A/B vs pre-change binary: **bit-identical**, 0 differing pixels of 23.7 M. This is the
  load-bearing check here — the refactors touched live rendering paths (`commit_params`,
  `modify_roi_out`, both distort callbacks) in all five modules.
- `include_graph.py` cycles 0, layering 184 unchanged; module boundaries held.

Still **nothing consumes** the chain: authority means shadow mode can compare, not that any
caller switched. That is G7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
