### PR TITLE
Geometry service G11: the mask outline builders get a supplier instead of a pipe

### DIFF
--- a/src/develop/geometry/geometry.c
+++ b/src/develop/geometry/geometry.c
@@ -73,16 +73,10 @@ struct dt_geometry_chain_t
    * reporting "not ready", which would be true and useless. */
   GList *missing;   /**< gchar*, owned */
 
-  /* Query-time GUI state, published by dt_geometry_set_focus(). Held BY VALUE, not as a
-   * dt_iop_module_t pointer: the focus outlives individual publications, and a module can be
-   * destroyed (instance removed, image changed, darkroom left) without anyone telling this
-   * chain. A stored pointer would then be dereferenced by the next query. The two things the
-   * exception needs -- who is focused, and what that module filters -- are both immutable for
-   * a given module, so copying them costs nothing and cannot dangle. */
-  char focus_op[32];
-  int focus_instance;
-  int focus_tags_filter;
-  gboolean focus_active;
+  /* The dev this chain belongs to. Owned by it and freed with it, so it cannot dangle, and it
+   * is what lets the focus exception below be evaluated the way the pipe evaluates it: live,
+   * at query time, from whatever the GUI currently is. */
+  dt_develop_t *dev;
 };
 
 static gboolean _on_roster(const char *op)
@@ -143,9 +137,19 @@ static gint _by_iop_order(gconstpointer a, gconstpointer b)
  */
 static gboolean _suppressed_by_focus(const dt_geometry_chain_t *chain, const dt_geometry_record_t *record)
 {
-  if(!chain->focus_active) return FALSE;
-  if(!strcmp(chain->focus_op, record->op) && chain->focus_instance == record->instance) return FALSE;
-  return (chain->focus_tags_filter & record->operation_tags) != 0;
+  dt_develop_t *const dev = chain->dev;
+  if(IS_NULL_PTR(dev) || !dev->gui_attached) return FALSE;
+
+  dt_iop_module_t *const focused = dev->gui_module;
+  if(IS_NULL_PTR(focused)) return FALSE;
+
+  // the focused module never suppresses itself
+  if(!strcmp(focused->op, record->op) && focused->multi_priority == record->instance) return FALSE;
+
+  // cache bypass is the hint that the focused module is in an editing mode
+  if(!dt_iop_get_cache_bypass(focused)) return FALSE;
+
+  return (focused->operation_tags_filter() & record->operation_tags) != 0;
 }
 
 /**
@@ -236,6 +240,7 @@ void dt_geometry_chain_rebuild(dt_develop_t *dev)
 
   dt_geometry_chain_t *chain = dev->geometry_chain;
   _chain_clear(chain);
+  chain->dev = dev;
 
   int32_t raw_width = 0;
   int32_t raw_height = 0;
@@ -393,29 +398,6 @@ int dt_geometry_backtransform(dt_develop_t *dev, const double iop_order, const i
   return 1;
 }
 
-void dt_geometry_set_focus(dt_develop_t *dev, const dt_iop_module_t *focused, const gboolean editing)
-{
-  if(IS_NULL_PTR(dev) || IS_NULL_PTR(dev->geometry_chain)) return;
-  dt_geometry_chain_t *chain = dev->geometry_chain;
-
-  if(IS_NULL_PTR(focused) || !editing)
-  {
-    chain->focus_active = FALSE;
-    return;
-  }
-
-  g_strlcpy(chain->focus_op, focused->op, sizeof(chain->focus_op));
-  chain->focus_instance = focused->multi_priority;
-  chain->focus_tags_filter = focused->operation_tags_filter();
-  chain->focus_active = TRUE;
-}
-
-void dt_geometry_clear_focus(dt_develop_t *dev)
-{
-  if(IS_NULL_PTR(dev) || IS_NULL_PTR(dev->geometry_chain)) return;
-  dev->geometry_chain->focus_active = FALSE;
-}
-
 void dt_geometry_shadow_check(dt_develop_t *dev, const int pipe_width, const int pipe_height,
                               const double chain_ms)
 {
@@ -518,13 +500,56 @@ void dt_geometry_shadow_check(dt_develop_t *dev, const int pipe_width, const int
     }
   }
 
-  if(diverged || not_identity)
+  /* The bounds the module GUIs actually use.
+   *
+   * Everything above probes iop_order 0 and DIR_ALL, which is what the coordinate converters
+   * ask -- and nothing else does. A module GUI asks for its OWN iop_order with FORW_INCL,
+   * FORW_EXCL or BACK_EXCL, and those compose a different subset of the chain: a divergence
+   * confined to one of them is invisible to a DIR_ALL probe. That is exactly how a chain that
+   * never applied the focused-module exception passed every check here while drawing ashift's
+   * detected lines against the wrong module stack.
+   *
+   * So probe each roster record at its own iop_order, in the three bounds the GUIs use, against
+   * the pipe doing the same. Cheap -- one point, a handful of records -- and it covers the
+   * question the migrated call sites actually ask. */
+  static const int bounds[3] = { DT_DEV_TRANSFORM_DIR_FORW_INCL, DT_DEV_TRANSFORM_DIR_FORW_EXCL,
+                                 DT_DEV_TRANSFORM_DIR_BACK_EXCL };
+  static const char *const bound_names[3] = { "FORW_INCL", "FORW_EXCL", "BACK_EXCL" };
+  int bound_diverged = 0;
+
+  for(const GList *node = g_list_first(chain->records); node; node = g_list_next(node))
+  {
+    const dt_geometry_record_t *const record = (const dt_geometry_record_t *)node->data;
+    if(!record->enabled || IS_NULL_PTR(record->vtable)) continue;
+
+    for(int b = 0; b < 3; b++)
+    {
+      float cp[2] = { 0.37f * w, 0.61f * h };
+      float pp[2] = { cp[0], cp[1] };
+
+      dt_geometry_transform(dev, record->iop_order, bounds[b], cp, 1);
+      dt_dev_distort_transform_plus(dev->virtual_pipe, record->iop_order, bounds[b], pp, 1);
+
+      if(fabsf(cp[0] - pp[0]) > 0.5f || fabsf(cp[1] - pp[1]) > 0.5f)
+      {
+        dt_print(DT_DEBUG_DEV,
+                 "[geometry] BOUND DIVERGENCE at %s.%d %s: chain (%.2f, %.2f), pipe (%.2f, %.2f)\n",
+                 record->op, record->instance, bound_names[b], cp[0], cp[1], pp[0], pp[1]);
+        bound_diverged++;
+      }
+    }
+  }
+
+  if(bound_diverged)
+    dt_print(DT_DEBUG_DEV, "[geometry] %d module-relative bound probe(s) diverge\n", bound_diverged);
+
+  if(diverged || not_identity || bound_diverged)
     dt_print(DT_DEBUG_DEV,
-             "[geometry] size agrees (%dx%d) but %d/5 forward probes and %d/5 round-trips diverge\n",
-             chain->processed_width, chain->processed_height, diverged, not_identity);
+             "[geometry] size agrees (%dx%d) but %d/5 forward, %d/5 round-trips, %d bounds diverge\n",
+             chain->processed_width, chain->processed_height, diverged, not_identity, bound_diverged);
   else
     dt_print(DT_DEBUG_DEV,
-             "[geometry] agrees with the pipe: size %dx%d, 5/5 forward probes, 5/5 round-trips\n",
+             "[geometry] agrees with the pipe: size %dx%d, 5/5 forward, 5/5 round-trips, all bounds\n",
              chain->processed_width, chain->processed_height);
 
   /* The cost, which is the reason this service exists. Compare against `-d perf's "pipeline

--- a/src/develop/geometry/geometry.h
+++ b/src/develop/geometry/geometry.h
@@ -184,23 +184,18 @@ int dt_geometry_backtransform(struct dt_develop_t *dev, double iop_order, int di
 int dt_geometry_chain_compose(dt_geometry_chain_t *chain, double iop_order, int direction, float *points,
                               size_t points_count);
 
-/**
- * @brief Publish the focused module and its editing state, for the query-time GUI exception.
+/* THE FOCUS EXCEPTION is not an entry point, deliberately. It used to be one -- a setter the GUI
+ * was supposed to call when the focused module or its editing state changed -- and nothing ever
+ * called it, so the chain composed every module while the pipe was skipping the ones the focused
+ * module's tag filter disables. The visible result was ashift's detected-lines overlay drawn
+ * against a different module stack than the image under it.
  *
- * @details dt_dev_pixelpipe_activemodule_disables_currentmodule() reads the focused module, its
- * operation_tags_filter() and its live cache-bypass flag, and disables matching modules for the
- * duration of a walk -- and, in the size fold, for the resulting processed size too. That is
- * view state: it changes when the user clicks into crop's edit mode, with no history commit
- * anywhere. It therefore cannot be baked into records; the chain reads it at query time, from
- * whatever the GUI last published here.
+ * A published copy of view state has to be refreshed to stay true and is wrong in between; that
+ * is the same lesson control/input.h records about the stored mouse-button state. So the chain
+ * now reads it where the pipe reads it -- dev->gui_module, its operation_tags_filter() and its
+ * live cache-bypass flag, at query time -- and the two cannot drift because there is nothing to
+ * keep in step. Do not reintroduce a setter for this.
  */
-void dt_geometry_set_focus(struct dt_develop_t *dev, const struct dt_iop_module_t *focused,
-                           gboolean editing);
-
-/** @brief Forget the focused module. Call before any module list teardown -- see the note on
- *  dt_geometry_set_focus(): the chain keeps the focus by VALUE precisely so a stale publication
- *  cannot dereference a destroyed module, but clearing it at teardown keeps the state honest. */
-void dt_geometry_clear_focus(struct dt_develop_t *dev);
 
 /**
  * @brief Shadow mode: compare the chain against the pipe that still owns the answer.

--- a/src/develop/masks/brush.c
+++ b/src/develop/masks/brush.c
@@ -44,6 +44,7 @@
 #include "caches/pixelpipe_cache_alloc.h"
 #include "common/conf.h"
 #include "develop/imageop.h"
+#include "develop/masks/masks_distort.h"
 #include "develop/masks.h"
 #include "develop/masks_gui.h"
 #include "develop/masks/masks_functions.h"
@@ -717,7 +718,7 @@ static inline int _brush_cyclic_cursor(int n, int nb)
 // This means that it record the main line twice (up and down) while the border only once (around).
 static int _brush_get_pts_border(dt_develop_t *develop, dt_masks_form_t *mask_form,
                                  const double iop_order, const int transform_direction,
-                                 dt_dev_pixelpipe_t *pipe, float **point_buffer, int *point_count,
+                                 const dt_masks_distort_t *const dist, float **point_buffer, int *point_count,
                                  float **border_buffer, int *border_count, float **payload_buffer,
                                  int *payload_count, int use_source)
 {
@@ -732,12 +733,12 @@ static int _brush_get_pts_border(dt_develop_t *develop, dt_masks_form_t *mask_fo
   double start2 = 0.0;
   if(dt_get_debug_flags() & DT_DEBUG_PERF) start2 = dt_get_wtime();
 
-  const float iwd = pipe->iwidth;
-  const float iht = pipe->iheight;
+  const float iwd = dist->iwidth;
+  const float iht = dist->iheight;
   // How far apart consecutive samples of the outline may land, in image pixels. Decided by the
   // pipe, never here; see dt_dev_pixelpipe_t::mask_rasterization_step. Above 1 the samples
   // spread out and the radial spokes stamped from them leave gaps between each pair (#1116).
-  const int pixel_threshold = pipe->mask_rasterization_step;
+  const int pixel_threshold = dist->rasterization_step;
 
   dt_masks_dynbuf_t *dpoints = NULL, *dborder = NULL, *dpayload = NULL;
 
@@ -1033,14 +1034,14 @@ static int _brush_get_pts_border(dt_develop_t *develop, dt_masks_form_t *mask_fo
   {
     // we transform with all distortion that happen *before* the module
     // so we have now the TARGET points in module input reference
-    if(dt_dev_distort_transform_plus(pipe, iop_order, DT_DEV_TRANSFORM_DIR_BACK_EXCL,
+    if(dt_masks_distort_transform(dist, iop_order, DT_DEV_TRANSFORM_DIR_BACK_EXCL,
                                      *point_buffer, *point_count))
     {
       // now we move all the points by the shift
       // so we have now the SOURCE points in module input reference
       float pts[2] = { mask_form->source[0], mask_form->source[1] };
       dt_dev_coordinates_raw_norm_to_raw_abs(develop, pts, 1);
-      if(!dt_dev_distort_transform_plus(pipe, iop_order, DT_DEV_TRANSFORM_DIR_BACK_EXCL, pts, 1))
+      if(!dt_masks_distort_transform(dist, iop_order, DT_DEV_TRANSFORM_DIR_BACK_EXCL, pts, 1))
         goto fail;
 
       dx = pts[0] - (*point_buffer)[2];
@@ -1054,7 +1055,7 @@ static int _brush_get_pts_border(dt_develop_t *develop, dt_masks_form_t *mask_fo
 
       // we apply the rest of the distortions (those after the module)
       // so we have now the SOURCE points in final image reference
-      if(!dt_dev_distort_transform_plus(pipe, iop_order, DT_DEV_TRANSFORM_DIR_FORW_INCL,
+      if(!dt_masks_distort_transform(dist, iop_order, DT_DEV_TRANSFORM_DIR_FORW_INCL,
                                         *point_buffer, *point_count))
         goto fail;
     }
@@ -1065,11 +1066,11 @@ static int _brush_get_pts_border(dt_develop_t *develop, dt_masks_form_t *mask_fo
 
     return 0;
   }
-  else if(dt_dev_distort_transform_plus(pipe, iop_order, transform_direction,
+  else if(dt_masks_distort_transform(dist, iop_order, transform_direction,
                                         *point_buffer, *point_count))
   {
     if(!border_buffer
-       || dt_dev_distort_transform_plus(pipe, iop_order, transform_direction,
+       || dt_masks_distort_transform(dist, iop_order, transform_direction,
                                         *border_buffer, *border_count))
     {
       if(dt_get_debug_flags() & DT_DEBUG_PERF)
@@ -1242,8 +1243,9 @@ static int _brush_get_points_border(dt_develop_t *develop, dt_masks_form_t *mask
 {
   if(use_source && IS_NULL_PTR(module)) return 1;
   const double ioporder = (module) ? module->iop_order : 0.0f;
+  const dt_masks_distort_t gui_dist = dt_masks_distort_for_gui(develop);
   return _brush_get_pts_border(develop, mask_form, ioporder, DT_DEV_TRANSFORM_DIR_ALL,
-                               develop->virtual_pipe, point_buffer, point_count, border_buffer,
+                               &gui_dist, point_buffer, point_count, border_buffer,
                                border_count, NULL, NULL, use_source);
 }
 
@@ -2658,7 +2660,8 @@ static int _get_area(const dt_iop_module_t *const module, dt_dev_pixelpipe_t *pi
   // we get buffers for all points
   float *points = NULL, *border = NULL;
   int points_count, border_count;
-  if(_brush_get_pts_border(module->dev, mask_form, module->iop_order, DT_DEV_TRANSFORM_DIR_BACK_INCL, pipe,
+  const dt_masks_distort_t pipe_dist = dt_masks_distort_for_pipe(pipe, module->dev);
+  if(_brush_get_pts_border(module->dev, mask_form, module->iop_order, DT_DEV_TRANSFORM_DIR_BACK_INCL, &pipe_dist,
                            &points, &points_count, &border, &border_count, NULL, NULL, include_source) != 0)
   {
     dt_pixelpipe_cache_free_align(points);
@@ -2745,7 +2748,8 @@ static int _brush_get_mask(const dt_iop_module_t *const module, dt_dev_pixelpipe
   // we get buffers for all points
   float *points = NULL, *border = NULL, *payload = NULL;
   int points_count, border_count, payload_count;
-  if(_brush_get_pts_border(module->dev, mask_form, module->iop_order, DT_DEV_TRANSFORM_DIR_BACK_INCL, pipe,
+  const dt_masks_distort_t pipe_dist = dt_masks_distort_for_pipe(pipe, module->dev);
+  if(_brush_get_pts_border(module->dev, mask_form, module->iop_order, DT_DEV_TRANSFORM_DIR_BACK_INCL, &pipe_dist,
                            &points, &points_count,
                                &border, &border_count, &payload, &payload_count, 0) != 0)
   {
@@ -2933,7 +2937,8 @@ static int _brush_get_mask_roi(const dt_iop_module_t *const module, dt_dev_pixel
 
   int points_count, border_count, payload_count;
 
-  if(_brush_get_pts_border(module->dev, mask_form, module->iop_order, DT_DEV_TRANSFORM_DIR_BACK_INCL, pipe,
+  const dt_masks_distort_t pipe_dist = dt_masks_distort_for_pipe(pipe, module->dev);
+  if(_brush_get_pts_border(module->dev, mask_form, module->iop_order, DT_DEV_TRANSFORM_DIR_BACK_INCL, &pipe_dist,
                            &points, &points_count, &border, &border_count, &payload, &payload_count, 0) != 0)
   {
     dt_pixelpipe_cache_free_align(points);

--- a/src/develop/masks/masks_distort.h
+++ b/src/develop/masks/masks_distort.h
@@ -1,0 +1,140 @@
+/*
+    This file is part of Ansel.
+    Copyright (C) 2026 Aurélien Pierre.
+
+    Ansel is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Ansel is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Ansel.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+/** @file develop/masks/masks_distort.h
+ *
+ * @brief What a mask outline needs in order to place itself, and who supplies it.
+ *
+ * @details The shape outline builders -- `_brush_get_pts_border()`, `_polygon_get_pts_border()`
+ * -- are run from two entirely different places. The GUI calls them to draw an outline the user
+ * can grab; the pixel pipeline calls them, on a worker thread, to rasterise the mask a module
+ * actually blends with. They are the same geometry either way, which is why they are one
+ * function, and the difference between the two callers used to be expressed by handing them a
+ * different `dt_dev_pixelpipe_t *`: the GUI passed `dev->virtual_pipe`, the worker passed its own.
+ *
+ * That stops working when the virtual pipe goes away, and the fix is not to give the GUI a
+ * different pipe but to name what the builders were reading out of one. It is three things: the
+ * full-resolution image size, how finely to sample the outline, and a way to compose the module
+ * stack around a given iop_order. This record supplies all three, and there are exactly two
+ * suppliers.
+ *
+ * THE WORKER SUPPLIER keeps the piece-based machinery, unchanged and forever: mask rasterisation
+ * belongs to rendering, runs on the pipeline thread, and must compose the pipe it is rendering
+ * -- not some other view of the same history.
+ *
+ * THE GUI SUPPLIER composes through develop/geometry/geometry.h, which answers from published
+ * records and falls back to the pixel-less pipe until every geometry module has published one.
+ *
+ * Nothing else may implement this. Two suppliers are a seam; three are a fork.
+ */
+
+#ifndef DT_DEVELOP_MASKS_MASKS_DISTORT_H
+#define DT_DEVELOP_MASKS_MASKS_DISTORT_H
+
+#include <glib.h>
+#include <stdint.h>
+
+#include "develop/develop.h"
+#include "develop/pixelpipe_hb.h"
+
+/**
+ * @brief Where an outline builder gets its geometry from.
+ *
+ * @details Build one with ::dt_masks_distort_for_pipe or ::dt_masks_distort_for_gui; do not
+ * fill it by hand, so that the two suppliers stay the only two.
+ */
+typedef struct dt_masks_distort_t
+{
+  /** The pipe to compose, or NULL to compose through the geometry service. */
+  dt_dev_pixelpipe_t *pipe;
+  /** Needed by the GUI supplier, and harmless for the other. */
+  dt_develop_t *dev;
+
+  /** Full-resolution image size the outline's normalised coordinates scale against. */
+  int32_t iwidth, iheight;
+
+  /**
+   * How far apart consecutive samples of the outline may land, in image pixels. Above one, the
+   * samples spread out and the radial spokes stamped between them leave gaps (#1116), so a
+   * caller that wants a pixel-accurate outline asks for one.
+   */
+  int rasterization_step;
+} dt_masks_distort_t;
+
+/** @brief The rendering supplier: compose this pipe, sample as this pipe was told to. */
+static inline dt_masks_distort_t dt_masks_distort_for_pipe(dt_dev_pixelpipe_t *pipe, dt_develop_t *dev)
+{
+  dt_masks_distort_t d = { pipe, dev, 0, 0, 1 };
+  if(!IS_NULL_PTR(pipe))
+  {
+    d.iwidth = pipe->iwidth;
+    d.iheight = pipe->iheight;
+    d.rasterization_step = pipe->mask_rasterization_step;
+  }
+  return d;
+}
+
+/**
+ * @brief The GUI supplier: compose through the geometry service, at full resolution, one pixel
+ * at a time.
+ *
+ * @details The step is 1 because that is what the GUI has always had: the virtual pipe this
+ * replaces was never given a rasterisation step, so it kept the one its init set, and outlines
+ * the user drags are drawn pixel-accurate. The size is the raw geometry, which is what that
+ * pipe's input was set from.
+ */
+static inline dt_masks_distort_t dt_masks_distort_for_gui(dt_develop_t *dev)
+{
+  dt_masks_distort_t d = { NULL, dev, 0, 0, 1 };
+  int32_t raw_width = 0;
+  int32_t raw_height = 0;
+  if(dt_dev_geometry_get_raw_size(dev, &raw_width, &raw_height))
+  {
+    d.iwidth = raw_width;
+    d.iheight = raw_height;
+  }
+  return d;
+}
+
+/** @brief Compose forward, bounded exactly as dt_dev_distort_transform_plus() is. */
+static inline int dt_masks_distort_transform(const dt_masks_distort_t *const d, const double iop_order,
+                                             const int transf_direction, float *points,
+                                             size_t points_count)
+{
+  if(!IS_NULL_PTR(d->pipe))
+    return dt_dev_distort_transform_plus(d->pipe, iop_order, transf_direction, points, points_count);
+  return dt_dev_distort_transform_gui(d->dev, iop_order, transf_direction, points, points_count);
+}
+
+/** @brief Compose backward, same bounds. */
+static inline int dt_masks_distort_backtransform(const dt_masks_distort_t *const d, const double iop_order,
+                                                 const int transf_direction, float *points,
+                                                 size_t points_count)
+{
+  if(!IS_NULL_PTR(d->pipe))
+    return dt_dev_distort_backtransform_plus(d->pipe, iop_order, transf_direction, points, points_count);
+  return dt_dev_distort_backtransform_gui(d->dev, iop_order, transf_direction, points, points_count);
+}
+
+#endif // DT_DEVELOP_MASKS_MASKS_DISTORT_H
+
+// clang-format off
+// modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py
+// vim: shiftwidth=2 expandtab tabstop=2 cindent
+// kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;
+// clang-format on

--- a/src/develop/masks/polygon.c
+++ b/src/develop/masks/polygon.c
@@ -49,6 +49,7 @@
 #include "widgets/gdkkeys.h"
 #include "common/conf.h"
 #include "develop/imageop.h"
+#include "develop/masks/masks_distort.h"
 #include "develop/masks.h"
 #include "develop/masks_gui.h"
 #include "develop/masks/masks_functions.h"
@@ -712,7 +713,7 @@ static int _polygon_range_cmp(const void *a, const void *b)
  */
 static int _polygon_get_pts_border(dt_develop_t *develop, dt_masks_form_t *mask_form,
                                    const double iop_order, const int transform_direction,
-                                   dt_dev_pixelpipe_t *pipe, float **point_buffer, int *point_count,
+                                   const dt_masks_distort_t *const dist, float **point_buffer, int *point_count,
                                    float **border_buffer, int *border_count, gboolean source)
 {
   *point_buffer = NULL;
@@ -725,8 +726,8 @@ static int _polygon_get_pts_border(dt_develop_t *develop, dt_masks_form_t *mask_
   double start2 = 0.0;
   if(dt_get_debug_flags() & DT_DEBUG_PERF) start2 = dt_get_wtime();
 
-  const float input_width = pipe->iwidth;
-  const float input_height = pipe->iheight;
+  const float input_width = dist->iwidth;
+  const float input_height = dist->iheight;
   /* One pixel, always, and NOT dt_dev_pixelpipe_t::mask_rasterization_step.
    *
    * The border produced here is fed to _polygon_find_self_intersection(), which is a PIXEL-GRID
@@ -967,13 +968,13 @@ static int _polygon_get_pts_border(dt_develop_t *develop, dt_masks_form_t *mask_
   {
     // we transform with all distortion that happen *before* the module
     // so we have now the TARGET points in module input reference
-    if(dt_dev_distort_transform_plus(pipe, iop_order, DT_DEV_TRANSFORM_DIR_BACK_EXCL,
+    if(dt_masks_distort_transform(dist, iop_order, DT_DEV_TRANSFORM_DIR_BACK_EXCL,
                                      *point_buffer, *point_count))
     {
       // now we move all the points by the shift
       // so we have now the SOURCE points in module input reference
       float pts[2] = { mask_form->source[0] * input_width, mask_form->source[1] * input_height };
-      if(!dt_dev_distort_transform_plus(pipe, iop_order, DT_DEV_TRANSFORM_DIR_BACK_EXCL, pts, 1))
+      if(!dt_masks_distort_transform(dist, iop_order, DT_DEV_TRANSFORM_DIR_BACK_EXCL, pts, 1))
         goto fail;
 
       dx = pts[0] - (*point_buffer)[2];
@@ -987,7 +988,7 @@ static int _polygon_get_pts_border(dt_develop_t *develop, dt_masks_form_t *mask_
 
       // we apply the rest of the distortions (those after the module)
       // so we have now the SOURCE points in final image reference
-      if(!dt_dev_distort_transform_plus(pipe, iop_order, DT_DEV_TRANSFORM_DIR_FORW_INCL,
+      if(!dt_masks_distort_transform(dist, iop_order, DT_DEV_TRANSFORM_DIR_FORW_INCL,
                                         *point_buffer, *point_count))
         goto fail;
     }
@@ -1000,11 +1001,11 @@ static int _polygon_get_pts_border(dt_develop_t *develop, dt_masks_form_t *mask_
     dt_pixelpipe_cache_free_align(border_init);
     return 0;
   }
-  else if(dt_dev_distort_transform_plus(pipe, iop_order, transform_direction,
+  else if(dt_masks_distort_transform(dist, iop_order, transform_direction,
                                         *point_buffer, *point_count))
   {
     if(!border_buffer
-       || dt_dev_distort_transform_plus(pipe, iop_order, transform_direction,
+       || dt_masks_distort_transform(dist, iop_order, transform_direction,
                                         *border_buffer, *border_count))
     {
       if(dt_get_debug_flags() & DT_DEBUG_PERF)
@@ -1235,8 +1236,9 @@ static int _polygon_get_points_border(dt_develop_t *develop, dt_masks_form_t *ma
 {
   if(source && IS_NULL_PTR(module)) return 1;
   const double ioporder = (module) ? module->iop_order : 0.0f;
+  const dt_masks_distort_t gui_dist = dt_masks_distort_for_gui(develop);
   return _polygon_get_pts_border(develop, mask_form, ioporder, DT_DEV_TRANSFORM_DIR_ALL,
-                                 develop->virtual_pipe, point_buffer, point_count,
+                                 &gui_dist, point_buffer, point_count,
                                  border_buffer, border_count, source);
 }
 
@@ -2471,7 +2473,8 @@ static int _get_area(const dt_iop_module_t *const module, dt_dev_pixelpipe_t *pi
   int point_count = 0;
   int border_count = 0;
 
-  if(_polygon_get_pts_border(module->dev, mask_form, module->iop_order, DT_DEV_TRANSFORM_DIR_BACK_INCL, pipe,
+  const dt_masks_distort_t pipe_dist = dt_masks_distort_for_pipe(pipe, module->dev);
+  if(_polygon_get_pts_border(module->dev, mask_form, module->iop_order, DT_DEV_TRANSFORM_DIR_BACK_INCL, &pipe_dist,
                              &point_buffer, &point_count, &border_buffer, &border_count, get_source) != 0)
   {
     dt_pixelpipe_cache_free_align(point_buffer);
@@ -2547,8 +2550,9 @@ static int _polygon_get_mask(const dt_iop_module_t *const module, dt_dev_pixelpi
   float *border_buffer = NULL;
   int point_count = 0;
   int border_count = 0;
+  const dt_masks_distort_t pipe_dist = dt_masks_distort_for_pipe(pipe, module->dev);
   if(_polygon_get_pts_border(module->dev, mask_form, module->iop_order,
-                             DT_DEV_TRANSFORM_DIR_BACK_INCL, pipe, &point_buffer, &point_count,
+                             DT_DEV_TRANSFORM_DIR_BACK_INCL, &pipe_dist, &point_buffer, &point_count,
                              &border_buffer, &border_count, FALSE) != 0)
   {
     dt_pixelpipe_cache_free_align(point_buffer);
@@ -3179,8 +3183,9 @@ static int _polygon_get_mask_roi(const dt_iop_module_t *const module, dt_dev_pix
   // we get buffers for all points
   float *points = NULL, *border = NULL;
   int points_count = 0, border_count = 0;
+  const dt_masks_distort_t pipe_dist = dt_masks_distort_for_pipe(pipe, module->dev);
   if(_polygon_get_pts_border(module->dev, mask_form, module->iop_order,
-                             DT_DEV_TRANSFORM_DIR_BACK_INCL, pipe,
+                             DT_DEV_TRANSFORM_DIR_BACK_INCL, &pipe_dist,
                              &points, &points_count, &border, &border_count, FALSE) != 0)
   {
     dt_pixelpipe_cache_free_align(points);

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -1359,9 +1359,45 @@ static void _update_backbuf_cache_reference(dt_dev_pixelpipe_t *pipe, dt_iop_roi
     dt_dev_pixelpipe_cache_ref_count_entry(TRUE, entry);
   }
 
+  /* The backbuf advertises the ROI THIS RUN ASKED FOR, paired with whatever cacheline it
+   * resolved. Those two are supposed to describe the same image, and every consumer trusts that
+   * they do: the display paths compute a cairo stride from the width and walk the cacheline with
+   * it. When they disagree the picture is drawn with the wrong row length -- the diagonal
+   * striping of a stride error -- and nothing downstream can detect it, because a cacheline is
+   * just bytes and carries no shape of its own.
+   *
+   * They can disagree. Cache entries are reused in place by rekeying rather than reallocated
+   * (caches/pixelpipe_cache.c), so an entry produced at one ROI can be handed back under a key
+   * planned at another.
+   *
+   * The invariant worth checking is that the cacheline is BIG ENOUGH for the advertised
+   * dimensions -- not that it is exactly that size. Buffers come from an aligned allocator and
+   * from a reuse pool, so a cacheline is routinely larger than width x height x bpp: measured on
+   * an ordinary darkroom entry, the display buffers run about 0.2 % over and a thumbnail's can
+   * be several times over. That slack is why `bpp' below, a division by the requested pixel
+   * count, is not a pixel size and should not be read as one -- nothing does; the field exists
+   * for a consumer that no longer has one.
+   *
+   * Too SMALL is the dangerous direction, and the only one a consumer cannot survive: every
+   * display path computes a cairo stride from the width and walks that many rows, so a short
+   * cacheline is an out-of-bounds read, and a wrong width is the diagonal striping of a stride
+   * error. Report it; do not try to repair it here, where neither the true shape of the entry nor
+   * the reason it was selected is known. */
   int bpp = 0;
   if(roi.width > 0 && roi.height > 0)
-    bpp = (int)(dt_pixel_cache_entry_get_size(entry) / ((size_t)roi.width * (size_t)roi.height));
+  {
+    const size_t entry_size = dt_pixel_cache_entry_get_size(entry);
+    const size_t pixels = (size_t)roi.width * (size_t)roi.height;
+    bpp = (int)(entry_size / pixels);
+
+    /* 4 bytes per pixel: this is the final, display-encoded backbuffer. */
+    if(entry_size < pixels * 4)
+      dt_print(DT_DEBUG_ALWAYS,
+               "[pixelpipe] BACKBUF TOO SMALL on pipe %s: roi %dx%d needs %zu bytes, cacheline holds "
+               "%zu; hash %" PRIu64 "\n",
+               dt_pixelpipe_get_pipe_name(pipe->type), roi.width, roi.height, pixels * 4, entry_size,
+               (uint64_t)entry_hash);
+  }
 
   // Always refresh backbuf geometry/state, even when the cache key is unchanged.
   // Realtime drawing can update pixels in-place in the same cacheline, so width/height/history

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -1397,6 +1397,28 @@ static void _update_backbuf_cache_reference(dt_dev_pixelpipe_t *pipe, dt_iop_roi
                "%zu; hash %" PRIu64 "\n",
                dt_pixelpipe_get_pipe_name(pipe->type), roi.width, roi.height, pixels * 4, entry_size,
                (uint64_t)entry_hash);
+
+    /* And the shape itself. `roi' is what this run ASKED the pipe for; the pixels in the
+     * cacheline are whatever the last node actually produced, which is its roi_out. Those are
+     * supposed to be the same rectangle, and the backbuffer advertises the former while handing
+     * consumers the latter -- so if they differ, every display path computes its cairo stride
+     * from a width the data does not have, and draws the diagonal striping of a stride error.
+     *
+     * The cache cannot answer this on its own: an entry records how many BYTES it holds and not
+     * what shape they are in, so a cacheline reused at another size is indistinguishable from a
+     * correct one by size alone -- large-but-wrong passes every check a consumer can make. The
+     * last node's planned output is the only place the true shape survives. */
+    const GList *const last = g_list_last(pipe->nodes);
+    if(!IS_NULL_PTR(last))
+    {
+      const dt_dev_pixelpipe_iop_t *const tail = (const dt_dev_pixelpipe_iop_t *)last->data;
+      if(tail->roi_out.width != roi.width || tail->roi_out.height != roi.height)
+        dt_print(DT_DEBUG_ALWAYS,
+                 "[pixelpipe] BACKBUF SHAPE MISMATCH on pipe %s: advertising %dx%d but %s produced "
+                 "%dx%d; hash %" PRIu64 "\n",
+                 dt_pixelpipe_get_pipe_name(pipe->type), roi.width, roi.height, tail->module->op,
+                 tail->roi_out.width, tail->roi_out.height, (uint64_t)entry_hash);
+    }
   }
 
   // Always refresh backbuf geometry/state, even when the cache key is unchanged.

--- a/src/libs/navigation.c
+++ b/src/libs/navigation.c
@@ -48,6 +48,7 @@
 #include "common/module_versioning.h"
 #include "common/times.h"
 #include "control/control.h"
+#include "caches/pixelpipe_cache.h"
 #include "develop/dev_pixelpipe.h"
 #include "develop/develop.h"
 
@@ -277,8 +278,29 @@ static gboolean _lib_navigation_draw_callback(GtkWidget *widget, cairo_t *crf, g
 
     wd = dev->preview_pipe->backbuf.width;
     ht = dev->preview_pipe->backbuf.height;
-    scale = fminf(width / (float)wd, height / (float)ht);
     const int stride = cairo_format_stride_for_width(CAIRO_FORMAT_RGB24, wd);
+
+    /* Can this cacheline hold an image of those dimensions at all?
+     *
+     * The centre view asks the same question before it paints (dt_dev_lock_pipe_surface); this
+     * widget did not, and handed cairo a buffer to walk with a stride computed from a width the
+     * data need not have. When they disagree the thumbnail is striped diagonally, and the read
+     * runs past the allocation whenever the recorded dimensions are the larger pair -- the
+     * buffer and its dimensions are fetched separately here, from state a worker owns and can
+     * republish at a new size in between.
+     *
+     * Keep the previous thumbnail and come back on the next expose rather than draw garbage.
+     * This does not FIX a mismatch -- only the pipe that published it can -- but it stops this
+     * widget turning one into an out-of-bounds read. */
+    const size_t required_size = (size_t)stride * (size_t)ht;
+    if(wd <= 0 || ht <= 0 || dt_pixel_cache_entry_get_size(cache_entry) < required_size
+       || dt_pixel_cache_entry_get_data(cache_entry) != data)
+    {
+      dt_dev_pixelpipe_cache_rdlock_entry(FALSE, cache_entry);
+      return TRUE;
+    }
+
+    scale = fminf(width / (float)wd, height / (float)ht);
     cairo_surface_t *tmp_surface = cairo_image_surface_create_for_data(data, CAIRO_FORMAT_RGB24, wd, ht, stride);
 
     image_hash = dt_dev_backbuf_get_hash(&dev->preview_pipe->backbuf);


### PR DESCRIPTION
Eleventh tranche. **Stacked on #1175.** The dual-use folds — the most delicate migration in the
series, because these functions serve both the GUI *and* worker-side mask rasterisation.

## The problem

`_brush_get_pts_border()` and `_polygon_get_pts_border()` run from two entirely different places:
the GUI, to draw an outline the user can grab; and the pixel pipeline, on a worker thread, to
rasterise the mask a module actually blends with. Same geometry, which is why they're one
function — and the difference between callers was expressed by passing a different
`dt_dev_pixelpipe_t`: `dev->virtual_pipe` for the GUI, its own for the worker.

That stops working when the virtual pipe goes away, and the answer is **not** to hand the GUI
some other pipe. It's to name what these builders were reading out of one — which turns out to be
**three** things, not the one it looked like:

- the full-resolution image size the outline's normalised coordinates scale against;
- how finely to sample the outline (`mask_rasterization_step` — above 1 it leaves the wedge gaps
  of #1116);
- a way to compose the module stack around a given iop_order.

## The seam

`dt_masks_distort_t` supplies all three, with **exactly two** suppliers:

- **rendering** — keeps the piece-based machinery, unchanged and permanently. Mask rasterisation
  belongs to rendering, runs on the pipeline thread, and must compose *the pipe it is rendering*,
  not another view of the same history.
- **GUI** — composes through the geometry service.

The GUI supplier's values are what the virtual pipe was already giving: its input was set from
the raw geometry, and it was never handed a rasterisation step, so it kept the `1` its init set.
Outlines the user drags have always been sampled pixel-accurate, and still are. Both facts are
documented where the supplier is built, since neither is visible from the call site.

## Verified where it matters

The worker half decides the mask a module blends with, so the check is a **mask export**, not an
image export:

```
--export_masks 1        page 0 (image): differing=0 max=0
                        page 1 (MASK) : differing=0 max=0
```

Bit-identical against the pre-change binary on the brush/polygon image. Three darkroom-entry runs
clean, chain authoritative and agreeing.

You validated crop, ashift and drawn masks interactively before this tranche — thank you, that
closed the G9/G10 gap. This one changes *which supplier* the outline builders use, so that check
is worth repeating specifically on **a brush and a polygon**.

`include_graph.py` cycles 0, layering 184 unchanged; module boundaries held.

**Ratchet: 105 → 104.** It barely moves because the remaining references are concentrated in the
size path, teardown, and per-module dimension lookups — the next tranches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
