### PR TITLE
Geometry service G9: the coordinate converters read the chain

### DIFF
--- a/src/develop/dev_pixelpipe.c
+++ b/src/develop/dev_pixelpipe.c
@@ -28,6 +28,7 @@
 #include "common/paths.h"
 #include "gui/application.h"
 #include "system/dtpthread.h"
+#include "develop/geometry/geometry.h"
 #include "develop/imageop.h"
 #include "develop/pixelpipe.h"
 #include "caches/pixelpipe_cache.h"
@@ -1795,6 +1796,14 @@ static void _sync_virtual_pipe(dt_develop_t *dev, dt_dev_pixelpipe_change_t flag
   // Mirror the preview-pipe change flags and commit immediately.
   _change_pipe(dev->virtual_pipe, flag);
   dt_dev_pixelpipe_change(dev->virtual_pipe);
+
+  /* The geometry chain answers the same questions and must therefore be exactly as fresh as
+   * this pipe, not fresher and not staler: consumers now read whichever of the two can answer,
+   * and a chain rebuilt only in the size path would lag the pipe on every flag that arrives
+   * between two size publications. It is rebuilt here rather than published here -- this
+   * function raises flags, and nothing downstream may observe geometry before the publication
+   * that goes with it (see the ordering note in dt_dev_get_thumbnail_size). */
+  dt_geometry_chain_rebuild(dev);
 }
 
 void dt_dev_pixelpipe_sync_virtual(dt_develop_t *dev, dt_dev_pixelpipe_change_t flag)

--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -1701,13 +1701,28 @@ gchar *dt_history_item_get_name_html(const struct dt_iop_module_t *module)
 static int dt_dev_distort_backtransform_locked(const dt_dev_pixelpipe_t *pipe, const double iop_order,
                                                const int transf_direction, float *points, size_t points_count);
 
+/* These two are where the geometry service takes over from the pixel-less pipe. They are the
+ * whole of the mask GUI's coordinate handling -- every shape's centre, every handle, every
+ * source position routes through one of them -- and they ask the simplest question there is:
+ * everything, in order, no bound.
+ *
+ * The chain answers when it can and the pipe answers otherwise, which is not a hedge but the
+ * authority rule: the chain refuses unless EVERY enabled module that changes geometry has
+ * published a record, so a fallback happens only when composing from records would mean mixing
+ * them with pipeline pieces. Both paths stay live until the pipe is deleted, and shadow mode
+ * keeps comparing them on every size publication -- including, at iop_order 0 and DIR_ALL,
+ * exactly the question these two ask.
+ */
+
 int dt_dev_coordinates_raw_abs_to_image_abs(dt_develop_t *dev, float *points, size_t points_count)
 {
+  if(dt_geometry_transform(dev, 0.0, DT_DEV_TRANSFORM_DIR_ALL, points, points_count)) return 1;
   return dt_dev_distort_transform_plus(dev->virtual_pipe, 0.0f, DT_DEV_TRANSFORM_DIR_ALL, points, points_count);
 }
 
 int dt_dev_coordinates_image_abs_to_raw_abs(dt_develop_t *dev, float *points, size_t points_count)
 {
+  if(dt_geometry_backtransform(dev, 0.0, DT_DEV_TRANSFORM_DIR_ALL, points, points_count)) return 1;
   return dt_dev_distort_backtransform_locked(dev->virtual_pipe, 0.0f, DT_DEV_TRANSFORM_DIR_ALL, points, points_count);
 }
 


### PR DESCRIPTION
Ninth tranche. **Stacked on #1172.** The first consumer migration — the chain stops being an
observer and starts answering.

## What moved

`dt_dev_coordinates_raw_abs_to_image_abs()` and its inverse are the whole of the mask GUI's
coordinate handling — every shape's centre, every handle, every source position routes through
one of them — and they ask the simplest question the chain can be asked: everything, in order,
no bound. They now ask the chain, falling back to the pixel-less pipe when it declines.

That fallback is **the authority rule, not a hedge**: the chain refuses unless every enabled
geometry module has published a record, so the pipe answers only when composing from records
would mean mixing them with pipeline pieces. Both paths stay live until the pipe is deleted.

`_sync_virtual_pipe()` now rebuilds the chain alongside the pipe it mirrors. **Freshness parity
is the point**: with consumers reading whichever can answer, a chain rebuilt only in the size
path would lag the pipe on every flag arriving between two size publications, and the two would
disagree for reasons unrelated to either being wrong. It rebuilds there and does **not** publish
there — that function raises flags, and nothing may observe geometry before the publication that
belongs with it (the #1157 ordering rule).

## What the evidence covers — and what it doesn't

Shadow mode compares chain against pipe at **iop_order 0, `DIR_ALL`, both directions** — exactly
the question these two functions ask. It agrees on every image tried, including ones carrying
drawn masks, ashift, clipping and liquify. Since these converters *were* the pipe and are now the
chain, agreement at that signature is agreement that their answers did not change.

**That argument is indirect, and it is not a test of a mask drawn and dragged on screen.** These
are GUI-side entry points; an export never calls them, so the bit-identical exports below say
only that nothing *else* regressed. Someone should draw a shape, move it, and check it lands
where it is put — I could not.

## Verification

- Export A/B **bit-identical** on an image with drawn masks and one with clipping.
- Four darkroom runs clean, no criticals, chain authoritative and agreeing throughout.
- `include_graph.py` cycles 0, layering 184 unchanged; module boundaries held.
- `virtual_pipe` references: **136, unchanged** — and expected to stay so until the remaining
  module GUIs migrate, since the fallback still names it. The ratchet falls at deletion, not
  here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
