### PR TITLE
Geometry service G4: lens, and the cost measurement that justifies the series

### DIFF
--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -396,8 +396,9 @@ int dt_dev_get_thumbnail_size(dt_develop_t *dev)
 
   /* Rebuild the geometry chain from the same modules and history the fold above just used, and
    * hold it against the answer the pipe produced. It publishes nothing and nothing consumes it
-   * yet (G2): while its roster is incomplete it reports which modules still owe it a record,
-   * per image, and once complete it reports divergence. Both under `-d dev'.
+   * yet: while its roster is incomplete it reports which modules still owe it a record, per
+   * image, and once complete it reports divergence and the cost of each side. Both under
+   * `-d dev'.
    *
    * STRICTLY AFTER the two publications above, and never between them. Those two are one
    * atomic-looking update to a consumer: the first moves the geometry record to the new
@@ -405,11 +406,14 @@ int dt_dev_get_thumbnail_size(dt_develop_t *dev)
    * (dt_dev_roi_request_publish, since the fix for #1157). Anything inserted between them
    * widens the window in which the darkroom worker can latch the OLD request against ALREADY
    * NEW history -- which is precisely the mixed frame #1157 is about, and this rebuild is not
-   * cheap enough to be invisible there: it costs milliseconds once a module with a real lookup
-   * publishes a record, against a worker that naps in tens of milliseconds. A shadow observer
-   * must not sit inside the update it is observing. */
+   * cheap enough to be invisible there: the lens record's database lookups alone cost 2-5 ms,
+   * against a worker that naps in tens of milliseconds. A shadow observer must not sit inside
+   * the update it is observing. */
+  const double chain_start = dt_get_wtime();
   dt_geometry_chain_rebuild(dev);
-  dt_geometry_shadow_check_size(dev, processed_width, processed_height);
+  const double chain_ms = (dt_get_wtime() - chain_start) * 1000.0;
+
+  dt_geometry_shadow_check(dev, processed_width, processed_height, chain_ms);
 
 
   dt_dev_update_mouse_effect_radius(dev);

--- a/src/develop/geometry/geometry.c
+++ b/src/develop/geometry/geometry.c
@@ -338,7 +338,8 @@ void dt_geometry_clear_focus(dt_develop_t *dev)
   dev->geometry_chain->focus_active = FALSE;
 }
 
-void dt_geometry_shadow_check_size(dt_develop_t *dev, const int pipe_width, const int pipe_height)
+void dt_geometry_shadow_check(dt_develop_t *dev, const int pipe_width, const int pipe_height,
+                              const double chain_ms)
 {
   if(IS_NULL_PTR(dev) || IS_NULL_PTR(dev->geometry_chain)) return;
   if(!(dt_get_debug_flags() & DT_DEBUG_DEV)) return;
@@ -447,6 +448,11 @@ void dt_geometry_shadow_check_size(dt_develop_t *dev, const int pipe_width, cons
     dt_print(DT_DEBUG_DEV,
              "[geometry] agrees with the pipe: size %dx%d, 5/5 forward probes, 5/5 round-trips\n",
              chain->processed_width, chain->processed_height);
+
+  /* The cost, which is the reason this service exists. Compare against `-d perf's "pipeline
+   * resync with history ... for pipe virtual-preview" line: that is the same product, computed
+   * the way this replaces. */
+  dt_print(DT_DEBUG_DEV, "[geometry] chain rebuilt in %.2f ms\n", chain_ms);
 }
 
 // clang-format off

--- a/src/develop/geometry/geometry.h
+++ b/src/develop/geometry/geometry.h
@@ -49,6 +49,15 @@
 
 #include "develop/pixelpipe_hb.h"   // dt_iop_roi_t
 
+/* C linkage: geometry.c is a C translation unit and iop/lens.cc -- the first module to publish
+ * a record -- is a C++ one. Without this its calls and its vtable would name mangled symbols
+ * nothing defines. Linux would still link the plugin (a shared object may carry undefined
+ * symbols and resolve them at dlopen time) and fail at runtime; macOS and Windows fail the
+ * build. Same reason control/user_message.h carries these guards. */
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 struct dt_develop_t;
 struct dt_iop_module_t;
 struct dt_geometry_record_t;
@@ -180,12 +189,23 @@ void dt_geometry_clear_focus(struct dt_develop_t *dev);
 /**
  * @brief Shadow mode: compare the chain against the pipe that still owns the answer.
  *
- * @details Called from the size path with whatever the virtual pipe just produced. While the
- * roster is incomplete this reports exactly which enabled modules are still missing a record --
- * measured per image, rather than assumed from a source audit -- and once it is complete it
- * reports any divergence. Both under `-d dev'. It never changes behaviour.
+ * @details Called from the size path with whatever the virtual pipe just produced, and with
+ * what each side cost. While the roster is incomplete this reports exactly which enabled
+ * modules are still missing a record -- measured per image, rather than assumed from a source
+ * audit -- and once it is complete it reports any divergence in size, in forward transforms and
+ * in round trips, together with the two costs. Both under `-d dev'. It never changes behaviour.
+ *
+ * @param chain_ms what the rebuild cost. The virtual pipe's counterpart is NOT measured here:
+ * its work is done in _sync_virtual_pipe(), off this path, and is already reported by `-d perf'
+ * as "pipeline resync with history ... for pipe virtual-preview". Timing it here would only ever
+ * catch a resync that had nothing to do, and report ~0 ms for the side that is expensive.
  */
-void dt_geometry_shadow_check_size(struct dt_develop_t *dev, int pipe_width, int pipe_height);
+void dt_geometry_shadow_check(struct dt_develop_t *dev, int pipe_width, int pipe_height,
+                              double chain_ms);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif // DT_DEVELOP_GEOMETRY_GEOMETRY_H
 

--- a/src/iop/lens.cc
+++ b/src/iop/lens.cc
@@ -103,6 +103,8 @@
 #include "widgets/widget_style.h"
 #include "control/signal.h"
 
+#include "develop/geometry/geometry.h"
+
 extern "C" {
 
 #if LF_VERSION < ((0 << 24) | (2 << 16) | (9 << 8) | 0)
@@ -1175,28 +1177,41 @@ void modify_roi_in(struct dt_iop_module_t *self, const struct dt_dev_pixelpipe_t
   delete modifier;
 }
 
-void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pixelpipe_t *pipe,
-                   dt_dev_pixelpipe_iop_t *piece)
+/* --- the shared geometry core ----------------------------------------------------------
+ *
+ * lens resolves its effective parameters and then builds a lensfun state out of them, and both
+ * halves are needed twice: once for the pixel pipe, once for the record the geometry service
+ * composes GUI coordinates from (develop/geometry/geometry.h). Expressed once here.
+ *
+ * Note what lens does NOT contribute: modify_roi_out() is the identity, so this module changes
+ * no dimensions. It is on the geometry roster purely for its point transforms.
+ */
+
+/**
+ * @brief Which parameters are actually in force.
+ *
+ * @details p->modified == 0 means "auto": the user never touched the GUI after autodetection,
+ * and the parameters that describe the correction are the module's DEFAULTS, filled in by
+ * reload_defaults() from the image's EXIF -- not the ones in history. A record built from
+ * history alone would describe a correction the pipe is not applying, on exactly the images
+ * where lens correction is automatic, which is most of them.
+ */
+static const dt_iop_lensfun_params_t *_lens_effective_params(dt_iop_module_t *self,
+                                                             const dt_iop_lensfun_params_t *const p)
 {
-  dt_iop_lensfun_params_t *p = (dt_iop_lensfun_params_t *)p1;
+  return (p->modified == 0) ? (const dt_iop_lensfun_params_t *)self->default_params : p;
+}
 
-  // FIXME: this is utter shit and should be made into a GUI "mode".
-  // If p->modified == 0, mode = auto and hide all controls
-  // if p->modidified == 1, mode = manual and show all controls.
-  if(p->modified == 0)
-  {
-    /*
-     * user did not modify anything in gui after autodetection - let's
-     * use current default_params as params - for presets and mass-export
-     */
-    p = (dt_iop_lensfun_params_t *)self->default_params;
-
-    // Temporary fix pending GUI unfucking
-    dt_iop_compute_module_hash(self, self->dev->forms);
-  }
-
-  dt_iop_lensfun_data_t *d = (dt_iop_lensfun_data_t *)piece->data;
-
+/**
+ * @brief Build the lensfun state from resolved parameters. THE constructor.
+ *
+ * @details @p d is zeroed or already owns a lens; either way it owns a fresh deep copy of the
+ * database's lfLens on return, and the caller must delete it (see _lens_free_data() and
+ * cleanup_pipe()). The database lookups take the plugin mutex, as they always have.
+ */
+static void _lens_build_data(dt_iop_module_t *self, const dt_iop_lensfun_params_t *const p,
+                             dt_iop_lensfun_data_t *d)
+{
   dt_iop_lensfun_global_data_t *gd = (dt_iop_lensfun_global_data_t *)self->global_data;
   lfDatabase *dt_iop_lensfun_db = (lfDatabase *)gd->db;
   const lfCamera *camera = NULL;
@@ -1284,8 +1299,120 @@ void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pix
   {
     d->do_nan_checks = FALSE;
   }
+}
+
+/** @brief The lensfun modify mask this image allows: monochrome sensors get no TCA correction. */
+static int _lens_used_mask(dt_iop_module_t *self)
+{
+  return dt_image_is_monochrome(&self->dev->image_storage) ? (LF_MODIFY_ALL & ~LF_MODIFY_TCA)
+                                                           : LF_MODIFY_ALL;
+}
+
+void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pixelpipe_t *pipe,
+                   dt_dev_pixelpipe_iop_t *piece)
+{
+  const dt_iop_lensfun_params_t *p = _lens_effective_params(self, (dt_iop_lensfun_params_t *)p1);
+
+  // FIXME: this is utter shit and should be made into a GUI "mode".
+  // If p->modified == 0, mode = auto and hide all controls
+  // if p->modidified == 1, mode = manual and show all controls.
+  if(((dt_iop_lensfun_params_t *)p1)->modified == 0)
+  {
+    // Temporary fix pending GUI unfucking
+    dt_iop_compute_module_hash(self, self->dev->forms);
+  }
+
+  _lens_build_data(self, p, (dt_iop_lensfun_data_t *)piece->data);
 
   piece->cache_output_on_ram = TRUE;
+}
+
+/* --- the geometry service's view of this module (develop/geometry/geometry.h) ---------
+ *
+ * The one record in the service whose payload is not plain data: evaluating a lens correction
+ * needs a live lfLens, a C++ object with heap-allocated calibration lists, so the record owns a
+ * deep copy and frees it. That is what dt_geometry_record_t::free_data exists for.
+ */
+
+typedef struct dt_iop_lens_geometry_t
+{
+  dt_iop_lensfun_data_t data;   /**< owns its own lfLens, exactly like a pipe piece does */
+  int used_lf_mask;
+} dt_iop_lens_geometry_t;
+
+static void _lens_free_data(void *ptr)
+{
+  dt_iop_lens_geometry_t *g = (dt_iop_lens_geometry_t *)ptr;
+  if(!g) return;
+  if(g->data.lens) delete g->data.lens;
+  free(g);
+}
+
+/** @brief Apply the correction to points. @p inverse selects the direction, as get_modifier()
+ *  means it: distort_transform() passes TRUE, distort_backtransform() passes FALSE. */
+static int _lens_geometry_apply(const void *data, const dt_geometry_record_t *const record,
+                                float *points, size_t points_count, gboolean inverse)
+{
+  const dt_iop_lens_geometry_t *const g = (const dt_iop_lens_geometry_t *)data;
+  const dt_iop_lensfun_data_t *const d = &g->data;
+
+  if(!d->lens || !d->lens->Maker || d->crop <= 0.0f) return 0;
+  if(record->in.width <= 0 || record->in.height <= 0) return 0;
+
+  int modflags = 0;
+  const lfModifier *modifier
+      = get_modifier(&modflags, record->in.width, record->in.height, d, g->used_lf_mask, inverse);
+  if(!modifier) return 0;
+
+  if(modflags & (LF_MODIFY_TCA | LF_MODIFY_DISTORTION | LF_MODIFY_GEOMETRY | LF_MODIFY_SCALE))
+  {
+    for(size_t i = 0; i < points_count * 2; i += 2)
+    {
+      float DT_ALIGNED_ARRAY buf[6];
+      modifier->ApplySubpixelGeometryDistortion(points[i], points[i + 1], 1, 1, buf);
+      // green channel, like distort_transform() and distort_mask() do, so x and y come from the
+      // same colour channel's distortion field instead of mixing red's x with green's y.
+      points[i] = buf[2];
+      points[i + 1] = buf[3];
+    }
+  }
+
+  delete modifier;
+  return 1;
+}
+
+static int _lens_geometry_transform(const void *data, const dt_geometry_record_t *const record,
+                                    dt_geometry_chain_t *chain, float *points, size_t points_count)
+{
+  return _lens_geometry_apply(data, record, points, points_count, TRUE);
+}
+
+static int _lens_geometry_backtransform(const void *data, const dt_geometry_record_t *const record,
+                                        dt_geometry_chain_t *chain, float *points, size_t points_count)
+{
+  return _lens_geometry_apply(data, record, points, points_count, FALSE);
+}
+
+static const dt_geometry_vtable_t _lens_geometry_vtable = {
+  /* .map_size = */ NULL,   // modify_roi_out() is the identity: lens changes no dimensions
+  /* .transform = */ _lens_geometry_transform,
+  /* .backtransform = */ _lens_geometry_backtransform,
+};
+
+gboolean geometry_record(dt_iop_module_t *self, dt_geometry_record_t *record)
+{
+  dt_iop_lens_geometry_t *g = (dt_iop_lens_geometry_t *)calloc(1, sizeof(dt_iop_lens_geometry_t));
+  if(!g) return FALSE;
+
+  const dt_iop_lensfun_params_t *p
+      = _lens_effective_params(self, (const dt_iop_lensfun_params_t *)self->params);
+  _lens_build_data(self, p, &g->data);
+  g->used_lf_mask = _lens_used_mask(self);
+
+  record->data = g;
+  record->free_data = _lens_free_data;
+  record->vtable = &_lens_geometry_vtable;
+  return TRUE;
 }
 
 void init_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)


### PR DESCRIPTION
Fourth tranche. **Stacked on #1166** (which is stacked on #1165). Lens was the *measured* next
step: after G3 it was the only module still gating the chain on every CR2, ARW and DNG tried.

## The cost, which is the gate for reviewing this series

Both sides on darkroom entry, five images, `-d dev -d perf`:

| image | virtual pipe resync | chain rebuild | ratio |
|---|---|---|---|
| _DSC9410.NEF | 0.108 s | 0.03 ms | ~3600× |
| 20180415_0021.CR2 | 0.105 s | 2.01 ms | ~52× |
| 2018-07-17__7M33262.ARW | 0.103 s | 2.91 ms | ~35× |
| 2019-02-03-0001.dng | 0.104 s | 5.13 ms | ~20× |
| 20181020_0038.RAF | 0.107 s | 0.04 ms | ~2700× |

All five agree with the pipe: size, 5/5 forward probes, 5/5 round-trips.

**Where the 2–5 ms goes**: entirely lensfun's `FindCamerasExt` + `FindLenses` string lookups —
the two images without lens correction cost 0.03 ms. Those lookups are a memo waiting to happen,
and it would speed up the **pixel pipes too**, since their `commit_params` repeats them on every
resync. Deliberately not done here: it belongs to lens, not to this service.

**A caveat on these numbers, and it matters more than they do.** Darkroom entry currently sizes
the preview *three times* — `1155x1736` → `1154x1734` → `1132x1702` — because the widget
allocation settles (1147×868 → 1147×867) and a panel then changes the layout (→ 1131×851). Each
resize costs a full re-render, ~2.4 s on these images. That is **pre-existing**: the same three
sizes, to the pixel, come out of the pre-series binary. It dwarfs both columns above, and the
timing of the third resize varies run to run, so any main-vs-preview cost comparison drawn from a
single entry is not controlled. Worth its own issue; I did not touch it here.

## Lens

- `modify_roi_out` is the **identity** — lens changes no dimensions, so its record has no
  `map_size`. It is on the roster purely for point transforms.
- Its payload is the one that **isn't plain data**: evaluation needs a live `lfLens`, so the
  record owns a deep copy and frees it via `free_data`. `get_modifier()` is already a pure
  function of `(data, w, h)`, so it is shared verbatim — no second derivation exists.
- `commit_params` split into `_lens_effective_params()` + `_lens_build_data()`. The first matters:
  `p->modified == 0` means the parameters in force are the module's **defaults** (from EXIF via
  `reload_defaults`), not history. A record built from history alone would describe a correction
  the pipe isn't applying — on exactly the images where lens correction is automatic, i.e. most
  of them. The `dt_iop_compute_module_hash()` side effect stays in `commit_params`.
- `geometry.h` gains `extern "C"` guards, needed exactly now: lens.cc is the first C++ publisher.
  Without them Linux would still link the plugin and fail at `dlopen`; macOS and Windows fail the
  build.

## Verification

- Export A/B vs pre-change binary: **bit-identical** on a lens-corrected CR2 (0 differing of
  54.0 M) and the NEF (0 of 23.7 M). Load-bearing here — lens's `commit_params` is live
  rendering code.
- `include_graph.py` cycles 0, layering 184 unchanged; module boundaries held.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
