### PR TITLE
Geometry service G10: every bounded GUI transform fold goes through the service

### DIFF
--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -1714,6 +1714,37 @@ static int dt_dev_distort_backtransform_locked(const dt_dev_pixelpipe_t *pipe, c
  * exactly the question these two ask.
  */
 
+/**
+ * @brief The GUI's bounded transform folds: ask the geometry service, fall back to the pipe.
+ *
+ * @details Same contract as dt_dev_distort_transform_plus() -- the iop_order bound and the five
+ * direction modes mean exactly what they mean there -- but stated in terms of the dev rather
+ * than a pipe, because which of the two answers is not the caller's business. The chain answers
+ * when every enabled geometry module has published a record; otherwise the pixel-less pipe does,
+ * as it always has.
+ *
+ * A module GUI must not reach for dev->virtual_pipe itself. That pipe is going away, and a call
+ * site naming it is a call site that will not compile then -- which is the point of routing
+ * every one of them through here first.
+ */
+int dt_dev_distort_transform_gui(dt_develop_t *dev, const double iop_order, const int transf_direction,
+                                 float *points, size_t points_count)
+{
+  if(IS_NULL_PTR(dev)) return 0;
+  if(dt_geometry_transform(dev, iop_order, transf_direction, points, points_count)) return 1;
+  return dt_dev_distort_transform_plus(dev->virtual_pipe, iop_order, transf_direction, points, points_count);
+}
+
+/** @brief The inverse of dt_dev_distort_transform_gui(), same rules. */
+int dt_dev_distort_backtransform_gui(dt_develop_t *dev, const double iop_order, const int transf_direction,
+                                     float *points, size_t points_count)
+{
+  if(IS_NULL_PTR(dev)) return 0;
+  if(dt_geometry_backtransform(dev, iop_order, transf_direction, points, points_count)) return 1;
+  return dt_dev_distort_backtransform_plus(dev->virtual_pipe, iop_order, transf_direction, points,
+                                           points_count);
+}
+
 int dt_dev_coordinates_raw_abs_to_image_abs(dt_develop_t *dev, float *points, size_t points_count)
 {
   if(dt_geometry_transform(dev, 0.0, DT_DEV_TRANSFORM_DIR_ALL, points, points_count)) return 1;

--- a/src/develop/develop.h
+++ b/src/develop/develop.h
@@ -645,6 +645,18 @@ int dt_dev_distort_transform_locked(const struct dt_dev_pixelpipe_t *pipe, const
 int dt_dev_distort_backtransform_plus(const struct dt_dev_pixelpipe_t *pipe, const double iop_order, const int transf_direction,
                                       float *points, size_t points_count);
 
+/**
+ * @brief GUI-side bounded transform folds. Ask the geometry service, fall back to the pixel-less
+ * pipe. Same iop_order bound and direction modes as dt_dev_distort_transform_plus().
+ *
+ * Module GUIs use THESE, never dev->virtual_pipe directly: that pipe is being removed, and a
+ * caller that names it is a caller that has not been migrated.
+ */
+int dt_dev_distort_transform_gui(struct dt_develop_t *dev, const double iop_order,
+                                 const int transf_direction, float *points, size_t points_count);
+int dt_dev_distort_backtransform_gui(struct dt_develop_t *dev, const double iop_order,
+                                     const int transf_direction, float *points, size_t points_count);
+
 /** get the iop_pixelpipe instance corresponding to the iop in the given pipe */
 struct dt_dev_pixelpipe_iop_t *dt_dev_distort_get_iop_pipe(struct dt_dev_pixelpipe_t *pipe,
                                                            struct dt_iop_module_t *module);

--- a/src/develop/masks/circle.c
+++ b/src/develop/masks/circle.c
@@ -518,7 +518,7 @@ static int _circle_get_points_source(dt_develop_t *dev, float x, float y, float 
 
   // we transform with all distortion that happen *before* the module
   // so we have now the TARGET points in module input reference
-  if(!dt_dev_distort_transform_plus(dev->virtual_pipe, module->iop_order, DT_DEV_TRANSFORM_DIR_BACK_EXCL,
+  if(!dt_dev_distort_transform_gui(dev, module->iop_order, DT_DEV_TRANSFORM_DIR_BACK_EXCL,
                                     *points, *points_count))
     goto error;
 
@@ -526,7 +526,7 @@ static int _circle_get_points_source(dt_develop_t *dev, float x, float y, float 
   // so we have now the SOURCE points in module input reference
   float pts[2] = { xs, ys };
   dt_dev_coordinates_raw_norm_to_raw_abs(dev, pts, 1);
-  if(!dt_dev_distort_transform_plus(dev->virtual_pipe, module->iop_order, DT_DEV_TRANSFORM_DIR_BACK_EXCL,
+  if(!dt_dev_distort_transform_gui(dev, module->iop_order, DT_DEV_TRANSFORM_DIR_BACK_EXCL,
                                     pts, 1))
     goto error;
 
@@ -543,7 +543,7 @@ static int _circle_get_points_source(dt_develop_t *dev, float x, float y, float 
 
   // we apply the rest of the distortions (those after the module)
   // so we have now the SOURCE points in final image reference
-  if(!dt_dev_distort_transform_plus(dev->virtual_pipe, module->iop_order, DT_DEV_TRANSFORM_DIR_FORW_INCL,
+  if(!dt_dev_distort_transform_gui(dev, module->iop_order, DT_DEV_TRANSFORM_DIR_FORW_INCL,
                                     *points, *points_count))
     goto error;
 

--- a/src/develop/masks/ellipse.c
+++ b/src/develop/masks/ellipse.c
@@ -399,7 +399,7 @@ static int _ellipse_get_points_source(dt_develop_t *dev, float xx, float yy, flo
 
   // we transform with all distortion that happen *before* the module
   // so we have now the TARGET points in module input reference
-  if(!dt_dev_distort_transform_plus(dev->virtual_pipe, module->iop_order, DT_DEV_TRANSFORM_DIR_BACK_EXCL,
+  if(!dt_dev_distort_transform_gui(dev, module->iop_order, DT_DEV_TRANSFORM_DIR_BACK_EXCL,
                                     *points, *points_count))
     goto error;
 
@@ -407,7 +407,7 @@ static int _ellipse_get_points_source(dt_develop_t *dev, float xx, float yy, flo
   // so we have now the SOURCE points in module input reference
   float pts[2] = { xs, ys };
   dt_dev_coordinates_raw_norm_to_raw_abs(dev, pts, 1);
-  if(!dt_dev_distort_transform_plus(dev->virtual_pipe, module->iop_order, DT_DEV_TRANSFORM_DIR_BACK_EXCL,
+  if(!dt_dev_distort_transform_gui(dev, module->iop_order, DT_DEV_TRANSFORM_DIR_BACK_EXCL,
                                     pts, 1))
     goto error;
 
@@ -426,7 +426,7 @@ static int _ellipse_get_points_source(dt_develop_t *dev, float xx, float yy, flo
 
   // we apply the rest of the distortions (those after the module)
   // so we have now the SOURCE points in final image reference
-  if(!dt_dev_distort_transform_plus(dev->virtual_pipe, module->iop_order, DT_DEV_TRANSFORM_DIR_FORW_INCL,
+  if(!dt_dev_distort_transform_gui(dev, module->iop_order, DT_DEV_TRANSFORM_DIR_FORW_INCL,
                                     *points, *points_count))
     goto error;
 

--- a/src/iop/ashift.c
+++ b/src/iop/ashift.c
@@ -2789,7 +2789,7 @@ static void _draw_save_lines_to_params(dt_iop_module_t *self)
     float pts[8] = { g->lines[0].p1[0], g->lines[0].p1[1], g->lines[0].p2[0],
                      g->lines[0].p2[1], g->lines[1].p1[0], g->lines[1].p1[1],
                      g->lines[1].p2[0], g->lines[1].p2[1] };
-    if(dt_dev_distort_backtransform_plus(self->dev->virtual_pipe, self->iop_order,
+    if(dt_dev_distort_backtransform_gui(self->dev, self->iop_order,
                                          DT_DEV_TRANSFORM_DIR_BACK_EXCL, pts, 4))
     {
       for(int i = 0; i < 8; i++) p->last_quad_lines[i] = pts[i];
@@ -2814,7 +2814,7 @@ static void _draw_save_lines_to_params(dt_iop_module_t *self)
         if(p->last_drawn_lines_count >= MAX_SAVED_LINES) break;
       }
     }
-    dt_dev_distort_backtransform_plus(self->dev->virtual_pipe, self->iop_order,
+    dt_dev_distort_backtransform_gui(self->dev, self->iop_order,
                                       DT_DEV_TRANSFORM_DIR_BACK_EXCL, p->last_drawn_lines,
                                       p->last_drawn_lines_count * 2);
   }
@@ -2840,7 +2840,7 @@ static gboolean _draw_retrieve_lines_from_params(dt_iop_module_t *self, dt_iop_a
                      p->last_quad_lines[2], p->last_quad_lines[3],
                      p->last_quad_lines[4], p->last_quad_lines[5],
                      p->last_quad_lines[6], p->last_quad_lines[7] };
-    if(dt_dev_distort_transform_plus(self->dev->virtual_pipe, self->iop_order,
+    if(dt_dev_distort_transform_gui(self->dev, self->iop_order,
                                      DT_DEV_TRANSFORM_DIR_BACK_EXCL, pts, 4))
     {
       if(g->lines)
@@ -2879,7 +2879,7 @@ static gboolean _draw_retrieve_lines_from_params(dt_iop_module_t *self, dt_iop_a
     for(int i = 0; i < p->last_drawn_lines_count * 4; i++)
       pts[i] = p->last_drawn_lines[i];
 
-    if(dt_dev_distort_transform_plus(self->dev->virtual_pipe, self->iop_order,
+    if(dt_dev_distort_transform_gui(self->dev, self->iop_order,
                                      DT_DEV_TRANSFORM_DIR_BACK_EXCL, pts, p->last_drawn_lines_count * 2))
     {
       if(g->lines)
@@ -3054,7 +3054,7 @@ static void _do_get_structure_quad(dt_iop_module_t *self)
     const float wd = geometry.processed_width;
     const float ht = geometry.processed_height;
     float pts[8] = { wd * 0.2, ht * 0.2, wd * 0.2, ht * 0.8, wd * 0.8, ht * 0.2, wd * 0.8, ht * 0.8 };
-    if(dt_dev_distort_backtransform_plus(self->dev->virtual_pipe, self->iop_order,
+    if(dt_dev_distort_backtransform_gui(self->dev, self->iop_order,
                                          DT_DEV_TRANSFORM_DIR_FORW_INCL, pts, 4))
     {
       g->current_structure_method = ASHIFT_METHOD_QUAD;
@@ -3198,7 +3198,7 @@ int process(struct dt_iop_module_t *self, const dt_dev_pixelpipe_t *pipe, const 
     float ivecl = sqrtf(ivec[0] * ivec[0] + ivec[1] * ivec[1]);
 
     // where do they go?
-    dt_dev_distort_backtransform_plus(self->dev->virtual_pipe, self->iop_order,
+    dt_dev_distort_backtransform_gui(self->dev, self->iop_order,
                                       DT_DEV_TRANSFORM_DIR_FORW_EXCL, points, 2);
 
     float ovec[2] = { points[2] - points[0], points[3] - points[1] };
@@ -3338,7 +3338,7 @@ int process_cl(struct dt_iop_module_t *self, const dt_dev_pixelpipe_t *pipe, con
     const float ivecl = sqrtf(ivec[0] * ivec[0] + ivec[1] * ivec[1]);
 
     // where do they go?
-    dt_dev_distort_backtransform_plus(self->dev->virtual_pipe, self->iop_order,
+    dt_dev_distort_backtransform_gui(self->dev, self->iop_order,
                                       DT_DEV_TRANSFORM_DIR_FORW_EXCL, points, 2);
 
     const float ovec[2] = { points[2] - points[0], points[3] - points[1] };
@@ -3690,9 +3690,9 @@ static int get_points(struct dt_iop_module_t *self, const dt_iop_ashift_line_t *
   }
 
   // third step: transform all points
-  if(!dt_dev_distort_transform_plus(dev->virtual_pipe, self->iop_order, DT_DEV_TRANSFORM_DIR_FORW_INCL, my_points, total_points))
+  if(!dt_dev_distort_transform_gui(dev, self->iop_order, DT_DEV_TRANSFORM_DIR_FORW_INCL, my_points, total_points))
     goto error;
-  if(!dt_dev_distort_transform_plus(dev->virtual_pipe, self->iop_order, DT_DEV_TRANSFORM_DIR_FORW_INCL,
+  if(!dt_dev_distort_transform_gui(dev, self->iop_order, DT_DEV_TRANSFORM_DIR_FORW_INCL,
                                     my_extremas, 2 * lines_count))
     goto error;
 
@@ -3948,10 +3948,10 @@ void gui_post_expose(struct dt_iop_module_t *self, cairo_t *cr, int32_t width, i
                     { xmin + p->cr * owd, ymin + p->ct * oht } };
 
   // convert clipping corners to final output image
-  if(!dt_dev_distort_transform_plus(self->dev->virtual_pipe, self->iop_order,
+  if(!dt_dev_distort_transform_gui(self->dev, self->iop_order,
                                     DT_DEV_TRANSFORM_DIR_FORW_EXCL, (float *)C, 4))
     return;
-  if(!dt_dev_distort_transform_plus(self->dev->virtual_pipe, self->iop_order,
+  if(!dt_dev_distort_transform_gui(self->dev, self->iop_order,
                                     DT_DEV_TRANSFORM_DIR_FORW_EXCL, (float *)V, 4))
     return;
 
@@ -4272,7 +4272,7 @@ int mouse_moved(struct dt_iop_module_t *self, double x, double y, double pressur
     const float pd_w = geometry.processed_width;
     const float pd_h = geometry.processed_height;
     float pts[2] = { pzx * pd_w, pzy * pd_h };
-    if(dt_dev_distort_backtransform_plus(self->dev->virtual_pipe, self->iop_order,
+    if(dt_dev_distort_backtransform_gui(self->dev, self->iop_order,
                                          DT_DEV_TRANSFORM_DIR_FORW_INCL, pts, 1))
     {
       // first we move the point
@@ -4339,7 +4339,7 @@ int mouse_moved(struct dt_iop_module_t *self, double x, double y, double pressur
     const float pd_w = geometry.processed_width;
     const float pd_h = geometry.processed_height;
     float pts[2] = { pzx * pd_w, pzy * pd_h };
-    if(dt_dev_distort_backtransform_plus(self->dev->virtual_pipe, self->iop_order,
+    if(dt_dev_distort_backtransform_gui(self->dev, self->iop_order,
                                          DT_DEV_TRANSFORM_DIR_FORW_INCL, pts, 1))
     {
       const float dx = (pts[0] - g->draw_pointmove_x);
@@ -4579,7 +4579,7 @@ int button_pressed(struct dt_iop_module_t *self, double x, double y, double pres
         const float pd_w = geometry.processed_width;
         const float pd_h = geometry.processed_height;
         float pts[2] = { pzx * pd_w, pzy * pd_h };
-        dt_dev_distort_backtransform_plus(self->dev->virtual_pipe, self->iop_order,
+        dt_dev_distort_backtransform_gui(self->dev, self->iop_order,
                                           DT_DEV_TRANSFORM_DIR_FORW_INCL, pts, 1);
         g->draw_line_move = n;
         g->draw_pointmove_x = pts[0];
@@ -4680,7 +4680,7 @@ int button_pressed(struct dt_iop_module_t *self, double x, double y, double pres
     const float pd_w = geometry.processed_width;
     const float pd_h = geometry.processed_height;
     float pts[2] = { pzx * pd_w, pzy * pd_h };
-    dt_dev_distort_backtransform_plus(self->dev->virtual_pipe, self->iop_order,
+    dt_dev_distort_backtransform_gui(self->dev, self->iop_order,
                                       DT_DEV_TRANSFORM_DIR_FORW_INCL, pts, 1);
     const int count = g->lines_count + 1;
     // if count > MAX_SAVED_LINES we alert that the next lines won't be saved in params
@@ -4752,7 +4752,7 @@ int button_released(struct dt_iop_module_t *self, double x, double y, int which,
     const float pd_w = geometry.processed_width;
     const float pd_h = geometry.processed_height;
     float pts[4] = { pzx * pd_w, pzy * pd_h, g->lastx * pd_w, g->lasty * pd_h };
-    dt_dev_distort_backtransform_plus(self->dev->virtual_pipe,
+    dt_dev_distort_backtransform_gui(self->dev,
                                       self->iop_order,
                                       DT_DEV_TRANSFORM_DIR_FORW_EXCL, pts, 2);
 

--- a/src/iop/clipping.c
+++ b/src/iop/clipping.c
@@ -705,7 +705,7 @@ static int _iop_clipping_set_max_clip(struct dt_iop_module_t *self)
   const float ch = CLAMPF(fabsf(p->ch), 0.1f, 1.0f);
 
   float points[8] = { 0.0f, 0.0f, wp, hp, cx * wp, cy * hp, cw * wp, ch * hp };
-  if(!dt_dev_distort_transform_plus(self->dev->virtual_pipe, self->iop_order, DT_DEV_TRANSFORM_DIR_FORW_EXCL, points, 4))
+  if(!dt_dev_distort_transform_gui(self->dev, self->iop_order, DT_DEV_TRANSFORM_DIR_FORW_EXCL, points, 4))
     return 0;
   dt_dev_coordinates_preview_abs_to_image_norm(self->dev, points, 4);
 
@@ -2603,7 +2603,7 @@ void gui_post_expose(struct dt_iop_module_t *self, cairo_t *cr, int32_t width, i
     const float wp = piece->buf_out.width, hp = piece->buf_out.height;
     float pts[8] = { p->kxa * wp, p->kya * hp, p->kxb * wp, p->kyb * hp,
                      p->kxc * wp, p->kyc * hp, p->kxd * wp, p->kyd * hp };
-    if(dt_dev_distort_transform_plus(self->dev->virtual_pipe, self->iop_order, DT_DEV_TRANSFORM_DIR_FORW_EXCL, pts, 4))
+    if(dt_dev_distort_transform_gui(self->dev, self->iop_order, DT_DEV_TRANSFORM_DIR_FORW_EXCL, pts, 4))
     {
       if(p->k_type == 3)
       {
@@ -2864,7 +2864,7 @@ int mouse_moved(struct dt_iop_module_t *self, double x, double y, double pressur
     if(g->k_drag == TRUE && g->k_selected >= 0)
     {
       float pts[2] = { pzx * wd, pzy * ht };
-      dt_dev_distort_backtransform_plus(self->dev->virtual_pipe, self->iop_order, DT_DEV_TRANSFORM_DIR_FORW_EXCL, pts, 1);
+      dt_dev_distort_backtransform_gui(self->dev, self->iop_order, DT_DEV_TRANSFORM_DIR_FORW_EXCL, pts, 1);
       dt_dev_pixelpipe_iop_t *piece = dt_dev_distort_get_iop_pipe(self->dev->virtual_pipe, self);
       const float xx = pts[0] / (float)piece->buf_out.width, yy = pts[1] / (float)piece->buf_out.height;
       if(g->k_selected == 0)
@@ -3069,7 +3069,7 @@ int mouse_moved(struct dt_iop_module_t *self, double x, double y, double pressur
       float points[4]
           = { g->clip_x * wd, g->clip_y * ht, (g->clip_x + g->clip_w) * wd, (g->clip_y + g->clip_h) * ht };
 
-      if(dt_dev_distort_backtransform_plus(self->dev->virtual_pipe, self->iop_order, DT_DEV_TRANSFORM_DIR_FORW_EXCL, points, 2))
+      if(dt_dev_distort_backtransform_gui(self->dev, self->iop_order, DT_DEV_TRANSFORM_DIR_FORW_EXCL, points, 2))
       {
         dt_dev_pixelpipe_iop_t *piece = dt_dev_distort_get_iop_pipe(self->dev->virtual_pipe, self);
         if(!IS_NULL_PTR(piece))
@@ -3138,7 +3138,7 @@ int mouse_moved(struct dt_iop_module_t *self, double x, double y, double pressur
     if(g->k_show == 1 && g->k_drag == FALSE)
     {
       float pts[2] = { pzx * wd, pzy * ht };
-      dt_dev_distort_backtransform_plus(self->dev->virtual_pipe, self->iop_order, DT_DEV_TRANSFORM_DIR_FORW_EXCL, pts, 1);
+      dt_dev_distort_backtransform_gui(self->dev, self->iop_order, DT_DEV_TRANSFORM_DIR_FORW_EXCL, pts, 1);
       dt_dev_pixelpipe_iop_t *piece = dt_dev_distort_get_iop_pipe(self->dev->virtual_pipe, self);
       float xx = pts[0] / (float)piece->buf_out.width, yy = pts[1] / (float)piece->buf_out.height;
       // are we near a keystone point ?
@@ -3208,7 +3208,7 @@ static void commit_box(dt_iop_module_t *self, dt_iop_clipping_gui_data_t *g, dt_
   const float ht = dt_dev_roi_request_preview_height(self->dev);
   float points[4]
       = { g->clip_x * wd, g->clip_y * ht, (g->clip_x + g->clip_w) * wd, (g->clip_y + g->clip_h) * ht };
-  if(dt_dev_distort_backtransform_plus(self->dev->virtual_pipe, self->iop_order, DT_DEV_TRANSFORM_DIR_FORW_EXCL, points, 2))
+  if(dt_dev_distort_backtransform_gui(self->dev, self->iop_order, DT_DEV_TRANSFORM_DIR_FORW_EXCL, points, 2))
   {
     dt_dev_pixelpipe_iop_t *piece = dt_dev_distort_get_iop_pipe(self->dev->virtual_pipe, self);
     if(!IS_NULL_PTR(piece))
@@ -3235,7 +3235,7 @@ int button_released(struct dt_iop_module_t *self, double x, double y, int which,
   {
     // adjust the line with possible current angle and flip on this module
     dt_boundingbox_t pts = { x, y, g->button_down_x, g->button_down_y };
-    dt_dev_distort_backtransform_plus(self->dev->virtual_pipe, self->iop_order, DT_DEV_TRANSFORM_DIR_FORW_INCL, pts, 2);
+    dt_dev_distort_backtransform_gui(self->dev, self->iop_order, DT_DEV_TRANSFORM_DIR_FORW_INCL, pts, 2);
 
     float dx = pts[0] - pts[2];
     float dy = pts[1] - pts[3];
@@ -3310,7 +3310,7 @@ int button_pressed(struct dt_iop_module_t *self, double x, double y, double pres
         const float wp = piece->buf_out.width, hp = piece->buf_out.height;
         float pts[8] = { p->kxa * wp, p->kya * hp, p->kxb * wp, p->kyb * hp,
                          p->kxc * wp, p->kyc * hp, p->kxd * wp, p->kyd * hp };
-        dt_dev_distort_transform_plus(dev->virtual_pipe, self->iop_order, DT_DEV_TRANSFORM_DIR_FORW_EXCL, pts, 4);
+        dt_dev_distort_transform_gui(dev, self->iop_order, DT_DEV_TRANSFORM_DIR_FORW_EXCL, pts, 4);
 
         float point[2] = { pzx, pzy };
         dt_dev_coordinates_image_norm_to_preview_abs(dev, point, 1);

--- a/src/iop/crop.c
+++ b/src/iop/crop.c
@@ -222,7 +222,7 @@ static void _commit_box(dt_iop_module_t *self, dt_iop_crop_gui_data_t *g, dt_iop
 
   dt_boundingbox_t points = { bbox_left, bbox_top, bbox_right, bbox_bottom };
 
-  if(dt_dev_distort_backtransform_plus(self->dev->virtual_pipe, self->iop_order,
+  if(dt_dev_distort_backtransform_gui(self->dev, self->iop_order,
                                        DT_DEV_TRANSFORM_DIR_FORW_EXCL, points, 2))
   {
     //dt_dev_pixelpipe_iop_t *piece = dt_dev_distort_get_iop_pipe(self->dev->virtual_pipe, self);

--- a/src/iop/drawlayer/coordinates.c
+++ b/src/iop/drawlayer/coordinates.c
@@ -55,7 +55,7 @@ gboolean dt_drawlayer_widget_points_to_layer_coords(dt_iop_module_t *self, float
   dt_dev_coordinates_widget_to_image_norm(self->dev, pts, count);
   dt_dev_coordinates_image_norm_to_preview_abs(self->dev, pts, count);
 
-  if(!dt_dev_distort_backtransform_plus(self->dev->virtual_pipe, self->iop_order,
+  if(!dt_dev_distort_backtransform_gui(self->dev, self->iop_order,
                                         DT_DEV_TRANSFORM_DIR_FORW_EXCL, pts, count))
     return FALSE;
   dt_dev_coordinates_preview_abs_to_image_norm(self->dev, pts, count);
@@ -70,7 +70,7 @@ gboolean dt_drawlayer_layer_points_to_widget_coords(dt_iop_module_t *self, float
   dt_dev_coordinates_image_abs_to_image_norm(self->dev, pts, count);
   dt_dev_coordinates_image_norm_to_preview_abs(self->dev, pts, count);
 
-  if(!dt_dev_distort_transform_plus(self->dev->virtual_pipe, self->iop_order,
+  if(!dt_dev_distort_transform_gui(self->dev, self->iop_order,
                                     DT_DEV_TRANSFORM_DIR_FORW_EXCL, pts, count))
     return FALSE;
 

--- a/src/iop/graduatednd.c
+++ b/src/iop/graduatednd.c
@@ -291,7 +291,7 @@ static int set_grad_from_points(struct dt_iop_module_t *self, const grad_point_t
   // we want absolute preview positions
   float pts[4] = { a->x, a->y, b->x, b->y };
   dt_dev_coordinates_image_norm_to_image_abs(self->dev, pts, 2);
-  dt_dev_distort_backtransform_plus(self->dev->virtual_pipe, self->iop_order, DT_DEV_TRANSFORM_DIR_FORW_EXCL, pts, 2);
+  dt_dev_distort_backtransform_gui(self->dev, self->iop_order, DT_DEV_TRANSFORM_DIR_FORW_EXCL, pts, 2);
   dt_dev_pixelpipe_iop_t *piece = dt_dev_distort_get_iop_pipe(self->dev->virtual_pipe, self);
   pts[0] /= (float)piece->buf_out.width;
   pts[2] /= (float)piece->buf_out.width;
@@ -389,7 +389,7 @@ static int set_points_from_grad(struct dt_iop_module_t *self, grad_point_t *a, g
   }
   // now we want that points to take care of distort modules
 
-  if(!dt_dev_distort_transform_plus(self->dev->virtual_pipe, self->iop_order, DT_DEV_TRANSFORM_DIR_FORW_EXCL, pts, 2))
+  if(!dt_dev_distort_transform_gui(self->dev, self->iop_order, DT_DEV_TRANSFORM_DIR_FORW_EXCL, pts, 2))
     return 0;
   dt_dev_coordinates_image_abs_to_image_norm(self->dev, pts, 2);
   a->x = pts[0];


### PR DESCRIPTION
Tenth tranche. **Stacked on #1173.**

## What moved

**35 call sites** across the module GUIs and two mask shapes stop naming `dev->virtual_pipe` and
ask the dev instead:

```
ashift 16 · clipping 8 · circle 3 · ellipse 3 · graduatednd 2 · drawlayer/coordinates 2 · crop 1
```

`dt_dev_distort_transform_gui()` and its inverse carry the same contract as the `_plus()` pair
they replace — the iop_order bound and the five direction modes mean exactly what they meant —
but stated in terms of the **dev**, because which implementation answers is not the caller's
business. The chain answers when every enabled geometry module has published; otherwise the pipe
does, as always.

**Why wrappers rather than testing authority at each site:** a module GUI has no business knowing
this service exists, let alone whether it is ready. And when the pipe is deleted, a call site
that still names it *will not compile* — which is precisely the signal wanted. The remaining
named references are now concentrated where they belong: per-module dimension lookups, the
dual-use mask folds, the size path, and teardown.

The repoint was mechanical and done as such: every site matching
`dt_dev_distort_{,back}transform_plus(<dev-expr>->virtual_pipe,` became the `_gui` form on the
same dev expression, with no other edit.

## Verification

- Five darkroom-entry runs across images carrying **drawn masks, crop, ashift, borders, clipping
  and liquify** — chain authoritative, size + 5/5 forward probes + 5/5 round-trips agreeing on
  all, no criticals, no divergence.
- Export A/B **bit-identical** on three of them.
- `include_graph.py` cycles 0, layering 184 unchanged; module boundaries held.
- **Ratchet: `virtual_pipe` references 136 → 105.**

## The caveat, which grows with each tranche

These are GUI entry points; an export never calls them, so the bit-identical exports say only
that nothing *else* regressed. The transforms this tranche moved are the ones that place **crop
and ashift handles, graduated-density lines, liquify nodes and mask outlines on screen**. Nothing
in my verification can see those. Someone has to look at them — and this is now the second
tranche in a row where that is the load-bearing check I cannot perform.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
