### PR TITLE
Geometry service G12: per-module dimensions come from the service

### DIFF
--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -1745,6 +1745,39 @@ int dt_dev_distort_backtransform_gui(dt_develop_t *dev, const double iop_order, 
                                            points_count);
 }
 
+/**
+ * @brief One module's own input and output rectangles, at full resolution.
+ *
+ * @details What a module GUI used to get by resolving its piece on the pixel-less pipe and
+ * reading piece->buf_in / piece->buf_out. Those rectangles are a product of the size fold, and
+ * the geometry service performs that fold over records for EVERY module -- not only the ones
+ * that change geometry, because not only those read the result: iop/graduatednd.c has no
+ * geometry callbacks at all and normalises its overlay against its own output rectangle.
+ *
+ * @return FALSE when neither source can answer, in which case @p in and @p out are untouched
+ * and the caller must not draw. A module that is disabled or absent has no rectangles.
+ */
+gboolean dt_dev_module_geometry_gui(dt_develop_t *dev, dt_iop_module_t *module, dt_iop_roi_t *in,
+                                    dt_iop_roi_t *out)
+{
+  if(IS_NULL_PTR(dev) || IS_NULL_PTR(module)) return FALSE;
+
+  const dt_geometry_record_t *const record
+      = dt_geometry_chain_find(dev->geometry_chain, module->op, module->multi_priority);
+  if(dt_geometry_chain_authoritative(dev->geometry_chain) && !IS_NULL_PTR(record))
+  {
+    if(!IS_NULL_PTR(in)) *in = record->in;
+    if(!IS_NULL_PTR(out)) *out = record->out;
+    return TRUE;
+  }
+
+  const dt_dev_pixelpipe_iop_t *const piece = dt_dev_distort_get_iop_pipe(dev->virtual_pipe, module);
+  if(IS_NULL_PTR(piece)) return FALSE;
+  if(!IS_NULL_PTR(in)) *in = piece->buf_in;
+  if(!IS_NULL_PTR(out)) *out = piece->buf_out;
+  return TRUE;
+}
+
 int dt_dev_coordinates_raw_abs_to_image_abs(dt_develop_t *dev, float *points, size_t points_count)
 {
   if(dt_geometry_transform(dev, 0.0, DT_DEV_TRANSFORM_DIR_ALL, points, points_count)) return 1;

--- a/src/develop/develop.h
+++ b/src/develop/develop.h
@@ -657,6 +657,17 @@ int dt_dev_distort_transform_gui(struct dt_develop_t *dev, const double iop_orde
 int dt_dev_distort_backtransform_gui(struct dt_develop_t *dev, const double iop_order,
                                      const int transf_direction, float *points, size_t points_count);
 
+/**
+ * @brief One module's own input and output rectangles at full resolution, from the geometry
+ * service or, until it can answer, from the pixel-less pipe.
+ *
+ * Replaces resolving a piece and reading piece->buf_in / piece->buf_out. Returns FALSE when
+ * neither source has them, leaving the out-params untouched -- a disabled or absent module has
+ * no rectangles, and a caller that draws anyway draws somewhere arbitrary.
+ */
+gboolean dt_dev_module_geometry_gui(struct dt_develop_t *dev, struct dt_iop_module_t *module,
+                                    dt_iop_roi_t *in, dt_iop_roi_t *out);
+
 /** get the iop_pixelpipe instance corresponding to the iop in the given pipe */
 struct dt_dev_pixelpipe_iop_t *dt_dev_distort_get_iop_pipe(struct dt_dev_pixelpipe_t *pipe,
                                                            struct dt_iop_module_t *module);

--- a/src/develop/geometry/geometry.c
+++ b/src/develop/geometry/geometry.c
@@ -79,6 +79,32 @@ struct dt_geometry_chain_t
   dt_develop_t *dev;
 };
 
+/**
+ * @brief A/B switch for bisecting this service against the pipe it replaces.
+ *
+ * @details Every migrated consumer falls back to dev->virtual_pipe when the chain is not
+ * authoritative, so refusing authority puts the whole GUI back on the pipeline path without
+ * rebuilding or reverting anything. Set ANSEL_GEOMETRY_DISABLE=1: a symptom that persists is
+ * not this service's doing, one that disappears is.
+ *
+ * It clears the authority FLAG rather than intercepting the accessor, because the walkers and
+ * the shadow harness read that field directly -- an accessor-only switch would have left the
+ * transform paths live, which is exactly the half a bisection needs to move.
+ */
+static gboolean _geometry_disabled(void)
+{
+  static int disabled = -1;
+  if(disabled < 0)
+  {
+    const char *const env = g_getenv("ANSEL_GEOMETRY_DISABLE");
+    disabled = (!IS_NULL_PTR(env) && env[0] == '1') ? 1 : 0;
+    if(disabled)
+      fprintf(stderr, "[geometry] ANSEL_GEOMETRY_DISABLE=1: the chain declines every query; "
+                      "every consumer falls back to the pixel-less pipe\n");
+  }
+  return disabled == 1;
+}
+
 static gboolean _on_roster(const char *op)
 {
   if(IS_NULL_PTR(op)) return FALSE;
@@ -298,7 +324,7 @@ void dt_geometry_chain_rebuild(dt_develop_t *dev)
   dt_pthread_rwlock_unlock(&dev->history_mutex);
 
   _fold_sizes(chain);
-  chain->authoritative = complete && chain->sized;
+  chain->authoritative = complete && chain->sized && !_geometry_disabled();
 }
 
 gboolean dt_geometry_chain_authoritative(const dt_geometry_chain_t *chain)

--- a/src/iop/ashift.c
+++ b/src/iop/ashift.c
@@ -2550,11 +2550,11 @@ static void do_crop(dt_iop_module_t *self, dt_iop_ashift_params_t *p)
   // ashift's process() to populate g->buf. ashift's roi_in is crop-dependent, while buf_in is the
   // stable full input geometry required by the fit.
   int crop_width = 0, crop_height = 0;
-  const dt_dev_pixelpipe_iop_t *crop_piece = dt_dev_distort_get_iop_pipe(self->dev->virtual_pipe, self);
-  if(!IS_NULL_PTR(crop_piece) && crop_piece->buf_in.width > 0 && crop_piece->buf_in.height > 0)
+  dt_iop_roi_t crop_in;
+  if(dt_dev_module_geometry_gui(self->dev, self, &crop_in, NULL) && crop_in.width > 0 && crop_in.height > 0)
   {
-    crop_width = crop_piece->buf_in.width;
-    crop_height = crop_piece->buf_in.height;
+    crop_width = crop_in.width;
+    crop_height = crop_in.height;
   }
   else
   {
@@ -3011,14 +3011,17 @@ static void _do_get_structure_lines(dt_iop_module_t *self)
   // Manual line drawing only needs the module input geometry, never the pixel buffer (unlike
   // auto-detection). Tying it to g->buf used to block all manual input whenever the preview buffer
   // was momentarily unavailable, e.g. when the module already had parameters set (#710).
-  dt_dev_pixelpipe_iop_t *piece = dt_dev_distort_get_iop_pipe(self->dev->virtual_pipe, self);
-  if(IS_NULL_PTR(piece) || piece->iwidth <= 0 || piece->iheight <= 0) return;
+  /* piece->iwidth/iheight was the PIPE's input size, which is the raw geometry -- not anything
+   * this module derives -- so it is read from where that fact lives. */
+  int32_t raw_width = 0, raw_height = 0;
+  if(!dt_dev_geometry_get_raw_size(self->dev, &raw_width, &raw_height)) return;
+  if(raw_width <= 0 || raw_height <= 0) return;
 
   _do_clean_structure(self, p, TRUE);
 
   g->current_structure_method = ASHIFT_METHOD_LINES;
-  g->lines_in_width = piece->iwidth;
-  g->lines_in_height = piece->iheight;
+  g->lines_in_width = raw_width;
+  g->lines_in_height = raw_height;
   g->lines_x_off = 0;
   g->lines_y_off = 0;
 
@@ -3037,8 +3040,11 @@ static void _do_get_structure_quad(dt_iop_module_t *self)
 
   // The manual perspective rectangle only needs the module input geometry, never the pixel buffer
   // (unlike auto-detection), so it must not wait for the preview input buffer (#710).
-  dt_dev_pixelpipe_iop_t *piece = dt_dev_distort_get_iop_pipe(self->dev->virtual_pipe, self);
-  if(IS_NULL_PTR(piece) || piece->iwidth <= 0 || piece->iheight <= 0) return;
+  /* piece->iwidth/iheight was the PIPE's input size, which is the raw geometry -- not anything
+   * this module derives -- so it is read from where that fact lives. */
+  int32_t raw_width = 0, raw_height = 0;
+  if(!dt_dev_geometry_get_raw_size(self->dev, &raw_width, &raw_height)) return;
+  if(raw_width <= 0 || raw_height <= 0) return;
 
   _do_clean_structure(self, p, TRUE);
 
@@ -3073,8 +3079,8 @@ static void _do_get_structure_quad(dt_iop_module_t *self)
       // get real line type (they may be wrong due to image rotation)
       for(int i = 0; i < 4; i++) _draw_retrieve_line_type(&g->lines[i]);
 
-      g->lines_in_width = piece->iwidth;
-      g->lines_in_height = piece->iheight;
+      g->lines_in_width = raw_width;
+      g->lines_in_height = raw_height;
       g->lines_x_off = 0;
       g->lines_y_off = 0;
       g->vertical_count = 2;
@@ -3879,16 +3885,16 @@ void gui_post_expose(struct dt_iop_module_t *self, cairo_t *cr, int32_t width, i
   dt_dev_rescale_roi(dev, cr, width, height);
 
   // we draw the cropping area; use the input ROI from the virtual pipe piece
-  dt_dev_pixelpipe_iop_t *piece = dt_dev_distort_get_iop_pipe(self->dev->virtual_pipe, self);
-  if(IS_NULL_PTR(piece))
+  dt_iop_roi_t mod_in;
+  if(!dt_dev_module_geometry_gui(self->dev, self, &mod_in, NULL))
   {
     cairo_restore(cr);
     return;
   }
-  const float iwd = piece->buf_in.width;
-  const float iht = piece->buf_in.height;
-  const float ixo = piece->buf_in.x;
-  const float iyo = piece->buf_in.y;
+  const float iwd = mod_in.width;
+  const float iht = mod_in.height;
+  const float ixo = mod_in.x;
+  const float iyo = mod_in.y;
 
   // The four corners of the inner image polygon
   float V[4][2] = { { ixo,        iyo       },

--- a/src/iop/clipping.c
+++ b/src/iop/clipping.c
@@ -695,10 +695,10 @@ static int _iop_clipping_set_max_clip(struct dt_iop_module_t *self)
   dt_iop_clipping_params_t *p = (dt_iop_clipping_params_t *)self->params;
 
   // we want to know the size of the actual buffer
-  dt_dev_pixelpipe_iop_t *piece = dt_dev_distort_get_iop_pipe(self->dev->virtual_pipe, self);
-  if(IS_NULL_PTR(piece)) return 0;
+  dt_iop_roi_t mod_out;
+  if(!dt_dev_module_geometry_gui(self->dev, self, NULL, &mod_out)) return 0;
 
-  float wp = piece->buf_out.width, hp = piece->buf_out.height;
+  float wp = mod_out.width, hp = mod_out.height;
   const float cx = CLAMPF(p->cx, 0.0f, 0.9f);
   const float cy = CLAMPF(p->cy, 0.0f, 0.9f);
   const float cw = CLAMPF(fabsf(p->cw), 0.1f, 1.0f);
@@ -1502,10 +1502,10 @@ static float _ratio_get_aspect(dt_iop_module_t *self, GtkWidget *combo)
   }
 
   // we want to know the size of the actual buffer
-  dt_dev_pixelpipe_iop_t *piece = dt_dev_distort_get_iop_pipe(self->dev->virtual_pipe, self);
-  if(IS_NULL_PTR(piece)) return 0.0f;
+  dt_iop_roi_t mod_in;
+  if(!dt_dev_module_geometry_gui(self->dev, self, &mod_in, NULL)) return 0.0f;
 
-  const int iwd = piece->buf_in.width, iht = piece->buf_in.height;
+  const int iwd = mod_in.width, iht = mod_in.height;
 
   // if we do not have yet computed the aspect ratio, let's do it now
   if(p->ratio_d == -2 && p->ratio_n == -2)
@@ -2597,10 +2597,10 @@ void gui_post_expose(struct dt_iop_module_t *self, cairo_t *cr, int32_t width, i
   if(g->k_show == 1 && p->k_type > 0)
   {
     // points in screen space
-    dt_dev_pixelpipe_iop_t *piece = dt_dev_distort_get_iop_pipe(self->dev->virtual_pipe, self);
-    if(IS_NULL_PTR(piece)) return;
+    dt_iop_roi_t mod_out;
+    if(!dt_dev_module_geometry_gui(self->dev, self, NULL, &mod_out)) return;
 
-    const float wp = piece->buf_out.width, hp = piece->buf_out.height;
+    const float wp = mod_out.width, hp = mod_out.height;
     float pts[8] = { p->kxa * wp, p->kya * hp, p->kxb * wp, p->kyb * hp,
                      p->kxc * wp, p->kyc * hp, p->kxd * wp, p->kyd * hp };
     if(dt_dev_distort_transform_gui(self->dev, self->iop_order, DT_DEV_TRANSFORM_DIR_FORW_EXCL, pts, 4))
@@ -2865,8 +2865,9 @@ int mouse_moved(struct dt_iop_module_t *self, double x, double y, double pressur
     {
       float pts[2] = { pzx * wd, pzy * ht };
       dt_dev_distort_backtransform_gui(self->dev, self->iop_order, DT_DEV_TRANSFORM_DIR_FORW_EXCL, pts, 1);
-      dt_dev_pixelpipe_iop_t *piece = dt_dev_distort_get_iop_pipe(self->dev->virtual_pipe, self);
-      const float xx = pts[0] / (float)piece->buf_out.width, yy = pts[1] / (float)piece->buf_out.height;
+      dt_iop_roi_t mod_out;
+      if(!dt_dev_module_geometry_gui(self->dev, self, NULL, &mod_out)) return FALSE;
+      const float xx = pts[0] / (float)mod_out.width, yy = pts[1] / (float)mod_out.height;
       if(g->k_selected == 0)
       {
         if(p->k_sym == 1 || p->k_sym == 3)
@@ -3139,8 +3140,9 @@ int mouse_moved(struct dt_iop_module_t *self, double x, double y, double pressur
     {
       float pts[2] = { pzx * wd, pzy * ht };
       dt_dev_distort_backtransform_gui(self->dev, self->iop_order, DT_DEV_TRANSFORM_DIR_FORW_EXCL, pts, 1);
-      dt_dev_pixelpipe_iop_t *piece = dt_dev_distort_get_iop_pipe(self->dev->virtual_pipe, self);
-      float xx = pts[0] / (float)piece->buf_out.width, yy = pts[1] / (float)piece->buf_out.height;
+      dt_iop_roi_t mod_out;
+      if(!dt_dev_module_geometry_gui(self->dev, self, NULL, &mod_out)) return FALSE;
+      float xx = pts[0] / (float)mod_out.width, yy = pts[1] / (float)mod_out.height;
       // are we near a keystone point ?
       g->k_selected = -1;
       g->k_selected_segment = -1;
@@ -3306,8 +3308,9 @@ int button_pressed(struct dt_iop_module_t *self, double x, double y, double pres
         float pzx = pzxpy[0];
         float pzy = pzxpy[1];
 
-        dt_dev_pixelpipe_iop_t *piece = dt_dev_distort_get_iop_pipe(dev->virtual_pipe, self);
-        const float wp = piece->buf_out.width, hp = piece->buf_out.height;
+        dt_iop_roi_t mod_out;
+        if(!dt_dev_module_geometry_gui(dev, self, NULL, &mod_out)) return 0;
+        const float wp = mod_out.width, hp = mod_out.height;
         float pts[8] = { p->kxa * wp, p->kya * hp, p->kxb * wp, p->kyb * hp,
                          p->kxc * wp, p->kyc * hp, p->kxd * wp, p->kyd * hp };
         dt_dev_distort_transform_gui(dev, self->iop_order, DT_DEV_TRANSFORM_DIR_FORW_EXCL, pts, 4);

--- a/src/iop/crop.c
+++ b/src/iop/crop.c
@@ -209,11 +209,11 @@ static void _params_to_gui(dt_iop_crop_params_t *p, dt_iop_crop_gui_data_t *g)
 
 static void _commit_box(dt_iop_module_t *self, dt_iop_crop_gui_data_t *g, dt_iop_crop_params_t *p)
 {
-  dt_dev_pixelpipe_iop_t *piece = dt_dev_distort_get_iop_pipe(self->dev->virtual_pipe, self);
-  if(IS_NULL_PTR(piece)) return;
+  dt_iop_roi_t mod_out;
+  if(!dt_dev_module_geometry_gui(self->dev, self, NULL, &mod_out)) return;
   // we want value in iop space
-  const float wd = (float)piece->buf_out.width; //dt_dev_roi_request_preview_width(self->dev);
-  const float ht = (float)piece->buf_out.height; //dt_dev_roi_request_preview_height(self->dev);
+  const float wd = (float)mod_out.width;
+  const float ht = (float)mod_out.height;
 
   const float bbox_left   = g->clip_x * wd;
   const float bbox_top    = g->clip_y * ht;
@@ -230,7 +230,7 @@ static void _commit_box(dt_iop_module_t *self, dt_iop_crop_gui_data_t *g, dt_iop
     //{
       //fprintf(stderr, "buf_out size: %dx%d\n", piece->buf_out.width, piece->buf_out.height);
 
-      if(piece->buf_out.width < 1 || piece->buf_out.height < 1) return;
+      if(mod_out.width < 1 || mod_out.height < 1) return;
       /*p->cx = CLAMPF(points[0] / (float)piece->buf_out.width, 0.0f, 0.9f);
       p->cy = CLAMPF(points[1] / (float)piece->buf_out.height, 0.0f, 0.9f);
       p->cw = CLAMPF(points[2] / (float)piece->buf_out.width, 0.1f, 1.0f);
@@ -560,10 +560,10 @@ static float _aspect_ratio_get(dt_iop_module_t *self, GtkWidget *combo)
   }
 
   // we want to know the size of the actual buffer
-  dt_dev_pixelpipe_iop_t *piece = dt_dev_distort_get_iop_pipe(self->dev->virtual_pipe, self);
-  if(IS_NULL_PTR(piece)) return 0.0f;
+  dt_iop_roi_t mod_in;
+  if(!dt_dev_module_geometry_gui(self->dev, self, &mod_in, NULL)) return 0.0f;
 
-  const int iwd = piece->buf_in.width, iht = piece->buf_in.height;
+  const int iwd = mod_in.width, iht = mod_in.height;
 
   // if we do not have yet computed the aspect ratio, let's do it now
   if(p->ratio_d == -2 && p->ratio_n == -2)

--- a/src/iop/graduatednd.c
+++ b/src/iop/graduatednd.c
@@ -292,11 +292,12 @@ static int set_grad_from_points(struct dt_iop_module_t *self, const grad_point_t
   float pts[4] = { a->x, a->y, b->x, b->y };
   dt_dev_coordinates_image_norm_to_image_abs(self->dev, pts, 2);
   dt_dev_distort_backtransform_gui(self->dev, self->iop_order, DT_DEV_TRANSFORM_DIR_FORW_EXCL, pts, 2);
-  dt_dev_pixelpipe_iop_t *piece = dt_dev_distort_get_iop_pipe(self->dev->virtual_pipe, self);
-  pts[0] /= (float)piece->buf_out.width;
-  pts[2] /= (float)piece->buf_out.width;
-  pts[1] /= (float)piece->buf_out.height;
-  pts[3] /= (float)piece->buf_out.height;
+  dt_iop_roi_t mod_out;
+  if(!dt_dev_module_geometry_gui(self->dev, self, NULL, &mod_out)) return 0;
+  pts[0] /= (float)mod_out.width;
+  pts[2] /= (float)mod_out.width;
+  pts[1] /= (float)mod_out.height;
+  pts[3] /= (float)mod_out.height;
 
   // directly compute the line angle from segment AB and keep one representative modulo PI
   const float eps = .0001f;
@@ -326,9 +327,9 @@ static int set_points_from_grad(struct dt_iop_module_t *self, grad_point_t *a, g
   const float eps = 1e-6f;
   dt_boundingbox_t pts;
 
-  dt_dev_pixelpipe_iop_t *piece = dt_dev_distort_get_iop_pipe(self->dev->virtual_pipe, self);
-  if(IS_NULL_PTR(piece)) return 0;
-  float wp = piece->buf_out.width, hp = piece->buf_out.height;
+  dt_iop_roi_t mod_out;
+  if(!dt_dev_module_geometry_gui(self->dev, self, NULL, &mod_out)) return 0;
+  float wp = mod_out.width, hp = mod_out.height;
 
   const float off = offset / 100.0f;
 


### PR DESCRIPTION
Twelfth tranche. **Stacked on #1176.** The last consumer category.

## What moved

Eighteen sites across **clipping (8), ashift (5), crop (3), graduatednd (2)** resolved their piece
on the pixel-less pipe and read `piece->buf_in` / `piece->buf_out`.
`dt_dev_module_geometry_gui()` answers instead — from the chain when authoritative, from the pipe
until then.

Those rectangles are a product of the size fold, and the service folds over records for **every**
module rather than only the geometric ones. That is a requirement, not generosity: `graduatednd`
has no geometry callbacks at all and normalises its overlay against its own output rectangle. It
is the reason the chain carries a record per module, and it is migrated here alongside the three
that do change geometry.

**Two of ashift's reads were not module rectangles at all.** `piece->iwidth`/`iheight` are the
*pipe's* input size — the raw geometry — which now comes from `dt_dev_geometry_get_raw_size()`,
where that fact lives, instead of from a module's piece that happened to carry a copy.

The accessor returns FALSE when neither source can answer and leaves its out-params untouched, so
a caller that would have drawn against an absent piece now doesn't draw. Most sites guarded for
that; **two did not** and dereferenced whatever the lookup returned.

## Not migrated, deliberately

- crop's `_set_max_clip()` takes a pipe parameter and runs with the worker's pipe too — provider
  seam, not this.
- `lens.cc`'s `gui_update()` reads a committed **data blob**, not a rectangle. The record can
  serve it, through a different accessor.

## Verification

- Four images (crop, ashift, borders, clipping, drawn masks): size, forward probes, round-trips
  and **all module-relative bounds** agree; no backbuffer shape reports; no criticals.
- Export bit-identical on the clipping image.
- `include_graph.py` cycles 0, layering 184 unchanged; boundaries held.
- **Ratchet: 105 → 92.**

## What remains

Only the **size path** (`dt_dev_get_thumbnail_size` still folds the virtual pipe), the two
deliberate exceptions above, and teardown. Once those move, the resync can stop — which is where
the measured ~100 ms → 0.03–5 ms per history commit finally reaches users, and where #1157's
residual window closes because the resync leaves the commit path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
