### PR TITLE
Geometry service G6: rotatepixels, borders and ashift publish records

### DIFF
--- a/src/iop/ashift.c
+++ b/src/iop/ashift.c
@@ -67,6 +67,7 @@
 #include "common/opencl.h"
 #include "control/control.h"
 #include "develop/develop.h"
+#include "develop/geometry/geometry.h"
 #include "develop/imageop.h"
 #include "develop/imageop_gui.h"
 #include "widgets/button.h"
@@ -5527,14 +5528,25 @@ static void _event_process_after_ui_callback(gpointer instance, gpointer user_da
   dt_control_queue_redraw_center();
 }
 
-void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pixelpipe_t *pipe,
-                   dt_dev_pixelpipe_iop_t *piece)
+/* --- the shared geometry core ----------------------------------------------------------
+ *
+ * commit_params() below and the geometry service's record (develop/geometry/geometry.h) both go
+ * through _ashift_resolve(), and both evaluate through homography(), which is already a pure
+ * function of the resolved parameters and the input dimensions. So the correction the pipe
+ * applies and the one the GUI overlays are drawn against are the same one, expressed once.
+ *
+ * The edit-mode branch is why the record cannot be built from history alone: while the ashift
+ * GUI is editing, the effective parameters live in g->new_params -- which never reach history --
+ * and the crop is neutralised so the full transformed frame is visible. A record built from
+ * history would describe a crop nobody is rendering, exactly when the overlays matter most.
+ */
+static void _ashift_resolve(struct dt_iop_module_t *self, const dt_iop_ashift_params_t *const p1,
+                            dt_iop_ashift_data_t *d)
 {
-  dt_iop_ashift_data_t *d = (dt_iop_ashift_data_t *)piece->data;
   dt_iop_ashift_gui_data_t *g = (dt_iop_ashift_gui_data_t *)dt_iop_gui_data(self);
 
   const gboolean editing = !IS_NULL_PTR(g) && g->editing;
-  dt_iop_ashift_params_t *p = editing ? &g->new_params : (dt_iop_ashift_params_t *)p1;
+  const dt_iop_ashift_params_t *p = editing ? &g->new_params : p1;
 
   d->rotation = p->rotation;
   d->lensshift_v = p->lensshift_v;
@@ -5564,6 +5576,107 @@ void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pix
     d->ct = p->ct;
     d->cb = p->cb;
   }
+}
+
+void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pixelpipe_t *pipe,
+                   dt_dev_pixelpipe_iop_t *piece)
+{
+  _ashift_resolve(self, (const dt_iop_ashift_params_t *)p1, (dt_iop_ashift_data_t *)piece->data);
+}
+
+/* --- the geometry service's view of this module (develop/geometry/geometry.h) --------- */
+
+/** @brief Apply the homography plus the clipping offset, in whichever direction. */
+static int _ashift_geometry_apply(const void *data, const dt_geometry_record_t *const record, float *points,
+                                  size_t points_count, const int direction)
+{
+  const dt_iop_ashift_data_t *const d = (const dt_iop_ashift_data_t *)data;
+  if(isneutral(d)) return 1;
+
+  float DT_ALIGNED_ARRAY h[3][3];
+  homography((float *)h, d->rotation, d->lensshift_v, d->lensshift_h, d->shear, d->f_length_kb, d->orthocorr,
+             d->aspect, record->in.width, record->in.height, direction);
+
+  // clipping offset
+  const float fullwidth = (float)record->out.width / (d->cr - d->cl);
+  const float fullheight = (float)record->out.height / (d->cb - d->ct);
+  const float cx = fullwidth * d->cl;
+  const float cy = fullheight * d->ct;
+
+  const gboolean forward = (direction == ASHIFT_HOMOGRAPH_FORWARD);
+  for(size_t i = 0; i < points_count * 2; i += 2)
+  {
+    float DT_ALIGNED_PIXEL pi[3] = { points[i] + (forward ? 0.f : cx), points[i + 1] + (forward ? 0.f : cy),
+                                     1.0f };
+    float DT_ALIGNED_PIXEL po[3];
+    mat3mulv(po, (float *)h, pi);
+    points[i] = po[0] / po[2] - (forward ? cx : 0.f);
+    points[i + 1] = po[1] / po[2] - (forward ? cy : 0.f);
+  }
+  return 1;
+}
+
+static void _ashift_geometry_map_size(const void *data, const dt_iop_roi_t *const in, dt_iop_roi_t *out)
+{
+  const dt_iop_ashift_data_t *const d = (const dt_iop_ashift_data_t *)data;
+  *out = *in;
+  if(isneutral(d)) return;
+
+  float h[3][3];
+  homography((float *)h, d->rotation, d->lensshift_v, d->lensshift_h, d->shear, d->f_length_kb, d->orthocorr,
+             d->aspect, in->width, in->height, ASHIFT_HOMOGRAPH_FORWARD);
+
+  float xm = FLT_MAX, xM = -FLT_MAX, ym = FLT_MAX, yM = -FLT_MAX;
+
+  // the four vertices of the input rect, through the homograph, give the output bounding box
+  for(int y = 0; y < in->height; y += in->height - 1)
+    for(int x = 0; x < in->width; x += in->width - 1)
+    {
+      float pin[3] = { (in->x + x) / in->scale, (in->y + y) / in->scale, 1.0f };
+      float pout[3];
+      mat3mulv(pout, (float *)h, pin);
+      pout[0] = pout[0] / pout[2] * out->scale;
+      pout[1] = pout[1] / pout[2] * out->scale;
+      xm = MIN(xm, pout[0]);
+      xM = MAX(xM, pout[0]);
+      ym = MIN(ym, pout[1]);
+      yM = MAX(yM, pout[1]);
+    }
+
+  // clipping adjustments
+  out->width = floorf((xM - xm + 1) * (d->cr - d->cl));
+  out->height = floorf((yM - ym + 1) * (d->cb - d->ct));
+}
+
+static int _ashift_geometry_transform(const void *data, const dt_geometry_record_t *const record,
+                                      dt_geometry_chain_t *chain, float *points, size_t points_count)
+{
+  return _ashift_geometry_apply(data, record, points, points_count, ASHIFT_HOMOGRAPH_FORWARD);
+}
+
+static int _ashift_geometry_backtransform(const void *data, const dt_geometry_record_t *const record,
+                                          dt_geometry_chain_t *chain, float *points, size_t points_count)
+{
+  return _ashift_geometry_apply(data, record, points, points_count, ASHIFT_HOMOGRAPH_INVERTED);
+}
+
+static const dt_geometry_vtable_t _ashift_geometry_vtable = {
+  .map_size = _ashift_geometry_map_size,
+  .transform = _ashift_geometry_transform,
+  .backtransform = _ashift_geometry_backtransform,
+};
+
+gboolean geometry_record(struct dt_iop_module_t *self, const void *params, dt_geometry_record_t *record)
+{
+  dt_iop_ashift_data_t *data = (dt_iop_ashift_data_t *)g_malloc0(sizeof(dt_iop_ashift_data_t));
+  if(IS_NULL_PTR(data)) return FALSE;
+
+  _ashift_resolve(self, (const dt_iop_ashift_params_t *)params, data);
+
+  record->data = data;
+  record->free_data = dt_free_gpointer;
+  record->vtable = &_ashift_geometry_vtable;
+  return TRUE;
 }
 
 gboolean runtime_data_hash(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe,

--- a/src/iop/borders.c
+++ b/src/iop/borders.c
@@ -60,6 +60,7 @@
 #include "common/imagebuf.h"
 #include "common/opencl.h"
 #include "develop/develop.h"
+#include "develop/geometry/geometry.h"
 #include "develop/imageop.h"
 #include "develop/imageop_gui.h"
 #include "develop/imageop_gui.h"
@@ -239,15 +240,29 @@ int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, const dt
   return IOP_CS_RGB;
 }
 
+/* --- the shared geometry core ----------------------------------------------------------
+ *
+ * The border's offset is DERIVED, not a parameter: it is the difference between the output and
+ * input sizes, apportioned by pos_h/pos_v. Both the pixel pipe's distort callbacks and the
+ * geometry service's record (develop/geometry/geometry.h) go through the two helpers below, so
+ * the size map and the offset can never drift apart.
+ */
+
+/** @brief The translation the border applies, from the two rects it sits between. */
+static void _borders_offset(const dt_iop_borders_data_t *const d, const dt_iop_roi_t *const in,
+                            const dt_iop_roi_t *const out, int *left, int *top)
+{
+  *left = (out->width - in->width) * d->pos_h;
+  *top = (out->height - in->height) * d->pos_v;
+}
+
 int distort_transform(dt_iop_module_t *self, const dt_dev_pixelpipe_t *pipe, const dt_dev_pixelpipe_iop_t *piece,
                       float *const restrict points, size_t points_count)
 {
   dt_iop_borders_data_t *d = (dt_iop_borders_data_t *)piece->data;
 
-  const int border_tot_width = (piece->buf_out.width - piece->buf_in.width);
-  const int border_tot_height = (piece->buf_out.height - piece->buf_in.height);
-  const int border_size_t = border_tot_height * d->pos_v;
-  const int border_size_l = border_tot_width * d->pos_h;
+  int border_size_l = 0, border_size_t = 0;
+  _borders_offset(d, &piece->buf_in, &piece->buf_out, &border_size_l, &border_size_t);
 
   // nothing to be done if parameters are set to neutral values (no top/left border)
   if (border_size_l == 0 && border_size_t == 0) return 1;
@@ -265,10 +280,8 @@ int distort_backtransform(dt_iop_module_t *self, const dt_dev_pixelpipe_t *pipe,
 {
   dt_iop_borders_data_t *d = (dt_iop_borders_data_t *)piece->data;
 
-  const int border_tot_width = (piece->buf_out.width - piece->buf_in.width);
-  const int border_tot_height = (piece->buf_out.height - piece->buf_in.height);
-  const int border_size_t = border_tot_height * d->pos_v;
-  const int border_size_l = border_tot_width * d->pos_h;
+  int border_size_l = 0, border_size_t = 0;
+  _borders_offset(d, &piece->buf_in, &piece->buf_out, &border_size_l, &border_size_t);
 
   // nothing to be done if parameters are set to neutral values (no top/left border)
   if (border_size_l == 0 && border_size_t == 0) return 1;
@@ -311,12 +324,13 @@ void distort_mask(struct dt_iop_module_t *self, const struct dt_dev_pixelpipe_t 
 
 // 1st pass: how large would the output be, given this input roi?
 // this is always called with the full buffer before processing.
-void modify_roi_out(struct dt_iop_module_t *self, const struct dt_dev_pixelpipe_t *pipe,
-                    struct dt_dev_pixelpipe_iop_t *piece, dt_iop_roi_t *roi_out,
-                    const dt_iop_roi_t *roi_in)
+/** @brief Input rect -> output rect. THE size evaluator: modify_roi_out() below and the
+ *  geometry record both call it, so the frame the pipe renders and the frame the GUI
+ *  measures are the same frame. */
+static void _borders_map_size(const dt_iop_borders_data_t *const d, const dt_iop_roi_t *const roi_in,
+                              dt_iop_roi_t *roi_out)
 {
   *roi_out = *roi_in;
-  const dt_iop_borders_data_t *d = (dt_iop_borders_data_t *)piece->data;
   const float size = fabsf(d->size);
   if(size == 0.0f || size >= 1.0f) return;
 
@@ -361,6 +375,13 @@ void modify_roi_out(struct dt_iop_module_t *self, const struct dt_dev_pixelpipe_
       roi_out->width  = roi_out->height * aspect;
     }
   }
+}
+
+void modify_roi_out(struct dt_iop_module_t *self, const struct dt_dev_pixelpipe_t *pipe,
+                    struct dt_dev_pixelpipe_iop_t *piece, dt_iop_roi_t *roi_out,
+                    const dt_iop_roi_t *roi_in)
+{
+  _borders_map_size((const dt_iop_borders_data_t *)piece->data, roi_in, roi_out);
 }
 
 // 2nd pass: which roi would this operation need as input to fill the given output region?
@@ -696,6 +717,61 @@ void cleanup_global(dt_iop_module_so_t *module)
   dt_free(module->data);
 }
 
+
+/* --- the geometry service's view of this module (develop/geometry/geometry.h) --------- */
+
+static void _borders_geometry_map_size(const void *data, const dt_iop_roi_t *const in, dt_iop_roi_t *out)
+{
+  _borders_map_size((const dt_iop_borders_data_t *)data, in, out);
+}
+
+static int _borders_geometry_transform(const void *data, const dt_geometry_record_t *const record,
+                                       dt_geometry_chain_t *chain, float *points, size_t points_count)
+{
+  int left = 0, top = 0;
+  _borders_offset((const dt_iop_borders_data_t *)data, &record->in, &record->out, &left, &top);
+  if(left == 0 && top == 0) return 1;
+  for(size_t i = 0; i < points_count * 2; i += 2)
+  {
+    points[i] += left;
+    points[i + 1] += top;
+  }
+  return 1;
+}
+
+static int _borders_geometry_backtransform(const void *data, const dt_geometry_record_t *const record,
+                                           dt_geometry_chain_t *chain, float *points, size_t points_count)
+{
+  int left = 0, top = 0;
+  _borders_offset((const dt_iop_borders_data_t *)data, &record->in, &record->out, &left, &top);
+  if(left == 0 && top == 0) return 1;
+  for(size_t i = 0; i < points_count * 2; i += 2)
+  {
+    points[i] -= left;
+    points[i + 1] -= top;
+  }
+  return 1;
+}
+
+static const dt_geometry_vtable_t _borders_geometry_vtable = {
+  .map_size = _borders_geometry_map_size,
+  .transform = _borders_geometry_transform,
+  .backtransform = _borders_geometry_backtransform,
+};
+
+gboolean geometry_record(dt_iop_module_t *self, const void *params, dt_geometry_record_t *record)
+{
+  /* commit_params() is a straight copy of the parameters into the data struct -- the two are the
+   * same type -- so the record carries that copy and nothing is derived twice. */
+  dt_iop_borders_data_t *data = (dt_iop_borders_data_t *)g_malloc0(sizeof(dt_iop_borders_data_t));
+  if(IS_NULL_PTR(data)) return FALSE;
+  memcpy(data, params, sizeof(dt_iop_borders_params_t));
+
+  record->data = data;
+  record->free_data = dt_free_gpointer;
+  record->vtable = &_borders_geometry_vtable;
+  return TRUE;
+}
 
 void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pixelpipe_t *pipe,
                    dt_dev_pixelpipe_iop_t *piece)

--- a/src/iop/rotatepixels.c
+++ b/src/iop/rotatepixels.c
@@ -40,6 +40,7 @@
 #include "pixel/interpolation.h"
 #include "math/math.h"
 #include "develop/develop.h"
+#include "develop/geometry/geometry.h"
 #include "develop/imageop.h"
 #include "iop/iop_api.h"
 
@@ -116,12 +117,17 @@ const char **description(struct dt_iop_module_t *self)
 }
 
 
+/* --- the shared geometry core ----------------------------------------------------------
+ *
+ * These take the committed data rather than a pipeline piece, so the pixel pipe's distort
+ * callbacks and the geometry service's record (develop/geometry/geometry.h) run the same
+ * arithmetic instead of two copies of it.
+ */
+
 __OMP_DECLARE_SIMD__()
-static void transform(const dt_dev_pixelpipe_iop_t *const piece, const float scale, const float *const x,
+static void transform(const dt_iop_rotatepixels_data_t *const d, const float scale, const float *const x,
                       float *o)
 {
-  dt_iop_rotatepixels_data_t *d = (dt_iop_rotatepixels_data_t *)piece->data;
-
   float pi[2] = { x[0] - d->rx * scale, x[1] - d->ry * scale };
 
   mul_mat_vec_2(d->m, pi, o);
@@ -129,16 +135,43 @@ static void transform(const dt_dev_pixelpipe_iop_t *const piece, const float sca
 
 
 __OMP_DECLARE_SIMD__()
-static void backtransform(const dt_dev_pixelpipe_iop_t *const piece, const float scale, const float *const x,
+static void backtransform(const dt_iop_rotatepixels_data_t *const d, const float scale, const float *const x,
                           float *o)
 {
-  dt_iop_rotatepixels_data_t *d = (dt_iop_rotatepixels_data_t *)piece->data;
-
   float rt[] = { d->m[0], -d->m[1], -d->m[2], d->m[3] };
   mul_mat_vec_2(rt, x, o);
 
   o[0] += d->rx * scale;
   o[1] += d->ry * scale;
+}
+
+/**
+ * @brief Input rect -> output rect: the inner rectangle of the 45-degree rotation.
+ *
+ * @details NOTE the non-parameter input: the output size depends on the user's interpolator
+ * preference, because the margin this trims is the interpolation kernel's width. A record
+ * captures it at publish time, which is correct as long as changing that preference
+ * re-publishes -- it forces a pipeline rebuild, which republishes the geometry.
+ */
+static void _rotatepixels_map_size(const dt_iop_rotatepixels_data_t *const d,
+                                   const dt_iop_roi_t *const roi_in, dt_iop_roi_t *roi_out)
+{
+  *roi_out = *roi_in;
+
+  const float scale = roi_in->scale;
+  const float T = (float)d->ry * scale;
+
+  const float y = sqrtf(2.0f * T * T),
+              x = sqrtf(2.0f * ((float)roi_in->width - T) * ((float)roi_in->width - T));
+
+  const struct dt_interpolation *interpolation = dt_interpolation_new(DT_INTERPOLATION_USERPREF);
+  const float IW = (float)interpolation->width * scale;
+
+  roi_out->width = y - IW;
+  roi_out->height = x - IW;
+
+  roi_out->width = MAX(0, roi_out->width & ~1);
+  roi_out->height = MAX(0, roi_out->height & ~1);
 }
 
 int distort_transform(dt_iop_module_t *self, const dt_dev_pixelpipe_t *pipe, const dt_dev_pixelpipe_iop_t *piece,
@@ -153,7 +186,7 @@ int distort_transform(dt_iop_module_t *self, const dt_dev_pixelpipe_t *pipe, con
     pi[0] = points[i];
     pi[1] = points[i + 1];
 
-    transform(piece, scale, pi, po);
+    transform((const dt_iop_rotatepixels_data_t *)piece->data, scale, pi, po);
 
     points[i] = po[0];
     points[i + 1] = po[1];
@@ -174,7 +207,7 @@ int distort_backtransform(dt_iop_module_t *self, const dt_dev_pixelpipe_t *pipe,
     pi[0] = points[i];
     pi[1] = points[i + 1];
 
-    backtransform(piece, scale, pi, po);
+    backtransform((const dt_iop_rotatepixels_data_t *)piece->data, scale, pi, po);
 
     points[i] = po[0];
     points[i + 1] = po[1];
@@ -199,44 +232,7 @@ void modify_roi_out(dt_iop_module_t *self, const dt_dev_pixelpipe_t *pipe, dt_de
                     dt_iop_roi_t *roi_out,
                     const dt_iop_roi_t *const roi_in)
 {
-  dt_iop_rotatepixels_data_t *d = (dt_iop_rotatepixels_data_t *)piece->data;
-
-  *roi_out = *roi_in;
-
-  /*
-   * Think of input image as:
-   * 1. Square, containing:
-   * 3. 4x Right triangles (two pairs), located in the Edges of square
-   * 2. Rectangle (rotated 45 degrees), located in between triangles.
-   *
-   * Therefore, output image dimensions, that are sizes of inner Rectangle
-   * can be found using Pythagorean theorem.
-   *
-   * Not precise pseudographics: (width == height + 1)
-   *         height
-   *     _  -------
-   *     |  |1 /\2|
-   * ty  |  | y  \|
-   *     _  |/   /| width
-   *        |\x / |
-   *        |2\/ 1|
-   *        -------
-   */
-
-  const float scale = roi_in->scale;
-  const float T = (float)d->ry * scale;
-
-  const float y = sqrtf(2.0f * T * T),
-              x = sqrtf(2.0f * ((float)roi_in->width - T) * ((float)roi_in->width - T));
-
-  const struct dt_interpolation *interpolation = dt_interpolation_new(DT_INTERPOLATION_USERPREF);
-  const float IW = (float)interpolation->width * scale;
-
-  roi_out->width = y - IW;
-  roi_out->height = x - IW;
-
-  roi_out->width = MAX(0, roi_out->width & ~1);
-  roi_out->height = MAX(0, roi_out->height & ~1);
+  _rotatepixels_map_size((const dt_iop_rotatepixels_data_t *)piece->data, roi_in, roi_out);
 }
 
 // 2nd pass: which roi would this operation need as input to fill the given output region?
@@ -259,7 +255,7 @@ void modify_roi_in(dt_iop_module_t *self, const dt_dev_pixelpipe_t *pipe, dt_dev
     // get corner points of roi_out
     get_corner(aabb, c, p);
 
-    backtransform(piece, scale, p, o);
+    backtransform((const dt_iop_rotatepixels_data_t *)piece->data, scale, p, o);
 
     // transform to roi_in space, get aabb.
     adjust_aabb(o, aabb_in);
@@ -311,7 +307,7 @@ int process(dt_iop_module_t *self, const dt_dev_pixelpipe_t *pipe, const dt_dev_
       pi[0] = roi_out->x + i;
       pi[1] = roi_out->y + j;
 
-      backtransform(piece, scale, pi, po);
+      backtransform((const dt_iop_rotatepixels_data_t *)piece->data, scale, pi, po);
 
       po[0] -= roi_in->x;
       po[1] -= roi_in->y;
@@ -323,23 +319,96 @@ int process(dt_iop_module_t *self, const dt_dev_pixelpipe_t *pipe, const dt_dev_
   return 0;
 }
 
+/** @brief Params -> committed data. THE constructor, shared with geometry_record(). */
+static void _rotatepixels_resolve(const dt_iop_rotatepixels_params_t *const p,
+                                  dt_iop_rotatepixels_data_t *d)
+{
+  d->rx = p->rx;
+  d->ry = p->ry;
+
+  const float angle = p->angle * M_PI / 180.0f;
+
+  const float rt[] = { cosf(angle), sinf(angle), -sinf(angle), cosf(angle) };
+  for(int k = 0; k < 4; k++) d->m[k] = rt[k];
+}
+
 void commit_params(dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pixelpipe_t *pipe,
                    dt_dev_pixelpipe_iop_t *piece)
 {
   dt_iop_rotatepixels_params_t *p = (dt_iop_rotatepixels_params_t *)p1;
   dt_iop_rotatepixels_data_t *d = (dt_iop_rotatepixels_data_t *)piece->data;
 
-  d->rx = p->rx;
-  d->ry = p->ry;
-
-  const float angle = p->angle * M_PI / 180.0f;
-
-  float rt[] = { cosf(angle), sinf(angle), -sinf(angle), cosf(angle) };
-  for(int k = 0; k < 4; k++) d->m[k] = rt[k];
+  _rotatepixels_resolve(p, d);
 
   // this should not be used for normal images
   // (i.e. for those, when this iop is off by default)
   if((d->rx == 0u) && (d->ry == 0u)) piece->enabled = 0;
+}
+
+/* --- the geometry service's view of this module (develop/geometry/geometry.h) --------- */
+
+static void _rotatepixels_geometry_map_size(const void *data, const dt_iop_roi_t *const in, dt_iop_roi_t *out)
+{
+  _rotatepixels_map_size((const dt_iop_rotatepixels_data_t *)data, in, out);
+}
+
+static int _rotatepixels_geometry_transform(const void *data, const dt_geometry_record_t *const record,
+                                            dt_geometry_chain_t *chain, float *points, size_t points_count)
+{
+  const dt_iop_rotatepixels_data_t *const d = (const dt_iop_rotatepixels_data_t *)data;
+  for(size_t i = 0; i < points_count * 2; i += 2)
+  {
+    const float pi[2] = { points[i], points[i + 1] };
+    float po[2];
+    transform(d, record->in.scale, pi, po);
+    points[i] = po[0];
+    points[i + 1] = po[1];
+  }
+  return 1;
+}
+
+static int _rotatepixels_geometry_backtransform(const void *data, const dt_geometry_record_t *const record,
+                                                dt_geometry_chain_t *chain, float *points,
+                                                size_t points_count)
+{
+  const dt_iop_rotatepixels_data_t *const d = (const dt_iop_rotatepixels_data_t *)data;
+  for(size_t i = 0; i < points_count * 2; i += 2)
+  {
+    const float pi[2] = { points[i], points[i + 1] };
+    float po[2];
+    backtransform(d, record->in.scale, pi, po);
+    points[i] = po[0];
+    points[i + 1] = po[1];
+  }
+  return 1;
+}
+
+static const dt_geometry_vtable_t _rotatepixels_geometry_vtable = {
+  .map_size = _rotatepixels_geometry_map_size,
+  .transform = _rotatepixels_geometry_transform,
+  .backtransform = _rotatepixels_geometry_backtransform,
+};
+
+gboolean geometry_record(dt_iop_module_t *self, const void *params, dt_geometry_record_t *record)
+{
+  dt_iop_rotatepixels_data_t *data
+      = (dt_iop_rotatepixels_data_t *)g_malloc0(sizeof(dt_iop_rotatepixels_data_t));
+  if(IS_NULL_PTR(data)) return FALSE;
+
+  _rotatepixels_resolve((const dt_iop_rotatepixels_params_t *)params, data);
+
+  /* A zero rotation centre is how commit_params() clears piece->enabled: the module is in the
+   * pipe but does nothing. Published with no vtable, which the chain reads as identity. */
+  if(data->rx == 0u && data->ry == 0u)
+  {
+    g_free(data);
+    return TRUE;
+  }
+
+  record->data = data;
+  record->free_data = dt_free_gpointer;
+  record->vtable = &_rotatepixels_geometry_vtable;
+  return TRUE;
 }
 
 void init_pipe(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)


### PR DESCRIPTION
Sixth tranche. **Stacked on #1169.** Three more roster modules, each a pure function of its
committed parameters and the rectangle it is handed — no opaque state, no upstream composition.

After this, what remains is **clipping** and **scalepixels** (which mutate `piece->data` inside
their ROI callbacks and need a pure constructor first) and **liquify** (whose transform re-enters
the walker).

## The three

- **rotatepixels** — `transform()`/`backtransform()` took a pipeline piece and dug `piece->data`
  out of it; they now take the data directly, so the pipe and the record run *the same two
  functions*. Its size map has a non-parameter input worth naming: the output is trimmed by the
  interpolation kernel's width, a **user preference**, captured at publish time. A zero rotation
  centre is how `commit_params()` clears `piece->enabled`; the record publishes identity.
- **borders** — the offset is **derived**, not a parameter (output minus input, apportioned by
  `pos_h`/`pos_v`), so it and the size map are one shared helper each. `commit_params()` is a
  straight copy of params into data, so the record carries that copy.
- **ashift** — `commit_params()` split into `_ashift_resolve()`; the evaluators use the existing
  `homography()`, already pure in the resolved parameters and input dimensions. Its **edit-mode
  branch is why a record cannot be built from history alone**: while editing, the effective
  parameters live in `g->new_params`, which never reach history, and the crop is neutralised.

## Measured, on images that actually use these modules

```
0001 (1).NEF   ashift + borders    agrees, 2680x4020, 5/5 probes, 5/5 round-trips
02837.CR2      borders             agrees, 8726x5840, 5/5 probes, 5/5 round-trips
0001-hdr.dng   ashift              agrees, 1658x2444, 5/5 probes, 5/5 round-trips
0004.NEF       ashift + liquify    agrees, 3635x2351  ← liquify on the roster but DISABLED,
                                   and G5 made a disabled roster module owe nothing
0002.NEF       ashift + clipping   not authoritative: clipping.0, as expected
```

## Export A/B, and a control that matters

Bit-identical on `0001 (1).NEF` and `0004.NEF`.

On `02837.CR2` it differs by **13.2 M pixels at max 1** — which looks like a regression until you
run the control:

```
reference vs ITSELF : differing=11,825,791  max=1
reference vs mine   : differing=13,178,098  max=1
```

That 50 MP export is **non-deterministic at one LSB independently of this change** (threading and
tile reduction order). The control run is what establishes it; without it the number reads as a
defect. This is exactly the trap the colour-management notes warn about — a one-LSB shift is the
real failure mode there — so the answer is to re-run the reference, not to squint at the diff.

`include_graph.py` cycles 0, layering 184 unchanged; module boundaries held.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
