### PR TITLE
Geometry service G14: the three consumers that needed more than a repoint

### DIFF
--- a/src/develop/geometry/geometry.c
+++ b/src/develop/geometry/geometry.c
@@ -389,6 +389,32 @@ static int _compose_forward(dt_geometry_chain_t *chain, const double iop_order, 
   return 1;
 }
 
+int dt_geometry_module_transform(dt_develop_t *dev, const dt_iop_module_t *module, float *points,
+                                 const size_t points_count)
+{
+  if(IS_NULL_PTR(dev) || IS_NULL_PTR(module) || IS_NULL_PTR(points)) return 0;
+
+  dt_geometry_chain_t *const chain = dev->geometry_chain;
+  if(IS_NULL_PTR(chain) || !chain->authoritative) return 0;
+
+  dt_geometry_record_t *record = NULL;
+  for(GList *node = g_list_first(chain->records); node; node = g_list_next(node))
+  {
+    dt_geometry_record_t *const candidate = (dt_geometry_record_t *)node->data;
+    if(!strcmp(candidate->op, module->op) && candidate->instance == module->multi_priority)
+    {
+      record = candidate;
+      break;
+    }
+  }
+
+  if(IS_NULL_PTR(record) || !record->enabled) return 0;
+  if(IS_NULL_PTR(record->vtable) || IS_NULL_PTR(record->vtable->transform)) return 0;
+  if(_suppressed_by_focus(chain, record)) return 0;
+
+  return record->vtable->transform(record->data, record, chain, points, points_count);
+}
+
 int dt_geometry_chain_compose(dt_geometry_chain_t *chain, const double iop_order, const int direction,
                               float *points, const size_t points_count)
 {

--- a/src/develop/geometry/geometry.h
+++ b/src/develop/geometry/geometry.h
@@ -169,6 +169,23 @@ int dt_geometry_backtransform(struct dt_develop_t *dev, double iop_order, int di
                               size_t points_count);
 
 /**
+ * @brief Apply ONE module's own transform, and nothing else.
+ *
+ * @details No direction bound expresses this: FORW_INCL at a module's own iop_order includes
+ * everything after it as well. iop/ashift.c wants exactly its own homography applied to the
+ * corners of its input, to work out where its output lands, and reached it by resolving its
+ * piece and calling its own distort_transform() through the module vtable.
+ *
+ * Honours the focused-module exception like every other composition here, so a module suppressed
+ * by whatever is being edited contributes nothing, exactly as it would in a full walk.
+ *
+ * @return 0 when the chain cannot answer -- not authoritative, no record, or that module has no
+ * transform -- in which case @p points is untouched and the caller should use the pipe.
+ */
+int dt_geometry_module_transform(struct dt_develop_t *dev, const struct dt_iop_module_t *module,
+                                 float *points, size_t points_count);
+
+/**
  * @brief Compose the chain over @p points, for a record evaluator that needs the transform
  * stack around its own module.
  *

--- a/src/iop/ashift.c
+++ b/src/iop/ashift.c
@@ -3762,6 +3762,12 @@ if(!dt_dev_distort_transform_plus(self->dev, self->dev->virtual_pipe, self->prio
 static int call_distort_transform(dt_dev_pixelpipe_t *pipe, struct dt_iop_module_t *self,
                                   float *points, size_t points_count)
 {
+  /* This module's own transform and nothing else. The geometry service expresses that directly;
+   * the pipe cannot, which is why the piece has to be resolved and its callback invoked by hand
+   * below. Both honour the focused-module exception, so the two agree on when this contributes
+   * nothing at all. */
+  if(dt_geometry_module_transform(self->dev, self, points, points_count)) return 1;
+
   int ret = 0;
   dt_dev_pixelpipe_iop_t *piece = dt_dev_distort_get_iop_pipe(pipe, self);
   if(IS_NULL_PTR(piece)) return ret;

--- a/src/iop/crop.c
+++ b/src/iop/crop.c
@@ -263,22 +263,24 @@ static void _commit_box(dt_iop_module_t *self, dt_iop_crop_gui_data_t *g, dt_iop
  * @param self the current module data
  * @return gboolean TRUE on success, FALSE otherwise 
  */
-static gboolean _set_max_clip(dt_dev_pixelpipe_t *pipe, struct dt_iop_module_t *self)
+/* Takes no pipe: both callers passed dev->virtual_pipe, so this was never the dual-use fold it
+ * resembled -- it is GUI-only, and asks the dev like every other GUI geometry query. */
+static gboolean _set_max_clip(struct dt_iop_module_t *self)
 {
   dt_iop_crop_gui_data_t *g = (dt_iop_crop_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_crop_params_t *p = (dt_iop_crop_params_t *)self->params;
 
   // we want to know the size of the actual buffer
-  dt_dev_pixelpipe_iop_t *piece = dt_dev_distort_get_iop_pipe(pipe, self);
-  if(IS_NULL_PTR(piece)) return FALSE;
+  dt_iop_roi_t mod_out;
+  if(!dt_dev_module_geometry_gui(self->dev, self, NULL, &mod_out)) return FALSE;
 
-  float wp = piece->buf_out.width;
-  float hp = piece->buf_out.height;
+  float wp = mod_out.width;
+  float hp = mod_out.height;
   float points[8] = { 0.0f, 0.0f, wp, hp, p->cx * wp, p->cy * hp, p->cw * wp, p->ch * hp };
-  if(!dt_dev_distort_transform_plus(pipe, self->iop_order,
-                                    DT_DEV_TRANSFORM_DIR_FORW_EXCL, points, 4))
+  if(!dt_dev_distort_transform_gui(self->dev, self->iop_order,
+                                   DT_DEV_TRANSFORM_DIR_FORW_EXCL, points, 4))
     return FALSE;
-  dt_dev_coordinates_preview_abs_to_image_norm(pipe->dev, points, 4);
+  dt_dev_coordinates_preview_abs_to_image_norm(self->dev, points, 4);
 
   g->clip_max_x = fmaxf(points[0], 0.0f);
   g->clip_max_y = fmaxf(points[1], 0.0f);
@@ -1500,7 +1502,7 @@ void gui_post_expose(struct dt_iop_module_t *self, cairo_t *cr, int32_t width, i
   float pzy = pzxpy[1];
   cairo_set_line_width(cr, border_width);
 
-  if(_set_max_clip(self->dev->virtual_pipe, self))
+  if(_set_max_clip(self))
   {
     cairo_set_source_rgba(cr, .1, .1, .1, .8);
     cairo_set_fill_rule(cr, CAIRO_FILL_RULE_EVEN_ODD);
@@ -1612,7 +1614,7 @@ int mouse_moved(struct dt_iop_module_t *self, double x, double y, double pressur
 
   const _grab_region_t grab = _gui_get_grab(pzx, pzy, g, border, g->wd, g->ht);
 
-  _set_max_clip(self->dev->virtual_pipe, self);
+  _set_max_clip(self);
 
   if(g->dragging)
   {

--- a/src/iop/lens.cc
+++ b/src/iop/lens.cc
@@ -2671,16 +2671,33 @@ void gui_update(struct dt_iop_module_t *self)
   // to a recently-rendered history state, leaving the label blank forever otherwise). commit_params()
   // already wrote this exact lensfun data into the synced piece regardless of that; read it back the
   // same GUI-thread-safe way ashift reads piece->buf_in from the virtual pipe.
-  const dt_dev_pixelpipe_iop_t *lens_piece = dt_dev_distort_get_iop_pipe(self->dev->virtual_pipe, self);
-  const dt_iop_lensfun_data_t *lens_d
-      = (!IS_NULL_PTR(lens_piece)) ? (const dt_iop_lensfun_data_t *)lens_piece->data : NULL;
+  /* The geometry record IS this data -- geometry_record() builds it with the same constructor
+   * commit_params() uses -- so ask the service for it, and the synced piece only while the
+   * service cannot answer. This is the one consumer in the migration that wants a module's
+   * committed state rather than a rectangle. */
+  const dt_iop_lensfun_data_t *lens_d = NULL;
+  const dt_geometry_record_t *const lens_record
+      = dt_geometry_chain_find(self->dev->geometry_chain, self->op, self->multi_priority);
+  if(dt_geometry_chain_authoritative(self->dev->geometry_chain) && !IS_NULL_PTR(lens_record)
+     && !IS_NULL_PTR(lens_record->data))
+    lens_d = &((const dt_iop_lens_geometry_t *)lens_record->data)->data;
+  else
+  {
+    const dt_dev_pixelpipe_iop_t *const lens_piece
+        = dt_dev_distort_get_iop_pipe(self->dev->virtual_pipe, self);
+    if(!IS_NULL_PTR(lens_piece)) lens_d = (const dt_iop_lensfun_data_t *)lens_piece->data;
+  }
+
+  dt_iop_roi_t lens_in;
+  const gboolean have_dims = dt_dev_module_geometry_gui(self->dev, self, &lens_in, NULL);
+
   if(!IS_NULL_PTR(lens_d) && !IS_NULL_PTR(lens_d->lens) && !IS_NULL_PTR(lens_d->lens->Maker) && lens_d->crop > 0.0f
-     && lens_piece->buf_in.width > 0 && lens_piece->buf_in.height > 0)
+     && have_dims && lens_in.width > 0 && lens_in.height > 0)
   {
     const gboolean raw_monochrome = dt_image_is_monochrome(&self->dev->image_storage);
     const int used_lf_mask = raw_monochrome ? (LF_MODIFY_ALL & ~LF_MODIFY_TCA) : LF_MODIFY_ALL;
     int modflags = 0;
-    lfModifier *modifier = get_modifier(&modflags, lens_piece->buf_in.width, lens_piece->buf_in.height,
+    lfModifier *modifier = get_modifier(&modflags, lens_in.width, lens_in.height,
                                         lens_d, used_lf_mask, FALSE);
     delete modifier;
 


### PR DESCRIPTION
Fourteenth tranche. **Stacked on #1179.** The last three consumers, each of which needed a new
capability rather than a repoint.

## ashift — a transform with no bound to express it

`call_distort_transform()` applies **this module's transform and nothing else**. No direction
bound says that: `FORW_INCL` at a module's own iop_order takes everything after it too. That is
why it resolved its piece and invoked the module's own callback by hand.
`dt_geometry_module_transform()` states it directly, honouring the focused-module exception like
every other composition so the two agree on when it contributes nothing.

## crop — not dual-use after all

`_set_max_clip()` took a pipe parameter and looked exactly like the folds that needed the provider
seam in G11. It isn't one: **both callers passed `dev->virtual_pipe`**, so it has only ever been a
GUI query. The parameter is *removed* rather than migrated.

## lens — the only consumer wanting state, not a rectangle

`gui_update()` rebuilds a lensfun modifier to report which corrections applied, because a
pixelpipe cache hit can skip `process()` entirely and leave the label blank forever. The geometry
record **is** that state — `geometry_record()` builds it with the same constructor `commit_params()`
uses — so it reads the record, falling back to the synced piece only while the service can't answer.

## Verification

- Four images (crop, ashift, clipping, lens, drawn masks): size, forward probes, round-trips and
  all module-relative bounds agree; no backbuffer reports; no criticals.
- Export **bit-identical** on the lens-corrected CR2 and the masked NEF.
- `include_graph.py` cycles 0, layering 184 unchanged; boundaries held.
- **Ratchet: 83 → 82.**

The count barely moves because what these left behind are **fallbacks** — each still names the pipe
for when the chain declines — and those stay until deletion. What is gone is the last consumer that
could *only* be served by a pipe. Everything still naming `dev->virtual_pipe` is now a fallback, a
shadow comparison, the size path, or teardown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
