### PR TITLE
Geometry service G13: drawlayer, liquify and clipping's last reads

### DIFF
--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -1757,6 +1757,46 @@ int dt_dev_distort_backtransform_gui(dt_develop_t *dev, const double iop_order, 
  * @return FALSE when neither source can answer, in which case @p in and @p out are untouched
  * and the caller must not draw. A module that is disabled or absent has no rectangles.
  */
+/**
+ * @brief The developed image's full-resolution size, for a GUI caller.
+ *
+ * @details Three sources, in order of freshness, which is why this exists rather than a plain
+ * read of the geometry record: the chain and the pixel-less pipe are both recomputed the moment
+ * the module stack changes, while the record is only republished when the size path runs. Code
+ * that needed the newest answer used to reach into the pipe's field to get it, and had to keep
+ * its own fallback for the case where the pipe had none.
+ *
+ * @return FALSE when no source has a usable size, leaving the out-params untouched.
+ */
+gboolean dt_dev_processed_size_gui(dt_develop_t *dev, int *width, int *height)
+{
+  if(IS_NULL_PTR(dev)) return FALSE;
+
+  int w = 0;
+  int h = 0;
+  if(dt_geometry_chain_processed_size(dev->geometry_chain, &w, &h)
+     && dt_geometry_chain_authoritative(dev->geometry_chain) && w > 0 && h > 0)
+  {
+    if(!IS_NULL_PTR(width)) *width = w;
+    if(!IS_NULL_PTR(height)) *height = h;
+    return TRUE;
+  }
+
+  if(!IS_NULL_PTR(dev->virtual_pipe) && dev->virtual_pipe->processed_width > 0
+     && dev->virtual_pipe->processed_height > 0)
+  {
+    if(!IS_NULL_PTR(width)) *width = dev->virtual_pipe->processed_width;
+    if(!IS_NULL_PTR(height)) *height = dev->virtual_pipe->processed_height;
+    return TRUE;
+  }
+
+  const dt_dev_image_geometry_t geometry = dt_dev_geometry_snapshot(dev);
+  if(geometry.processed_width <= 0 || geometry.processed_height <= 0) return FALSE;
+  if(!IS_NULL_PTR(width)) *width = geometry.processed_width;
+  if(!IS_NULL_PTR(height)) *height = geometry.processed_height;
+  return TRUE;
+}
+
 gboolean dt_dev_module_geometry_gui(dt_develop_t *dev, dt_iop_module_t *module, dt_iop_roi_t *in,
                                     dt_iop_roi_t *out)
 {

--- a/src/develop/develop.h
+++ b/src/develop/develop.h
@@ -668,6 +668,12 @@ int dt_dev_distort_backtransform_gui(struct dt_develop_t *dev, const double iop_
 gboolean dt_dev_module_geometry_gui(struct dt_develop_t *dev, struct dt_iop_module_t *module,
                                     dt_iop_roi_t *in, dt_iop_roi_t *out);
 
+/**
+ * @brief The developed image's full-resolution size for a GUI caller: the geometry service, the
+ * pixel-less pipe, or the published record, in that order of freshness. FALSE when none has one.
+ */
+gboolean dt_dev_processed_size_gui(struct dt_develop_t *dev, int *width, int *height);
+
 /** get the iop_pixelpipe instance corresponding to the iop in the given pipe */
 struct dt_dev_pixelpipe_iop_t *dt_dev_distort_get_iop_pipe(struct dt_dev_pixelpipe_t *pipe,
                                                            struct dt_iop_module_t *module);

--- a/src/iop/clipping.c
+++ b/src/iop/clipping.c
@@ -3072,8 +3072,8 @@ int mouse_moved(struct dt_iop_module_t *self, double x, double y, double pressur
 
       if(dt_dev_distort_backtransform_gui(self->dev, self->iop_order, DT_DEV_TRANSFORM_DIR_FORW_EXCL, points, 2))
       {
-        dt_dev_pixelpipe_iop_t *piece = dt_dev_distort_get_iop_pipe(self->dev->virtual_pipe, self);
-        if(!IS_NULL_PTR(piece))
+        dt_iop_roi_t mod_out;
+        if(dt_dev_module_geometry_gui(self->dev, self, NULL, &mod_out))
         {
           // only update the sliders, not the dt_iop_clipping_params_t structure, so that the call to
           // dt_control_queue_redraw_center below doesn't go rerun the pixelpipe because it thinks that
@@ -3212,13 +3212,13 @@ static void commit_box(dt_iop_module_t *self, dt_iop_clipping_gui_data_t *g, dt_
       = { g->clip_x * wd, g->clip_y * ht, (g->clip_x + g->clip_w) * wd, (g->clip_y + g->clip_h) * ht };
   if(dt_dev_distort_backtransform_gui(self->dev, self->iop_order, DT_DEV_TRANSFORM_DIR_FORW_EXCL, points, 2))
   {
-    dt_dev_pixelpipe_iop_t *piece = dt_dev_distort_get_iop_pipe(self->dev->virtual_pipe, self);
-    if(!IS_NULL_PTR(piece))
+    dt_iop_roi_t mod_out;
+    if(dt_dev_module_geometry_gui(self->dev, self, NULL, &mod_out))
     {
-      p->cx = CLAMPF(points[0] / (float)piece->buf_out.width, 0.0f, 0.9f);
-      p->cy = CLAMPF(points[1] / (float)piece->buf_out.height, 0.0f, 0.9f);
-      p->cw = copysignf(CLAMPF(points[2] / (float)piece->buf_out.width, 0.1f, 1.0f), p->cw);
-      p->ch = copysignf(CLAMPF(points[3] / (float)piece->buf_out.height, 0.1f, 1.0f), p->ch);
+      p->cx = CLAMPF(points[0] / (float)mod_out.width, 0.0f, 0.9f);
+      p->cy = CLAMPF(points[1] / (float)mod_out.height, 0.0f, 0.9f);
+      p->cw = copysignf(CLAMPF(points[2] / (float)mod_out.width, 0.1f, 1.0f), p->cw);
+      p->ch = copysignf(CLAMPF(points[3] / (float)mod_out.height, 0.1f, 1.0f), p->ch);
     }
   }
   g->applied = 1;

--- a/src/iop/drawlayer.c
+++ b/src/iop/drawlayer.c
@@ -387,17 +387,9 @@ static inline __attribute__((always_inline)) gboolean _resolve_layer_geometry(dt
   {
     return FALSE;
   }
-  else if(self->dev->virtual_pipe && self->dev->virtual_pipe->processed_width > 0
-          && self->dev->virtual_pipe->processed_height > 0)
+  else if(!dt_dev_processed_size_gui(self->dev, &resolved_width, &resolved_height))
   {
-    resolved_width = self->dev->virtual_pipe->processed_width;
-    resolved_height = self->dev->virtual_pipe->processed_height;
-  }
-  else
-  {
-    const dt_dev_image_geometry_t geometry = dt_dev_geometry_snapshot(self->dev);
-    resolved_width = geometry.processed_width;
-    resolved_height = geometry.processed_height;
+    return FALSE;
   }
 
   if(!IS_NULL_PTR(layer_width)) *layer_width = resolved_width;

--- a/src/iop/drawlayer/coordinates.c
+++ b/src/iop/drawlayer/coordinates.c
@@ -31,18 +31,7 @@ static gboolean _virtual_piece_layer_geometry(dt_iop_module_t *self, int *layer_
    * display-pipe refresh catches up. */
   int resolved_width = 0;
   int resolved_height = 0;
-  if(self->dev->virtual_pipe && self->dev->virtual_pipe->processed_width > 0
-     && self->dev->virtual_pipe->processed_height > 0)
-  {
-    resolved_width = self->dev->virtual_pipe->processed_width;
-    resolved_height = self->dev->virtual_pipe->processed_height;
-  }
-  else
-  {
-    const dt_dev_image_geometry_t geometry = dt_dev_geometry_snapshot(self->dev);
-    resolved_width = geometry.processed_width;
-    resolved_height = geometry.processed_height;
-  }
+  dt_dev_processed_size_gui(self->dev, &resolved_width, &resolved_height);
   if(!IS_NULL_PTR(layer_width)) *layer_width = resolved_width;
   if(!IS_NULL_PTR(layer_height)) *layer_height = resolved_height;
   return resolved_width > 0 && resolved_height > 0;
@@ -50,7 +39,7 @@ static gboolean _virtual_piece_layer_geometry(dt_iop_module_t *self, int *layer_
 
 gboolean dt_drawlayer_widget_points_to_layer_coords(dt_iop_module_t *self, float *pts, const int count)
 {
-  if(IS_NULL_PTR(self) || IS_NULL_PTR(self->dev) || IS_NULL_PTR(self->dev->virtual_pipe) || IS_NULL_PTR(pts) || count <= 0) return FALSE;
+  if(IS_NULL_PTR(self) || IS_NULL_PTR(self->dev) || IS_NULL_PTR(pts) || count <= 0) return FALSE;
 
   dt_dev_coordinates_widget_to_image_norm(self->dev, pts, count);
   dt_dev_coordinates_image_norm_to_preview_abs(self->dev, pts, count);
@@ -137,7 +126,7 @@ gboolean dt_drawlayer_layer_bounds_to_widget_bounds(dt_iop_module_t *self, const
 float dt_drawlayer_widget_brush_radius(dt_iop_module_t *self, const dt_drawlayer_brush_dab_t *dab,
                                        const float fallback)
 {
-  if(IS_NULL_PTR(self) || IS_NULL_PTR(self->dev) || IS_NULL_PTR(self->dev->virtual_pipe) || IS_NULL_PTR(dab)) return fallback;
+  if(IS_NULL_PTR(self) || IS_NULL_PTR(self->dev) || IS_NULL_PTR(dab)) return fallback;
 
   float pts[6] = {
     dab->x, dab->y, dab->x + dab->radius, dab->y, dab->x, dab->y + dab->radius,

--- a/src/iop/liquify.c
+++ b/src/iop/liquify.c
@@ -3026,9 +3026,9 @@ static void get_point_scale(struct dt_iop_module_t *module, float x, float y, fl
   float pts[2] = { (float)x, (float)y };
   dt_dev_coordinates_widget_to_image_norm(module->dev, pts, 1);
   dt_dev_coordinates_image_norm_to_image_abs(module->dev, pts, 1);
-  dt_dev_distort_backtransform_plus(module->dev->virtual_pipe,
+  dt_dev_distort_backtransform_gui(module->dev,
                                     module->iop_order,DT_DEV_TRANSFORM_DIR_FORW_EXCL, pts, 1);
-  dt_dev_distort_backtransform_plus(module->dev->virtual_pipe,
+  dt_dev_distort_backtransform_gui(module->dev,
                                     module->iop_order,DT_DEV_TRANSFORM_DIR_BACK_EXCL, pts, 1);
 
   *scale = get_zoom_scale(module->dev);


### PR DESCRIPTION
Thirteenth tranche. **Stacked on #1177.** Clears the migratable remainder, and settles a question
left open since G1.

## drawlayer — the deferred G1 item

It read `dev->virtual_pipe->processed_width/height` directly, **preferring it to the published
geometry record**, with a comment explaining why: the pipe "tracks the currently committed
distortion stack even before the global darkroom ROI bookkeeping is fully refreshed."

That was correct, and it is why G1 did *not* migrate these — the two sources genuinely differ in
freshness, and G1's own fix (undo not publishing sizes) proved the record really did go stale.

`dt_dev_processed_size_gui()` ends the argument by **keeping the tiering** rather than removing
it: chain → pipe → record, in order of freshness. The chain and the pipe are both recomputed the
moment the module stack changes (since G9 the chain rebuilds wherever the pipe resyncs), so the
newest answer is available without any caller reaching into a pipe's fields — and drawlayer's
hand-written fallback goes away with the reach.

liquify's two bounded backtransforms and clipping's last two dimension lookups are repoints of the
kind G10/G12 established.

## Deliberately left — each needs more than a repoint

| site | why |
|---|---|
| crop `_set_max_clip()` | takes a pipe parameter, runs with the worker's pipe too → provider seam |
| `lens.cc` `gui_update()` | reads a committed **data blob**, not a rectangle; needs a record-data accessor |
| ashift `call_distort_transform()` | applies **this module's transform alone** — no bound expresses that, so the chain needs a single-record composition entry point |
| colorout early return, `dev_history` bookkeeping, darkroom/studio_capture teardown | about the pipe's *existence*, not its geometry — they disappear with it |

## Verification

- Four images (crop, ashift, clipping, liquify, drawn masks): size, forward probes, round-trips
  and all module-relative bounds agree; no backbuffer reports; no criticals.
- Mask export **bit-identical on both pages**.
- `include_graph.py` cycles 0, layering 184 unchanged; boundaries held.
- **Ratchet: 92 → 83.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
