### PR TITLE
Geometry service G15: the size comes from the chain, and the pipe stops being resynced

### DIFF
--- a/src/develop/dev_pixelpipe.c
+++ b/src/develop/dev_pixelpipe.c
@@ -1793,17 +1793,35 @@ static void _sync_virtual_pipe(dt_develop_t *dev, dt_dev_pixelpipe_change_t flag
                                raw_width, raw_height, 1.0f, DT_MIPMAP_FULL);
   }
 
-  // Mirror the preview-pipe change flags and commit immediately.
+  // Mirror the preview-pipe change flags.
   _change_pipe(dev->virtual_pipe, flag);
-  dt_dev_pixelpipe_change(dev->virtual_pipe);
 
-  /* The geometry chain answers the same questions and must therefore be exactly as fresh as
-   * this pipe, not fresher and not staler: consumers now read whichever of the two can answer,
-   * and a chain rebuilt only in the size path would lag the pipe on every flag that arrives
-   * between two size publications. It is rebuilt here rather than published here -- this
-   * function raises flags, and nothing downstream may observe geometry before the publication
-   * that goes with it (see the ordering note in dt_dev_get_thumbnail_size). */
+  /* The geometry chain answers the same questions and must be exactly as fresh as the pipe it
+   * replaces -- consumers read whichever of the two can answer, and a chain rebuilt only in the
+   * size path would lag on every flag arriving between two size publications. Rebuilt here, and
+   * deliberately not PUBLISHED here: this function raises flags, and nothing may observe
+   * geometry before the publication that belongs with it (the ordering rule from #1157). */
   dt_geometry_chain_rebuild(dev);
+
+  /* And the pipe itself only when something will read it. This is the expensive half of this
+   * function -- a full resync commits every module's parameters and costs ~0.1 s on the GUI
+   * thread, measured at darkroom entry -- and it is exactly what the geometry service exists to
+   * stop paying. The flag above stays raised either way, so a later
+   * dt_dev_virtual_pipe_ensure_synced() still has everything it needs to catch the pipe up if a
+   * fallback does end up consulting it. */
+  if(!dt_geometry_chain_authoritative(dev->geometry_chain))
+    dt_dev_pixelpipe_change(dev->virtual_pipe);
+}
+
+void dt_dev_virtual_pipe_ensure_synced(dt_develop_t *dev)
+{
+  /* Catch the pixel-less pipe up with the flags raised while the geometry service was answering
+   * for it. Cheap when it is already current -- the flags are cleared by a resync -- and the
+   * only thing standing between "we stopped resyncing it eagerly" and a consumer reading a pipe
+   * that history moved out from under. */
+  if(IS_NULL_PTR(dev) || !dev->gui_attached || IS_NULL_PTR(dev->virtual_pipe)) return;
+  if(dt_dev_pixelpipe_get_changed(dev->virtual_pipe) == DT_DEV_PIPE_UNCHANGED) return;
+  dt_dev_pixelpipe_change(dev->virtual_pipe);
 }
 
 void dt_dev_pixelpipe_sync_virtual(dt_develop_t *dev, dt_dev_pixelpipe_change_t flag)

--- a/src/develop/dev_pixelpipe.h
+++ b/src/develop/dev_pixelpipe.h
@@ -113,6 +113,16 @@ gboolean dt_dev_pixelpipe_activemodule_disables_currentmodule(struct dt_develop_
 void dt_dev_pixelpipe_change(struct dt_dev_pixelpipe_t *pipe);
 void dt_dev_pixelpipe_sync_virtual(struct dt_develop_t *dev, dt_dev_pixelpipe_change_t flag);
 
+/**
+ * @brief Bring the pixel-less pipe up to date with the flags raised since it was last resynced.
+ *
+ * @details It is no longer resynced eagerly: while the geometry service can answer, the flags
+ * are raised and the ~0.1 s resync is skipped. Anything that consults the pipe directly -- the
+ * fallbacks taken when the service declines, and shadow mode -- calls this first. A no-op when
+ * the pipe is already current.
+ */
+void dt_dev_virtual_pipe_ensure_synced(struct dt_develop_t *dev);
+
 // Get the global hash of a pipe node (piece), or a fallback if none.
 uint64_t dt_dev_pixelpipe_node_hash(struct dt_dev_pixelpipe_t *pipe, 
                                     const struct dt_dev_pixelpipe_iop_t *piece, 

--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -379,7 +379,28 @@ int dt_dev_get_thumbnail_size(dt_develop_t *dev)
       dt_dev_pixelpipe_or_changed(dev->virtual_pipe, DT_DEV_PIPE_SYNCH);
   }
 
-  if(dt_dev_pixelpipe_get_changed(dev->virtual_pipe) != DT_DEV_PIPE_UNCHANGED)
+  /* The chain is rebuilt BEFORE the size is decided now, because it is what decides it. It is
+   * cheap -- small derivations of already-committed parameters, no LUT, no colour transform, no
+   * disk -- which is the whole point of the exercise: the resync below is not. */
+  const double chain_start = dt_get_wtime();
+  dt_geometry_chain_rebuild(dev);
+  const double chain_ms = (dt_get_wtime() - chain_start) * 1000.0;
+
+  /* Resync the pixel-less pipe only when something will actually read it: when the chain cannot
+   * answer and the fallbacks will therefore be taken, or when shadow mode is on and there would
+   * be nothing to compare against otherwise. This is where the cost of this service's absence
+   * was: measured on darkroom entry, a resync is ~0.105 s against the chain's 0.03-5 ms, and it
+   * ran on the GUI thread at every history commit.
+   *
+   * Skipping it leaves the pipe FLAGGED but not rebuilt, which is the invariant the fallbacks
+   * rely on: they run only while the chain is not authoritative, and in exactly that case the
+   * resync below has run. dt_dev_virtual_pipe_ensure_synced() is there for anything that needs
+   * to consult the pipe outside that arrangement. */
+  const gboolean chain_answers = dt_geometry_chain_authoritative(dev->geometry_chain);
+  const gboolean want_shadow = (dt_get_debug_flags() & DT_DEBUG_DEV) != 0;
+
+  if((!chain_answers || want_shadow)
+     && dt_dev_pixelpipe_get_changed(dev->virtual_pipe) != DT_DEV_PIPE_UNCHANGED)
     dt_dev_pixelpipe_change(dev->virtual_pipe);
 
   // Compute the virtual full-res output. This needs an inited history.
@@ -387,33 +408,33 @@ int dt_dev_get_thumbnail_size(dt_develop_t *dev)
   // nothing between here and there republishes the raw geometry.
   int processed_width = 0;
   int processed_height = 0;
-  dt_dev_pixelpipe_get_roi_out(dev->virtual_pipe, raw_width, raw_height,
-                               &processed_width, &processed_height);
+  int pipe_width = 0;
+  int pipe_height = 0;
+
+  if(!chain_answers || want_shadow)
+    dt_dev_pixelpipe_get_roi_out(dev->virtual_pipe, raw_width, raw_height, &pipe_width, &pipe_height);
+
+  if(chain_answers)
+    dt_geometry_chain_processed_size(dev->geometry_chain, &processed_width, &processed_height);
+  else
+  {
+    processed_width = pipe_width;
+    processed_height = pipe_height;
+  }
+
   dt_dev_geometry_set_processed_size(dev, processed_width, processed_height);
 
   // Derive and publish everything the pipes plan from, as one record.
   dt_dev_roi_request_publish(dev);
 
-  /* Rebuild the geometry chain from the same modules and history the fold above just used, and
-   * hold it against the answer the pipe produced. It publishes nothing and nothing consumes it
-   * yet: while its roster is incomplete it reports which modules still owe it a record, per
-   * image, and once complete it reports divergence and the cost of each side. Both under
-   * `-d dev'.
-   *
-   * STRICTLY AFTER the two publications above, and never between them. Those two are one
-   * atomic-looking update to a consumer: the first moves the geometry record to the new
-   * processed size, the second moves the ROI request to match AND flags the pipes to replan
-   * (dt_dev_roi_request_publish, since the fix for #1157). Anything inserted between them
-   * widens the window in which the darkroom worker can latch the OLD request against ALREADY
-   * NEW history -- which is precisely the mixed frame #1157 is about, and this rebuild is not
-   * cheap enough to be invisible there: the lens record's database lookups alone cost 2-5 ms,
-   * against a worker that naps in tens of milliseconds. A shadow observer must not sit inside
-   * the update it is observing. */
-  const double chain_start = dt_get_wtime();
-  dt_geometry_chain_rebuild(dev);
-  const double chain_ms = (dt_get_wtime() - chain_start) * 1000.0;
-
-  dt_geometry_shadow_check(dev, processed_width, processed_height, chain_ms);
+  /* Shadow mode compares against the pipe's own fold, which only exists when the pipe was
+   * resynced above -- so it is asked for, and paid for, under `-d dev' and nowhere else. It runs
+   * STRICTLY AFTER both publications and never between them: those two are one atomic-looking
+   * update, the first moving the geometry record to the new size and the second moving the ROI
+   * request to match AND flagging the pipes to replan. Anything inserted between them widens the
+   * window in which the darkroom worker latches the OLD request against ALREADY NEW history,
+   * which is the mixed frame of #1157. An observer must not sit inside the update it observes. */
+  if(want_shadow) dt_geometry_shadow_check(dev, pipe_width, pipe_height, chain_ms);
 
 
   dt_dev_update_mouse_effect_radius(dev);
@@ -1732,6 +1753,7 @@ int dt_dev_distort_transform_gui(dt_develop_t *dev, const double iop_order, cons
 {
   if(IS_NULL_PTR(dev)) return 0;
   if(dt_geometry_transform(dev, iop_order, transf_direction, points, points_count)) return 1;
+  dt_dev_virtual_pipe_ensure_synced(dev);
   return dt_dev_distort_transform_plus(dev->virtual_pipe, iop_order, transf_direction, points, points_count);
 }
 
@@ -1741,6 +1763,7 @@ int dt_dev_distort_backtransform_gui(dt_develop_t *dev, const double iop_order, 
 {
   if(IS_NULL_PTR(dev)) return 0;
   if(dt_geometry_backtransform(dev, iop_order, transf_direction, points, points_count)) return 1;
+  dt_dev_virtual_pipe_ensure_synced(dev);
   return dt_dev_distort_backtransform_plus(dev->virtual_pipe, iop_order, transf_direction, points,
                                            points_count);
 }
@@ -1782,6 +1805,7 @@ gboolean dt_dev_processed_size_gui(dt_develop_t *dev, int *width, int *height)
     return TRUE;
   }
 
+  dt_dev_virtual_pipe_ensure_synced(dev);
   if(!IS_NULL_PTR(dev->virtual_pipe) && dev->virtual_pipe->processed_width > 0
      && dev->virtual_pipe->processed_height > 0)
   {
@@ -1811,6 +1835,7 @@ gboolean dt_dev_module_geometry_gui(dt_develop_t *dev, dt_iop_module_t *module, 
     return TRUE;
   }
 
+  dt_dev_virtual_pipe_ensure_synced(dev);
   const dt_dev_pixelpipe_iop_t *const piece = dt_dev_distort_get_iop_pipe(dev->virtual_pipe, module);
   if(IS_NULL_PTR(piece)) return FALSE;
   if(!IS_NULL_PTR(in)) *in = piece->buf_in;
@@ -1821,12 +1846,14 @@ gboolean dt_dev_module_geometry_gui(dt_develop_t *dev, dt_iop_module_t *module, 
 int dt_dev_coordinates_raw_abs_to_image_abs(dt_develop_t *dev, float *points, size_t points_count)
 {
   if(dt_geometry_transform(dev, 0.0, DT_DEV_TRANSFORM_DIR_ALL, points, points_count)) return 1;
+  dt_dev_virtual_pipe_ensure_synced(dev);
   return dt_dev_distort_transform_plus(dev->virtual_pipe, 0.0f, DT_DEV_TRANSFORM_DIR_ALL, points, points_count);
 }
 
 int dt_dev_coordinates_image_abs_to_raw_abs(dt_develop_t *dev, float *points, size_t points_count)
 {
   if(dt_geometry_backtransform(dev, 0.0, DT_DEV_TRANSFORM_DIR_ALL, points, points_count)) return 1;
+  dt_dev_virtual_pipe_ensure_synced(dev);
   return dt_dev_distort_backtransform_locked(dev->virtual_pipe, 0.0f, DT_DEV_TRANSFORM_DIR_ALL, points, points_count);
 }
 

--- a/src/iop/ashift.c
+++ b/src/iop/ashift.c
@@ -3769,6 +3769,7 @@ static int call_distort_transform(dt_dev_pixelpipe_t *pipe, struct dt_iop_module
   if(dt_geometry_module_transform(self->dev, self, points, points_count)) return 1;
 
   int ret = 0;
+  if(pipe == self->dev->virtual_pipe) dt_dev_virtual_pipe_ensure_synced(self->dev);
   dt_dev_pixelpipe_iop_t *piece = dt_dev_distort_get_iop_pipe(pipe, self);
   if(IS_NULL_PTR(piece)) return ret;
   if(piece->module == self && /*piece->enabled && */  //see note below

--- a/src/iop/lens.cc
+++ b/src/iop/lens.cc
@@ -2683,6 +2683,7 @@ void gui_update(struct dt_iop_module_t *self)
     lens_d = &((const dt_iop_lens_geometry_t *)lens_record->data)->data;
   else
   {
+    dt_dev_virtual_pipe_ensure_synced(self->dev);
     const dt_dev_pixelpipe_iop_t *const lens_piece
         = dt_dev_distort_get_iop_pipe(self->dev->virtual_pipe, self);
     if(!IS_NULL_PTR(lens_piece)) lens_d = (const dt_iop_lensfun_data_t *)lens_piece->data;


### PR DESCRIPTION
Fifteenth tranche. **Stacked on #1181.** This is the one the series was for.

## The measurement

Darkroom entry, same build, with and without `ANSEL_GEOMETRY_DISABLE=1`:

| image | virtual-pipe resyncs (pipe only) | with the service |
|---|---|---|
| 0001-hdr.dng | 5, totalling **0.141 s** | **0**, 0.000 s |
| 20180415_0021.CR2 | 5, totalling **0.105 s** | **0** |
| _DSC9410.NEF | 5, totalling **0.104 s** | **0** |

That work ran on the GUI thread, at every history commit, to compute two integers. It is gone.

## How the pipe stays correct while not being rebuilt

It is still **flagged** on every change; only the rebuild is skipped, and only while the chain can
answer. Everything that consults the pipe directly is a fallback taken exactly when the chain
cannot — and each now calls `dt_dev_virtual_pipe_ensure_synced()` first, which applies the
accumulated flags and is a no-op when there are none. **Eight such sites**: the four bounded
transform wrappers and coordinate converters, the per-module rectangles, the processed size, and
the two module-side fallbacks in lens and ashift.

So the pipe is *lazily* synced rather than eagerly: flagged always, rebuilt only when something
reads it. In a session where the chain answers throughout — every image tried — that is never.

## Shadow mode costs what it diagnoses

Comparing against the pipe requires the pipe, so `-d dev` resyncs and folds it, paying the 0.1 s.
That is the right trade for a diagnostic: it is asked for explicitly, and without it there is
nothing to compare. Verified still working — three images agree on size, forward probes,
round-trips and all module-relative bounds.

`ANSEL_GEOMETRY_DISABLE=1` remains a complete bisection: chain declines, every fallback is taken,
the pipe is resynced eagerly again, and the table above is what that costs.

## Verification

- Export **bit-identical** on three images, including a lens-corrected CR2 and the masked NEF's
  **mask page**.
- `include_graph.py` cycles 0, layering 184 unchanged; boundaries held.

## Worth testing interactively

This changes what *every* GUI consumer reads, not where one of them reads from. The thing to
watch for is anything that looks correct on entry and wrong after an edit — a stale size would
show as overlays or the crop frame lagging a change by one action.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
