### PR TITLE
Geometry service G5: records describe what the pipe will render, not what the GUI holds

### DIFF
--- a/src/develop/geometry/geometry.c
+++ b/src/develop/geometry/geometry.c
@@ -20,6 +20,7 @@
 
 #include "common/logging.h"
 #include "develop/dev_geometry.h"
+#include "develop/dev_history.h"
 #include "develop/develop.h"
 #include "develop/imageop.h"
 #include "system/mem_alloc.h"
@@ -184,6 +185,51 @@ static void _fold_sizes(dt_geometry_chain_t *chain)
   chain->sized = (chain->raw_width > 0 && chain->raw_height > 0);
 }
 
+/**
+ * @brief What will this module be committed with? Mirrors the pipe's own resolution.
+ *
+ * @details dt_dev_pixelpipe_change() decides a piece's parameters and its enabled state in two
+ * ways, and the chain has to reproduce both or it describes a geometry the pipes are not
+ * rendering:
+ *
+ *  - IOP_FLAGS_NO_HISTORY_STACK modules are committed from their DEFAULTS
+ *    (dt_dev_pixelpipe_sync_no_history), because they enable and disable themselves;
+ *  - every other module takes the last history item at or before history_end, falling back to
+ *    its defaults when it has none (_sync_pipe_nodes_from_history).
+ *
+ * What it must NOT read is module->params and module->enabled. Those are the GUI thread's live
+ * values, and dt_dev_add_history_item() is throttled, so between an edit and its commit they
+ * are ahead of what any pipe has been told -- which shadow mode caught as a size divergence
+ * while the crop module's piece was mid-transition.
+ *
+ * @param params out: the blob to hand geometry_record(). Borrowed, valid while history_mutex
+ * is held.
+ * @return the enabled state the pipe will use.
+ */
+static gboolean _resolve_from_history(dt_develop_t *dev, dt_iop_module_t *module,
+                                      const int32_t history_end, const void **params)
+{
+  if(module->flags() & IOP_FLAGS_NO_HISTORY_STACK)
+  {
+    *params = module->default_params;
+    return module->default_enabled;
+  }
+
+  *params = module->default_params;
+  gboolean enabled = module->default_enabled;
+
+  for(GList *item = g_list_nth(dev->history, history_end - 1); item; item = g_list_previous(item))
+  {
+    const dt_dev_history_item_t *const hist = (const dt_dev_history_item_t *)item->data;
+    if(IS_NULL_PTR(hist) || hist->module != module) continue;
+    *params = hist->params;
+    enabled = hist->enabled;
+    break;
+  }
+
+  return enabled;
+}
+
 void dt_geometry_chain_rebuild(dt_develop_t *dev)
 {
   if(IS_NULL_PTR(dev) || IS_NULL_PTR(dev->geometry_chain)) return;
@@ -199,10 +245,17 @@ void dt_geometry_chain_rebuild(dt_develop_t *dev)
 
   gboolean complete = TRUE;
 
+  /* Resolve each module the way the pipe will, from HISTORY -- see _resolve_from_history(). The
+   * read lock is what dt_dev_pixelpipe_change() takes for the same walk; it is same-thread
+   * recursive, so a caller that already holds it (a history commit republishing geometry) is
+   * fine. */
+  dt_pthread_rwlock_rdlock(&dev->history_mutex);
+  const int32_t history_end = dt_dev_get_history_end_ext(dev);
+
   for(GList *node = g_list_first(dev->iop); node; node = g_list_next(node))
   {
     dt_iop_module_t *module = (dt_iop_module_t *)node->data;
-    if(IS_NULL_PTR(module) || !module->enabled) continue;
+    if(IS_NULL_PTR(module)) continue;
 
     dt_geometry_record_t *record = (dt_geometry_record_t *)g_malloc0(sizeof(dt_geometry_record_t));
     if(IS_NULL_PTR(record)) continue;
@@ -210,16 +263,24 @@ void dt_geometry_chain_rebuild(dt_develop_t *dev)
     g_strlcpy(record->op, module->op, sizeof(record->op));
     record->instance = module->multi_priority;
     record->iop_order = module->iop_order;
-    record->enabled = TRUE;
     record->operation_tags = module->operation_tags();
 
-    /* A module that publishes nothing is identity, which is correct for the ~80 modules that
-     * do not touch geometry -- their record exists only to carry dimensions. A ROSTER module
-     * that publishes nothing is a gap, and the chain must not be trusted until it closes. */
-    const gboolean published = !IS_NULL_PTR(module->geometry_record)
-                               && module->geometry_record(module, record);
+    const void *params = NULL;
+    record->enabled = _resolve_from_history(dev, module, history_end, &params);
 
-    if(!published && _on_roster(module->op))
+    /* A record exists for EVERY module, enabled or not, because the fold this mirrors writes
+     * per-piece dimensions for disabled pieces too and consumers read them. A disabled module
+     * simply publishes nothing and is identity.
+     *
+     * A module that publishes nothing is also correct for the ~80 that do not touch geometry.
+     * A ROSTER module that publishes nothing is a gap, and the chain must not be trusted until
+     * it closes -- but only while it is ENABLED: a disabled lens owes this service nothing, and
+     * asking it for a record would build a lensfun modifier for a correction nobody applies. */
+    gboolean published = FALSE;
+    if(record->enabled && !IS_NULL_PTR(module->geometry_record))
+      published = module->geometry_record(module, params, record);
+
+    if(record->enabled && !published && _on_roster(module->op))
     {
       complete = FALSE;
       chain->missing = g_list_prepend(chain->missing,
@@ -228,6 +289,8 @@ void dt_geometry_chain_rebuild(dt_develop_t *dev)
 
     chain->records = g_list_insert_sorted(chain->records, record, _by_iop_order);
   }
+
+  dt_pthread_rwlock_unlock(&dev->history_mutex);
 
   _fold_sizes(chain);
   chain->authoritative = complete && chain->sized;

--- a/src/iop/basebuffer.c
+++ b/src/iop/basebuffer.c
@@ -94,7 +94,7 @@ static const dt_geometry_vtable_t _basebuffer_geometry_vtable = {
   .backtransform = NULL,
 };
 
-gboolean geometry_record(dt_iop_module_t *self, dt_geometry_record_t *record)
+gboolean geometry_record(dt_iop_module_t *self, const void *params, dt_geometry_record_t *record)
 {
   record->vtable = &_basebuffer_geometry_vtable;
   return TRUE;

--- a/src/iop/crop.c
+++ b/src/iop/crop.c
@@ -503,7 +503,7 @@ static const dt_geometry_vtable_t _crop_geometry_vtable = {
   .backtransform = _crop_geometry_backtransform,
 };
 
-gboolean geometry_record(dt_iop_module_t *self, dt_geometry_record_t *record)
+gboolean geometry_record(dt_iop_module_t *self, const void *params, dt_geometry_record_t *record)
 {
   /* Same constructor commit_params() uses, including the edit-mode neutralisation: while the
    * crop GUI is in editing mode the pipe renders the full uncropped frame, and the overlays
@@ -511,7 +511,7 @@ gboolean geometry_record(dt_iop_module_t *self, dt_geometry_record_t *record)
   dt_iop_crop_data_t *data = (dt_iop_crop_data_t *)g_malloc0(sizeof(dt_iop_crop_data_t));
   if(IS_NULL_PTR(data)) return FALSE;
 
-  _crop_resolve(self, (const dt_iop_crop_params_t *)self->params, data);
+  _crop_resolve(self, (const dt_iop_crop_params_t *)params, data);
 
   record->data = data;
   record->free_data = dt_free_gpointer;

--- a/src/iop/demosaic.c
+++ b/src/iop/demosaic.c
@@ -984,9 +984,9 @@ static const dt_geometry_vtable_t _demosaic_geometry_vtable = {
   .backtransform = NULL,
 };
 
-gboolean geometry_record(dt_iop_module_t *self, dt_geometry_record_t *record)
+gboolean geometry_record(dt_iop_module_t *self, const void *params, dt_geometry_record_t *record)
 {
-  const dt_iop_demosaic_params_t *const p = (const dt_iop_demosaic_params_t *)self->params;
+  const dt_iop_demosaic_params_t *const p = (const dt_iop_demosaic_params_t *)params;
 
   dt_iop_demosaic_geometry_t *data
       = (dt_iop_demosaic_geometry_t *)g_malloc0(sizeof(dt_iop_demosaic_geometry_t));

--- a/src/iop/flip.c
+++ b/src/iop/flip.c
@@ -518,10 +518,10 @@ static const dt_geometry_vtable_t _flip_geometry_vtable = {
   .backtransform = _flip_geometry_backtransform,
 };
 
-gboolean geometry_record(dt_iop_module_t *self, dt_geometry_record_t *record)
+gboolean geometry_record(dt_iop_module_t *self, const void *params, dt_geometry_record_t *record)
 {
   const dt_image_orientation_t orientation
-      = _flip_resolve(self, (const dt_iop_flip_params_t *)self->params);
+      = _flip_resolve(self, (const dt_iop_flip_params_t *)params);
 
   /* ORIENTATION_NONE is how commit_params() clears piece->enabled: an enabled flip module whose
    * resolved orientation is a no-op contributes nothing to the pipe, and must contribute nothing

--- a/src/iop/iop_api.h
+++ b/src/iop/iop_api.h
@@ -204,13 +204,20 @@ DEFAULT(gboolean, runtime_data_hash, struct dt_iop_module_t *self, struct dt_dev
  *  pixel-less virtual pipe -- see doc/geometry-service.md).
  *
  *  Fill @p record's vtable/data and return TRUE; return FALSE (the default) for a module that
- *  does not change geometry. Called on the GUI thread, after params are committed.
+ *  does not change geometry. Called on the GUI thread.
+ *
+ *  @p params is THE SAME BLOB commit_params() is handed for this module -- resolved from the
+ *  history stack, or the module's defaults where the pipe would use those. It is not
+ *  self->params: those are the GUI thread's live values, and dt_dev_add_history_item() is
+ *  throttled, so between an edit and its commit they describe a geometry the pipes are not
+ *  rendering. Read this argument, exactly as commit_params() reads its own.
  *
  *  THE ONE-CONSTRUCTOR RULE: whatever commit_params() derives for geometry and whatever the
  *  record carries must come from ONE shared helper, and the record's evaluators must be the
  *  same code distort_transform()/modify_roi_out() run. Two derivations of the same geometry
  *  drift, and the drift surfaces as an overlay that no longer sits on what it describes. */
-OPTIONAL(gboolean, geometry_record, struct dt_iop_module_t *self, struct dt_geometry_record_t *record);
+OPTIONAL(gboolean, geometry_record, struct dt_iop_module_t *self, const void *params,
+                                    struct dt_geometry_record_t *record);
 
 /** called after the image has changed in darkroom */
 OPTIONAL(void, change_image, struct dt_iop_module_t *self);

--- a/src/iop/lens.cc
+++ b/src/iop/lens.cc
@@ -1399,13 +1399,13 @@ static const dt_geometry_vtable_t _lens_geometry_vtable = {
   /* .backtransform = */ _lens_geometry_backtransform,
 };
 
-gboolean geometry_record(dt_iop_module_t *self, dt_geometry_record_t *record)
+gboolean geometry_record(dt_iop_module_t *self, const void *params, dt_geometry_record_t *record)
 {
   dt_iop_lens_geometry_t *g = (dt_iop_lens_geometry_t *)calloc(1, sizeof(dt_iop_lens_geometry_t));
   if(!g) return FALSE;
 
   const dt_iop_lensfun_params_t *p
-      = _lens_effective_params(self, (const dt_iop_lensfun_params_t *)self->params);
+      = _lens_effective_params(self, (const dt_iop_lensfun_params_t *)params);
   _lens_build_data(self, p, &g->data);
   g->used_lf_mask = _lens_used_mask(self);
 

--- a/src/iop/rawprepare.c
+++ b/src/iop/rawprepare.c
@@ -998,9 +998,9 @@ static const dt_geometry_vtable_t _rawprepare_geometry_vtable = {
   .backtransform = _rawprepare_geometry_backtransform,
 };
 
-gboolean geometry_record(dt_iop_module_t *self, dt_geometry_record_t *record)
+gboolean geometry_record(dt_iop_module_t *self, const void *params, dt_geometry_record_t *record)
 {
-  const dt_iop_rawprepare_params_t *const p = (const dt_iop_rawprepare_params_t *)self->params;
+  const dt_iop_rawprepare_params_t *const p = (const dt_iop_rawprepare_params_t *)params;
 
   dt_iop_rawprepare_geometry_t *data
       = (dt_iop_rawprepare_geometry_t *)g_malloc0(sizeof(dt_iop_rawprepare_geometry_t));


### PR DESCRIPTION
Fifth tranche. **Stacked on #1167.** Fixes the divergence shadow mode found after the stack was
rebased onto current master.

## What it caught

```
09.9s  agrees: 4016x6016
12.2s  SIZE DIVERGENCE: chain 2464x3213, pipe 4016x6016
12.4s  agrees: 2464x3213
```

One sample, self-resolving, while crop's piece was mid-transition. The chain was right about the
GUI and **wrong about the pixels**.

## Cause

Every `geometry_record()` read `self->params`, and the rebuild filtered on `module->enabled`.
Those are the GUI thread's live values, and `dt_dev_add_history_item()` is throttled
(`processing/timeout`, 200 ms), so between an edit and its commit they run ahead of anything the
pipes have been told. CLAUDE.md states the rule this broke: *`module->params` belong to the GUI
thread, and the pipeline interface is history — commit from the history snapshot, never the live
module params.*

## Fix

The chain resolves each module the way `dt_dev_pixelpipe_change()` does and hands the result to
`geometry_record()` as an argument, mirroring `commit_params()`:

- **`IOP_FLAGS_NO_HISTORY_STACK`** → the module's **defaults**, which is what
  `dt_dev_pixelpipe_sync_no_history()` commits. Only `basebuffer` on the roster is one, and it
  carries no parameters — but the distinction lives in the resolver rather than a comment,
  because the next roster module may not be so forgiving.
- **everything else** → the last history item at or before `history_end`, falling back to
  defaults, exactly as `_sync_pipe_nodes_from_history()` does — **including the enabled flag**,
  now read from that item rather than from `module->enabled`.

Two structural consequences, both matching the fold being mirrored:

- there is a record for **every** module now, not only enabled ones, because
  `dt_dev_pixelpipe_get_roi_out()` writes per-piece dimensions for disabled pieces too and
  consumers read them. A disabled module publishes nothing and is identity;
- a roster module owes a record only while **enabled** — a disabled lens owes nothing, and asking
  would build a lensfun modifier for a correction nobody applies.

The history walk takes `history_mutex` as reader (what `dt_dev_pixelpipe_change()` takes for the
same walk); it is same-thread recursive, so a history commit republishing geometry proceeds
rather than deadlocks.

## Verification

- Divergence **gone: 0 across 8 darkroom-entry runs** on the image that produced it, against 1
  occurrence before. I can only claim one pre-fix occurrence — it appeared once, in one run — so
  the strength here is the mechanism, not the rate.
- Both test images still agree: size, 5/5 forward probes, 5/5 round-trips.
- Export bit-identical on a lens-corrected CR2 (0 of 54.0 M) and the NEF (0 of 23.7 M).
- `include_graph.py` cycles 0, layering 184 unchanged; module boundaries held.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
