### PR TITLE
Geometry service G16: delete the pixel-less pipe

### DIFF
--- a/doc/develop-split.md
+++ b/doc/develop-split.md
@@ -236,9 +236,10 @@ in place.
   `_backend_worker_process_sample` → `_process_backend_input` →
   `dt_drawlayer_paint_interpolate_path` → the `layer_to_widget` callback →
   `dt_dev_coordinates_image_norm_to_widget()`, which reads `roi.orig_width`/`orig_height`
-  (develop.c:1100-1101) and calls `dt_dev_distort_transform_plus(self->dev->virtual_pipe, …)`
-  — a pipe documented as owned by the GUI main thread. It runs once per dab, so a window
-  resize or panel toggle during a stroke races it.
+  (develop.c:1100-1101) and composes the GUI's own geometry — at the time of writing, a
+  pixel-less pipe owned by the GUI main thread; since the geometry service replaced it
+  (`doc/geometry-service.md`), the GUI-thread-only geometry chain. Either way it runs once per
+  dab, so a window resize or panel toggle during a stroke races it.
 * `dt_focus_draw_clusters()` (gui/dtgtk/focus.h:288) reads
   `dt_dev_get_global()->roi.border_size` from `_get_image_buffer`, a `dt_control_job` body
   (thumbnail.c:657). A lighttable thumbnail render job thus reads darkroom viewport state

--- a/doc/gui-sizing.md
+++ b/doc/gui-sizing.md
@@ -1,11 +1,16 @@
 # GUI sizing without a full pixel-less pipeline — analysis and plan
 
 Written while fixing #1157, whose root cause is entangled with the virtual pipe's cost.
-Status: analysis + recommendation. Nothing here is implemented except where noted.
 
-## What the virtual pipe is, and what it costs
+**Status: superseded by what was actually built.** The maintainer picked option C, and
+`doc/geometry-service.md` is the canonical record of it: the virtual pipe no longer exists, and
+the GUI composes sizes and coordinates from published per-module records. This file is kept for
+the measurements and the consumer audit that produced that decision — everything below describes
+the tree as it was, in the present tense it was written in.
 
-`dev->virtual_pipe` is a full clone of the module stack — every one of the ~95 IOPs gets a
+## What the virtual pipe was, and what it cost
+
+`dev->virtual_pipe` was a full clone of the module stack — every one of the ~95 IOPs gets a
 node, params committed from history — that never processes a pixel. It exists so the GUI
 thread can answer two questions synchronously, without waiting for a worker pipe:
 

--- a/src/develop/dev_geometry.h
+++ b/src/develop/dev_geometry.h
@@ -53,7 +53,7 @@ typedef struct dt_dev_image_geometry_t
   /** TRUE once the raw pair has been published from a successful mipmap read. */
   gboolean raw_inited;
 
-  /** TRUE once the processed pair has been published from the virtual pipe. There is no
+  /** TRUE once the processed pair has been published from the size fold. There is no
    *  headless producer for it today, so a caller that gets FALSE must not read 0x0 as though
    *  it were an answer -- that is the raw_width mistake, one field over. */
   gboolean processed_inited;
@@ -84,7 +84,7 @@ void dt_dev_geometry_init(struct dt_develop_t *dev);
 void dt_dev_geometry_set_raw_size(struct dt_develop_t *dev, int32_t width, int32_t height,
                                   gboolean valid);
 
-/** Publish the processed pair. GUI thread only: its producer runs the virtual pipe. */
+/** Publish the processed pair. GUI thread only: its producer is the geometry service's fold. */
 void dt_dev_geometry_set_processed_size(struct dt_develop_t *dev, int32_t width, int32_t height);
 
 /** Coherent copy of the whole record, by value -- the ordinary way to read it:

--- a/src/develop/dev_history.c
+++ b/src/develop/dev_history.c
@@ -1185,7 +1185,7 @@ dt_dev_history_item_t *dt_dev_history_cow_touch(dt_develop_t *dev, dt_dev_histor
   // dt_dev_pixelpipe_synch_top to bound the resync range). dt_dev_pixelpipe_change() holds
   // history_mutex for its whole resync, same as this splice, so a plain compare-and-assign is
   // enough -- no concurrent access is possible.
-  dt_dev_pixelpipe_t *const pipes[] = { dev->pipe, dev->preview_pipe, dev->virtual_pipe };
+  dt_dev_pixelpipe_t *const pipes[] = { dev->pipe, dev->preview_pipe };
   for(size_t i = 0; i < G_N_ELEMENTS(pipes); i++)
     if(pipes[i] && pipes[i]->last_history_item == hist)
       pipes[i]->last_history_item = clone;
@@ -1410,7 +1410,7 @@ void dt_apply_dev_history_update(dt_develop_t *dev)
   dt_dev_reload_history_items(dev, dev->image_storage.id);
   dt_dev_history_gui_update(dev);
   // Re-derive dev->roi.processed_{width,height} (and the natural scale) from the new
-  // history through the virtual pipe. Without this, a history change that alters the
+  // history, through the geometry service's size fold. Without this, a history change that alters the
   // final image geometry (e.g. removing a crop/ashift step) still renders at the old,
   // stale ROI -- same fix as _history_apply_history_end() in libs/history.c.
   if(dev->gui_attached) dt_dev_get_thumbnail_size(dev);

--- a/src/develop/dev_pixelpipe.c
+++ b/src/develop/dev_pixelpipe.c
@@ -39,8 +39,6 @@
 #include <stdint.h>
 #include <stdlib.h>
 
-// Keep a preview-like virtual pipe in sync with history without running pixels.
-static void _sync_virtual_pipe(dt_develop_t *dev, dt_dev_pixelpipe_change_t flag);
 static void _sync_pipe_nodes_from_history_from_node(dt_dev_pixelpipe_t *pipe,
                                                     const uint32_t history_end, GList *start_node,
                                                     const char *debug_label);
@@ -162,9 +160,7 @@ static gboolean _module_feeds_color_picker(const dt_dev_pixelpipe_t *pipe,
 
 static gchar *_get_debug_pipe_name(const dt_dev_pixelpipe_t *pipe, const dt_develop_t *dev)
 {
-  if(!IS_NULL_PTR(dev) && !IS_NULL_PTR(pipe) && dev->virtual_pipe == pipe)
-    return g_strdup("virtual-preview");
-
+  (void)dev;
   return g_strdup(dt_pixelpipe_get_pipe_name(!IS_NULL_PTR(pipe) ? pipe->type : DT_DEV_PIXELPIPE_NONE));
 }
 
@@ -404,7 +400,10 @@ void dt_dev_pixelpipe_rebuild_all_real(dt_develop_t *dev)
   if(IS_NULL_PTR(dev) || !dev->gui_attached) return;
   _change_pipe(dev->preview_pipe, DT_DEV_PIPE_REMOVE);
   _change_pipe(dev->pipe, DT_DEV_PIPE_REMOVE);
-  _sync_virtual_pipe(dev, DT_DEV_PIPE_REMOVE);
+  /* Rebuilt here, and deliberately not PUBLISHED here: these are the flag-raising paths, and
+   * nothing may observe geometry before the publication that belongs with it -- the ordering
+   * rule from the fix for #1157. */
+  dt_geometry_chain_rebuild(dev);
 }
 
 void dt_dev_pixelpipe_resync_history_main_real(dt_develop_t *dev)
@@ -417,8 +416,7 @@ void dt_dev_pixelpipe_resync_history_preview_real(dt_develop_t *dev)
 {
   if(IS_NULL_PTR(dev) || !dev->gui_attached) return;
   _change_pipe(dev->preview_pipe, DT_DEV_PIPE_SYNCH);
-  // Virtual pipe mirrors preview history for GUI coordinate transforms.
-  _sync_virtual_pipe(dev, DT_DEV_PIPE_SYNCH);
+  dt_geometry_chain_rebuild(dev);
 }
 
 void dt_dev_pixelpipe_resync_history_all_real(dt_develop_t *dev)
@@ -438,8 +436,7 @@ void dt_dev_pixelpipe_update_history_preview_real(dt_develop_t *dev)
 {
   if(IS_NULL_PTR(dev) || !dev->gui_attached) return;
   _change_pipe(dev->preview_pipe, DT_DEV_PIPE_TOP_CHANGED);
-  // Virtual pipe mirrors preview history for GUI coordinate transforms.
-  _sync_virtual_pipe(dev, DT_DEV_PIPE_TOP_CHANGED);
+  dt_geometry_chain_rebuild(dev);
 }
 
 void dt_dev_pixelpipe_update_history_all_real(dt_develop_t *dev)
@@ -453,8 +450,7 @@ void dt_dev_pixelpipe_update_zoom_preview_real(dt_develop_t *dev)
 {
   if(IS_NULL_PTR(dev) || !dev->gui_attached) return;
   _change_pipe(dev->preview_pipe, DT_DEV_PIPE_ZOOMED);
-  // Keep the virtual pipe aligned with preview ROI/zoom changes for GUI transforms.
-  _sync_virtual_pipe(dev, DT_DEV_PIPE_ZOOMED);
+  dt_geometry_chain_rebuild(dev);
 }
 
 void dt_dev_pixelpipe_update_zoom_main_real(dt_develop_t *dev)
@@ -466,7 +462,7 @@ void dt_dev_pixelpipe_update_zoom_main_real(dt_develop_t *dev)
    * best-effort backbuffer policy. */
   dt_dev_pixelpipe_set_realtime(dev->pipe, FALSE);
   _change_pipe(dev->pipe, DT_DEV_PIPE_ZOOMED);
-  _sync_virtual_pipe(dev, DT_DEV_PIPE_ZOOMED);
+  dt_geometry_chain_rebuild(dev);
 }
 
 void dt_dev_pixelpipe_reset_all(dt_develop_t *dev)
@@ -568,8 +564,7 @@ void dt_dev_pixelpipe_get_roi_in(dt_dev_pixelpipe_t *pipe, const struct dt_iop_r
   // upstream in the pipeline for proper pipeline cache invalidation, so we need to browse the pipeline
   // backwards.
 
-  // The virtual pipe is expected to be ready before calling this.
-  // This function no longer supports NULL pipes or ad-hoc temp nodes.
+  // This function does not support NULL pipes or ad-hoc temp nodes.
 
   dt_iop_roi_t roi_out_temp = roi_out;
   dt_iop_roi_t roi_in;
@@ -1492,8 +1487,8 @@ void dt_pixelpipe_get_global_hash(dt_dev_pixelpipe_t *pipe)
 
       // bypass_cache_variant (see dt_iop_module_t.bypass_cache_variant) is, like
       // request_mask_display above, module-owned GUI state whose real effect a module such as
-      // retouch applies only to this main/FULL pipe -- never to preview/virtual-preview, which
-      // always render as if none of these toggles were active. But the field itself lives on
+      // retouch applies only to this main/FULL pipe -- never to the preview pipe, which always
+      // renders as if none of these toggles were active. But the field itself lives on
       // the shared dt_iop_module_t, so it reads the same non-zero value from every pipe type. Left
       // ungated, a preview-pipe run with the same ROI/params (e.g. at zoom == fit) can compute the
       // exact same hash chain as the FULL pipe despite publishing different pixels, and either
@@ -1703,8 +1698,7 @@ void dt_dev_pixelpipe_change(dt_dev_pixelpipe_t *pipe)
     _refresh_pipe_detail_mask_state(pipe);
 
   // A call chain that already holds history_mutex as writer on this same thread can re-enter
-  // here (e.g. history-commit paths that resync the virtual pipe while still holding the write
-  // lock). dt_pthread_rwlock_rdlock is same-thread-recursive for this exact case (see
+  // here (e.g. history-commit paths that resync a pipe while still holding the write lock). dt_pthread_rwlock_rdlock is same-thread-recursive for this exact case (see
   // dtpthread.h), so this proceeds immediately instead of deadlocking or deferring the sync.
   const double _history_mutex_hold_start = dt_get_wtime();
   dt_pthread_rwlock_rdlock(&pipe->dev->history_mutex);
@@ -1773,60 +1767,6 @@ void dt_dev_pixelpipe_change(dt_dev_pixelpipe_t *pipe)
 
   dt_show_times_f(&start, "[dev_pixelpipe] pipeline resync with history", "for pipe %s", type);
   dt_free(type);
-}
-
-static void _sync_virtual_pipe(dt_develop_t *dev, dt_dev_pixelpipe_change_t flag)
-{
-  // Virtual pipe exists only for GUI geometry (ROI/mask transforms) and never processes pixels.
-  if(IS_NULL_PTR(dev) || !dev->gui_attached || IS_NULL_PTR(dev->virtual_pipe)) return;
-  int32_t raw_width = 0;
-  int32_t raw_height = 0;
-  if(!dt_dev_geometry_get_raw_size(dev, &raw_width, &raw_height) || dev->image_storage.id <= 0) return;
-
-  // Ensure its input image metadata matches the current dev state.
-  if(dev->virtual_pipe->imgid != dev->image_storage.id
-     || dev->virtual_pipe->iwidth != raw_width
-     || dev->virtual_pipe->iheight != raw_height
-     || dev->virtual_pipe->dev->image_storage.id != dev->image_storage.id)
-  {
-    dt_dev_pixelpipe_set_input(dev->virtual_pipe, dev->image_storage.id,
-                               raw_width, raw_height, 1.0f, DT_MIPMAP_FULL);
-  }
-
-  // Mirror the preview-pipe change flags.
-  _change_pipe(dev->virtual_pipe, flag);
-
-  /* The geometry chain answers the same questions and must be exactly as fresh as the pipe it
-   * replaces -- consumers read whichever of the two can answer, and a chain rebuilt only in the
-   * size path would lag on every flag arriving between two size publications. Rebuilt here, and
-   * deliberately not PUBLISHED here: this function raises flags, and nothing may observe
-   * geometry before the publication that belongs with it (the ordering rule from #1157). */
-  dt_geometry_chain_rebuild(dev);
-
-  /* And the pipe itself only when something will read it. This is the expensive half of this
-   * function -- a full resync commits every module's parameters and costs ~0.1 s on the GUI
-   * thread, measured at darkroom entry -- and it is exactly what the geometry service exists to
-   * stop paying. The flag above stays raised either way, so a later
-   * dt_dev_virtual_pipe_ensure_synced() still has everything it needs to catch the pipe up if a
-   * fallback does end up consulting it. */
-  if(!dt_geometry_chain_authoritative(dev->geometry_chain))
-    dt_dev_pixelpipe_change(dev->virtual_pipe);
-}
-
-void dt_dev_virtual_pipe_ensure_synced(dt_develop_t *dev)
-{
-  /* Catch the pixel-less pipe up with the flags raised while the geometry service was answering
-   * for it. Cheap when it is already current -- the flags are cleared by a resync -- and the
-   * only thing standing between "we stopped resyncing it eagerly" and a consumer reading a pipe
-   * that history moved out from under. */
-  if(IS_NULL_PTR(dev) || !dev->gui_attached || IS_NULL_PTR(dev->virtual_pipe)) return;
-  if(dt_dev_pixelpipe_get_changed(dev->virtual_pipe) == DT_DEV_PIPE_UNCHANGED) return;
-  dt_dev_pixelpipe_change(dev->virtual_pipe);
-}
-
-void dt_dev_pixelpipe_sync_virtual(dt_develop_t *dev, dt_dev_pixelpipe_change_t flag)
-{
-  _sync_virtual_pipe(dev, flag);
 }
 
 gboolean dt_dev_pixelpipe_is_backbufer_valid(dt_dev_pixelpipe_t *pipe)

--- a/src/develop/dev_pixelpipe.h
+++ b/src/develop/dev_pixelpipe.h
@@ -85,7 +85,7 @@ void dt_dev_pixelpipe_change_zoom_main(struct dt_develop_t *dev);
 // returns the dimensions of a virtual image of size (width_in, height_in) image after processing
 // all modules of the pipe. This chains calls to module's modify_roi_out() methods in pipeline order.
 // Doesn't actually compute pixels.
-// NOTE: pipe must be a real or virtual pipe with nodes; NULL pipes are not supported anymore.
+// NOTE: pipe must have nodes; NULL pipes are not supported anymore.
 void dt_dev_pixelpipe_get_roi_out(struct dt_dev_pixelpipe_t *pipe, const int width_in,
                                   const int height_in, int *width, int *height);
                                 
@@ -93,7 +93,7 @@ void dt_dev_pixelpipe_get_roi_out(struct dt_dev_pixelpipe_t *pipe, const int wid
 // the desired sizes from roi_out, from end to start. This chains calls to module's modify_roi_in() methods
 // in pipeline reverse order.
 // Doesn't actually compute pixels.
-// NOTE: pipe must be a real or virtual pipe with nodes; NULL pipes are not supported anymore.
+// NOTE: pipe must have nodes; NULL pipes are not supported anymore.
 void dt_dev_pixelpipe_get_roi_in(struct dt_dev_pixelpipe_t *pipe, const struct dt_iop_roi_t roi_out);
 
 // Check if current_module is performing operations that dev->gui_module (active GUI module)
@@ -111,17 +111,8 @@ gboolean dt_dev_pixelpipe_activemodule_disables_currentmodule(struct dt_develop_
 // wrapper for cleanup_nodes, create_nodes, synch_all and synch_top, decides upon changed event which one to
 // take on. also locks dev->history_mutex.
 void dt_dev_pixelpipe_change(struct dt_dev_pixelpipe_t *pipe);
-void dt_dev_pixelpipe_sync_virtual(struct dt_develop_t *dev, dt_dev_pixelpipe_change_t flag);
 
-/**
- * @brief Bring the pixel-less pipe up to date with the flags raised since it was last resynced.
- *
- * @details It is no longer resynced eagerly: while the geometry service can answer, the flags
- * are raised and the ~0.1 s resync is skipped. Anything that consults the pipe directly -- the
- * fallbacks taken when the service declines, and shadow mode -- calls this first. A no-op when
- * the pipe is already current.
- */
-void dt_dev_virtual_pipe_ensure_synced(struct dt_develop_t *dev);
+
 
 // Get the global hash of a pipe node (piece), or a fallback if none.
 uint64_t dt_dev_pixelpipe_node_hash(struct dt_dev_pixelpipe_t *pipe, 

--- a/src/develop/dev_roi_request.h
+++ b/src/develop/dev_roi_request.h
@@ -59,7 +59,7 @@ typedef struct dt_dev_roi_request_t
    * i.e. "all three inputs of this record have been published at least once".
    *
    * It is NOT a statement about which image those numbers describe. Between an image change
-   * republishing the raw pair and dt_dev_get_thumbnail_size() rerunning the virtual pipe,
+   * republishing the raw pair and dt_dev_get_thumbnail_size() refolding the composed geometry,
    * processed_* -- and everything derived from it -- still measures the PREVIOUS image, with
    * valid TRUE throughout. On the darkroom's own image-change path that window contains no
    * running worker (views/darkroom.c's leave() joins it before the new raw geometry is

--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -145,15 +145,12 @@ void dt_dev_init(dt_develop_t *dev, int32_t gui_attached)
   {
     dev->pipe = (dt_dev_pixelpipe_t *)malloc(sizeof(dt_dev_pixelpipe_t));
     dev->preview_pipe = (dt_dev_pixelpipe_t *)malloc(sizeof(dt_dev_pixelpipe_t));
-    // Virtual pipe mirrors preview_pipe for geometry, but is never processed.
-    dev->virtual_pipe = (dt_dev_pixelpipe_t *)malloc(sizeof(dt_dev_pixelpipe_t));
     dt_dev_pixelpipe_init(dev->pipe, dev);
     dt_dev_pixelpipe_init_preview(dev->preview_pipe, dev);
-    dt_dev_pixelpipe_init_preview(dev->virtual_pipe, dev);
 
-    /* The geometry chain runs beside the virtual pipe and will replace it (G2 skeleton --
-     * doc/geometry-service.md). GUI devs only: it answers GUI questions and is GUI-thread
-     * state, so a headless dev has nothing to do with one. */
+    /* Where the GUI gets sizes and coordinates from (doc/geometry-service.md). GUI devs only:
+     * it answers GUI questions and is GUI-thread state, so a headless dev has nothing to do with
+     * one -- which is also what makes the NULL chain the guard on every entry point. */
     dev->geometry_chain = dt_geometry_chain_new();
   }
 
@@ -244,12 +241,6 @@ void dt_dev_cleanup(dt_develop_t *dev)
   {
     dt_dev_pixelpipe_cleanup(dev->preview_pipe);
     dt_free(dev->preview_pipe);
-  }
-  if(dev->virtual_pipe)
-  {
-    // Virtual pipe has nodes and committed params but no pixel buffers.
-    dt_dev_pixelpipe_cleanup(dev->virtual_pipe);
-    dt_free(dev->virtual_pipe);
   }
   dt_geometry_chain_free(dev->geometry_chain);
   dev->geometry_chain = NULL;
@@ -356,28 +347,9 @@ int dt_dev_get_thumbnail_size(dt_develop_t *dev)
 {
   if(!dt_dev_geometry_raw_inited(dev) || !dt_dev_viewport_configured(dev)) return 1;
 
-  // Keep the virtual pipe synced so ROI computations on the GUI thread
-  // always use up-to-date history and input sizes.
   const dt_dev_image_geometry_t geometry = dt_dev_geometry_snapshot(dev);
   const int32_t raw_width = geometry.raw_width;
   const int32_t raw_height = geometry.raw_height;
-
-  if(dev->virtual_pipe->imgid != dev->image_storage.id
-      || dev->virtual_pipe->iwidth != raw_width
-      || dev->virtual_pipe->iheight != raw_height
-      || dev->virtual_pipe->dev->image_storage.id != dev->image_storage.id)
-    dt_dev_pixelpipe_set_input(dev->virtual_pipe, dev->image_storage.id,
-                                raw_width, raw_height, 1.0f, DT_MIPMAP_FULL);
-
-  if(!dev->virtual_pipe->nodes)
-    dt_dev_pixelpipe_or_changed(dev->virtual_pipe, DT_DEV_PIPE_REMOVE);
-  else if(dt_dev_pixelpipe_get_history_hash(dev->virtual_pipe) != dt_dev_get_history_hash(dev))
-  {
-    if(dt_dev_pixelpipe_get_realtime(dev->pipe))
-      dt_dev_pixelpipe_set_history_hash(dev->virtual_pipe, dt_dev_get_history_hash(dev));
-    else
-      dt_dev_pixelpipe_or_changed(dev->virtual_pipe, DT_DEV_PIPE_SYNCH);
-  }
 
   /* The chain is rebuilt BEFORE the size is decided now, because it is what decides it. It is
    * cheap -- small derivations of already-committed parameters, no LUT, no colour transform, no
@@ -386,41 +358,12 @@ int dt_dev_get_thumbnail_size(dt_develop_t *dev)
   dt_geometry_chain_rebuild(dev);
   const double chain_ms = (dt_get_wtime() - chain_start) * 1000.0;
 
-  /* Resync the pixel-less pipe only when something will actually read it: when the chain cannot
-   * answer and the fallbacks will therefore be taken, or when shadow mode is on and there would
-   * be nothing to compare against otherwise. This is where the cost of this service's absence
-   * was: measured on darkroom entry, a resync is ~0.105 s against the chain's 0.03-5 ms, and it
-   * ran on the GUI thread at every history commit.
-   *
-   * Skipping it leaves the pipe FLAGGED but not rebuilt, which is the invariant the fallbacks
-   * rely on: they run only while the chain is not authoritative, and in exactly that case the
-   * resync below has run. dt_dev_virtual_pipe_ensure_synced() is there for anything that needs
-   * to consult the pipe outside that arrangement. */
-  const gboolean chain_answers = dt_geometry_chain_authoritative(dev->geometry_chain);
-  const gboolean want_shadow = (dt_get_debug_flags() & DT_DEBUG_DEV) != 0;
-
-  if((!chain_answers || want_shadow)
-     && dt_dev_pixelpipe_get_changed(dev->virtual_pipe) != DT_DEV_PIPE_UNCHANGED)
-    dt_dev_pixelpipe_change(dev->virtual_pipe);
-
-  // Compute the virtual full-res output. This needs an inited history.
-  // raw_width/raw_height come from the single coherent read at the top of this function:
-  // nothing between here and there republishes the raw geometry.
+  /* The developed size, folded from the geometry records. Nothing is rebuilt to obtain it: that
+   * is what this service replaced, and what it cost is recorded in doc/geometry-service.md. */
   int processed_width = 0;
   int processed_height = 0;
-  int pipe_width = 0;
-  int pipe_height = 0;
-
-  if(!chain_answers || want_shadow)
-    dt_dev_pixelpipe_get_roi_out(dev->virtual_pipe, raw_width, raw_height, &pipe_width, &pipe_height);
-
-  if(chain_answers)
-    dt_geometry_chain_processed_size(dev->geometry_chain, &processed_width, &processed_height);
-  else
-  {
-    processed_width = pipe_width;
-    processed_height = pipe_height;
-  }
+  if(!dt_geometry_chain_processed_size(dev->geometry_chain, &processed_width, &processed_height))
+    return 1;
 
   dt_dev_geometry_set_processed_size(dev, processed_width, processed_height);
 
@@ -434,7 +377,7 @@ int dt_dev_get_thumbnail_size(dt_develop_t *dev)
    * request to match AND flagging the pipes to replan. Anything inserted between them widens the
    * window in which the darkroom worker latches the OLD request against ALREADY NEW history,
    * which is the mixed frame of #1157. An observer must not sit inside the update it observes. */
-  if(want_shadow) dt_geometry_shadow_check(dev, pipe_width, pipe_height, chain_ms);
+  dt_geometry_self_check(dev, chain_ms);
 
 
   dt_dev_update_mouse_effect_radius(dev);
@@ -490,7 +433,7 @@ gboolean dt_dev_pixelpipe_has_preview_output(const dt_develop_t *dev, const dt_d
   // GUI buffer on portrait images, breaking structure detection and manual drawing (#710).
   //
   // Tolerate a couple of pixels of slack on the dimensions. `dev->roi.preview_*` is derived from the
-  // virtual pipe at scale 1.0, whereas `roi` is produced at `natural_scale`; geometric modules
+  // composed geometry at scale 1.0, whereas `roi` is produced at `natural_scale`; geometric modules
   // (ashift, lens) round their transformed bounding box with floorf() independently at each scale,
   // so the two legitimately disagree by ~1px for the very same full image. The real discriminators
   // are the origin and scale tests below: a zoomed or panned ROI has a non-zero x/y and a scale
@@ -983,7 +926,7 @@ static gboolean _dt_dev_mipmap_prefetch_full(dt_develop_t *dev, const int32_t im
   // Publish what the read actually produced. `ok' is FALSE when the mipmap cache handed back
   // no buffer or a 0-sized one; claiming raw_inited in that case told every later reader that
   // 0x0 was a measured fact about the image, and dt_dev_geometry_refresh()'s own guard
-  // (dt_dev_geometry_raw_inited) then let the virtual pipe run on it.
+  // (dt_dev_geometry_raw_inited) then let the size fold run on it.
   dt_dev_geometry_set_raw_size(dev, ok ? buf.width : 0, ok ? buf.height : 0, ok);
 
   dt_mipmap_cache_release(&buf);
@@ -1722,39 +1665,25 @@ gchar *dt_history_item_get_name_html(const struct dt_iop_module_t *module)
 static int dt_dev_distort_backtransform_locked(const dt_dev_pixelpipe_t *pipe, const double iop_order,
                                                const int transf_direction, float *points, size_t points_count);
 
-/* These two are where the geometry service takes over from the pixel-less pipe. They are the
- * whole of the mask GUI's coordinate handling -- every shape's centre, every handle, every
- * source position routes through one of them -- and they ask the simplest question there is:
- * everything, in order, no bound.
- *
- * The chain answers when it can and the pipe answers otherwise, which is not a hedge but the
- * authority rule: the chain refuses unless EVERY enabled module that changes geometry has
- * published a record, so a fallback happens only when composing from records would mean mixing
- * them with pipeline pieces. Both paths stay live until the pipe is deleted, and shadow mode
- * keeps comparing them on every size publication -- including, at iop_order 0 and DIR_ALL,
- * exactly the question these two ask.
+/* These two are the whole of the mask GUI's coordinate handling -- every shape's centre, every
+ * handle, every source position routes through one of them -- and they ask the geometry service
+ * the simplest question there is: everything, in order, no bound.
  */
 
 /**
- * @brief The GUI's bounded transform folds: ask the geometry service, fall back to the pipe.
+ * @brief The GUI's bounded transform folds, composed by the geometry service.
  *
  * @details Same contract as dt_dev_distort_transform_plus() -- the iop_order bound and the five
- * direction modes mean exactly what they mean there -- but stated in terms of the dev rather
- * than a pipe, because which of the two answers is not the caller's business. The chain answers
- * when every enabled geometry module has published a record; otherwise the pixel-less pipe does,
- * as it always has.
- *
- * A module GUI must not reach for dev->virtual_pipe itself. That pipe is going away, and a call
- * site naming it is a call site that will not compile then -- which is the point of routing
- * every one of them through here first.
+ * direction modes mean exactly what they mean there -- but stated in terms of the dev rather than
+ * a pipe, because a GUI has no pipe of its own to name. It used to fall back to a pixel-less
+ * clone of the pipeline when the chain could not answer; that clone is deleted, so a chain that
+ * cannot answer returns 0 and leaves @p points untouched.
  */
 int dt_dev_distort_transform_gui(dt_develop_t *dev, const double iop_order, const int transf_direction,
                                  float *points, size_t points_count)
 {
   if(IS_NULL_PTR(dev)) return 0;
-  if(dt_geometry_transform(dev, iop_order, transf_direction, points, points_count)) return 1;
-  dt_dev_virtual_pipe_ensure_synced(dev);
-  return dt_dev_distort_transform_plus(dev->virtual_pipe, iop_order, transf_direction, points, points_count);
+  return dt_geometry_transform(dev, iop_order, transf_direction, points, points_count);
 }
 
 /** @brief The inverse of dt_dev_distort_transform_gui(), same rules. */
@@ -1762,32 +1691,30 @@ int dt_dev_distort_backtransform_gui(dt_develop_t *dev, const double iop_order, 
                                      float *points, size_t points_count)
 {
   if(IS_NULL_PTR(dev)) return 0;
-  if(dt_geometry_backtransform(dev, iop_order, transf_direction, points, points_count)) return 1;
-  dt_dev_virtual_pipe_ensure_synced(dev);
-  return dt_dev_distort_backtransform_plus(dev->virtual_pipe, iop_order, transf_direction, points,
-                                           points_count);
+  return dt_geometry_backtransform(dev, iop_order, transf_direction, points, points_count);
 }
 
 /**
  * @brief One module's own input and output rectangles, at full resolution.
  *
- * @details What a module GUI used to get by resolving its piece on the pixel-less pipe and
- * reading piece->buf_in / piece->buf_out. Those rectangles are a product of the size fold, and
+ * @details What a module GUI used to get by resolving its piece on a pixel-less clone of the
+ * pipeline and reading piece->buf_in / piece->buf_out. Those rectangles are a product of the
+ * size fold, and
  * the geometry service performs that fold over records for EVERY module -- not only the ones
  * that change geometry, because not only those read the result: iop/graduatednd.c has no
  * geometry callbacks at all and normalises its overlay against its own output rectangle.
  *
- * @return FALSE when neither source can answer, in which case @p in and @p out are untouched
+ * @return FALSE when the service cannot answer, in which case @p in and @p out are untouched
  * and the caller must not draw. A module that is disabled or absent has no rectangles.
  */
 /**
  * @brief The developed image's full-resolution size, for a GUI caller.
  *
- * @details Three sources, in order of freshness, which is why this exists rather than a plain
- * read of the geometry record: the chain and the pixel-less pipe are both recomputed the moment
- * the module stack changes, while the record is only republished when the size path runs. Code
- * that needed the newest answer used to reach into the pipe's field to get it, and had to keep
- * its own fallback for the case where the pipe had none.
+ * @details Two sources, in order of freshness, which is why this exists rather than a plain
+ * read of the geometry record: the chain is recomputed the moment the module stack changes,
+ * while the record is only republished when the size path runs. Code that needed the newest
+ * answer used to reach into a pipe's processed_width field to get it, and had to keep its own
+ * fallback for the case where that pipe had none.
  *
  * @return FALSE when no source has a usable size, leaving the out-params untouched.
  */
@@ -1805,15 +1732,6 @@ gboolean dt_dev_processed_size_gui(dt_develop_t *dev, int *width, int *height)
     return TRUE;
   }
 
-  dt_dev_virtual_pipe_ensure_synced(dev);
-  if(!IS_NULL_PTR(dev->virtual_pipe) && dev->virtual_pipe->processed_width > 0
-     && dev->virtual_pipe->processed_height > 0)
-  {
-    if(!IS_NULL_PTR(width)) *width = dev->virtual_pipe->processed_width;
-    if(!IS_NULL_PTR(height)) *height = dev->virtual_pipe->processed_height;
-    return TRUE;
-  }
-
   const dt_dev_image_geometry_t geometry = dt_dev_geometry_snapshot(dev);
   if(geometry.processed_width <= 0 || geometry.processed_height <= 0) return FALSE;
   if(!IS_NULL_PTR(width)) *width = geometry.processed_width;
@@ -1828,33 +1746,21 @@ gboolean dt_dev_module_geometry_gui(dt_develop_t *dev, dt_iop_module_t *module, 
 
   const dt_geometry_record_t *const record
       = dt_geometry_chain_find(dev->geometry_chain, module->op, module->multi_priority);
-  if(dt_geometry_chain_authoritative(dev->geometry_chain) && !IS_NULL_PTR(record))
-  {
-    if(!IS_NULL_PTR(in)) *in = record->in;
-    if(!IS_NULL_PTR(out)) *out = record->out;
-    return TRUE;
-  }
+  if(IS_NULL_PTR(record) || !dt_geometry_chain_authoritative(dev->geometry_chain)) return FALSE;
 
-  dt_dev_virtual_pipe_ensure_synced(dev);
-  const dt_dev_pixelpipe_iop_t *const piece = dt_dev_distort_get_iop_pipe(dev->virtual_pipe, module);
-  if(IS_NULL_PTR(piece)) return FALSE;
-  if(!IS_NULL_PTR(in)) *in = piece->buf_in;
-  if(!IS_NULL_PTR(out)) *out = piece->buf_out;
+  if(!IS_NULL_PTR(in)) *in = record->in;
+  if(!IS_NULL_PTR(out)) *out = record->out;
   return TRUE;
 }
 
 int dt_dev_coordinates_raw_abs_to_image_abs(dt_develop_t *dev, float *points, size_t points_count)
 {
-  if(dt_geometry_transform(dev, 0.0, DT_DEV_TRANSFORM_DIR_ALL, points, points_count)) return 1;
-  dt_dev_virtual_pipe_ensure_synced(dev);
-  return dt_dev_distort_transform_plus(dev->virtual_pipe, 0.0f, DT_DEV_TRANSFORM_DIR_ALL, points, points_count);
+  return dt_geometry_transform(dev, 0.0, DT_DEV_TRANSFORM_DIR_ALL, points, points_count);
 }
 
 int dt_dev_coordinates_image_abs_to_raw_abs(dt_develop_t *dev, float *points, size_t points_count)
 {
-  if(dt_geometry_backtransform(dev, 0.0, DT_DEV_TRANSFORM_DIR_ALL, points, points_count)) return 1;
-  dt_dev_virtual_pipe_ensure_synced(dev);
-  return dt_dev_distort_backtransform_locked(dev->virtual_pipe, 0.0f, DT_DEV_TRANSFORM_DIR_ALL, points, points_count);
+  return dt_geometry_backtransform(dev, 0.0, DT_DEV_TRANSFORM_DIR_ALL, points, points_count);
 }
 
 // only call directly or indirectly from dt_dev_distort_transform_plus, so that it runs with the history locked

--- a/src/develop/develop.h
+++ b/src/develop/develop.h
@@ -215,7 +215,6 @@ typedef struct dt_develop_t
   // Virtual preview-like pipeline used for geometry/ROI computations on the GUI thread.
   // It mirrors preview_pipe history/nodes but never processes pixels.
   // It is meant for fast access from the GUI mainthread without waiting for threads to return.
-  struct dt_dev_pixelpipe_t *virtual_pipe;
 
   // image under consideration, which
   // is copied each time an image is changed. this means we have some information
@@ -464,7 +463,7 @@ typedef struct dt_develop_t
 
   cairo_surface_t *image_surface;
 
-  /* Composed geometry, GUI thread only: what dev->virtual_pipe is walked for today, as data.
+  /* Composed geometry, GUI thread only: where the GUI gets sizes and coordinates from.
    * Appended at the end of this struct deliberately -- IOP plugins are compiled against this
    * layout, so a field inserted anywhere else silently shifts what they read. See
    * develop/geometry/geometry.h and doc/geometry-service.md. NULL on non-gui devs. */
@@ -649,8 +648,7 @@ int dt_dev_distort_backtransform_plus(const struct dt_dev_pixelpipe_t *pipe, con
  * @brief GUI-side bounded transform folds. Ask the geometry service, fall back to the pixel-less
  * pipe. Same iop_order bound and direction modes as dt_dev_distort_transform_plus().
  *
- * Module GUIs use THESE, never dev->virtual_pipe directly: that pipe is being removed, and a
- * caller that names it is a caller that has not been migrated.
+ * The only way a GUI asks for a composed transform.
  */
 int dt_dev_distort_transform_gui(struct dt_develop_t *dev, const double iop_order,
                                  const int transf_direction, float *points, size_t points_count);
@@ -659,18 +657,18 @@ int dt_dev_distort_backtransform_gui(struct dt_develop_t *dev, const double iop_
 
 /**
  * @brief One module's own input and output rectangles at full resolution, from the geometry
- * service or, until it can answer, from the pixel-less pipe.
+ * service.
  *
- * Replaces resolving a piece and reading piece->buf_in / piece->buf_out. Returns FALSE when
- * neither source has them, leaving the out-params untouched -- a disabled or absent module has
- * no rectangles, and a caller that draws anyway draws somewhere arbitrary.
+ * Replaces resolving a piece and reading piece->buf_in / piece->buf_out. Returns FALSE when the
+ * service has none, leaving the out-params untouched -- a disabled or absent module has no
+ * rectangles, and a caller that draws anyway draws somewhere arbitrary.
  */
 gboolean dt_dev_module_geometry_gui(struct dt_develop_t *dev, struct dt_iop_module_t *module,
                                     dt_iop_roi_t *in, dt_iop_roi_t *out);
 
 /**
- * @brief The developed image's full-resolution size for a GUI caller: the geometry service, the
- * pixel-less pipe, or the published record, in that order of freshness. FALSE when none has one.
+ * @brief The developed image's full-resolution size for a GUI caller: the geometry service,
+ * then the published record, in that order of freshness. FALSE when neither has one.
  */
 gboolean dt_dev_processed_size_gui(struct dt_develop_t *dev, int *width, int *height);
 

--- a/src/develop/geometry/geometry.c
+++ b/src/develop/geometry/geometry.c
@@ -51,7 +51,12 @@
  *   - useless: the module template, not built.
  *
  * A module added to this list without a geometry_record() implementation keeps the chain
- * non-authoritative forever, which is the safe direction: consumers go on using the pipe.
+ * non-authoritative forever. That used to be the safe direction because consumers fell back to
+ * the pixel-less pipe; there is no fallback now, so it is instead the LOUD direction -- sizes
+ * come back FALSE and the darkroom cannot lay itself out, with the missing modules named under
+ * `-d dev'. Wholesale authority is still the rule it enforces: composing some modules from
+ * records and the rest from somewhere else interleaves two states, and the result is wrong in a
+ * way that looks plausible.
  */
 static const char *const _roster[] = {
   "rawprepare", "basebuffer", "demosaic", "lens",     "ashift",  "liquify", "rotatepixels",
@@ -78,32 +83,6 @@ struct dt_geometry_chain_t
    * at query time, from whatever the GUI currently is. */
   dt_develop_t *dev;
 };
-
-/**
- * @brief A/B switch for bisecting this service against the pipe it replaces.
- *
- * @details Every migrated consumer falls back to dev->virtual_pipe when the chain is not
- * authoritative, so refusing authority puts the whole GUI back on the pipeline path without
- * rebuilding or reverting anything. Set ANSEL_GEOMETRY_DISABLE=1: a symptom that persists is
- * not this service's doing, one that disappears is.
- *
- * It clears the authority FLAG rather than intercepting the accessor, because the walkers and
- * the shadow harness read that field directly -- an accessor-only switch would have left the
- * transform paths live, which is exactly the half a bisection needs to move.
- */
-static gboolean _geometry_disabled(void)
-{
-  static int disabled = -1;
-  if(disabled < 0)
-  {
-    const char *const env = g_getenv("ANSEL_GEOMETRY_DISABLE");
-    disabled = (!IS_NULL_PTR(env) && env[0] == '1') ? 1 : 0;
-    if(disabled)
-      fprintf(stderr, "[geometry] ANSEL_GEOMETRY_DISABLE=1: the chain declines every query; "
-                      "every consumer falls back to the pixel-less pipe\n");
-  }
-  return disabled == 1;
-}
 
 static gboolean _on_roster(const char *op)
 {
@@ -324,7 +303,7 @@ void dt_geometry_chain_rebuild(dt_develop_t *dev)
   dt_pthread_rwlock_unlock(&dev->history_mutex);
 
   _fold_sizes(chain);
-  chain->authoritative = complete && chain->sized && !_geometry_disabled();
+  chain->authoritative = complete && chain->sized;
 }
 
 gboolean dt_geometry_chain_authoritative(const dt_geometry_chain_t *chain)
@@ -450,8 +429,33 @@ int dt_geometry_backtransform(dt_develop_t *dev, const double iop_order, const i
   return 1;
 }
 
-void dt_geometry_shadow_check(dt_develop_t *dev, const int pipe_width, const int pipe_height,
-                              const double chain_ms)
+/**
+ * @brief What the shadow harness became once there was nothing left to shadow.
+ *
+ * @details It used to compare every answer against the pixel-less pipe, which was the right check
+ * while the pipe still owned them -- it is what caught the chain composing modules the pipe was
+ * suppressing, and it is why the focus exception is evaluated live. That reference is gone with
+ * the pipe, so what is left has to test the chain against ITSELF, and only identities that a
+ * wrong chain can actually fail are worth printing.
+ *
+ * Two of them are:
+ *
+ *   - the round trip. transform then backtransform over the whole chain must return the point it
+ *     started from. Every evaluator's inverse is exercised, and an inverse derived in the wrong
+ *     frame fails it -- which is the question flip's 90-degree orientations pose.
+ *
+ *   - the partition. The bounds are a cut of the same ordered list, so composing the two halves
+ *     must equal composing all of it: FORW_INCL(x) after BACK_EXCL(x) is DIR_ALL, and so is
+ *     FORW_EXCL(x) after BACK_INCL(x), for x at every module's own iop_order. This is the bound
+ *     bookkeeping the module GUIs depend on -- they ask for their own iop_order, never DIR_ALL --
+ *     and an off-by-one in _in_bound() drops or repeats exactly one module here.
+ *
+ * What it can no longer catch is a chain that is self-consistently wrong: both halves of a
+ * partition composing the same wrong subset still add up. That check needed a second
+ * implementation, and keeping a whole pipeline alive to be one was the cost this service exists
+ * to remove. Under `-d dev'; never changes behaviour.
+ */
+void dt_geometry_self_check(dt_develop_t *dev, const double chain_ms)
 {
   if(IS_NULL_PTR(dev) || IS_NULL_PTR(dev->geometry_chain)) return;
   if(!(dt_get_debug_flags() & DT_DEBUG_DEV)) return;
@@ -483,60 +487,17 @@ void dt_geometry_shadow_check(dt_develop_t *dev, const int pipe_width, const int
     return;
   }
 
-  if(chain->processed_width != pipe_width || chain->processed_height != pipe_height)
-  {
-    dt_print(DT_DEBUG_DEV, "[geometry] SIZE DIVERGENCE: chain %dx%d, pipe %dx%d\n", chain->processed_width,
-             chain->processed_height, pipe_width, pipe_height);
-    return;
-  }
-
-  /* The size fold only exercises map_size. Probe the point transforms too, or the evaluators
-   * that actually move overlays would go unverified until a consumer switched over and a user
-   * noticed a mask sitting in the wrong place.
-   *
-   * Five points spanning the raw frame, forward through everything (iop_order 0, DIR_ALL --
-   * what dt_dev_coordinates_raw_abs_to_image_abs() asks for), then the same through the pipe.
-   * The tolerance is half a pixel: both sides do the same arithmetic in the same order, so they
-   * should agree exactly, but the fold's rects reach the evaluators as ints on one side and
-   * through piece->buf_in on the other, and a rounding difference of that size is not a defect
-   * worth failing on. Anything larger is a real divergence and is printed with the point. */
+  /* Five points spanning the raw frame. The tolerance is half a pixel throughout: every identity
+   * below composes the same evaluators in the same order, so they should agree exactly, but the
+   * fold's rects reach them as ints and a rounding difference of that size is not a defect worth
+   * failing on. Anything larger is real and is printed with the point. */
   const float w = (float)chain->raw_width;
   const float h = (float)chain->raw_height;
-  float chain_points[10] = { 0.f, 0.f, w, 0.f, 0.f, h, w, h, 0.5f * w, 0.5f * h };
-  float pipe_points[10];
-  memcpy(pipe_points, chain_points, sizeof(pipe_points));
-
-  if(!dt_geometry_transform(dev, 0.0, DT_DEV_TRANSFORM_DIR_ALL, chain_points, 5)) return;
-  if(IS_NULL_PTR(dev->virtual_pipe)) return;
-  dt_dev_distort_transform_plus(dev->virtual_pipe, 0.0, DT_DEV_TRANSFORM_DIR_ALL, pipe_points, 5);
-
-  int diverged = 0;
-  for(int i = 0; i < 5; i++)
-  {
-    if(fabsf(chain_points[2 * i] - pipe_points[2 * i]) > 0.5f
-       || fabsf(chain_points[2 * i + 1] - pipe_points[2 * i + 1]) > 0.5f)
-    {
-      dt_print(DT_DEBUG_DEV,
-               "[geometry] TRANSFORM DIVERGENCE at probe %d: chain (%.2f, %.2f), pipe (%.2f, %.2f)\n", i,
-               chain_points[2 * i], chain_points[2 * i + 1], pipe_points[2 * i], pipe_points[2 * i + 1]);
-      diverged++;
-    }
-  }
-
-  /* And the inverse. Comparing forward against the pipe leaves every backtransform evaluator
-   * unverified -- they are only ever exercised by GUI consumers that have not switched over yet
-   * -- so round-trip the same probes through the chain and require the identity back.
-   *
-   * This is the check that decides a real question about flip, whose forward flips against the
-   * input dimensions and THEN swaps the axes. Its inverse un-swaps and unflips against those
-   * same dimensions, in the pre-swap frame where they are the right ones; swapping the
-   * dimensions as well -- which the neighbouring modify_roi_in helper legitimately does, in its
-   * own rectangle-mapping convention -- would break exactly the 90-degree orientations this
-   * probe covers. Composed here rather than argued. */
-  float roundtrip[10] = { 0.f, 0.f, w, 0.f, 0.f, h, w, h, 0.5f * w, 0.5f * h };
   const float origin[10] = { 0.f, 0.f, w, 0.f, 0.f, h, w, h, 0.5f * w, 0.5f * h };
 
-  dt_geometry_transform(dev, 0.0, DT_DEV_TRANSFORM_DIR_ALL, roundtrip, 5);
+  float roundtrip[10];
+  memcpy(roundtrip, origin, sizeof(roundtrip));
+  if(!dt_geometry_transform(dev, 0.0, DT_DEV_TRANSFORM_DIR_ALL, roundtrip, 5)) return;
   dt_geometry_backtransform(dev, 0.0, DT_DEV_TRANSFORM_DIR_ALL, roundtrip, 5);
 
   int not_identity = 0;
@@ -552,21 +513,13 @@ void dt_geometry_shadow_check(dt_develop_t *dev, const int pipe_width, const int
     }
   }
 
-  /* The bounds the module GUIs actually use.
-   *
-   * Everything above probes iop_order 0 and DIR_ALL, which is what the coordinate converters
-   * ask -- and nothing else does. A module GUI asks for its OWN iop_order with FORW_INCL,
-   * FORW_EXCL or BACK_EXCL, and those compose a different subset of the chain: a divergence
-   * confined to one of them is invisible to a DIR_ALL probe. That is exactly how a chain that
-   * never applied the focused-module exception passed every check here while drawing ashift's
-   * detected lines against the wrong module stack.
-   *
-   * So probe each roster record at its own iop_order, in the three bounds the GUIs use, against
-   * the pipe doing the same. Cheap -- one point, a handful of records -- and it covers the
-   * question the migrated call sites actually ask. */
-  static const int bounds[3] = { DT_DEV_TRANSFORM_DIR_FORW_INCL, DT_DEV_TRANSFORM_DIR_FORW_EXCL,
-                                 DT_DEV_TRANSFORM_DIR_BACK_EXCL };
-  static const char *const bound_names[3] = { "FORW_INCL", "FORW_EXCL", "BACK_EXCL" };
+  // The whole chain, once: what both halves of every partition below must add up to.
+  float whole[2] = { 0.37f * w, 0.61f * h };
+  dt_geometry_transform(dev, 0.0, DT_DEV_TRANSFORM_DIR_ALL, whole, 1);
+
+  static const int back[2] = { DT_DEV_TRANSFORM_DIR_BACK_EXCL, DT_DEV_TRANSFORM_DIR_BACK_INCL };
+  static const int forw[2] = { DT_DEV_TRANSFORM_DIR_FORW_INCL, DT_DEV_TRANSFORM_DIR_FORW_EXCL };
+  static const char *const cut_names[2] = { "BACK_EXCL|FORW_INCL", "BACK_INCL|FORW_EXCL" };
   int bound_diverged = 0;
 
   for(const GList *node = g_list_first(chain->records); node; node = g_list_next(node))
@@ -574,39 +527,32 @@ void dt_geometry_shadow_check(dt_develop_t *dev, const int pipe_width, const int
     const dt_geometry_record_t *const record = (const dt_geometry_record_t *)node->data;
     if(!record->enabled || IS_NULL_PTR(record->vtable)) continue;
 
-    for(int b = 0; b < 3; b++)
+    for(int c = 0; c < 2; c++)
     {
-      float cp[2] = { 0.37f * w, 0.61f * h };
-      float pp[2] = { cp[0], cp[1] };
+      float cut[2] = { 0.37f * w, 0.61f * h };
+      dt_geometry_transform(dev, record->iop_order, back[c], cut, 1);
+      dt_geometry_transform(dev, record->iop_order, forw[c], cut, 1);
 
-      dt_geometry_transform(dev, record->iop_order, bounds[b], cp, 1);
-      dt_dev_distort_transform_plus(dev->virtual_pipe, record->iop_order, bounds[b], pp, 1);
-
-      if(fabsf(cp[0] - pp[0]) > 0.5f || fabsf(cp[1] - pp[1]) > 0.5f)
+      if(fabsf(cut[0] - whole[0]) > 0.5f || fabsf(cut[1] - whole[1]) > 0.5f)
       {
         dt_print(DT_DEBUG_DEV,
-                 "[geometry] BOUND DIVERGENCE at %s.%d %s: chain (%.2f, %.2f), pipe (%.2f, %.2f)\n",
-                 record->op, record->instance, bound_names[b], cp[0], cp[1], pp[0], pp[1]);
+                 "[geometry] BOUND DIVERGENCE at %s.%d %s: cut (%.2f, %.2f), whole (%.2f, %.2f)\n",
+                 record->op, record->instance, cut_names[c], cut[0], cut[1], whole[0], whole[1]);
         bound_diverged++;
       }
     }
   }
 
-  if(bound_diverged)
-    dt_print(DT_DEBUG_DEV, "[geometry] %d module-relative bound probe(s) diverge\n", bound_diverged);
-
-  if(diverged || not_identity || bound_diverged)
-    dt_print(DT_DEBUG_DEV,
-             "[geometry] size agrees (%dx%d) but %d/5 forward, %d/5 round-trips, %d bounds diverge\n",
-             chain->processed_width, chain->processed_height, diverged, not_identity, bound_diverged);
+  if(not_identity || bound_diverged)
+    dt_print(DT_DEBUG_DEV, "[geometry] size %dx%d, %d/5 round-trips and %d bound cut(s) diverge\n",
+             chain->processed_width, chain->processed_height, not_identity, bound_diverged);
   else
-    dt_print(DT_DEBUG_DEV,
-             "[geometry] agrees with the pipe: size %dx%d, 5/5 forward, 5/5 round-trips, all bounds\n",
+    dt_print(DT_DEBUG_DEV, "[geometry] consistent: size %dx%d, 5/5 round-trips, all bound cuts\n",
              chain->processed_width, chain->processed_height);
 
-  /* The cost, which is the reason this service exists. Compare against `-d perf's "pipeline
-   * resync with history ... for pipe virtual-preview" line: that is the same product, computed
-   * the way this replaces. */
+  /* The cost, which is the reason this service exists. Its predecessor's counterpart is in the
+   * git history of this file and in doc/geometry-service.md: `-d perf's "pipeline resync with
+   * history ... for pipe virtual-preview", 0.10 to 0.33 s, on this same thread. */
   dt_print(DT_DEBUG_DEV, "[geometry] chain rebuilt in %.2f ms\n", chain_ms);
 }
 

--- a/src/develop/geometry/geometry.h
+++ b/src/develop/geometry/geometry.h
@@ -21,24 +21,20 @@
  * @brief Where things are on the image, answered without a pipeline.
  *
  * @details The GUI constantly needs two geometric facts: how big the developed image is, and
- * where a point on it lands after the distorting modules have had their say. Today both are
- * answered by `dev->virtual_pipe' -- a complete, pixel-less clone of all ~95 IOP modules, their
- * history committed into real pipeline nodes, resynchronised on the GUI thread at every history
- * commit for 0.10 to 0.33 s. It renders nothing. It exists only to be walked.
+ * where a point on it lands after the distorting modules have had their say. Both used to be
+ * answered by a complete, pixel-less clone of all ~95 IOP modules -- their history committed
+ * into real pipeline nodes, resynchronised on the GUI thread at every history commit for 0.10 to
+ * 0.33 s. It rendered nothing. It existed only to be walked.
  *
- * This module replaces that with the data the walk actually consumes. Each module that changes
- * geometry publishes a small record -- its transform as values, not as a node -- and the GUI
- * composes sizes and coordinates from the ordered list. See doc/geometry-service.md for the
- * decision, the survey behind it, and the tranche plan; the traps section there is not
- * optional reading.
+ * This module is the data that walk actually consumed. Each module that changes geometry
+ * publishes a small record -- its transform as values, not as a node -- and the GUI composes
+ * sizes and coordinates from the ordered list. See doc/geometry-service.md for the decision, the
+ * survey behind it, and what each tranche moved; the traps section there is not optional reading.
  *
  * THREADING. This is GUI-thread state and takes no locks. Nothing else may touch it. The pixel
  * pipelines keep their own piece-based modify_roi and distort callbacks for rendering, and the
- * two must never be crossed: a worker that needs geometry asks its own pieces.
- *
- * STATUS: skeleton (tranche G2). No module publishes a record yet, so the chain is never
- * authoritative and nothing consumes it; it runs beside the virtual pipe and reports what it
- * would need in order to take over. Shadow mode is the whole point of this tranche.
+ * two must never be crossed: a worker that needs geometry asks its own pieces. That separation
+ * is the whole design: the GUI's copy of the module stack is gone, not shared.
  */
 
 #ifndef DT_DEVELOP_GEOMETRY_GEOMETRY_H
@@ -116,8 +112,8 @@ typedef struct dt_geometry_record_t
   void (*free_data)(void *data);        /**< NULL when ::data needs no teardown */
 
   /* Filled by the chain's own size fold, at full resolution and scale 1 -- the same numbers
-   * dt_dev_pixelpipe_get_roi_out() writes into piece->buf_in/buf_out today, which is what
-   * consumers actually read off the virtual pipe. */
+   * dt_dev_pixelpipe_get_roi_out() writes into a piece's buf_in/buf_out, which is what GUI
+   * consumers used to resolve a piece in order to read. */
   dt_iop_roi_t in;
   dt_iop_roi_t out;
 } dt_geometry_record_t;
@@ -131,10 +127,10 @@ void dt_geometry_chain_free(dt_geometry_chain_t *chain);
 /**
  * @brief Rebuild the chain from the dev's current modules and history. GUI thread only.
  *
- * @details Called wherever the virtual pipe is resynchronised today. Cheap by construction --
- * a record is a small derivation of already-committed params, with no LUT, no colour transform
- * and no disk access -- which is the point: it can run in the same step as the history write,
- * where the virtual pipe's 0.1-0.3 s could not.
+ * @details Called wherever the pixel-less pipe used to be resynchronised. Cheap by construction
+ * -- a record is a small derivation of already-committed params, with no LUT, no colour transform
+ * and no disk access -- which is the point: it runs in the same step as the history write, where
+ * its predecessor's 0.1-0.3 s could not.
  */
 void dt_geometry_chain_rebuild(struct dt_develop_t *dev);
 
@@ -142,10 +138,14 @@ void dt_geometry_chain_rebuild(struct dt_develop_t *dev);
  * @brief Can this chain answer questions yet?
  *
  * @details TRUE only when every enabled module the roster names has published a record.
- * Authority is WHOLESALE: composing some modules from records and the rest from pipeline
- * pieces would interleave two states, and the result would be wrong in a way that looks
- * plausible. Until the last roster module lands, this stays FALSE and every consumer keeps
- * using the pipe.
+ * Authority is WHOLESALE: composing some modules from records and the rest from pipeline pieces
+ * would interleave two states, and the result would be wrong in a way that looks plausible.
+ *
+ * There is no longer anything to fall back TO -- the pipe this replaced is deleted -- so a FALSE
+ * here is not a degraded mode, it is the GUI declining to answer: sizes come back FALSE, the
+ * transforms return 0 and leave their points untouched. Before an image is loaded that is simply
+ * the truth. After one is, it is a defect, and ::dt_geometry_self_check names which module owes
+ * a record.
  */
 gboolean dt_geometry_chain_authoritative(const dt_geometry_chain_t *chain);
 
@@ -180,7 +180,7 @@ int dt_geometry_backtransform(struct dt_develop_t *dev, double iop_order, int di
  * by whatever is being edited contributes nothing, exactly as it would in a full walk.
  *
  * @return 0 when the chain cannot answer -- not authoritative, no record, or that module has no
- * transform -- in which case @p points is untouched and the caller should use the pipe.
+ * transform -- in which case @p points is untouched.
  */
 int dt_geometry_module_transform(struct dt_develop_t *dev, const struct dt_iop_module_t *module,
                                  float *points, size_t points_count);
@@ -215,21 +215,17 @@ int dt_geometry_chain_compose(dt_geometry_chain_t *chain, double iop_order, int 
  */
 
 /**
- * @brief Shadow mode: compare the chain against the pipe that still owns the answer.
+ * @brief Check the chain against itself, and report what the rebuild cost.
  *
- * @details Called from the size path with whatever the virtual pipe just produced, and with
- * what each side cost. While the roster is incomplete this reports exactly which enabled
- * modules are still missing a record -- measured per image, rather than assumed from a source
- * audit -- and once it is complete it reports any divergence in size, in forward transforms and
- * in round trips, together with the two costs. Both under `-d dev'. It never changes behaviour.
+ * @details What the shadow harness became. It compared every answer against the pipe while the
+ * pipe still owned them; with the pipe gone the only checks left are identities the chain must
+ * satisfy on its own -- the round trip, and the bound partition. See the comment on the
+ * definition for what that does and does not still catch. Under `-d dev'; never changes
+ * behaviour.
  *
- * @param chain_ms what the rebuild cost. The virtual pipe's counterpart is NOT measured here:
- * its work is done in _sync_virtual_pipe(), off this path, and is already reported by `-d perf'
- * as "pipeline resync with history ... for pipe virtual-preview". Timing it here would only ever
- * catch a resync that had nothing to do, and report ~0 ms for the side that is expensive.
+ * @param chain_ms what the rebuild cost.
  */
-void dt_geometry_shadow_check(struct dt_develop_t *dev, int pipe_width, int pipe_height,
-                              double chain_ms);
+void dt_geometry_self_check(struct dt_develop_t *dev, double chain_ms);
 
 #ifdef __cplusplus
 }

--- a/src/develop/masks/masks_distort.h
+++ b/src/develop/masks/masks_distort.h
@@ -25,9 +25,10 @@
  * can grab; the pixel pipeline calls them, on a worker thread, to rasterise the mask a module
  * actually blends with. They are the same geometry either way, which is why they are one
  * function, and the difference between the two callers used to be expressed by handing them a
- * different `dt_dev_pixelpipe_t *`: the GUI passed `dev->virtual_pipe`, the worker passed its own.
+ * different `dt_dev_pixelpipe_t *`: the GUI passed a pixel-less clone of the pipeline, the worker
+ * passed its own.
  *
- * That stops working when the virtual pipe goes away, and the fix is not to give the GUI a
+ * That stopped working when the clone was deleted, and the fix was not to give the GUI a
  * different pipe but to name what the builders were reading out of one. It is three things: the
  * full-resolution image size, how finely to sample the outline, and a way to compose the module
  * stack around a given iop_order. This record supplies all three, and there are exactly two
@@ -38,7 +39,7 @@
  * -- not some other view of the same history.
  *
  * THE GUI SUPPLIER composes through develop/geometry/geometry.h, which answers from published
- * records and falls back to the pixel-less pipe until every geometry module has published one.
+ * records.
  *
  * Nothing else may implement this. Two suppliers are a seam; three are a fork.
  */
@@ -93,7 +94,7 @@ static inline dt_masks_distort_t dt_masks_distort_for_pipe(dt_dev_pixelpipe_t *p
  * @brief The GUI supplier: compose through the geometry service, at full resolution, one pixel
  * at a time.
  *
- * @details The step is 1 because that is what the GUI has always had: the virtual pipe this
+ * @details The step is 1 because that is what the GUI has always had: the pixel-less pipe this
  * replaces was never given a rasterisation step, so it kept the one its init set, and outlines
  * the user drags are drawn pixel-accurate. The size is the raw geometry, which is what that
  * pipe's input was set from.

--- a/src/iop/ashift.c
+++ b/src/iop/ashift.c
@@ -2537,7 +2537,7 @@ static void do_crop(dt_iop_module_t *self, dt_iop_ashift_params_t *p)
     g->grid_hash = DT_PIXELPIPE_CACHE_HASH_INVALID;
     if(g->editing)
     {
-      dt_dev_pixelpipe_sync_virtual(self->dev, DT_DEV_PIPE_SYNCH);
+      dt_geometry_chain_rebuild(self->dev);
       dt_dev_get_thumbnail_size(self->dev);
       dt_dev_pixelpipe_resync_history_all(self->dev);
     }
@@ -2545,9 +2545,9 @@ static void do_crop(dt_iop_module_t *self, dt_iop_ashift_params_t *p)
   }
 
   // Auto-crop is a purely geometric fit: it only needs ashift's *full* (uncropped) input size, not
-  // pixel data. Read it from the virtual-pipe piece, which is synchronized on the GUI thread and
-  // remains available when the preview worker exact-hits downstream cache entries without running
-  // ashift's process() to populate g->buf. ashift's roi_in is crop-dependent, while buf_in is the
+  // pixel data. Read it from the geometry record, which is GUI-thread state and remains available
+  // when the preview worker exact-hits downstream cache entries without running ashift's process()
+  // to populate g->buf. ashift's roi_in is crop-dependent, while buf_in is the
   // stable full input geometry required by the fit.
   int crop_width = 0, crop_height = 0;
   dt_iop_roi_t crop_in;
@@ -2710,7 +2710,7 @@ static void do_crop(dt_iop_module_t *self, dt_iop_ashift_params_t *p)
 
   if(g->editing)
   {
-    dt_dev_pixelpipe_sync_virtual(self->dev, DT_DEV_PIPE_SYNCH);
+    dt_geometry_chain_rebuild(self->dev);
     dt_dev_get_thumbnail_size(self->dev);
     dt_dev_pixelpipe_resync_history_all(self->dev);
   }
@@ -2830,7 +2830,12 @@ static gboolean _draw_retrieve_lines_from_params(dt_iop_module_t *self, dt_iop_a
   dt_iop_ashift_params_t *p = _get_ashift_params(self);
   if(IS_NULL_PTR(g) || IS_NULL_PTR(p)) return FALSE;
 
-  dt_dev_pixelpipe_iop_t *piece = dt_dev_distort_get_iop_pipe(self->dev->virtual_pipe, self);
+  /* The saved lines are in the raw frame, and so is the size they are measured against -- what
+   * used to be read off a pipe piece's iwidth/iheight, which is the pipe's own input size. Ask
+   * the dev for it, the same way _do_get_structure_lines() below does. */
+  int32_t raw_width = 0;
+  int32_t raw_height = 0;
+  if(!dt_dev_geometry_get_raw_size(self->dev, &raw_width, &raw_height)) return FALSE;
 
   if(method == ASHIFT_METHOD_QUAD
      && p->last_quad_lines[0] > 0.0f && p->last_quad_lines[1] > 0.0f
@@ -2865,8 +2870,8 @@ static gboolean _draw_retrieve_lines_from_params(dt_iop_module_t *self, dt_iop_a
       g->horizontal_count = 2;
       g->vertical_weight = 2.0;
       g->horizontal_weight = 2.0;
-      g->lines_in_width = piece->iwidth;
-      g->lines_in_height = piece->iheight;
+      g->lines_in_width = raw_width;
+      g->lines_in_height = raw_height;
       g->current_structure_method = method;
       return TRUE;
     }
@@ -2909,8 +2914,8 @@ static gboolean _draw_retrieve_lines_from_params(dt_iop_module_t *self, dt_iop_a
       g->horizontal_count = hnb;
       g->vertical_weight = (float)vnb;
       g->horizontal_weight = (float)hnb;
-      g->lines_in_width = piece->iwidth;
-      g->lines_in_height = piece->iheight;
+      g->lines_in_width = raw_width;
+      g->lines_in_height = raw_height;
       g->current_structure_method = method;
       return TRUE;
     }
@@ -3755,34 +3760,21 @@ error:
   return FALSE;
 }
 
-/* this function replaces this sentence, it calls distort_transform() for this module on the pipe
-if(!dt_dev_distort_transform_plus(self->dev, self->dev->virtual_pipe, self->priority, self->priority + 1,
-      (float *)V, 4))
-*/
-static int call_distort_transform(dt_dev_pixelpipe_t *pipe, struct dt_iop_module_t *self,
-                                  float *points, size_t points_count)
+/* This module's own transform and nothing else -- no direction bound expresses that, since
+ * FORW_INCL at this module's own iop_order includes everything after it too.
+ *
+ * It used to be done by resolving this module's piece on the GUI's pixel-less pipe and invoking
+ * its distort_transform() by hand, with the focused-module exception applied around it. The
+ * geometry service expresses the whole thing directly and applies the same exception, so what is
+ * left is the call.
+ *
+ * The old hand-rolled version deliberately did NOT test piece->enabled: it is FALSE for exactly
+ * the first mouse_moved following a button_pressed while ASHIFT_CROP_ASPECT is active, which drew
+ * one frame of the centre image without the crop overlay. Records carry their enabled state from
+ * history rather than from a piece mid-commit, so that flicker has no equivalent here. */
+static int call_distort_transform(struct dt_iop_module_t *self, float *points, size_t points_count)
 {
-  /* This module's own transform and nothing else. The geometry service expresses that directly;
-   * the pipe cannot, which is why the piece has to be resolved and its callback invoked by hand
-   * below. Both honour the focused-module exception, so the two agree on when this contributes
-   * nothing at all. */
-  if(dt_geometry_module_transform(self->dev, self, points, points_count)) return 1;
-
-  int ret = 0;
-  if(pipe == self->dev->virtual_pipe) dt_dev_virtual_pipe_ensure_synced(self->dev);
-  dt_dev_pixelpipe_iop_t *piece = dt_dev_distort_get_iop_pipe(pipe, self);
-  if(IS_NULL_PTR(piece)) return ret;
-  if(piece->module == self && /*piece->enabled && */  //see note below
-     !dt_dev_pixelpipe_activemodule_disables_currentmodule(pipe->dev, piece->module))
-  {
-    if(piece->module->distort_transform)
-    ret = piece->module->distort_transform(piece->module, pipe, piece, points, points_count);
-  }
-  return ret;
-  //NOTE: piece->enabled is FALSE for exactly the first mouse_moved event following a button_pressed event
-  //  when ASHIFT_CROP_ASPECT is active, which causes the first gui_post_expose call on starting to resize
-  //  the crop box to draw the center image without the crop overlay, resulting in an annoying visual glitch.
-  //  Removing the check appears to have no adverse effects and eliminates the glitch.
+  return dt_geometry_module_transform(self->dev, self, points, points_count);
 }
 
 void gui_post_expose(struct dt_iop_module_t *self, cairo_t *cr, int32_t width, int32_t height,
@@ -3891,7 +3883,7 @@ void gui_post_expose(struct dt_iop_module_t *self, cairo_t *cr, int32_t width, i
   dt_dev_clip_roi(dev, cr, width, height);
   dt_dev_rescale_roi(dev, cr, width, height);
 
-  // we draw the cropping area; use the input ROI from the virtual pipe piece
+  // we draw the cropping area; use this module's own input rectangle
   dt_iop_roi_t mod_in;
   if(!dt_dev_module_geometry_gui(self->dev, self, &mod_in, NULL))
   {
@@ -3910,7 +3902,7 @@ void gui_post_expose(struct dt_iop_module_t *self, cairo_t *cr, int32_t width, i
                     { ixo + iwd,  iyo       } };
 
   // convert coordinates of corners to coordinates of this module's output
-  if(!call_distort_transform(self->dev->virtual_pipe, self, (float *)V, 4))
+  if(!call_distort_transform(self, (float *)V, 4))
     return;
 
   // get x/y-offset as well as width and height of output buffer
@@ -3927,10 +3919,10 @@ void gui_post_expose(struct dt_iop_module_t *self, cairo_t *cr, int32_t width, i
   // Paint black outside area when not in editing mode then returns.
   if(!g->editing)
   {
-    if(!dt_dev_distort_transform_plus(self->dev, self->dev->virtual_pipe, self->iop_order,
+    if(!dt_dev_distort_transform_gui(self->dev, self->iop_order,
                                     DT_DEV_TRANSFORM_DIR_FORW_EXCL, (float *)V, 4))
       return;
-    const float scale_factor = dt_dev_get_natural_scale(dev, dev->virtual_pipe);
+    const float scale_factor = dt_dev_get_natural_scale(dev, dev->preview_pipe);
     for(size_t i = 0; i < 4; i++)
     {
       V[i][0] *= scale_factor;
@@ -4025,12 +4017,10 @@ void gui_post_expose(struct dt_iop_module_t *self, cairo_t *cr, int32_t width, i
   // no structural data or visibility switched off? -> stop here
   if(g->fitting || IS_NULL_PTR(g->lines) || IS_NULL_PTR(g->buf) || !self->enabled) return;
 
-  // ensure virtual pipe params are in sync so distortions use current settings
-  if(dt_dev_pixelpipe_get_history_hash(dev->virtual_pipe) != dt_dev_get_history_hash(dev))
-    dt_dev_pixelpipe_sync_virtual(dev, DT_DEV_PIPE_TOP_CHANGED);
-
-  // get hash value that changes if distortions from here to the end of the pixelpipe changed
-  // virtual_pipe doesn't process pixels, so its hash isn't reliable for invalidation.
+  // get hash value that changes if distortions from here to the end of the pixelpipe changed.
+  // The composed geometry has no hash of its own -- it is rebuilt wherever a pipe flag is raised,
+  // so it cannot be stale here -- and the preview pipe's is what actually tracks the distortions
+  // these points are drawn against.
   const uint64_t hash = dt_dev_pixelpipe_get_hash(dev->preview_pipe);
   // get hash value that changes if coordinates of lines have changed
   const uint64_t lines_hash = _get_lines_hash(g->lines, g->lines_count);
@@ -5416,12 +5406,12 @@ static void _enter_edit_mode(GtkToggleButton* button, struct dt_iop_module_t *se
     gtk_widget_set_sensitive(g->commit_button, FALSE);
   }
 
-  // Entering or leaving edit mode changes ashift's runtime crop contract. Settle that contract on
-  // the virtual pipe first, then publish the resulting full-image dimensions before waking either
-  // pixel worker. Resyncing first and queuing separate ZOOMED updates afterwards let a worker start
+  // Entering or leaving edit mode changes ashift's runtime crop contract. Settle the composed
+  // geometry first, then publish the resulting full-image dimensions before waking either pixel
+  // worker. Resyncing first and queuing separate ZOOMED updates afterwards let a worker start
   // with the previous ROI, get killed by the next update, and repeatedly feed slightly different
   // preview dimensions back into the GUI geometry.
-  dt_dev_pixelpipe_sync_virtual(self->dev, DT_DEV_PIPE_SYNCH);
+  dt_geometry_chain_rebuild(self->dev);
   dt_dev_get_thumbnail_size(self->dev);
   dt_dev_pixelpipe_resync_history_all(self->dev);
 }

--- a/src/iop/colorequal.c
+++ b/src/iop/colorequal.c
@@ -152,7 +152,7 @@ typedef struct dt_iop_colorequal_global_data_t
 {
   // Truly global, read-only-after-init state only. Do NOT add a shared LUT/params cache
   // here: this struct is the same instance for every module instance, every piece, and
-  // every pipe (full/preview/thumbnail/export/virtual-preview) of colorequal in the whole
+  // every pipe (full/preview/thumbnail/export) of colorequal in the whole
   // application -- there is exactly one of it, not one per instance. A memoized LUT stored
   // here can only ever hold one instance's content at a time, and gets silently overwritten
   // by whichever piece/instance last committed -- including disabled instances, since

--- a/src/iop/colorout.c
+++ b/src/iop/colorout.c
@@ -108,7 +108,7 @@ typedef struct dt_iop_colorout_data_t
    * matrices, tone curves, extrapolation fits, or an lcms2 proofing transform. Built by
    * colorprofiles/conversion.c, which is where the lifetime and locking rules for the
    * profiles behind it are written down and enforced. NULL when the module is a nop
-   * (Lab output, or the virtual pipe, which never processes pixels). */
+   * (a Lab output). */
   dt_colorspaces_conversion_t *conversion;
 } dt_iop_colorout_data_t;
 
@@ -376,8 +376,7 @@ int process(struct dt_iop_module_t *self, const dt_dev_pixelpipe_t *pipe, const 
   const dt_iop_roi_t *const roi_out = &piece->roi_out;
   const dt_iop_colorout_data_t *const d = (dt_iop_colorout_data_t *)piece->data;
 
-  /* Lab output is a nop -- the pipe already carries Lab -- and so is the virtual pipe, which
-   * commits module contracts but never processes pixels. Both leave `conversion` NULL. */
+  /* Lab output is a nop -- the pipe already carries Lab -- and leaves `conversion` NULL. */
   if(d->type == DT_COLORSPACE_LAB || IS_NULL_PTR(d->conversion))
     dt_iop_image_copy_by_size(ovoid, ivoid, roi_out->width, roi_out->height, 4);
   else
@@ -424,8 +423,7 @@ void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pix
 
   dt_colorspaces_free_conversion(&d->conversion);
   /* Cleared here rather than beside each prepare below, so that every path which returns
-   * without building a conversion -- the virtual pipe, a Lab output -- leaves a hashed prefix
-   * that says so. */
+   * without building a conversion -- a Lab output -- leaves a hashed prefix that says so. */
   d->conversion_id = 0;
   piece->process_cl_ready = 1;
 
@@ -483,17 +481,6 @@ void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pix
   // when the output type is Lab then process is a nop, so we can avoid creating a transform
   // and the subsequent error messages
   d->type = out_type;
-  /* The virtual pipe mirrors history only for GUI geometry queries. It must
-   * still commit module contracts so ROI transforms see the same enabled
-   * modules, but creating an LCMS output transform for a pipe that will never
-   * process pixels only adds lifetime coupling to display/softproof profiles. */
-  if(!IS_NULL_PTR(pipe->dev) && pipe->dev->virtual_pipe == pipe)
-  {
-    d->type = DT_COLORSPACE_LAB;
-    piece->process_cl_ready = 0;
-    return;
-  }
-
   if(out_type == DT_COLORSPACE_LAB)
     return;
 

--- a/src/iop/colorprimaries.c
+++ b/src/iop/colorprimaries.c
@@ -118,7 +118,7 @@ typedef struct dt_iop_colorprimaries_global_data_t
 {
   // Truly global, read-only-after-init state only. Do NOT add a shared LUT/params cache
   // here: this struct is the same instance for every module instance, every piece, and
-  // every pipe (full/preview/thumbnail/export/virtual-preview) of colorprimaries in the
+  // every pipe (full/preview/thumbnail/export) of colorprimaries in the
   // whole application -- there is exactly one of it, not one per instance. A memoized LUT
   // stored here can only ever hold one instance's content at a time, and gets silently
   // overwritten by whichever piece/instance last committed -- including disabled instances,

--- a/src/iop/crop.c
+++ b/src/iop/crop.c
@@ -225,29 +225,12 @@ static void _commit_box(dt_iop_module_t *self, dt_iop_crop_gui_data_t *g, dt_iop
   if(dt_dev_distort_backtransform_gui(self->dev, self->iop_order,
                                        DT_DEV_TRANSFORM_DIR_FORW_EXCL, points, 2))
   {
-    //dt_dev_pixelpipe_iop_t *piece = dt_dev_distort_get_iop_pipe(self->dev->virtual_pipe, self);
-    //if(piece)
-    //{
-      //fprintf(stderr, "buf_out size: %dx%d\n", piece->buf_out.width, piece->buf_out.height);
+    if(mod_out.width < 1 || mod_out.height < 1) return;
 
-      if(mod_out.width < 1 || mod_out.height < 1) return;
-      /*p->cx = CLAMPF(points[0] / (float)piece->buf_out.width, 0.0f, 0.9f);
-      p->cy = CLAMPF(points[1] / (float)piece->buf_out.height, 0.0f, 0.9f);
-      p->cw = CLAMPF(points[2] / (float)piece->buf_out.width, 0.1f, 1.0f);
-      p->ch = CLAMPF(points[3] / (float)piece->buf_out.height, 0.1f, 1.0f);
-      */
-      p->cx = CLAMPF(points[0] / wd, 0.0f, 0.9f);
-      p->cy = CLAMPF(points[1] / ht, 0.0f, 0.9f);
-      p->cw = CLAMPF(points[2] / wd, 0.1f, 1.0f);
-      p->ch = CLAMPF(points[3] / ht, 0.1f, 1.0f);
-
-      /*fprintf(stderr, "Divisions: cx=%.1f/%d=%.4f, cy=%.1f/%d=%.4f, cw=%.1f/%d=%.4f, ch=%.1f/%d=%.4f\n",
-        points[0], piece->buf_out.width, p->cx,
-        points[1], piece->buf_out.height, p->cy,
-        points[2], piece->buf_out.width, p->cw,
-        points[3], piece->buf_out.height, p->ch);
-        */
-    //}
+    p->cx = CLAMPF(points[0] / wd, 0.0f, 0.9f);
+    p->cy = CLAMPF(points[1] / ht, 0.0f, 0.9f);
+    p->cw = CLAMPF(points[2] / wd, 0.1f, 1.0f);
+    p->ch = CLAMPF(points[3] / ht, 0.1f, 1.0f);
   }
 
   //fprintf(stderr, "_commit_box: cx:%.4f cy:%.4f cw:%.4f ch:%.4f\n", p->cx, p->cy, p->cw, p->ch);
@@ -263,8 +246,9 @@ static void _commit_box(dt_iop_module_t *self, dt_iop_crop_gui_data_t *g, dt_iop
  * @param self the current module data
  * @return gboolean TRUE on success, FALSE otherwise 
  */
-/* Takes no pipe: both callers passed dev->virtual_pipe, so this was never the dual-use fold it
- * resembled -- it is GUI-only, and asks the dev like every other GUI geometry query. */
+/* Takes no pipe: both callers passed the GUI's own pixel-less pipe, so this was never the
+ * dual-use fold it resembled -- it is GUI-only, and asks the dev like every other GUI geometry
+ * query. */
 static gboolean _set_max_clip(struct dt_iop_module_t *self)
 {
   dt_iop_crop_gui_data_t *g = (dt_iop_crop_gui_data_t *)dt_iop_gui_data(self);

--- a/src/iop/drawlayer/coordinates.c
+++ b/src/iop/drawlayer/coordinates.c
@@ -24,11 +24,11 @@ static gboolean _virtual_piece_layer_geometry(dt_iop_module_t *self, int *layer_
   if(!IS_NULL_PTR(layer_height)) *layer_height = 0;
   if(IS_NULL_PTR(self) || IS_NULL_PTR(self->dev)) return FALSE;
 
-  /* GUI coordinate mapping should prefer the virtual pipe geometry because it
-   * tracks the currently committed distortion stack even before the global
-   * darkroom ROI bookkeeping is fully refreshed. Falling back to `dev->roi`
-   * too early makes the first displayed layer appear stretched until the next
-   * display-pipe refresh catches up. */
+  /* GUI coordinate mapping should prefer the composed geometry because it tracks
+   * the currently committed distortion stack even before the global darkroom ROI
+   * bookkeeping is fully refreshed. Falling back to `dev->roi` too early makes the
+   * first displayed layer appear stretched until the next display-pipe refresh
+   * catches up. */
   int resolved_width = 0;
   int resolved_height = 0;
   dt_dev_processed_size_gui(self->dev, &resolved_width, &resolved_height);

--- a/src/iop/iop_api.h
+++ b/src/iop/iop_api.h
@@ -200,8 +200,8 @@ DEFAULT(gboolean, has_defaults, struct dt_iop_module_t *self);
 DEFAULT(gboolean, runtime_data_hash, struct dt_iop_module_t *self, struct dt_dev_pixelpipe_t *pipe,
                                      const struct dt_dev_pixelpipe_iop_t *piece);
 
-/** Publish this module's geometry as data, for develop/geometry (the service replacing the
- *  pixel-less virtual pipe -- see doc/geometry-service.md).
+/** Publish this module's geometry as data, for develop/geometry (the service that replaced the
+ *  GUI's pixel-less clone of the pipeline -- see doc/geometry-service.md).
  *
  *  Fill @p record's vtable/data and return TRUE; return FALSE (the default) for a module that
  *  does not change geometry. Called on the GUI thread.

--- a/src/iop/lens.cc
+++ b/src/iop/lens.cc
@@ -2668,26 +2668,16 @@ void gui_update(struct dt_iop_module_t *self)
   // Which corrections are actually available/applied only depends on the current camera+lens+params
   // combo, not on process() having just run -- so don't gate the label on the pixel pipe having
   // (re)executed (it may not: a pixelpipe cache hit skips process() entirely, e.g. after undo/redo
-  // to a recently-rendered history state, leaving the label blank forever otherwise). commit_params()
-  // already wrote this exact lensfun data into the synced piece regardless of that; read it back the
-  // same GUI-thread-safe way ashift reads piece->buf_in from the virtual pipe.
+  // to a recently-rendered history state, leaving the label blank forever otherwise).
   /* The geometry record IS this data -- geometry_record() builds it with the same constructor
-   * commit_params() uses -- so ask the service for it, and the synced piece only while the
-   * service cannot answer. This is the one consumer in the migration that wants a module's
-   * committed state rather than a rectangle. */
+   * commit_params() uses -- so ask the service for it. This is the one consumer in the migration
+   * that wants a module's committed state rather than a rectangle. */
   const dt_iop_lensfun_data_t *lens_d = NULL;
   const dt_geometry_record_t *const lens_record
       = dt_geometry_chain_find(self->dev->geometry_chain, self->op, self->multi_priority);
   if(dt_geometry_chain_authoritative(self->dev->geometry_chain) && !IS_NULL_PTR(lens_record)
      && !IS_NULL_PTR(lens_record->data))
     lens_d = &((const dt_iop_lens_geometry_t *)lens_record->data)->data;
-  else
-  {
-    dt_dev_virtual_pipe_ensure_synced(self->dev);
-    const dt_dev_pixelpipe_iop_t *const lens_piece
-        = dt_dev_distort_get_iop_pipe(self->dev->virtual_pipe, self);
-    if(!IS_NULL_PTR(lens_piece)) lens_d = (const dt_iop_lensfun_data_t *)lens_piece->data;
-  }
 
   dt_iop_roi_t lens_in;
   const gboolean have_dims = dt_dev_module_geometry_gui(self->dev, self, &lens_in, NULL);

--- a/src/iop/liquify.c
+++ b/src/iop/liquify.c
@@ -2966,10 +2966,16 @@ void gui_post_expose(struct dt_iop_module_t *module,
   memcpy(&copy_params, &g->params, sizeof(dt_iop_liquify_params_t));
   dt_iop_gui_leave_critical_section(module);
 
-  // distort all points
-  if(dt_dev_pixelpipe_get_history_hash(develop->virtual_pipe) != dt_dev_get_history_hash(develop))
-    dt_dev_pixelpipe_sync_virtual(develop, DT_DEV_PIPE_TOP_CHANGED);
-  const distort_params_t d_params = { develop, develop->virtual_pipe, NULL, 1.0, 1.0, DT_DEV_TRANSFORM_DIR_ALL, FALSE };
+  /* Distort all points, through the geometry service. Nothing is resynchronised first: the
+   * chain is rebuilt wherever a pipe flag is raised, and this fold excludes the module itself
+   * (BACK_EXCL then FORW_EXCL), so the live params being dragged are not what it reads. If the
+   * chain cannot answer, its compose leaves the points in RAW coordinates -- which would draw
+   * the whole path in the wrong place -- so draw nothing instead. */
+  if(!dt_geometry_chain_authoritative(develop->geometry_chain))
+    return;
+
+  const distort_params_t d_params = { develop, NULL, develop->geometry_chain, 1.0, 1.0,
+                                      DT_DEV_TRANSFORM_DIR_ALL, FALSE };
   _distort_paths(module, &d_params, &copy_params);
 
   // You're not supposed to understand this

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -1968,7 +1968,6 @@ void leave(dt_view_t *self)
   dev->exit = 1;
   dt_atomic_set_int(&dev->pipe->shutdown, TRUE);
   dt_atomic_set_int(&dev->preview_pipe->shutdown, TRUE);
-  if(dev->virtual_pipe) dt_atomic_set_int(&dev->virtual_pipe->shutdown, TRUE);
   dev->pipelines_started = FALSE;
 
   /* dev->exit / the shutdown atomics above are only checked by the darkroom worker thread
@@ -2050,13 +2049,6 @@ void leave(dt_view_t *self)
   dt_dev_set_backbuf(&dev->preview_pipe->backbuf, 0, 0, 0, DT_PIXELPIPE_CACHE_HASH_INVALID,
                      DT_PIXELPIPE_CACHE_HASH_INVALID);
   dt_pthread_mutex_unlock(&dev->preview_pipe->busy_mutex);
-
-  dt_pthread_mutex_lock(&dev->virtual_pipe->busy_mutex);
-  dt_dev_pixelpipe_cleanup_nodes(dev->virtual_pipe);
-  dt_dev_pixelpipe_cache_unref_hash(dt_dev_backbuf_get_hash(&dev->virtual_pipe->backbuf));
-  dt_dev_set_backbuf(&dev->virtual_pipe->backbuf, 0, 0, 0, DT_PIXELPIPE_CACHE_HASH_INVALID,
-                     DT_PIXELPIPE_CACHE_HASH_INVALID);
-  dt_pthread_mutex_unlock(&dev->virtual_pipe->busy_mutex);
 
   /* Device-side cache payloads are only an acceleration layer. Once darkroom
    * leaves, drop the cl_mem objects these pipes produced -- but only on the

--- a/src/views/studio_capture.c
+++ b/src/views/studio_capture.c
@@ -298,7 +298,6 @@ static void _studio_dev_teardown(dt_studio_capture_t *d)
   dev->exit = 1;
   dt_atomic_set_int(&dev->pipe->shutdown, TRUE);
   dt_atomic_set_int(&dev->preview_pipe->shutdown, TRUE);
-  if(dev->virtual_pipe) dt_atomic_set_int(&dev->virtual_pipe->shutdown, TRUE);
   dev->pipelines_started = FALSE;
 
   // Stop module background threads before freeing the nodes/history they read.
@@ -321,16 +320,6 @@ static void _studio_dev_teardown(dt_studio_capture_t *d)
   dt_dev_set_backbuf(&dev->preview_pipe->backbuf, 0, 0, 0, DT_PIXELPIPE_CACHE_HASH_INVALID,
                      DT_PIXELPIPE_CACHE_HASH_INVALID);
   dt_pthread_mutex_unlock(&dev->preview_pipe->busy_mutex);
-
-  if(dev->virtual_pipe)
-  {
-    dt_pthread_mutex_lock(&dev->virtual_pipe->busy_mutex);
-    dt_dev_pixelpipe_cleanup_nodes(dev->virtual_pipe);
-    dt_dev_pixelpipe_cache_unref_hash(dt_dev_backbuf_get_hash(&dev->virtual_pipe->backbuf));
-    dt_dev_set_backbuf(&dev->virtual_pipe->backbuf, 0, 0, 0, DT_PIXELPIPE_CACHE_HASH_INVALID,
-                       DT_PIXELPIPE_CACHE_HASH_INVALID);
-    dt_pthread_mutex_unlock(&dev->virtual_pipe->busy_mutex);
-  }
 
   dt_dev_pixelpipe_cache_flush_clmem_for_pipe(dev->pipe->last_devid);
   if(dev->preview_pipe->last_devid != dev->pipe->last_devid)


### PR DESCRIPTION
Sixteenth and last tranche of the geometry service (`doc/geometry-service.md`, #1163). Stacked on
#1183 (G15).

The GUI kept `dev->virtual_pipe`: a complete clone of the module stack — every one of the ~95 IOPs
given a node, its parameters committed from history — that never processed a pixel. It existed so
the GUI thread could answer two questions synchronously: how big the developed image is, and where
a point on it lands. Fifteen tranches moved both answers onto published per-module records. This
one removes what they replaced.

### What goes

- `dev->virtual_pipe`, its allocation and cleanup, and its teardown in `views/darkroom.c`'s
  `leave()` and `views/studio_capture.c`'s.
- `_sync_virtual_pipe()`, which resynced it at every flag-raising path, and
  `dt_dev_virtual_pipe_ensure_synced()`, which caught it up for a consumer that still read it. The
  five call sites now just rebuild the chain — which they were already doing alongside.
- Every fallback: the four `_gui` transform wrappers, `dt_dev_module_geometry_gui()`,
  `dt_dev_processed_size_gui()`'s pipe tier, `iop/ashift.c`'s hand-rolled per-module transform,
  `iop/lens.cc`'s committed-data read, `iop/liquify.c`'s overlay fold.
- `iop/colorout.c`'s "this is the virtual pipe" early return, and `dev_history.c`'s bookkeeping
  entry for a third pipe.

`ANSEL_GEOMETRY_DISABLE` goes with them. It cleared the authority flag so every consumer fell back
to the pipe, which was the right bisection tool while there was something to fall back to; with the
fallbacks gone it can only turn the GUI off.

### Shadow mode becomes a self-check

`dt_geometry_shadow_check()` compared every answer against the pipe — which is what caught the chain
composing modules the pipe was suppressing, and why the focus exception is evaluated live. That
reference is gone with the pipe, so `dt_geometry_self_check()` tests identities the chain must
satisfy on its own:

- **the round trip** — transform then backtransform over the whole chain returns the point it
  started from, which exercises every evaluator's inverse;
- **the bound partition** — `FORW_INCL(x)` after `BACK_EXCL(x)` must equal `DIR_ALL`, and likewise
  `FORW_EXCL(x)` after `BACK_INCL(x)`, for `x` at every module's own `iop_order`. That is the bound
  bookkeeping the module GUIs depend on: they ask for their own `iop_order`, never `DIR_ALL`.

What no longer has a check is a chain that is *self-consistently* wrong: both halves of a partition
composing the same wrong subset still add up. That check needed a second implementation, and keeping
a whole pipeline alive to be one is the cost this service exists to remove. Stated in the code.

### Authority

Still wholesale — composing some modules from records and the rest from somewhere else interleaves
two states, and the result is wrong in a way that looks plausible. Its failure mode changes: a
roster module without a record used to leave consumers on the pipe, and now leaves the GUI unable
to size the image, with the missing modules named under `-d dev`. Loud rather than silently
degraded, which is the right direction once "half from records, half from somewhere else" is the
alternative.

### Verification

- `virtual_pipe` / `sync_virtual` / `ensure_synced` / `ANSEL_GEOMETRY_DISABLE` ratchet: **110 matching lines → 0**.
- Builds clean in Release and in `build-nofeatures` (the `USE_OPENCL=OFF` CI mirror).
- `tools/check_export_pixels.sh HEAD~1 HEAD <NEF>`: both variants (colorout-chosen output profile, and forced sRGB) **3 217 408 pixels identical**, on `_DSC9410.NEF`.
- Static gates: `pragma_once_to_guards --verify` clean, `include_graph --summary` cycles 0,
  `check_module_boundaries.sh` all baselines held.

### Sequencing

G15 (#1183) has not been exercised interactively yet, and this PR deletes the fallbacks that make
`ANSEL_GEOMETRY_DISABLE` a working bisection switch. Worth landing after G15 has had a session in
the darkroom, not before.
