### PR TITLE
Backbuffer: publish the shape and the cacheline as one fact

### DIFF
--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -515,8 +515,10 @@ static void dt_dev_resync_mipmap_cache(dt_develop_t *dev, dt_dev_pixelpipe_t *pi
 {
   const int32_t imgid = pipe->dev->image_storage.id;
 
-  // Get the mip size that is at most as big as our pipeline backbuf
-  dt_mipmap_size_t mip = dt_mipmap_cache_get_fitting_size(pipe->backbuf.width, pipe->backbuf.height, imgid);
+  // Get the mip size that is at most as big as our pipeline backbuf. One read: these dimensions
+  // are handed to the mipmap cache alongside the payload below, so they must describe it.
+  const dt_backbuf_state_t published = dt_dev_backbuf_snapshot(&pipe->backbuf);
+  dt_mipmap_size_t mip = dt_mipmap_cache_get_fitting_size(published.width, published.height, imgid);
   
   // Flush backup to mipmap_cache. This runs after dt_dev_pixelpipe_process() released the OpenCL device
   // lock, so we must NOT pass pipe->devid (now stale/unlocked): a device-only payload would otherwise be
@@ -530,7 +532,7 @@ static void dt_dev_resync_mipmap_cache(dt_develop_t *dev, dt_dev_pixelpipe_t *pi
     dt_dev_pixelpipe_cache_rdlock_entry(TRUE, entry);
     dt_colorprofiles_settings_t settings;
     dt_colorprofiles_get_settings(&settings);
-    dt_mipmap_cache_swap_at_size(imgid, mip, data, pipe->backbuf.width, pipe->backbuf.height,
+    dt_mipmap_cache_swap_at_size(imgid, mip, data, published.width, published.height,
                                  settings.display_type);
     dt_dev_pixelpipe_cache_rdlock_entry(FALSE, entry);
     dt_dev_pixelpipe_cache_ref_count_entry(FALSE, entry);
@@ -2125,11 +2127,16 @@ void dt_dev_update_mouse_effect_radius(dt_develop_t *dev)
 void dt_dev_set_backbuf(dt_backbuf_t *backbuf, const int width, const int height, const size_t bpp, 
                         const int64_t hash, const int64_t history_hash)
 {
+  /* One publication: the shape and the cacheline it describes settle together, so no consumer
+   * can pair a hash with dimensions from a different frame. The atomics are written directly
+   * rather than through the single-field setters, which bracket the counter themselves. */
+  dt_dev_backbuf_publish_begin(backbuf);
   backbuf->height = height;
   backbuf->width = width;
-  dt_dev_backbuf_set_hash(backbuf, hash);
   backbuf->bpp = bpp;
-  dt_dev_backbuf_set_history_hash(backbuf, history_hash);
+  dt_atomic_set_uint64(&backbuf->hash, (uint64_t)hash);
+  dt_atomic_set_uint64(&backbuf->history_hash, (uint64_t)history_hash);
+  dt_dev_backbuf_publish_end(backbuf);
 }
 
 // clang-format off

--- a/src/develop/pixelpipe_hb.h
+++ b/src/develop/pixelpipe_hb.h
@@ -190,6 +190,31 @@ typedef enum dt_dev_pixelpipe_cache_request_t
  * for previews and full blits to cairo and for
  * the export function.
  */
+/**
+ * @brief What the pipeline last published: which cacheline, and what shape its pixels are in.
+ *
+ * @details These five fields are ONE fact and must be read as one. `hash' names a cacheline and
+ * `width'/`height' say what shape the pixels in it are -- a cacheline records how many BYTES it
+ * holds and nothing about their layout, so a consumer that pairs a hash from one publication with
+ * dimensions from the next has no way to notice. It computes a cairo stride from the wrong width
+ * and paints the diagonal striping of a stride error, or writes a mis-shaped thumbnail into the
+ * mipmap cache. The published entry is routinely LARGER than width x height x bpp (aligned
+ * allocation, pool reuse), so a size check does not catch it either.
+ *
+ * That was reachable: `hash' was atomic and the dimensions were plain fields, so a GUI thread
+ * could read the hash, resolve its entry, and then read dimensions the worker had republished in
+ * between. It needs a publication whose SHAPE changes to become visible, which is why entering a
+ * clipping module's edit mode -- where the crop is neutralised and the frame jumps to the full
+ * transformed image -- is where it was reported.
+ *
+ * So the record carries a seqlock, exactly as dt_dev_geometry_store_t does (develop/dev_geometry.h),
+ * and ::dt_dev_backbuf_snapshot is how a consumer reads it. Do not read the fields directly to
+ * pair them with pixels; a bare read is fine only for something that pairs with nothing.
+ *
+ * WRITERS ARE SERIALISED BY CONVENTION, not by a lock: each backbuffer belongs to one pipe and is
+ * published by the thread that runs it, with the view's leave() joining that thread before it
+ * touches anything. A second concurrent publisher needs a real lock, not a second odd counter.
+ */
 typedef struct dt_backbuf_t
 {
   size_t bpp;            // bits per pixel
@@ -197,7 +222,60 @@ typedef struct dt_backbuf_t
   size_t height;         // pixel size of image
   dt_atomic_uint64 hash;         // data checksum/integrity hash, for example to connect to a cacheline
   dt_atomic_uint64 history_hash; // arbitrary state hash
+
+  /** Odd while a publication is in flight, even once it has settled. See ::dt_dev_backbuf_snapshot. */
+  dt_atomic_uint64 generation;
 } dt_backbuf_t;
+
+/** @brief One coherent publication, by value. */
+typedef struct dt_backbuf_state_t
+{
+  size_t bpp;
+  size_t width;
+  size_t height;
+  uint64_t hash;
+  uint64_t history_hash;
+} dt_backbuf_state_t;
+
+static inline void dt_dev_backbuf_publish_begin(dt_backbuf_t *backbuf)
+{
+  dt_atomic_set_uint64(&backbuf->generation, dt_atomic_get_uint64(&backbuf->generation) + 1);
+}
+
+static inline void dt_dev_backbuf_publish_end(dt_backbuf_t *backbuf)
+{
+  dt_atomic_set_uint64(&backbuf->generation, dt_atomic_get_uint64(&backbuf->generation) + 1);
+}
+
+/**
+ * @brief Read the whole record as one publication.
+ *
+ * @details Retries until a settled generation is read twice with no write in between. A
+ * publication is five stores between two counter bumps, so this converges immediately unless a
+ * writer is running right now; there is no waiting and no lock to order against anything.
+ */
+static inline dt_backbuf_state_t dt_dev_backbuf_snapshot(const dt_backbuf_t *backbuf)
+{
+  dt_backbuf_state_t state = { 0, 0, 0, DT_PIXELPIPE_CACHE_HASH_INVALID, DT_PIXELPIPE_CACHE_HASH_INVALID };
+  if(IS_NULL_PTR(backbuf)) return state;
+
+  for(;;)
+  {
+    const uint64_t before = dt_atomic_get_uint64(&backbuf->generation);
+    if(before & 1) continue;   // publication in flight
+
+    state.bpp = backbuf->bpp;
+    state.width = backbuf->width;
+    state.height = backbuf->height;
+    state.hash = dt_atomic_get_uint64(&backbuf->hash);
+    state.history_hash = dt_atomic_get_uint64(&backbuf->history_hash);
+
+    const uint64_t after = dt_atomic_get_uint64(&backbuf->generation);
+    if(before == after) break;
+  }
+
+  return state;
+}
 
 static inline uint64_t dt_dev_backbuf_get_hash(const dt_backbuf_t *backbuf)
 {
@@ -206,7 +284,9 @@ static inline uint64_t dt_dev_backbuf_get_hash(const dt_backbuf_t *backbuf)
 
 static inline void dt_dev_backbuf_set_hash(dt_backbuf_t *backbuf, const uint64_t hash)
 {
+  dt_dev_backbuf_publish_begin(backbuf);
   dt_atomic_set_uint64(&backbuf->hash, hash);
+  dt_dev_backbuf_publish_end(backbuf);
 }
 
 static inline uint64_t dt_dev_backbuf_get_history_hash(const dt_backbuf_t *backbuf)
@@ -216,7 +296,9 @@ static inline uint64_t dt_dev_backbuf_get_history_hash(const dt_backbuf_t *backb
 
 static inline void dt_dev_backbuf_set_history_hash(dt_backbuf_t *backbuf, const uint64_t history_hash)
 {
+  dt_dev_backbuf_publish_begin(backbuf);
   dt_atomic_set_uint64(&backbuf->history_hash, history_hash);
+  dt_dev_backbuf_publish_end(backbuf);
 }
 
 typedef struct dt_dev_pixelpipe_t

--- a/src/libs/navigation.c
+++ b/src/libs/navigation.c
@@ -276,8 +276,12 @@ static gboolean _lib_navigation_draw_callback(GtkWidget *widget, cairo_t *crf, g
 
     dt_dev_pixelpipe_cache_rdlock_entry(TRUE, cache_entry);
 
-    wd = dev->preview_pipe->backbuf.width;
-    ht = dev->preview_pipe->backbuf.height;
+    /* One read of the publication: the cacheline just resolved and the shape its pixels are in
+     * have to come from the same frame, or the stride below is computed from the next frame's
+     * width and this paints diagonal striping. See dt_backbuf_t. */
+    const dt_backbuf_state_t published = dt_dev_backbuf_snapshot(&dev->preview_pipe->backbuf);
+    wd = published.width;
+    ht = published.height;
     const int stride = cairo_format_stride_for_width(CAIRO_FORMAT_RGB24, wd);
 
     /* Can this cacheline hold an image of those dimensions at all?
@@ -285,13 +289,13 @@ static gboolean _lib_navigation_draw_callback(GtkWidget *widget, cairo_t *crf, g
      * The centre view asks the same question before it paints (dt_dev_lock_pipe_surface); this
      * widget did not, and handed cairo a buffer to walk with a stride computed from a width the
      * data need not have. When they disagree the thumbnail is striped diagonally, and the read
-     * runs past the allocation whenever the recorded dimensions are the larger pair -- the
-     * buffer and its dimensions are fetched separately here, from state a worker owns and can
-     * republish at a new size in between.
+     * runs past the allocation whenever the recorded dimensions are the larger pair.
      *
-     * Keep the previous thumbnail and come back on the next expose rather than draw garbage.
-     * This does not FIX a mismatch -- only the pipe that published it can -- but it stops this
-     * widget turning one into an out-of-bounds read. */
+     * The way they came to disagree -- a hash resolved from one publication paired with
+     * dimensions from the next -- is closed by the snapshot above. This stays because it answers
+     * a different question: whether the cacheline this hash names is big enough at all, which
+     * neither the snapshot nor the cache can tell. Keep the previous thumbnail and come back on
+     * the next expose rather than draw garbage. */
     const size_t required_size = (size_t)stride * (size_t)ht;
     if(wd <= 0 || ht <= 0 || dt_pixel_cache_entry_get_size(cache_entry) < required_size
        || dt_pixel_cache_entry_get_data(cache_entry) != data)
@@ -303,7 +307,7 @@ static gboolean _lib_navigation_draw_callback(GtkWidget *widget, cairo_t *crf, g
     scale = fminf(width / (float)wd, height / (float)ht);
     cairo_surface_t *tmp_surface = cairo_image_surface_create_for_data(data, CAIRO_FORMAT_RGB24, wd, ht, stride);
 
-    image_hash = dt_dev_backbuf_get_hash(&dev->preview_pipe->backbuf);
+    image_hash = published.hash;
 
     cairo_t *cri = cairo_create(d->image_surface);
     cairo_rectangle(cri, 0, 0, width, height);

--- a/src/tests/unittests/CMakeLists.txt
+++ b/src/tests/unittests/CMakeLists.txt
@@ -12,9 +12,10 @@ set(DATABASE_UNIT_TESTS
   test_preset_repository
   test_tag_selection_metadata
   test_metadata_notify
-  # Not a database test, but it wants the same standalone-binary-linking-lib_ansel treatment,
+  # Not database tests, but they want the same standalone-binary-linking-lib_ansel treatment,
   # and splitting the list to say so would be more ceremony than it is worth.
   test_pipe_cache_policy
+  test_backbuf_publish
 )
 
 foreach(test ${DATABASE_UNIT_TESTS})

--- a/src/tests/unittests/test_backbuf_publish.c
+++ b/src/tests/unittests/test_backbuf_publish.c
@@ -1,0 +1,184 @@
+/*
+    This file is part of Ansel,
+    Copyright (C) 2026 Aurélien PIERRE.
+
+    Ansel is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Ansel is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Ansel.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+/** The backbuffer publication is one fact, and a consumer must read it as one.
+ *
+ * `hash' names a cacheline; `width'/`height' say what shape the pixels in it are. A consumer
+ * that pairs a hash from one publication with dimensions from the next computes a cairo stride
+ * from a width the data does not have and paints the diagonal striping of a stride error. The
+ * cacheline cannot help: it records how many BYTES it holds and nothing about their layout, and
+ * it is routinely LARGER than width x height x bpp (aligned allocation, pool reuse), so a size
+ * check passes.
+ *
+ * The first test reproduces the cross-pairing against the fields read one at a time -- the way
+ * every display path read them -- and fails the day it stops being reproducible, which is the
+ * point: it is what says the second test is measuring something. The second asserts that a
+ * snapshot never crosses. Both run the same writer.
+ *
+ * This is a race, so the first test is written to be overwhelmingly likely rather than certain:
+ * a writer flipping between two shapes as fast as it can, against a reader that reads the hash,
+ * does a little work, and then reads the dimensions -- the same shape as
+ * "resolve the cacheline, then compute the stride". If it ever goes quiet on some machine,
+ * do not delete it: it is reporting that the window closed on that scheduler, not that the
+ * hazard is gone.
+ */
+
+#include "develop/develop.h"   // dt_dev_set_backbuf()
+#include "develop/pixelpipe_hb.h"
+
+#include <stdarg.h>
+#include <stddef.h>
+// cmocka.h declares `extern jmp_buf global_expect_assert_env' at file scope without including
+// <setjmp.h> itself. Same suppression as test_metadata_notify.c, and for the same reason.
+#include <setjmp.h>  // NOLINT(misc-include-cleaner)
+#include <stdint.h>
+#include <cmocka.h>
+
+#include <glib.h>
+
+/* Two publications a clipping module's edit mode swaps between: the cropped frame, and the full
+ * transformed one it neutralises the crop to show. Different shape, different cacheline. */
+#define SHAPE_A_W 4032
+#define SHAPE_A_H 3024
+#define SHAPE_A_HASH 0x1111111111111111ull
+#define SHAPE_B_W 5104
+#define SHAPE_B_H 3880
+#define SHAPE_B_HASH 0x2222222222222222ull
+
+typedef struct publisher_t
+{
+  dt_backbuf_t backbuf;
+  volatile gint stop;
+  guint64 publications;
+} publisher_t;
+
+static gpointer _publisher_main(gpointer user_data)
+{
+  publisher_t *p = (publisher_t *)user_data;
+  while(!g_atomic_int_get(&p->stop))
+  {
+    dt_dev_set_backbuf(&p->backbuf, SHAPE_A_W, SHAPE_A_H, 4, SHAPE_A_HASH, 1);
+    dt_dev_set_backbuf(&p->backbuf, SHAPE_B_W, SHAPE_B_H, 4, SHAPE_B_HASH, 2);
+    p->publications += 2;
+  }
+  return NULL;
+}
+
+/** @brief Is this (hash, width, height) triple one that was ever published together? */
+static gboolean _pairing_is_coherent(const uint64_t hash, const size_t width, const size_t height)
+{
+  if(hash == SHAPE_A_HASH) return width == SHAPE_A_W && height == SHAPE_A_H;
+  if(hash == SHAPE_B_HASH) return width == SHAPE_B_W && height == SHAPE_B_H;
+  return TRUE;   // the seed value; not a publication either side authored
+}
+
+/* How long to hunt. Long enough that a miss means something on an idle machine, short enough
+ * that the suite stays a suite. */
+#define HUNT_MICROSECONDS 400000
+
+static void test_field_by_field_read_crosses_publications(void **state)
+{
+  (void)state;
+  publisher_t p = { { 0 } };
+  dt_dev_set_backbuf(&p.backbuf, SHAPE_A_W, SHAPE_A_H, 4, SHAPE_A_HASH, 1);
+
+  GThread *writer = g_thread_new("backbuf-publisher", _publisher_main, &p);
+  assert_non_null(writer);
+
+  gint64 crossed = 0;
+  gint64 reads = 0;
+  const gint64 deadline = g_get_monotonic_time() + HUNT_MICROSECONDS;
+  while(g_get_monotonic_time() < deadline && crossed == 0)
+  {
+    /* The display path's shape: take the hash, resolve a cacheline from it, and only then ask
+     * how wide the pixels are. The resolve is what makes the window wide enough to matter; a
+     * compiler barrier stands in for it. */
+    const uint64_t hash = dt_dev_backbuf_get_hash(&p.backbuf);
+    __asm__ __volatile__("" ::: "memory");
+    const size_t width = p.backbuf.width;
+    const size_t height = p.backbuf.height;
+
+    reads++;
+    if(!_pairing_is_coherent(hash, width, height)) crossed++;
+  }
+
+  g_atomic_int_set(&p.stop, 1);
+  g_thread_join(writer);
+
+  print_message("field-by-field: %" G_GINT64_FORMAT " reads, %" G_GINT64_FORMAT " crossed pairings\n", reads,
+                crossed);
+  assert_true(crossed > 0);
+}
+
+static void test_snapshot_never_crosses_publications(void **state)
+{
+  (void)state;
+  publisher_t p = { { 0 } };
+  dt_dev_set_backbuf(&p.backbuf, SHAPE_A_W, SHAPE_A_H, 4, SHAPE_A_HASH, 1);
+
+  GThread *writer = g_thread_new("backbuf-publisher", _publisher_main, &p);
+  assert_non_null(writer);
+
+  gint64 crossed = 0;
+  gint64 reads = 0;
+  const gint64 deadline = g_get_monotonic_time() + HUNT_MICROSECONDS;
+  while(g_get_monotonic_time() < deadline)
+  {
+    const dt_backbuf_state_t published = dt_dev_backbuf_snapshot(&p.backbuf);
+    reads++;
+    if(!_pairing_is_coherent(published.hash, published.width, published.height)) crossed++;
+  }
+
+  g_atomic_int_set(&p.stop, 1);
+  g_thread_join(writer);
+
+  print_message("snapshot: %" G_GINT64_FORMAT " reads, %" G_GINT64_FORMAT " crossed pairings\n", reads, crossed);
+  assert_int_equal(crossed, 0);
+}
+
+/** @brief A single-field setter must publish coherently too -- the histogram backbuffers are
+ *  invalidated that way when a view leaves. */
+static void test_single_field_setter_is_a_publication(void **state)
+{
+  (void)state;
+  dt_backbuf_t backbuf = { 0 };
+  dt_dev_set_backbuf(&backbuf, SHAPE_A_W, SHAPE_A_H, 4, SHAPE_A_HASH, 1);
+
+  dt_dev_backbuf_set_hash(&backbuf, DT_PIXELPIPE_CACHE_HASH_INVALID);
+
+  const dt_backbuf_state_t published = dt_dev_backbuf_snapshot(&backbuf);
+  assert_int_equal(published.hash, DT_PIXELPIPE_CACHE_HASH_INVALID);
+  assert_int_equal(published.width, SHAPE_A_W);
+  assert_int_equal(published.height, SHAPE_A_H);
+}
+
+int main(void)
+{
+  const struct CMUnitTest tests[] = {
+    cmocka_unit_test(test_field_by_field_read_crosses_publications),
+    cmocka_unit_test(test_snapshot_never_crosses_publications),
+    cmocka_unit_test(test_single_field_setter_is_a_publication),
+  };
+  return cmocka_run_group_tests(tests, NULL, NULL);
+}
+
+// clang-format off
+// modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py
+// vim: shiftwidth=2 expandtab tabstop=2 cindent
+// kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;
+// clang-format on

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -505,7 +505,9 @@ static gboolean _render_main_direct_debug(cairo_t *cr, dt_develop_t *dev, const 
   cairo_paint(cr);
 
   if(!dt_dev_pixelpipe_is_backbufer_valid(dev->pipe, dev)) return FALSE;
-  const uint64_t hash = dt_dev_backbuf_get_hash(&dev->pipe->backbuf);
+  // One read of the publication: the hash and the shape must come from the same frame (dt_backbuf_t).
+  const dt_backbuf_state_t published = dt_dev_backbuf_snapshot(&dev->pipe->backbuf);
+  const uint64_t hash = published.hash;
   if(hash == (uint64_t)-1) return FALSE;
 
   dt_pixel_cache_entry_t *entry = NULL;
@@ -518,8 +520,8 @@ static gboolean _render_main_direct_debug(cairo_t *cr, dt_develop_t *dev, const 
 
   dt_dev_pixelpipe_cache_rdlock_entry(TRUE, entry);
 
-  const int bw = (int)dev->pipe->backbuf.width;
-  const int bh = (int)dev->pipe->backbuf.height;
+  const int bw = (int)published.width;
+  const int bh = (int)published.height;
   if(bw <= 0 || bh <= 0)
   {
     dt_dev_pixelpipe_cache_rdlock_entry(FALSE, entry);
@@ -845,8 +847,9 @@ void expose(
   cairo_t *cr = cairo_create(dev->image_surface);
   const int full_width = dt_dev_roi_request_preview_width(dev);
   const int full_height = dt_dev_roi_request_preview_height(dev);
+  const dt_backbuf_state_t preview_published = dt_dev_backbuf_snapshot(&dev->preview_pipe->backbuf);
   const uint64_t main_backbuf_hash = dt_dev_backbuf_get_hash(&dev->pipe->backbuf);
-  const uint64_t preview_backbuf_hash = dt_dev_backbuf_get_hash(&dev->preview_pipe->backbuf);
+  const uint64_t preview_backbuf_hash = preview_published.hash;
   const gboolean main_has_backbuf = main_backbuf_hash != DT_PIXELPIPE_CACHE_HASH_INVALID;
   const gboolean preview_has_backbuf = preview_backbuf_hash != DT_PIXELPIPE_CACHE_HASH_INVALID;
   // Compare main against the last main surface, not against the last source painted into
@@ -859,8 +862,8 @@ void expose(
   const gboolean preview_matches_full_image
       = preview_has_backbuf && dt_dev_pipelines_share_preview_output(dev)
         && full_width > 0 && full_height > 0
-        && dev->preview_pipe->backbuf.width == full_width
-        && dev->preview_pipe->backbuf.height == full_height;
+        && preview_published.width == (size_t)full_width
+        && preview_published.height == (size_t)full_height;
   const gboolean full_image_backbuf_ready = main_ready_for_current_view || preview_matches_full_image;
 
   dt_aligned_pixel_t bg_color = { 0.0f };
@@ -1458,7 +1461,8 @@ static void _preview_pipe_finished(gpointer instance, gpointer user_data)
   const gboolean autoset_running_before
       = !IS_NULL_PTR(_autoset_manager) && _autoset_manager->progress_cursor_active;
   const int32_t imgid = dt_dev_get_global()->image_storage.id;
-  dt_mipmap_size_t mip = dt_mipmap_cache_get_fitting_size(pipe->backbuf.width, pipe->backbuf.height, imgid);
+  const dt_backbuf_state_t published = dt_dev_backbuf_snapshot(&pipe->backbuf);
+  dt_mipmap_size_t mip = dt_mipmap_cache_get_fitting_size(published.width, published.height, imgid);
 
   // Check if the cache is ready for that mipmap size.
   dt_mipmap_buffer_t tmp;

--- a/src/views/dev_backbuf.c
+++ b/src/views/dev_backbuf.c
@@ -126,7 +126,12 @@ gboolean dt_dev_lock_pipe_surface(dt_develop_t *dev, dt_dev_pixelpipe_t *pipe, d
   if(!IS_NULL_PTR(wait))
     dt_dev_pixelpipe_cache_wait_set_owner(wait, wait_owner_tag, dev);
 
-  const uint64_t hash = dt_dev_backbuf_get_hash(&pipe->backbuf);
+  /* ONE read of the publication. The hash names the cacheline this surface will be built on and
+   * the dimensions say what shape its pixels are; reading them separately lets a republication
+   * land in between and pairs a cacheline with the next frame's width -- which is a wrong cairo
+   * stride, i.e. diagonal striping. See dt_backbuf_t. */
+  const dt_backbuf_state_t published = dt_dev_backbuf_snapshot(&pipe->backbuf);
+  const uint64_t hash = published.hash;
   if(hash == DT_PIXELPIPE_CACHE_HASH_INVALID) return keep_previous_on_fail && (!IS_NULL_PTR(locked->surface));
 
   /* Fast-path reuse is only valid if the cacheline identity/data pointer are
@@ -137,12 +142,18 @@ gboolean dt_dev_lock_pipe_surface(dt_develop_t *dev, dt_dev_pixelpipe_t *pipe, d
   if(!IS_NULL_PTR(locked->surface) && locked->hash == hash
      && dt_dev_pixelpipe_cache_peek_gui(pipe, NULL, &live_data, &live_entry, wait,
                                         _dev_backbuf_restart_cache_wait, dev)
-     && live_entry == locked->entry && live_data == locked->data)
+     && live_entry == locked->entry && live_data == locked->data
+     && locked->width == (int)published.width && locked->height == (int)published.height)
   {
-    locked->width = pipe->backbuf.width;
-    locked->height = pipe->backbuf.height;
     return TRUE;
   }
+
+  /* Note what this fast path must NOT do: assign the published dimensions to `locked' and keep
+   * the existing surface. That surface was created with a stride baked in from the dimensions it
+   * was built at, so writing new ones over it describes the cairo surface falsely -- and it also
+   * defeats the slow path's own shape check below, which compares against exactly these fields.
+   * A publication that changes the shape must build a new surface, which is what falling through
+   * to the slow path does. */
 
   struct dt_pixel_cache_entry_t *entry = NULL;
   /* GUI surfaces only borrow the currently published backbuffer. They rely on the backbuffer keepalive ref
@@ -161,8 +172,8 @@ gboolean dt_dev_lock_pipe_surface(dt_develop_t *dev, dt_dev_pixelpipe_t *pipe, d
     return FALSE;
   }
 
-  const int width = pipe->backbuf.width;
-  const int height = pipe->backbuf.height;
+  const int width = (int)published.width;
+  const int height = (int)published.height;
   const int stride = cairo_format_stride_for_width(CAIRO_FORMAT_RGB24, width);
   const size_t required_size = (size_t)stride * (size_t)height;
   const size_t entry_size = dt_pixel_cache_entry_get_size(entry);


### PR DESCRIPTION
Reported twice as a stride error — diagonal striping in the navigation thumbnail and the main
darkroom image on entering ashift's edit mode with a keystone already set, reproducible on
`DSCF0175.RAF`. The [first pass](https://github.com/aurelienpierreeng/ansel/pull/1176) added a
guard and a diagnostic and said plainly that neither was a fix for the race, because I could not
reproduce it. This is the race, measured.

### The mechanism

`dt_backbuf_t` carries five fields that are **one fact**: `hash` names a cacheline,
`width`/`height` say what shape the pixels in it are. `hash` was atomic and the dimensions were
plain fields, and every display path read them in that order — take the hash, resolve the
cacheline, then compute a cairo stride from the width. A publication landing in between pairs one
frame's pixels with the next frame's width, and the stride is then wrong for the data: diagonal
striping.

Nothing downstream can catch it:

- a cacheline records how many **bytes** it holds and nothing about their layout;
- it is routinely **larger** than `width × height × bpp` (aligned allocation, pool reuse), so the
  size check every consumer already makes passes on a large-but-wrong entry.

It also needs a publication whose **shape** changes to become visible at all — which is why a
clipping module's edit mode, where the crop is neutralised and the frame jumps to the full
transformed image, is where it gets reported.

### The fix

The record gets a seqlock — the same one `dt_dev_geometry_store_t` has used since the fix for
#1157 — and `dt_dev_backbuf_snapshot()` is how a consumer reads it. Converted: the centre view's
surface lock, darkroom's own debug surface path and its preview-matches-full-image predicate, the
navigation thumbnail, and the two mipmap-cache writes that hand dimensions and payload to the
cache together. The export path reads its own pipe's backbuffer with no concurrent publisher and
is left alone.

**A second defect in the same place.** `dt_dev_lock_pipe_surface()`'s fast path assigned the newly
published dimensions onto `locked` while keeping the surface built at the old ones — so the
surface's baked-in stride and the fields describing it disagreed, and the assignment also defeated
the slow path's own shape check further down, which compares against exactly those fields. A
publication that changes the shape now falls through and builds a new surface.

### Measured

`src/tests/unittests/test_backbuf_publish.c` — a writer flipping between two shapes, and a reader
shaped like the display path:

```
field-by-field: 1227 reads, 1 crossed pairings
snapshot:      54329 reads, 0 crossed pairings
```

The field-by-field test is kept, and is what says the snapshot test is measuring something. It
stops at the first cross, so "1" is how many it needed to find, not a rate.

Release and `build-nofeatures` build clean; 9/9 unit tests pass; `pragma_once` verify clean,
include-graph cycles 0, module boundaries all baselines held.

### Note for testing

This is on `master`, where the bug is; the geometry-service stack does not touch this path. To
exercise it on top of that stack, cherry-pick `03c5cb8b8b` — it applies cleanly.
