### PR TITLE
Darkroom: one widget, one size — the startup configure disagreed with GTK by 16 px

### DIFF
--- a/src/control/control.h
+++ b/src/control/control.h
@@ -190,7 +190,6 @@ void dt_control_hinter_message(const struct dt_control_t *s, const char *message
 typedef struct dt_control_t
 {
   // gui related stuff
-  double tabborder;
   int32_t width, height;
   pthread_t gui_thread;
   double button_x, button_y;

--- a/src/gui/application.c
+++ b/src/gui/application.c
@@ -1268,10 +1268,19 @@ void dt_gui_gtk_run(dt_gui_gtk_t *gui)
 
   darktable.gui->surface
       = dt_cairo_image_surface_create(CAIRO_FORMAT_ARGB32, allocation.width, allocation.height);
-  // need to pre-configure views to avoid crash caused by draw coming before configure-event
-  dt_control_get_global()->tabborder = 8;
-  const int tb = dt_control_get_global()->tabborder;
-  dt_view_manager_configure(darktable.view_manager, allocation.width - 2 * tb, allocation.height - 2 * tb);
+  /* Pre-configure the views so a draw arriving before the first configure-event has a valid
+   * size to work with.
+   *
+   * The size handed over must be THE SAME size the configure-event handler will report for the
+   * same widget, and it was not: this passed the allocation minus twice an 8 px `tabborder',
+   * while dt_control_configure() passes the event's width and height untouched. Two callers,
+   * one widget, two answers 16 px apart -- so the view was configured at one size here and at
+   * another as soon as GTK delivered an allocation, and a view that recomputes on a size change
+   * (the darkroom pipeline does) paid for both.
+   *
+   * The border was not drawn by anything: `tabborder' was written on the line above and read on
+   * the line below, and nowhere else in the program. It is gone. */
+  dt_view_manager_configure(darktable.view_manager, allocation.width, allocation.height);
 #ifdef MAC_INTEGRATION
 #ifdef GTK_TYPE_OSX_APPLICATION
   gtk_osxapplication_ready(g_object_new(GTK_TYPE_OSX_APPLICATION, NULL));


### PR DESCRIPTION
Fixes the darkroom-entry double render reported while reviewing the geometry series: the view was
configured at two different sizes and the pipeline rendered twice, the second time for nothing.

## Root cause

Two callers hand a size to `dt_view_manager_configure()`, and **both describe the same widget**,
`dt_ui_center()`:

| caller | size passed |
|---|---|
| `dt_control_configure()` (on that widget's `configure-event`) | `event->width, event->height` — untouched |
| `dt_gui_gtk_run()` startup pre-configure | `allocation.width - 2*tb, allocation.height - 2*tb`, `tb = 8` |

So the view was configured once at the allocation minus 16 px, and again at the allocation itself
as soon as GTK delivered one. A view that recomputes when its size changes — the darkroom
pipeline does — paid for both.

That border was drawn by **nothing**: `tabborder` was assigned on one line of `dt_gui_gtk_run()`
and read on the next, and appeared nowhere else in the program. Both the subtraction and the
field are gone.

## Measured

Darkroom entry on an ARW, counting runs in which the 16-px-shrunk configure appears:

```
before   5 / 6 runs
after    0 / 6 runs
```

## Why it cost a full render, not just a configure

The shrunk size arrived at an unpredictable moment — 3.4 s after entry in one run, 30.6 s in
another, absent in a third. That is what made it look like a window-manager quirk rather than our
own code, and it is why I chased it with repeated runs rather than by reading.

When it landed **after** the preview pipe had produced its frame, the main pipe could no longer
reuse it (`dt_dev_pipelines_share_preview_output()` compares the two planned ROIs) and recomputed
the whole image: **2.8 s** on this file, against **0.057 s** when the sizes agree and it shares.
That is the "two renderings when opening an image" symptom.

## What remains, deliberately

GTK still settles the centre widget by one pixel (`1147×868` → `1147×867`) on every run. Both
arrive before the pipeline starts, so they coalesce into one render and cost nothing today.
Removing that means changing *when* the view reacts to an allocation — a different change from
making two callers agree, and not worth bundling here.

## Verification

- Export bit-identical (0 differing pixels of 23.7 M) — this touches no pixel code, run as a guard.
- `include_graph.py` cycles 0, layering 184 unchanged; `check_module_boundaries.sh` held;
  `pragma_once_to_guards.py --verify` clean.
- Removing a field from `dt_control_t` shifts that struct's layout, so this needs a full rebuild
  of the IOP plugins; done here, and CI builds from scratch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
