### PR TITLE
Geometry service: replace the GUI's pixel-less pipeline clone with published records

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -292,6 +292,5 @@ xyz1001
 zhaowq32
 
 * Sub-module samples contributors (at least 1 commit):
-Guillaume Stutin
 
 And all those of you that made previous releases possible

--- a/doc/develop-split.md
+++ b/doc/develop-split.md
@@ -236,9 +236,10 @@ in place.
   `_backend_worker_process_sample` → `_process_backend_input` →
   `dt_drawlayer_paint_interpolate_path` → the `layer_to_widget` callback →
   `dt_dev_coordinates_image_norm_to_widget()`, which reads `roi.orig_width`/`orig_height`
-  (develop.c:1100-1101) and calls `dt_dev_distort_transform_plus(self->dev->virtual_pipe, …)`
-  — a pipe documented as owned by the GUI main thread. It runs once per dab, so a window
-  resize or panel toggle during a stroke races it.
+  (develop.c:1100-1101) and composes the GUI's own geometry — at the time of writing, a
+  pixel-less pipe owned by the GUI main thread; since the geometry service replaced it
+  (`doc/geometry-service.md`), the GUI-thread-only geometry chain. Either way it runs once per
+  dab, so a window resize or panel toggle during a stroke races it.
 * `dt_focus_draw_clusters()` (gui/dtgtk/focus.h:288) reads
   `dt_dev_get_global()->roi.border_size` from `_get_image_buffer`, a `dt_control_job` body
   (thumbnail.c:657). A lighttable thumbnail render job thus reads darkroom viewport state

--- a/doc/gui-sizing.md
+++ b/doc/gui-sizing.md
@@ -1,11 +1,16 @@
 # GUI sizing without a full pixel-less pipeline — analysis and plan
 
 Written while fixing #1157, whose root cause is entangled with the virtual pipe's cost.
-Status: analysis + recommendation. Nothing here is implemented except where noted.
 
-## What the virtual pipe is, and what it costs
+**Status: superseded by what was actually built.** The maintainer picked option C, and
+`doc/geometry-service.md` is the canonical record of it: the virtual pipe no longer exists, and
+the GUI composes sizes and coordinates from published per-module records. This file is kept for
+the measurements and the consumer audit that produced that decision — everything below describes
+the tree as it was, in the present tense it was written in.
 
-`dev->virtual_pipe` is a full clone of the module stack — every one of the ~95 IOPs gets a
+## What the virtual pipe was, and what it cost
+
+`dev->virtual_pipe` was a full clone of the module stack — every one of the ~95 IOPs gets a
 node, params committed from history — that never processes a pixel. It exists so the GUI
 thread can answer two questions synchronously, without waiting for a worker pipe:
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -183,6 +183,7 @@ FILE(GLOB SOURCE_FILES
   "control/signal.c"
   "develop/develop.c"
   "develop/dev_geometry.c"
+  "develop/geometry/geometry.c"
   "develop/dev_viewport.c"
   "develop/dev_roi_request.c"
   "develop/gui_throttle.c"

--- a/src/develop/dev_geometry.h
+++ b/src/develop/dev_geometry.h
@@ -53,7 +53,7 @@ typedef struct dt_dev_image_geometry_t
   /** TRUE once the raw pair has been published from a successful mipmap read. */
   gboolean raw_inited;
 
-  /** TRUE once the processed pair has been published from the virtual pipe. There is no
+  /** TRUE once the processed pair has been published from the size fold. There is no
    *  headless producer for it today, so a caller that gets FALSE must not read 0x0 as though
    *  it were an answer -- that is the raw_width mistake, one field over. */
   gboolean processed_inited;
@@ -84,7 +84,7 @@ void dt_dev_geometry_init(struct dt_develop_t *dev);
 void dt_dev_geometry_set_raw_size(struct dt_develop_t *dev, int32_t width, int32_t height,
                                   gboolean valid);
 
-/** Publish the processed pair. GUI thread only: its producer runs the virtual pipe. */
+/** Publish the processed pair. GUI thread only: its producer is the geometry service's fold. */
 void dt_dev_geometry_set_processed_size(struct dt_develop_t *dev, int32_t width, int32_t height);
 
 /** Coherent copy of the whole record, by value -- the ordinary way to read it:

--- a/src/develop/dev_history.c
+++ b/src/develop/dev_history.c
@@ -1200,7 +1200,7 @@ dt_dev_history_item_t *dt_dev_history_cow_touch(dt_develop_t *dev, dt_dev_histor
   // dt_dev_pixelpipe_synch_top to bound the resync range). dt_dev_pixelpipe_change() holds
   // history_mutex for its whole resync, same as this splice, so a plain compare-and-assign is
   // enough -- no concurrent access is possible.
-  dt_dev_pixelpipe_t *const pipes[] = { dev->pipe, dev->preview_pipe, dev->virtual_pipe };
+  dt_dev_pixelpipe_t *const pipes[] = { dev->pipe, dev->preview_pipe };
   for(size_t i = 0; i < G_N_ELEMENTS(pipes); i++)
     if(pipes[i] && pipes[i]->last_history_item == hist)
       pipes[i]->last_history_item = clone;
@@ -1425,7 +1425,7 @@ void dt_apply_dev_history_update(dt_develop_t *dev)
   dt_dev_reload_history_items(dev, dev->image_storage.id);
   dt_dev_history_gui_update(dev);
   // Re-derive dev->roi.processed_{width,height} (and the natural scale) from the new
-  // history through the virtual pipe. Without this, a history change that alters the
+  // history, through the geometry service's size fold. Without this, a history change that alters the
   // final image geometry (e.g. removing a crop/ashift step) still renders at the old,
   // stale ROI -- same fix as _history_apply_history_end() in libs/history.c.
   if(dev->gui_attached) dt_dev_get_thumbnail_size(dev);

--- a/src/develop/dev_history.c
+++ b/src/develop/dev_history.c
@@ -676,6 +676,21 @@ static void _pop_undo(gpointer user_data, dt_undo_type_t type, dt_undo_data_t da
   // TODO: check if we need to rebuild the full pipeline and do it only if needed
   dt_dev_history_pixelpipe_update(dev, TRUE);
 
+  /* Republish the darkroom geometry, like every other path that replays history in bulk:
+   * dt_dev_pop_history_items() does it, so does the history-row click in libs/history.c, and
+   * so do image load and compress/truncate. This one did not, and undo is the path where it
+   * matters most -- undoing a crop changes the processed size, and without this the geometry
+   * record (hence natural_scale, the preview dimensions, and everything the pipes plan from)
+   * kept describing the pre-undo image until some unrelated later caller happened to refresh
+   * it. dt_dev_history_pixelpipe_update() above rebuilds the virtual pipe, so this only folds
+   * and publishes.
+   *
+   * After the history lock is released, never inside it: dt_dev_get_thumbnail_size() resyncs
+   * the virtual pipe, which takes history_mutex as reader, and the same-thread reentrancy that
+   * makes this survivable is a safety net, not a licence -- the sibling call sites all note the
+   * same ordering constraint. */
+  if(dev->gui_attached) dt_dev_get_thumbnail_size(dev);
+
   if(dev->gui_module)
   {
     dt_masks_set_edit_mode(dev->gui_module, hist->mask_edit_mode);

--- a/src/develop/dev_pixelpipe.c
+++ b/src/develop/dev_pixelpipe.c
@@ -28,6 +28,7 @@
 #include "common/paths.h"
 #include "gui/application.h"
 #include "system/dtpthread.h"
+#include "develop/geometry/geometry.h"
 #include "develop/imageop.h"
 #include "develop/pixelpipe.h"
 #include "caches/pixelpipe_cache.h"
@@ -1795,6 +1796,14 @@ static void _sync_virtual_pipe(dt_develop_t *dev, dt_dev_pixelpipe_change_t flag
   // Mirror the preview-pipe change flags and commit immediately.
   _change_pipe(dev->virtual_pipe, flag);
   dt_dev_pixelpipe_change(dev->virtual_pipe);
+
+  /* The geometry chain answers the same questions and must therefore be exactly as fresh as
+   * this pipe, not fresher and not staler: consumers now read whichever of the two can answer,
+   * and a chain rebuilt only in the size path would lag the pipe on every flag that arrives
+   * between two size publications. It is rebuilt here rather than published here -- this
+   * function raises flags, and nothing downstream may observe geometry before the publication
+   * that goes with it (see the ordering note in dt_dev_get_thumbnail_size). */
+  dt_geometry_chain_rebuild(dev);
 }
 
 void dt_dev_pixelpipe_sync_virtual(dt_develop_t *dev, dt_dev_pixelpipe_change_t flag)

--- a/src/develop/dev_pixelpipe.c
+++ b/src/develop/dev_pixelpipe.c
@@ -1793,17 +1793,35 @@ static void _sync_virtual_pipe(dt_develop_t *dev, dt_dev_pixelpipe_change_t flag
                                raw_width, raw_height, 1.0f, DT_MIPMAP_FULL);
   }
 
-  // Mirror the preview-pipe change flags and commit immediately.
+  // Mirror the preview-pipe change flags.
   _change_pipe(dev->virtual_pipe, flag);
-  dt_dev_pixelpipe_change(dev->virtual_pipe);
 
-  /* The geometry chain answers the same questions and must therefore be exactly as fresh as
-   * this pipe, not fresher and not staler: consumers now read whichever of the two can answer,
-   * and a chain rebuilt only in the size path would lag the pipe on every flag that arrives
-   * between two size publications. It is rebuilt here rather than published here -- this
-   * function raises flags, and nothing downstream may observe geometry before the publication
-   * that goes with it (see the ordering note in dt_dev_get_thumbnail_size). */
+  /* The geometry chain answers the same questions and must be exactly as fresh as the pipe it
+   * replaces -- consumers read whichever of the two can answer, and a chain rebuilt only in the
+   * size path would lag on every flag arriving between two size publications. Rebuilt here, and
+   * deliberately not PUBLISHED here: this function raises flags, and nothing may observe
+   * geometry before the publication that belongs with it (the ordering rule from #1157). */
   dt_geometry_chain_rebuild(dev);
+
+  /* And the pipe itself only when something will read it. This is the expensive half of this
+   * function -- a full resync commits every module's parameters and costs ~0.1 s on the GUI
+   * thread, measured at darkroom entry -- and it is exactly what the geometry service exists to
+   * stop paying. The flag above stays raised either way, so a later
+   * dt_dev_virtual_pipe_ensure_synced() still has everything it needs to catch the pipe up if a
+   * fallback does end up consulting it. */
+  if(!dt_geometry_chain_authoritative(dev->geometry_chain))
+    dt_dev_pixelpipe_change(dev->virtual_pipe);
+}
+
+void dt_dev_virtual_pipe_ensure_synced(dt_develop_t *dev)
+{
+  /* Catch the pixel-less pipe up with the flags raised while the geometry service was answering
+   * for it. Cheap when it is already current -- the flags are cleared by a resync -- and the
+   * only thing standing between "we stopped resyncing it eagerly" and a consumer reading a pipe
+   * that history moved out from under. */
+  if(IS_NULL_PTR(dev) || !dev->gui_attached || IS_NULL_PTR(dev->virtual_pipe)) return;
+  if(dt_dev_pixelpipe_get_changed(dev->virtual_pipe) == DT_DEV_PIPE_UNCHANGED) return;
+  dt_dev_pixelpipe_change(dev->virtual_pipe);
 }
 
 void dt_dev_pixelpipe_sync_virtual(dt_develop_t *dev, dt_dev_pixelpipe_change_t flag)

--- a/src/develop/dev_pixelpipe.c
+++ b/src/develop/dev_pixelpipe.c
@@ -39,8 +39,6 @@
 #include <stdint.h>
 #include <stdlib.h>
 
-// Keep a preview-like virtual pipe in sync with history without running pixels.
-static void _sync_virtual_pipe(dt_develop_t *dev, dt_dev_pixelpipe_change_t flag);
 static void _sync_pipe_nodes_from_history_from_node(dt_dev_pixelpipe_t *pipe,
                                                     const uint32_t history_end, GList *start_node,
                                                     const char *debug_label);
@@ -162,9 +160,7 @@ static gboolean _module_feeds_color_picker(const dt_dev_pixelpipe_t *pipe,
 
 static gchar *_get_debug_pipe_name(const dt_dev_pixelpipe_t *pipe, const dt_develop_t *dev)
 {
-  if(!IS_NULL_PTR(dev) && !IS_NULL_PTR(pipe) && dev->virtual_pipe == pipe)
-    return g_strdup("virtual-preview");
-
+  (void)dev;
   return g_strdup(dt_pixelpipe_get_pipe_name(!IS_NULL_PTR(pipe) ? pipe->type : DT_DEV_PIXELPIPE_NONE));
 }
 
@@ -404,7 +400,10 @@ void dt_dev_pixelpipe_rebuild_all_real(dt_develop_t *dev)
   if(IS_NULL_PTR(dev) || !dev->gui_attached) return;
   _change_pipe(dev->preview_pipe, DT_DEV_PIPE_REMOVE);
   _change_pipe(dev->pipe, DT_DEV_PIPE_REMOVE);
-  _sync_virtual_pipe(dev, DT_DEV_PIPE_REMOVE);
+  /* Rebuilt here, and deliberately not PUBLISHED here: these are the flag-raising paths, and
+   * nothing may observe geometry before the publication that belongs with it -- the ordering
+   * rule from the fix for #1157. */
+  dt_geometry_chain_rebuild(dev);
 }
 
 void dt_dev_pixelpipe_resync_history_main_real(dt_develop_t *dev)
@@ -417,8 +416,7 @@ void dt_dev_pixelpipe_resync_history_preview_real(dt_develop_t *dev)
 {
   if(IS_NULL_PTR(dev) || !dev->gui_attached) return;
   _change_pipe(dev->preview_pipe, DT_DEV_PIPE_SYNCH);
-  // Virtual pipe mirrors preview history for GUI coordinate transforms.
-  _sync_virtual_pipe(dev, DT_DEV_PIPE_SYNCH);
+  dt_geometry_chain_rebuild(dev);
 }
 
 void dt_dev_pixelpipe_resync_history_all_real(dt_develop_t *dev)
@@ -438,8 +436,7 @@ void dt_dev_pixelpipe_update_history_preview_real(dt_develop_t *dev)
 {
   if(IS_NULL_PTR(dev) || !dev->gui_attached) return;
   _change_pipe(dev->preview_pipe, DT_DEV_PIPE_TOP_CHANGED);
-  // Virtual pipe mirrors preview history for GUI coordinate transforms.
-  _sync_virtual_pipe(dev, DT_DEV_PIPE_TOP_CHANGED);
+  dt_geometry_chain_rebuild(dev);
 }
 
 void dt_dev_pixelpipe_update_history_all_real(dt_develop_t *dev)
@@ -453,8 +450,7 @@ void dt_dev_pixelpipe_update_zoom_preview_real(dt_develop_t *dev)
 {
   if(IS_NULL_PTR(dev) || !dev->gui_attached) return;
   _change_pipe(dev->preview_pipe, DT_DEV_PIPE_ZOOMED);
-  // Keep the virtual pipe aligned with preview ROI/zoom changes for GUI transforms.
-  _sync_virtual_pipe(dev, DT_DEV_PIPE_ZOOMED);
+  dt_geometry_chain_rebuild(dev);
 }
 
 void dt_dev_pixelpipe_update_zoom_main_real(dt_develop_t *dev)
@@ -466,7 +462,7 @@ void dt_dev_pixelpipe_update_zoom_main_real(dt_develop_t *dev)
    * best-effort backbuffer policy. */
   dt_dev_pixelpipe_set_realtime(dev->pipe, FALSE);
   _change_pipe(dev->pipe, DT_DEV_PIPE_ZOOMED);
-  _sync_virtual_pipe(dev, DT_DEV_PIPE_ZOOMED);
+  dt_geometry_chain_rebuild(dev);
 }
 
 void dt_dev_pixelpipe_reset_all(dt_develop_t *dev)
@@ -568,8 +564,7 @@ void dt_dev_pixelpipe_get_roi_in(dt_dev_pixelpipe_t *pipe, const struct dt_iop_r
   // upstream in the pipeline for proper pipeline cache invalidation, so we need to browse the pipeline
   // backwards.
 
-  // The virtual pipe is expected to be ready before calling this.
-  // This function no longer supports NULL pipes or ad-hoc temp nodes.
+  // This function does not support NULL pipes or ad-hoc temp nodes.
 
   dt_iop_roi_t roi_out_temp = roi_out;
   dt_iop_roi_t roi_in;
@@ -1492,8 +1487,8 @@ void dt_pixelpipe_get_global_hash(dt_dev_pixelpipe_t *pipe)
 
       // bypass_cache_variant (see dt_iop_module_t.bypass_cache_variant) is, like
       // request_mask_display above, module-owned GUI state whose real effect a module such as
-      // retouch applies only to this main/FULL pipe -- never to preview/virtual-preview, which
-      // always render as if none of these toggles were active. But the field itself lives on
+      // retouch applies only to this main/FULL pipe -- never to the preview pipe, which always
+      // renders as if none of these toggles were active. But the field itself lives on
       // the shared dt_iop_module_t, so it reads the same non-zero value from every pipe type. Left
       // ungated, a preview-pipe run with the same ROI/params (e.g. at zoom == fit) can compute the
       // exact same hash chain as the FULL pipe despite publishing different pixels, and either
@@ -1703,8 +1698,7 @@ void dt_dev_pixelpipe_change(dt_dev_pixelpipe_t *pipe)
     _refresh_pipe_detail_mask_state(pipe);
 
   // A call chain that already holds history_mutex as writer on this same thread can re-enter
-  // here (e.g. history-commit paths that resync the virtual pipe while still holding the write
-  // lock). dt_pthread_rwlock_rdlock is same-thread-recursive for this exact case (see
+  // here (e.g. history-commit paths that resync a pipe while still holding the write lock). dt_pthread_rwlock_rdlock is same-thread-recursive for this exact case (see
   // dtpthread.h), so this proceeds immediately instead of deadlocking or deferring the sync.
   const double _history_mutex_hold_start = dt_get_wtime();
   dt_pthread_rwlock_rdlock(&pipe->dev->history_mutex);
@@ -1773,60 +1767,6 @@ void dt_dev_pixelpipe_change(dt_dev_pixelpipe_t *pipe)
 
   dt_show_times_f(&start, "[dev_pixelpipe] pipeline resync with history", "for pipe %s", type);
   dt_free(type);
-}
-
-static void _sync_virtual_pipe(dt_develop_t *dev, dt_dev_pixelpipe_change_t flag)
-{
-  // Virtual pipe exists only for GUI geometry (ROI/mask transforms) and never processes pixels.
-  if(IS_NULL_PTR(dev) || !dev->gui_attached || IS_NULL_PTR(dev->virtual_pipe)) return;
-  int32_t raw_width = 0;
-  int32_t raw_height = 0;
-  if(!dt_dev_geometry_get_raw_size(dev, &raw_width, &raw_height) || dev->image_storage.id <= 0) return;
-
-  // Ensure its input image metadata matches the current dev state.
-  if(dev->virtual_pipe->imgid != dev->image_storage.id
-     || dev->virtual_pipe->iwidth != raw_width
-     || dev->virtual_pipe->iheight != raw_height
-     || dev->virtual_pipe->dev->image_storage.id != dev->image_storage.id)
-  {
-    dt_dev_pixelpipe_set_input(dev->virtual_pipe, dev->image_storage.id,
-                               raw_width, raw_height, 1.0f, DT_MIPMAP_FULL);
-  }
-
-  // Mirror the preview-pipe change flags.
-  _change_pipe(dev->virtual_pipe, flag);
-
-  /* The geometry chain answers the same questions and must be exactly as fresh as the pipe it
-   * replaces -- consumers read whichever of the two can answer, and a chain rebuilt only in the
-   * size path would lag on every flag arriving between two size publications. Rebuilt here, and
-   * deliberately not PUBLISHED here: this function raises flags, and nothing may observe
-   * geometry before the publication that belongs with it (the ordering rule from #1157). */
-  dt_geometry_chain_rebuild(dev);
-
-  /* And the pipe itself only when something will read it. This is the expensive half of this
-   * function -- a full resync commits every module's parameters and costs ~0.1 s on the GUI
-   * thread, measured at darkroom entry -- and it is exactly what the geometry service exists to
-   * stop paying. The flag above stays raised either way, so a later
-   * dt_dev_virtual_pipe_ensure_synced() still has everything it needs to catch the pipe up if a
-   * fallback does end up consulting it. */
-  if(!dt_geometry_chain_authoritative(dev->geometry_chain))
-    dt_dev_pixelpipe_change(dev->virtual_pipe);
-}
-
-void dt_dev_virtual_pipe_ensure_synced(dt_develop_t *dev)
-{
-  /* Catch the pixel-less pipe up with the flags raised while the geometry service was answering
-   * for it. Cheap when it is already current -- the flags are cleared by a resync -- and the
-   * only thing standing between "we stopped resyncing it eagerly" and a consumer reading a pipe
-   * that history moved out from under. */
-  if(IS_NULL_PTR(dev) || !dev->gui_attached || IS_NULL_PTR(dev->virtual_pipe)) return;
-  if(dt_dev_pixelpipe_get_changed(dev->virtual_pipe) == DT_DEV_PIPE_UNCHANGED) return;
-  dt_dev_pixelpipe_change(dev->virtual_pipe);
-}
-
-void dt_dev_pixelpipe_sync_virtual(dt_develop_t *dev, dt_dev_pixelpipe_change_t flag)
-{
-  _sync_virtual_pipe(dev, flag);
 }
 
 gboolean dt_dev_pixelpipe_is_backbufer_valid(dt_dev_pixelpipe_t *pipe)

--- a/src/develop/dev_pixelpipe.h
+++ b/src/develop/dev_pixelpipe.h
@@ -85,7 +85,7 @@ void dt_dev_pixelpipe_change_zoom_main(struct dt_develop_t *dev);
 // returns the dimensions of a virtual image of size (width_in, height_in) image after processing
 // all modules of the pipe. This chains calls to module's modify_roi_out() methods in pipeline order.
 // Doesn't actually compute pixels.
-// NOTE: pipe must be a real or virtual pipe with nodes; NULL pipes are not supported anymore.
+// NOTE: pipe must have nodes; NULL pipes are not supported anymore.
 void dt_dev_pixelpipe_get_roi_out(struct dt_dev_pixelpipe_t *pipe, const int width_in,
                                   const int height_in, int *width, int *height);
                                 
@@ -93,7 +93,7 @@ void dt_dev_pixelpipe_get_roi_out(struct dt_dev_pixelpipe_t *pipe, const int wid
 // the desired sizes from roi_out, from end to start. This chains calls to module's modify_roi_in() methods
 // in pipeline reverse order.
 // Doesn't actually compute pixels.
-// NOTE: pipe must be a real or virtual pipe with nodes; NULL pipes are not supported anymore.
+// NOTE: pipe must have nodes; NULL pipes are not supported anymore.
 void dt_dev_pixelpipe_get_roi_in(struct dt_dev_pixelpipe_t *pipe, const struct dt_iop_roi_t roi_out);
 
 // Check if current_module is performing operations that dev->gui_module (active GUI module)
@@ -111,17 +111,8 @@ gboolean dt_dev_pixelpipe_activemodule_disables_currentmodule(struct dt_develop_
 // wrapper for cleanup_nodes, create_nodes, synch_all and synch_top, decides upon changed event which one to
 // take on. also locks dev->history_mutex.
 void dt_dev_pixelpipe_change(struct dt_dev_pixelpipe_t *pipe);
-void dt_dev_pixelpipe_sync_virtual(struct dt_develop_t *dev, dt_dev_pixelpipe_change_t flag);
 
-/**
- * @brief Bring the pixel-less pipe up to date with the flags raised since it was last resynced.
- *
- * @details It is no longer resynced eagerly: while the geometry service can answer, the flags
- * are raised and the ~0.1 s resync is skipped. Anything that consults the pipe directly -- the
- * fallbacks taken when the service declines, and shadow mode -- calls this first. A no-op when
- * the pipe is already current.
- */
-void dt_dev_virtual_pipe_ensure_synced(struct dt_develop_t *dev);
+
 
 // Get the global hash of a pipe node (piece), or a fallback if none.
 uint64_t dt_dev_pixelpipe_node_hash(struct dt_dev_pixelpipe_t *pipe, 

--- a/src/develop/dev_pixelpipe.h
+++ b/src/develop/dev_pixelpipe.h
@@ -113,6 +113,16 @@ gboolean dt_dev_pixelpipe_activemodule_disables_currentmodule(struct dt_develop_
 void dt_dev_pixelpipe_change(struct dt_dev_pixelpipe_t *pipe);
 void dt_dev_pixelpipe_sync_virtual(struct dt_develop_t *dev, dt_dev_pixelpipe_change_t flag);
 
+/**
+ * @brief Bring the pixel-less pipe up to date with the flags raised since it was last resynced.
+ *
+ * @details It is no longer resynced eagerly: while the geometry service can answer, the flags
+ * are raised and the ~0.1 s resync is skipped. Anything that consults the pipe directly -- the
+ * fallbacks taken when the service declines, and shadow mode -- calls this first. A no-op when
+ * the pipe is already current.
+ */
+void dt_dev_virtual_pipe_ensure_synced(struct dt_develop_t *dev);
+
 // Get the global hash of a pipe node (piece), or a fallback if none.
 uint64_t dt_dev_pixelpipe_node_hash(struct dt_dev_pixelpipe_t *pipe, 
                                     const struct dt_dev_pixelpipe_iop_t *piece, 

--- a/src/develop/dev_roi_request.h
+++ b/src/develop/dev_roi_request.h
@@ -59,7 +59,7 @@ typedef struct dt_dev_roi_request_t
    * i.e. "all three inputs of this record have been published at least once".
    *
    * It is NOT a statement about which image those numbers describe. Between an image change
-   * republishing the raw pair and dt_dev_get_thumbnail_size() rerunning the virtual pipe,
+   * republishing the raw pair and dt_dev_get_thumbnail_size() refolding the composed geometry,
    * processed_* -- and everything derived from it -- still measures the PREVIOUS image, with
    * valid TRUE throughout. On the darkroom's own image-change path that window contains no
    * running worker (views/darkroom.c's leave() joins it before the new raw geometry is

--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -396,8 +396,9 @@ int dt_dev_get_thumbnail_size(dt_develop_t *dev)
 
   /* Rebuild the geometry chain from the same modules and history the fold above just used, and
    * hold it against the answer the pipe produced. It publishes nothing and nothing consumes it
-   * yet (G2): while its roster is incomplete it reports which modules still owe it a record,
-   * per image, and once complete it reports divergence. Both under `-d dev'.
+   * yet: while its roster is incomplete it reports which modules still owe it a record, per
+   * image, and once complete it reports divergence and the cost of each side. Both under
+   * `-d dev'.
    *
    * STRICTLY AFTER the two publications above, and never between them. Those two are one
    * atomic-looking update to a consumer: the first moves the geometry record to the new
@@ -405,11 +406,14 @@ int dt_dev_get_thumbnail_size(dt_develop_t *dev)
    * (dt_dev_roi_request_publish, since the fix for #1157). Anything inserted between them
    * widens the window in which the darkroom worker can latch the OLD request against ALREADY
    * NEW history -- which is precisely the mixed frame #1157 is about, and this rebuild is not
-   * cheap enough to be invisible there: it costs milliseconds once a module with a real lookup
-   * publishes a record, against a worker that naps in tens of milliseconds. A shadow observer
-   * must not sit inside the update it is observing. */
+   * cheap enough to be invisible there: the lens record's database lookups alone cost 2-5 ms,
+   * against a worker that naps in tens of milliseconds. A shadow observer must not sit inside
+   * the update it is observing. */
+  const double chain_start = dt_get_wtime();
   dt_geometry_chain_rebuild(dev);
-  dt_geometry_shadow_check_size(dev, processed_width, processed_height);
+  const double chain_ms = (dt_get_wtime() - chain_start) * 1000.0;
+
+  dt_geometry_shadow_check(dev, processed_width, processed_height, chain_ms);
 
 
   dt_dev_update_mouse_effect_radius(dev);

--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -391,15 +391,25 @@ int dt_dev_get_thumbnail_size(dt_develop_t *dev)
                                &processed_width, &processed_height);
   dt_dev_geometry_set_processed_size(dev, processed_width, processed_height);
 
+  // Derive and publish everything the pipes plan from, as one record.
+  dt_dev_roi_request_publish(dev);
+
   /* Rebuild the geometry chain from the same modules and history the fold above just used, and
    * hold it against the answer the pipe produced. It publishes nothing and nothing consumes it
    * yet (G2): while its roster is incomplete it reports which modules still owe it a record,
-   * per image, and once complete it reports divergence. Both under `-d dev'. */
+   * per image, and once complete it reports divergence. Both under `-d dev'.
+   *
+   * STRICTLY AFTER the two publications above, and never between them. Those two are one
+   * atomic-looking update to a consumer: the first moves the geometry record to the new
+   * processed size, the second moves the ROI request to match AND flags the pipes to replan
+   * (dt_dev_roi_request_publish, since the fix for #1157). Anything inserted between them
+   * widens the window in which the darkroom worker can latch the OLD request against ALREADY
+   * NEW history -- which is precisely the mixed frame #1157 is about, and this rebuild is not
+   * cheap enough to be invisible there: it costs milliseconds once a module with a real lookup
+   * publishes a record, against a worker that naps in tens of milliseconds. A shadow observer
+   * must not sit inside the update it is observing. */
   dt_geometry_chain_rebuild(dev);
   dt_geometry_shadow_check_size(dev, processed_width, processed_height);
-
-  // Derive and publish everything the pipes plan from, as one record.
-  dt_dev_roi_request_publish(dev);
 
 
   dt_dev_update_mouse_effect_radius(dev);

--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -379,7 +379,28 @@ int dt_dev_get_thumbnail_size(dt_develop_t *dev)
       dt_dev_pixelpipe_or_changed(dev->virtual_pipe, DT_DEV_PIPE_SYNCH);
   }
 
-  if(dt_dev_pixelpipe_get_changed(dev->virtual_pipe) != DT_DEV_PIPE_UNCHANGED)
+  /* The chain is rebuilt BEFORE the size is decided now, because it is what decides it. It is
+   * cheap -- small derivations of already-committed parameters, no LUT, no colour transform, no
+   * disk -- which is the whole point of the exercise: the resync below is not. */
+  const double chain_start = dt_get_wtime();
+  dt_geometry_chain_rebuild(dev);
+  const double chain_ms = (dt_get_wtime() - chain_start) * 1000.0;
+
+  /* Resync the pixel-less pipe only when something will actually read it: when the chain cannot
+   * answer and the fallbacks will therefore be taken, or when shadow mode is on and there would
+   * be nothing to compare against otherwise. This is where the cost of this service's absence
+   * was: measured on darkroom entry, a resync is ~0.105 s against the chain's 0.03-5 ms, and it
+   * ran on the GUI thread at every history commit.
+   *
+   * Skipping it leaves the pipe FLAGGED but not rebuilt, which is the invariant the fallbacks
+   * rely on: they run only while the chain is not authoritative, and in exactly that case the
+   * resync below has run. dt_dev_virtual_pipe_ensure_synced() is there for anything that needs
+   * to consult the pipe outside that arrangement. */
+  const gboolean chain_answers = dt_geometry_chain_authoritative(dev->geometry_chain);
+  const gboolean want_shadow = (dt_get_debug_flags() & DT_DEBUG_DEV) != 0;
+
+  if((!chain_answers || want_shadow)
+     && dt_dev_pixelpipe_get_changed(dev->virtual_pipe) != DT_DEV_PIPE_UNCHANGED)
     dt_dev_pixelpipe_change(dev->virtual_pipe);
 
   // Compute the virtual full-res output. This needs an inited history.
@@ -387,33 +408,33 @@ int dt_dev_get_thumbnail_size(dt_develop_t *dev)
   // nothing between here and there republishes the raw geometry.
   int processed_width = 0;
   int processed_height = 0;
-  dt_dev_pixelpipe_get_roi_out(dev->virtual_pipe, raw_width, raw_height,
-                               &processed_width, &processed_height);
+  int pipe_width = 0;
+  int pipe_height = 0;
+
+  if(!chain_answers || want_shadow)
+    dt_dev_pixelpipe_get_roi_out(dev->virtual_pipe, raw_width, raw_height, &pipe_width, &pipe_height);
+
+  if(chain_answers)
+    dt_geometry_chain_processed_size(dev->geometry_chain, &processed_width, &processed_height);
+  else
+  {
+    processed_width = pipe_width;
+    processed_height = pipe_height;
+  }
+
   dt_dev_geometry_set_processed_size(dev, processed_width, processed_height);
 
   // Derive and publish everything the pipes plan from, as one record.
   dt_dev_roi_request_publish(dev);
 
-  /* Rebuild the geometry chain from the same modules and history the fold above just used, and
-   * hold it against the answer the pipe produced. It publishes nothing and nothing consumes it
-   * yet: while its roster is incomplete it reports which modules still owe it a record, per
-   * image, and once complete it reports divergence and the cost of each side. Both under
-   * `-d dev'.
-   *
-   * STRICTLY AFTER the two publications above, and never between them. Those two are one
-   * atomic-looking update to a consumer: the first moves the geometry record to the new
-   * processed size, the second moves the ROI request to match AND flags the pipes to replan
-   * (dt_dev_roi_request_publish, since the fix for #1157). Anything inserted between them
-   * widens the window in which the darkroom worker can latch the OLD request against ALREADY
-   * NEW history -- which is precisely the mixed frame #1157 is about, and this rebuild is not
-   * cheap enough to be invisible there: the lens record's database lookups alone cost 2-5 ms,
-   * against a worker that naps in tens of milliseconds. A shadow observer must not sit inside
-   * the update it is observing. */
-  const double chain_start = dt_get_wtime();
-  dt_geometry_chain_rebuild(dev);
-  const double chain_ms = (dt_get_wtime() - chain_start) * 1000.0;
-
-  dt_geometry_shadow_check(dev, processed_width, processed_height, chain_ms);
+  /* Shadow mode compares against the pipe's own fold, which only exists when the pipe was
+   * resynced above -- so it is asked for, and paid for, under `-d dev' and nowhere else. It runs
+   * STRICTLY AFTER both publications and never between them: those two are one atomic-looking
+   * update, the first moving the geometry record to the new size and the second moving the ROI
+   * request to match AND flagging the pipes to replan. Anything inserted between them widens the
+   * window in which the darkroom worker latches the OLD request against ALREADY NEW history,
+   * which is the mixed frame of #1157. An observer must not sit inside the update it observes. */
+  if(want_shadow) dt_geometry_shadow_check(dev, pipe_width, pipe_height, chain_ms);
 
 
   dt_dev_update_mouse_effect_radius(dev);
@@ -1732,6 +1753,7 @@ int dt_dev_distort_transform_gui(dt_develop_t *dev, const double iop_order, cons
 {
   if(IS_NULL_PTR(dev)) return 0;
   if(dt_geometry_transform(dev, iop_order, transf_direction, points, points_count)) return 1;
+  dt_dev_virtual_pipe_ensure_synced(dev);
   return dt_dev_distort_transform_plus(dev->virtual_pipe, iop_order, transf_direction, points, points_count);
 }
 
@@ -1741,6 +1763,7 @@ int dt_dev_distort_backtransform_gui(dt_develop_t *dev, const double iop_order, 
 {
   if(IS_NULL_PTR(dev)) return 0;
   if(dt_geometry_backtransform(dev, iop_order, transf_direction, points, points_count)) return 1;
+  dt_dev_virtual_pipe_ensure_synced(dev);
   return dt_dev_distort_backtransform_plus(dev->virtual_pipe, iop_order, transf_direction, points,
                                            points_count);
 }
@@ -1782,6 +1805,7 @@ gboolean dt_dev_processed_size_gui(dt_develop_t *dev, int *width, int *height)
     return TRUE;
   }
 
+  dt_dev_virtual_pipe_ensure_synced(dev);
   if(!IS_NULL_PTR(dev->virtual_pipe) && dev->virtual_pipe->processed_width > 0
      && dev->virtual_pipe->processed_height > 0)
   {
@@ -1811,6 +1835,7 @@ gboolean dt_dev_module_geometry_gui(dt_develop_t *dev, dt_iop_module_t *module, 
     return TRUE;
   }
 
+  dt_dev_virtual_pipe_ensure_synced(dev);
   const dt_dev_pixelpipe_iop_t *const piece = dt_dev_distort_get_iop_pipe(dev->virtual_pipe, module);
   if(IS_NULL_PTR(piece)) return FALSE;
   if(!IS_NULL_PTR(in)) *in = piece->buf_in;
@@ -1821,12 +1846,14 @@ gboolean dt_dev_module_geometry_gui(dt_develop_t *dev, dt_iop_module_t *module, 
 int dt_dev_coordinates_raw_abs_to_image_abs(dt_develop_t *dev, float *points, size_t points_count)
 {
   if(dt_geometry_transform(dev, 0.0, DT_DEV_TRANSFORM_DIR_ALL, points, points_count)) return 1;
+  dt_dev_virtual_pipe_ensure_synced(dev);
   return dt_dev_distort_transform_plus(dev->virtual_pipe, 0.0f, DT_DEV_TRANSFORM_DIR_ALL, points, points_count);
 }
 
 int dt_dev_coordinates_image_abs_to_raw_abs(dt_develop_t *dev, float *points, size_t points_count)
 {
   if(dt_geometry_backtransform(dev, 0.0, DT_DEV_TRANSFORM_DIR_ALL, points, points_count)) return 1;
+  dt_dev_virtual_pipe_ensure_synced(dev);
   return dt_dev_distort_backtransform_locked(dev->virtual_pipe, 0.0f, DT_DEV_TRANSFORM_DIR_ALL, points, points_count);
 }
 

--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -1757,6 +1757,46 @@ int dt_dev_distort_backtransform_gui(dt_develop_t *dev, const double iop_order, 
  * @return FALSE when neither source can answer, in which case @p in and @p out are untouched
  * and the caller must not draw. A module that is disabled or absent has no rectangles.
  */
+/**
+ * @brief The developed image's full-resolution size, for a GUI caller.
+ *
+ * @details Three sources, in order of freshness, which is why this exists rather than a plain
+ * read of the geometry record: the chain and the pixel-less pipe are both recomputed the moment
+ * the module stack changes, while the record is only republished when the size path runs. Code
+ * that needed the newest answer used to reach into the pipe's field to get it, and had to keep
+ * its own fallback for the case where the pipe had none.
+ *
+ * @return FALSE when no source has a usable size, leaving the out-params untouched.
+ */
+gboolean dt_dev_processed_size_gui(dt_develop_t *dev, int *width, int *height)
+{
+  if(IS_NULL_PTR(dev)) return FALSE;
+
+  int w = 0;
+  int h = 0;
+  if(dt_geometry_chain_processed_size(dev->geometry_chain, &w, &h)
+     && dt_geometry_chain_authoritative(dev->geometry_chain) && w > 0 && h > 0)
+  {
+    if(!IS_NULL_PTR(width)) *width = w;
+    if(!IS_NULL_PTR(height)) *height = h;
+    return TRUE;
+  }
+
+  if(!IS_NULL_PTR(dev->virtual_pipe) && dev->virtual_pipe->processed_width > 0
+     && dev->virtual_pipe->processed_height > 0)
+  {
+    if(!IS_NULL_PTR(width)) *width = dev->virtual_pipe->processed_width;
+    if(!IS_NULL_PTR(height)) *height = dev->virtual_pipe->processed_height;
+    return TRUE;
+  }
+
+  const dt_dev_image_geometry_t geometry = dt_dev_geometry_snapshot(dev);
+  if(geometry.processed_width <= 0 || geometry.processed_height <= 0) return FALSE;
+  if(!IS_NULL_PTR(width)) *width = geometry.processed_width;
+  if(!IS_NULL_PTR(height)) *height = geometry.processed_height;
+  return TRUE;
+}
+
 gboolean dt_dev_module_geometry_gui(dt_develop_t *dev, dt_iop_module_t *module, dt_iop_roi_t *in,
                                     dt_iop_roi_t *out)
 {

--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -86,6 +86,7 @@
 #include "develop/masks.h"
 #include "caches/pixelpipe_cache.h"
 #include "gui/application.h"
+#include "develop/geometry/geometry.h"
 #include "develop/gui_throttle.h"
 #include "libs/colorpicker.h"
 #include "widgets/label.h"
@@ -149,6 +150,11 @@ void dt_dev_init(dt_develop_t *dev, int32_t gui_attached)
     dt_dev_pixelpipe_init(dev->pipe, dev);
     dt_dev_pixelpipe_init_preview(dev->preview_pipe, dev);
     dt_dev_pixelpipe_init_preview(dev->virtual_pipe, dev);
+
+    /* The geometry chain runs beside the virtual pipe and will replace it (G2 skeleton --
+     * doc/geometry-service.md). GUI devs only: it answers GUI questions and is GUI-thread
+     * state, so a headless dev has nothing to do with one. */
+    dev->geometry_chain = dt_geometry_chain_new();
   }
 
   dt_dev_set_backbuf(&dev->raw_histogram, 0, 0, 0, -1, -1);
@@ -245,6 +251,8 @@ void dt_dev_cleanup(dt_develop_t *dev)
     dt_dev_pixelpipe_cleanup(dev->virtual_pipe);
     dt_free(dev->virtual_pipe);
   }
+  dt_geometry_chain_free(dev->geometry_chain);
+  dev->geometry_chain = NULL;
 
   dt_pthread_rwlock_wrlock(&dev->history_mutex);
   while(dev->history)
@@ -382,6 +390,13 @@ int dt_dev_get_thumbnail_size(dt_develop_t *dev)
   dt_dev_pixelpipe_get_roi_out(dev->virtual_pipe, raw_width, raw_height,
                                &processed_width, &processed_height);
   dt_dev_geometry_set_processed_size(dev, processed_width, processed_height);
+
+  /* Rebuild the geometry chain from the same modules and history the fold above just used, and
+   * hold it against the answer the pipe produced. It publishes nothing and nothing consumes it
+   * yet (G2): while its roster is incomplete it reports which modules still owe it a record,
+   * per image, and once complete it reports divergence. Both under `-d dev'. */
+  dt_geometry_chain_rebuild(dev);
+  dt_geometry_shadow_check_size(dev, processed_width, processed_height);
 
   // Derive and publish everything the pipes plan from, as one record.
   dt_dev_roi_request_publish(dev);

--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -1701,13 +1701,28 @@ gchar *dt_history_item_get_name_html(const struct dt_iop_module_t *module)
 static int dt_dev_distort_backtransform_locked(const dt_dev_pixelpipe_t *pipe, const double iop_order,
                                                const int transf_direction, float *points, size_t points_count);
 
+/* These two are where the geometry service takes over from the pixel-less pipe. They are the
+ * whole of the mask GUI's coordinate handling -- every shape's centre, every handle, every
+ * source position routes through one of them -- and they ask the simplest question there is:
+ * everything, in order, no bound.
+ *
+ * The chain answers when it can and the pipe answers otherwise, which is not a hedge but the
+ * authority rule: the chain refuses unless EVERY enabled module that changes geometry has
+ * published a record, so a fallback happens only when composing from records would mean mixing
+ * them with pipeline pieces. Both paths stay live until the pipe is deleted, and shadow mode
+ * keeps comparing them on every size publication -- including, at iop_order 0 and DIR_ALL,
+ * exactly the question these two ask.
+ */
+
 int dt_dev_coordinates_raw_abs_to_image_abs(dt_develop_t *dev, float *points, size_t points_count)
 {
+  if(dt_geometry_transform(dev, 0.0, DT_DEV_TRANSFORM_DIR_ALL, points, points_count)) return 1;
   return dt_dev_distort_transform_plus(dev->virtual_pipe, 0.0f, DT_DEV_TRANSFORM_DIR_ALL, points, points_count);
 }
 
 int dt_dev_coordinates_image_abs_to_raw_abs(dt_develop_t *dev, float *points, size_t points_count)
 {
+  if(dt_geometry_backtransform(dev, 0.0, DT_DEV_TRANSFORM_DIR_ALL, points, points_count)) return 1;
   return dt_dev_distort_backtransform_locked(dev->virtual_pipe, 0.0f, DT_DEV_TRANSFORM_DIR_ALL, points, points_count);
 }
 

--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -1745,6 +1745,39 @@ int dt_dev_distort_backtransform_gui(dt_develop_t *dev, const double iop_order, 
                                            points_count);
 }
 
+/**
+ * @brief One module's own input and output rectangles, at full resolution.
+ *
+ * @details What a module GUI used to get by resolving its piece on the pixel-less pipe and
+ * reading piece->buf_in / piece->buf_out. Those rectangles are a product of the size fold, and
+ * the geometry service performs that fold over records for EVERY module -- not only the ones
+ * that change geometry, because not only those read the result: iop/graduatednd.c has no
+ * geometry callbacks at all and normalises its overlay against its own output rectangle.
+ *
+ * @return FALSE when neither source can answer, in which case @p in and @p out are untouched
+ * and the caller must not draw. A module that is disabled or absent has no rectangles.
+ */
+gboolean dt_dev_module_geometry_gui(dt_develop_t *dev, dt_iop_module_t *module, dt_iop_roi_t *in,
+                                    dt_iop_roi_t *out)
+{
+  if(IS_NULL_PTR(dev) || IS_NULL_PTR(module)) return FALSE;
+
+  const dt_geometry_record_t *const record
+      = dt_geometry_chain_find(dev->geometry_chain, module->op, module->multi_priority);
+  if(dt_geometry_chain_authoritative(dev->geometry_chain) && !IS_NULL_PTR(record))
+  {
+    if(!IS_NULL_PTR(in)) *in = record->in;
+    if(!IS_NULL_PTR(out)) *out = record->out;
+    return TRUE;
+  }
+
+  const dt_dev_pixelpipe_iop_t *const piece = dt_dev_distort_get_iop_pipe(dev->virtual_pipe, module);
+  if(IS_NULL_PTR(piece)) return FALSE;
+  if(!IS_NULL_PTR(in)) *in = piece->buf_in;
+  if(!IS_NULL_PTR(out)) *out = piece->buf_out;
+  return TRUE;
+}
+
 int dt_dev_coordinates_raw_abs_to_image_abs(dt_develop_t *dev, float *points, size_t points_count)
 {
   if(dt_geometry_transform(dev, 0.0, DT_DEV_TRANSFORM_DIR_ALL, points, points_count)) return 1;

--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -145,15 +145,12 @@ void dt_dev_init(dt_develop_t *dev, int32_t gui_attached)
   {
     dev->pipe = (dt_dev_pixelpipe_t *)malloc(sizeof(dt_dev_pixelpipe_t));
     dev->preview_pipe = (dt_dev_pixelpipe_t *)malloc(sizeof(dt_dev_pixelpipe_t));
-    // Virtual pipe mirrors preview_pipe for geometry, but is never processed.
-    dev->virtual_pipe = (dt_dev_pixelpipe_t *)malloc(sizeof(dt_dev_pixelpipe_t));
     dt_dev_pixelpipe_init(dev->pipe, dev);
     dt_dev_pixelpipe_init_preview(dev->preview_pipe, dev);
-    dt_dev_pixelpipe_init_preview(dev->virtual_pipe, dev);
 
-    /* The geometry chain runs beside the virtual pipe and will replace it (G2 skeleton --
-     * doc/geometry-service.md). GUI devs only: it answers GUI questions and is GUI-thread
-     * state, so a headless dev has nothing to do with one. */
+    /* Where the GUI gets sizes and coordinates from (doc/geometry-service.md). GUI devs only:
+     * it answers GUI questions and is GUI-thread state, so a headless dev has nothing to do with
+     * one -- which is also what makes the NULL chain the guard on every entry point. */
     dev->geometry_chain = dt_geometry_chain_new();
   }
 
@@ -244,12 +241,6 @@ void dt_dev_cleanup(dt_develop_t *dev)
   {
     dt_dev_pixelpipe_cleanup(dev->preview_pipe);
     dt_free(dev->preview_pipe);
-  }
-  if(dev->virtual_pipe)
-  {
-    // Virtual pipe has nodes and committed params but no pixel buffers.
-    dt_dev_pixelpipe_cleanup(dev->virtual_pipe);
-    dt_free(dev->virtual_pipe);
   }
   dt_geometry_chain_free(dev->geometry_chain);
   dev->geometry_chain = NULL;
@@ -356,28 +347,9 @@ int dt_dev_get_thumbnail_size(dt_develop_t *dev)
 {
   if(!dt_dev_geometry_raw_inited(dev) || !dt_dev_viewport_configured(dev)) return 1;
 
-  // Keep the virtual pipe synced so ROI computations on the GUI thread
-  // always use up-to-date history and input sizes.
   const dt_dev_image_geometry_t geometry = dt_dev_geometry_snapshot(dev);
   const int32_t raw_width = geometry.raw_width;
   const int32_t raw_height = geometry.raw_height;
-
-  if(dev->virtual_pipe->imgid != dev->image_storage.id
-      || dev->virtual_pipe->iwidth != raw_width
-      || dev->virtual_pipe->iheight != raw_height
-      || dev->virtual_pipe->dev->image_storage.id != dev->image_storage.id)
-    dt_dev_pixelpipe_set_input(dev->virtual_pipe, dev->image_storage.id,
-                                raw_width, raw_height, 1.0f, DT_MIPMAP_FULL);
-
-  if(!dev->virtual_pipe->nodes)
-    dt_dev_pixelpipe_or_changed(dev->virtual_pipe, DT_DEV_PIPE_REMOVE);
-  else if(dt_dev_pixelpipe_get_history_hash(dev->virtual_pipe) != dt_dev_get_history_hash(dev))
-  {
-    if(dt_dev_pixelpipe_get_realtime(dev->pipe))
-      dt_dev_pixelpipe_set_history_hash(dev->virtual_pipe, dt_dev_get_history_hash(dev));
-    else
-      dt_dev_pixelpipe_or_changed(dev->virtual_pipe, DT_DEV_PIPE_SYNCH);
-  }
 
   /* The chain is rebuilt BEFORE the size is decided now, because it is what decides it. It is
    * cheap -- small derivations of already-committed parameters, no LUT, no colour transform, no
@@ -386,41 +358,12 @@ int dt_dev_get_thumbnail_size(dt_develop_t *dev)
   dt_geometry_chain_rebuild(dev);
   const double chain_ms = (dt_get_wtime() - chain_start) * 1000.0;
 
-  /* Resync the pixel-less pipe only when something will actually read it: when the chain cannot
-   * answer and the fallbacks will therefore be taken, or when shadow mode is on and there would
-   * be nothing to compare against otherwise. This is where the cost of this service's absence
-   * was: measured on darkroom entry, a resync is ~0.105 s against the chain's 0.03-5 ms, and it
-   * ran on the GUI thread at every history commit.
-   *
-   * Skipping it leaves the pipe FLAGGED but not rebuilt, which is the invariant the fallbacks
-   * rely on: they run only while the chain is not authoritative, and in exactly that case the
-   * resync below has run. dt_dev_virtual_pipe_ensure_synced() is there for anything that needs
-   * to consult the pipe outside that arrangement. */
-  const gboolean chain_answers = dt_geometry_chain_authoritative(dev->geometry_chain);
-  const gboolean want_shadow = (dt_get_debug_flags() & DT_DEBUG_DEV) != 0;
-
-  if((!chain_answers || want_shadow)
-     && dt_dev_pixelpipe_get_changed(dev->virtual_pipe) != DT_DEV_PIPE_UNCHANGED)
-    dt_dev_pixelpipe_change(dev->virtual_pipe);
-
-  // Compute the virtual full-res output. This needs an inited history.
-  // raw_width/raw_height come from the single coherent read at the top of this function:
-  // nothing between here and there republishes the raw geometry.
+  /* The developed size, folded from the geometry records. Nothing is rebuilt to obtain it: that
+   * is what this service replaced, and what it cost is recorded in doc/geometry-service.md. */
   int processed_width = 0;
   int processed_height = 0;
-  int pipe_width = 0;
-  int pipe_height = 0;
-
-  if(!chain_answers || want_shadow)
-    dt_dev_pixelpipe_get_roi_out(dev->virtual_pipe, raw_width, raw_height, &pipe_width, &pipe_height);
-
-  if(chain_answers)
-    dt_geometry_chain_processed_size(dev->geometry_chain, &processed_width, &processed_height);
-  else
-  {
-    processed_width = pipe_width;
-    processed_height = pipe_height;
-  }
+  if(!dt_geometry_chain_processed_size(dev->geometry_chain, &processed_width, &processed_height))
+    return 1;
 
   dt_dev_geometry_set_processed_size(dev, processed_width, processed_height);
 
@@ -434,7 +377,7 @@ int dt_dev_get_thumbnail_size(dt_develop_t *dev)
    * request to match AND flagging the pipes to replan. Anything inserted between them widens the
    * window in which the darkroom worker latches the OLD request against ALREADY NEW history,
    * which is the mixed frame of #1157. An observer must not sit inside the update it observes. */
-  if(want_shadow) dt_geometry_shadow_check(dev, pipe_width, pipe_height, chain_ms);
+  dt_geometry_self_check(dev, chain_ms);
 
 
   dt_dev_update_mouse_effect_radius(dev);
@@ -490,7 +433,7 @@ gboolean dt_dev_pixelpipe_has_preview_output(const dt_develop_t *dev, const dt_d
   // GUI buffer on portrait images, breaking structure detection and manual drawing (#710).
   //
   // Tolerate a couple of pixels of slack on the dimensions. `dev->roi.preview_*` is derived from the
-  // virtual pipe at scale 1.0, whereas `roi` is produced at `natural_scale`; geometric modules
+  // composed geometry at scale 1.0, whereas `roi` is produced at `natural_scale`; geometric modules
   // (ashift, lens) round their transformed bounding box with floorf() independently at each scale,
   // so the two legitimately disagree by ~1px for the very same full image. The real discriminators
   // are the origin and scale tests below: a zoomed or panned ROI has a non-zero x/y and a scale
@@ -983,7 +926,7 @@ static gboolean _dt_dev_mipmap_prefetch_full(dt_develop_t *dev, const int32_t im
   // Publish what the read actually produced. `ok' is FALSE when the mipmap cache handed back
   // no buffer or a 0-sized one; claiming raw_inited in that case told every later reader that
   // 0x0 was a measured fact about the image, and dt_dev_geometry_refresh()'s own guard
-  // (dt_dev_geometry_raw_inited) then let the virtual pipe run on it.
+  // (dt_dev_geometry_raw_inited) then let the size fold run on it.
   dt_dev_geometry_set_raw_size(dev, ok ? buf.width : 0, ok ? buf.height : 0, ok);
 
   dt_mipmap_cache_release(&buf);
@@ -1722,39 +1665,25 @@ gchar *dt_history_item_get_name_html(const struct dt_iop_module_t *module)
 static int dt_dev_distort_backtransform_locked(const dt_dev_pixelpipe_t *pipe, const double iop_order,
                                                const int transf_direction, float *points, size_t points_count);
 
-/* These two are where the geometry service takes over from the pixel-less pipe. They are the
- * whole of the mask GUI's coordinate handling -- every shape's centre, every handle, every
- * source position routes through one of them -- and they ask the simplest question there is:
- * everything, in order, no bound.
- *
- * The chain answers when it can and the pipe answers otherwise, which is not a hedge but the
- * authority rule: the chain refuses unless EVERY enabled module that changes geometry has
- * published a record, so a fallback happens only when composing from records would mean mixing
- * them with pipeline pieces. Both paths stay live until the pipe is deleted, and shadow mode
- * keeps comparing them on every size publication -- including, at iop_order 0 and DIR_ALL,
- * exactly the question these two ask.
+/* These two are the whole of the mask GUI's coordinate handling -- every shape's centre, every
+ * handle, every source position routes through one of them -- and they ask the geometry service
+ * the simplest question there is: everything, in order, no bound.
  */
 
 /**
- * @brief The GUI's bounded transform folds: ask the geometry service, fall back to the pipe.
+ * @brief The GUI's bounded transform folds, composed by the geometry service.
  *
  * @details Same contract as dt_dev_distort_transform_plus() -- the iop_order bound and the five
- * direction modes mean exactly what they mean there -- but stated in terms of the dev rather
- * than a pipe, because which of the two answers is not the caller's business. The chain answers
- * when every enabled geometry module has published a record; otherwise the pixel-less pipe does,
- * as it always has.
- *
- * A module GUI must not reach for dev->virtual_pipe itself. That pipe is going away, and a call
- * site naming it is a call site that will not compile then -- which is the point of routing
- * every one of them through here first.
+ * direction modes mean exactly what they mean there -- but stated in terms of the dev rather than
+ * a pipe, because a GUI has no pipe of its own to name. It used to fall back to a pixel-less
+ * clone of the pipeline when the chain could not answer; that clone is deleted, so a chain that
+ * cannot answer returns 0 and leaves @p points untouched.
  */
 int dt_dev_distort_transform_gui(dt_develop_t *dev, const double iop_order, const int transf_direction,
                                  float *points, size_t points_count)
 {
   if(IS_NULL_PTR(dev)) return 0;
-  if(dt_geometry_transform(dev, iop_order, transf_direction, points, points_count)) return 1;
-  dt_dev_virtual_pipe_ensure_synced(dev);
-  return dt_dev_distort_transform_plus(dev->virtual_pipe, iop_order, transf_direction, points, points_count);
+  return dt_geometry_transform(dev, iop_order, transf_direction, points, points_count);
 }
 
 /** @brief The inverse of dt_dev_distort_transform_gui(), same rules. */
@@ -1762,32 +1691,30 @@ int dt_dev_distort_backtransform_gui(dt_develop_t *dev, const double iop_order, 
                                      float *points, size_t points_count)
 {
   if(IS_NULL_PTR(dev)) return 0;
-  if(dt_geometry_backtransform(dev, iop_order, transf_direction, points, points_count)) return 1;
-  dt_dev_virtual_pipe_ensure_synced(dev);
-  return dt_dev_distort_backtransform_plus(dev->virtual_pipe, iop_order, transf_direction, points,
-                                           points_count);
+  return dt_geometry_backtransform(dev, iop_order, transf_direction, points, points_count);
 }
 
 /**
  * @brief One module's own input and output rectangles, at full resolution.
  *
- * @details What a module GUI used to get by resolving its piece on the pixel-less pipe and
- * reading piece->buf_in / piece->buf_out. Those rectangles are a product of the size fold, and
+ * @details What a module GUI used to get by resolving its piece on a pixel-less clone of the
+ * pipeline and reading piece->buf_in / piece->buf_out. Those rectangles are a product of the
+ * size fold, and
  * the geometry service performs that fold over records for EVERY module -- not only the ones
  * that change geometry, because not only those read the result: iop/graduatednd.c has no
  * geometry callbacks at all and normalises its overlay against its own output rectangle.
  *
- * @return FALSE when neither source can answer, in which case @p in and @p out are untouched
+ * @return FALSE when the service cannot answer, in which case @p in and @p out are untouched
  * and the caller must not draw. A module that is disabled or absent has no rectangles.
  */
 /**
  * @brief The developed image's full-resolution size, for a GUI caller.
  *
- * @details Three sources, in order of freshness, which is why this exists rather than a plain
- * read of the geometry record: the chain and the pixel-less pipe are both recomputed the moment
- * the module stack changes, while the record is only republished when the size path runs. Code
- * that needed the newest answer used to reach into the pipe's field to get it, and had to keep
- * its own fallback for the case where the pipe had none.
+ * @details Two sources, in order of freshness, which is why this exists rather than a plain
+ * read of the geometry record: the chain is recomputed the moment the module stack changes,
+ * while the record is only republished when the size path runs. Code that needed the newest
+ * answer used to reach into a pipe's processed_width field to get it, and had to keep its own
+ * fallback for the case where that pipe had none.
  *
  * @return FALSE when no source has a usable size, leaving the out-params untouched.
  */
@@ -1805,15 +1732,6 @@ gboolean dt_dev_processed_size_gui(dt_develop_t *dev, int *width, int *height)
     return TRUE;
   }
 
-  dt_dev_virtual_pipe_ensure_synced(dev);
-  if(!IS_NULL_PTR(dev->virtual_pipe) && dev->virtual_pipe->processed_width > 0
-     && dev->virtual_pipe->processed_height > 0)
-  {
-    if(!IS_NULL_PTR(width)) *width = dev->virtual_pipe->processed_width;
-    if(!IS_NULL_PTR(height)) *height = dev->virtual_pipe->processed_height;
-    return TRUE;
-  }
-
   const dt_dev_image_geometry_t geometry = dt_dev_geometry_snapshot(dev);
   if(geometry.processed_width <= 0 || geometry.processed_height <= 0) return FALSE;
   if(!IS_NULL_PTR(width)) *width = geometry.processed_width;
@@ -1828,33 +1746,21 @@ gboolean dt_dev_module_geometry_gui(dt_develop_t *dev, dt_iop_module_t *module, 
 
   const dt_geometry_record_t *const record
       = dt_geometry_chain_find(dev->geometry_chain, module->op, module->multi_priority);
-  if(dt_geometry_chain_authoritative(dev->geometry_chain) && !IS_NULL_PTR(record))
-  {
-    if(!IS_NULL_PTR(in)) *in = record->in;
-    if(!IS_NULL_PTR(out)) *out = record->out;
-    return TRUE;
-  }
+  if(IS_NULL_PTR(record) || !dt_geometry_chain_authoritative(dev->geometry_chain)) return FALSE;
 
-  dt_dev_virtual_pipe_ensure_synced(dev);
-  const dt_dev_pixelpipe_iop_t *const piece = dt_dev_distort_get_iop_pipe(dev->virtual_pipe, module);
-  if(IS_NULL_PTR(piece)) return FALSE;
-  if(!IS_NULL_PTR(in)) *in = piece->buf_in;
-  if(!IS_NULL_PTR(out)) *out = piece->buf_out;
+  if(!IS_NULL_PTR(in)) *in = record->in;
+  if(!IS_NULL_PTR(out)) *out = record->out;
   return TRUE;
 }
 
 int dt_dev_coordinates_raw_abs_to_image_abs(dt_develop_t *dev, float *points, size_t points_count)
 {
-  if(dt_geometry_transform(dev, 0.0, DT_DEV_TRANSFORM_DIR_ALL, points, points_count)) return 1;
-  dt_dev_virtual_pipe_ensure_synced(dev);
-  return dt_dev_distort_transform_plus(dev->virtual_pipe, 0.0f, DT_DEV_TRANSFORM_DIR_ALL, points, points_count);
+  return dt_geometry_transform(dev, 0.0, DT_DEV_TRANSFORM_DIR_ALL, points, points_count);
 }
 
 int dt_dev_coordinates_image_abs_to_raw_abs(dt_develop_t *dev, float *points, size_t points_count)
 {
-  if(dt_geometry_backtransform(dev, 0.0, DT_DEV_TRANSFORM_DIR_ALL, points, points_count)) return 1;
-  dt_dev_virtual_pipe_ensure_synced(dev);
-  return dt_dev_distort_backtransform_locked(dev->virtual_pipe, 0.0f, DT_DEV_TRANSFORM_DIR_ALL, points, points_count);
+  return dt_geometry_backtransform(dev, 0.0, DT_DEV_TRANSFORM_DIR_ALL, points, points_count);
 }
 
 // only call directly or indirectly from dt_dev_distort_transform_plus, so that it runs with the history locked

--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -1714,6 +1714,37 @@ static int dt_dev_distort_backtransform_locked(const dt_dev_pixelpipe_t *pipe, c
  * exactly the question these two ask.
  */
 
+/**
+ * @brief The GUI's bounded transform folds: ask the geometry service, fall back to the pipe.
+ *
+ * @details Same contract as dt_dev_distort_transform_plus() -- the iop_order bound and the five
+ * direction modes mean exactly what they mean there -- but stated in terms of the dev rather
+ * than a pipe, because which of the two answers is not the caller's business. The chain answers
+ * when every enabled geometry module has published a record; otherwise the pixel-less pipe does,
+ * as it always has.
+ *
+ * A module GUI must not reach for dev->virtual_pipe itself. That pipe is going away, and a call
+ * site naming it is a call site that will not compile then -- which is the point of routing
+ * every one of them through here first.
+ */
+int dt_dev_distort_transform_gui(dt_develop_t *dev, const double iop_order, const int transf_direction,
+                                 float *points, size_t points_count)
+{
+  if(IS_NULL_PTR(dev)) return 0;
+  if(dt_geometry_transform(dev, iop_order, transf_direction, points, points_count)) return 1;
+  return dt_dev_distort_transform_plus(dev->virtual_pipe, iop_order, transf_direction, points, points_count);
+}
+
+/** @brief The inverse of dt_dev_distort_transform_gui(), same rules. */
+int dt_dev_distort_backtransform_gui(dt_develop_t *dev, const double iop_order, const int transf_direction,
+                                     float *points, size_t points_count)
+{
+  if(IS_NULL_PTR(dev)) return 0;
+  if(dt_geometry_backtransform(dev, iop_order, transf_direction, points, points_count)) return 1;
+  return dt_dev_distort_backtransform_plus(dev->virtual_pipe, iop_order, transf_direction, points,
+                                           points_count);
+}
+
 int dt_dev_coordinates_raw_abs_to_image_abs(dt_develop_t *dev, float *points, size_t points_count)
 {
   if(dt_geometry_transform(dev, 0.0, DT_DEV_TRANSFORM_DIR_ALL, points, points_count)) return 1;

--- a/src/develop/develop.h
+++ b/src/develop/develop.h
@@ -668,6 +668,12 @@ int dt_dev_distort_backtransform_gui(struct dt_develop_t *dev, const double iop_
 gboolean dt_dev_module_geometry_gui(struct dt_develop_t *dev, struct dt_iop_module_t *module,
                                     dt_iop_roi_t *in, dt_iop_roi_t *out);
 
+/**
+ * @brief The developed image's full-resolution size for a GUI caller: the geometry service, the
+ * pixel-less pipe, or the published record, in that order of freshness. FALSE when none has one.
+ */
+gboolean dt_dev_processed_size_gui(struct dt_develop_t *dev, int *width, int *height);
+
 /** get the iop_pixelpipe instance corresponding to the iop in the given pipe */
 struct dt_dev_pixelpipe_iop_t *dt_dev_distort_get_iop_pipe(struct dt_dev_pixelpipe_t *pipe,
                                                            struct dt_iop_module_t *module);

--- a/src/develop/develop.h
+++ b/src/develop/develop.h
@@ -463,6 +463,12 @@ typedef struct dt_develop_t
   gboolean mask_lock;
 
   cairo_surface_t *image_surface;
+
+  /* Composed geometry, GUI thread only: what dev->virtual_pipe is walked for today, as data.
+   * Appended at the end of this struct deliberately -- IOP plugins are compiled against this
+   * layout, so a field inserted anywhere else silently shifts what they read. See
+   * develop/geometry/geometry.h and doc/geometry-service.md. NULL on non-gui devs. */
+  struct dt_geometry_chain_t *geometry_chain;
 } dt_develop_t;
 
 static inline uint64_t dt_dev_get_history_hash(const dt_develop_t *dev)

--- a/src/develop/develop.h
+++ b/src/develop/develop.h
@@ -645,6 +645,18 @@ int dt_dev_distort_transform_locked(const struct dt_dev_pixelpipe_t *pipe, const
 int dt_dev_distort_backtransform_plus(const struct dt_dev_pixelpipe_t *pipe, const double iop_order, const int transf_direction,
                                       float *points, size_t points_count);
 
+/**
+ * @brief GUI-side bounded transform folds. Ask the geometry service, fall back to the pixel-less
+ * pipe. Same iop_order bound and direction modes as dt_dev_distort_transform_plus().
+ *
+ * Module GUIs use THESE, never dev->virtual_pipe directly: that pipe is being removed, and a
+ * caller that names it is a caller that has not been migrated.
+ */
+int dt_dev_distort_transform_gui(struct dt_develop_t *dev, const double iop_order,
+                                 const int transf_direction, float *points, size_t points_count);
+int dt_dev_distort_backtransform_gui(struct dt_develop_t *dev, const double iop_order,
+                                     const int transf_direction, float *points, size_t points_count);
+
 /** get the iop_pixelpipe instance corresponding to the iop in the given pipe */
 struct dt_dev_pixelpipe_iop_t *dt_dev_distort_get_iop_pipe(struct dt_dev_pixelpipe_t *pipe,
                                                            struct dt_iop_module_t *module);

--- a/src/develop/develop.h
+++ b/src/develop/develop.h
@@ -215,7 +215,6 @@ typedef struct dt_develop_t
   // Virtual preview-like pipeline used for geometry/ROI computations on the GUI thread.
   // It mirrors preview_pipe history/nodes but never processes pixels.
   // It is meant for fast access from the GUI mainthread without waiting for threads to return.
-  struct dt_dev_pixelpipe_t *virtual_pipe;
 
   // image under consideration, which
   // is copied each time an image is changed. this means we have some information
@@ -464,7 +463,7 @@ typedef struct dt_develop_t
 
   cairo_surface_t *image_surface;
 
-  /* Composed geometry, GUI thread only: what dev->virtual_pipe is walked for today, as data.
+  /* Composed geometry, GUI thread only: where the GUI gets sizes and coordinates from.
    * Appended at the end of this struct deliberately -- IOP plugins are compiled against this
    * layout, so a field inserted anywhere else silently shifts what they read. See
    * develop/geometry/geometry.h and doc/geometry-service.md. NULL on non-gui devs. */
@@ -649,8 +648,7 @@ int dt_dev_distort_backtransform_plus(const struct dt_dev_pixelpipe_t *pipe, con
  * @brief GUI-side bounded transform folds. Ask the geometry service, fall back to the pixel-less
  * pipe. Same iop_order bound and direction modes as dt_dev_distort_transform_plus().
  *
- * Module GUIs use THESE, never dev->virtual_pipe directly: that pipe is being removed, and a
- * caller that names it is a caller that has not been migrated.
+ * The only way a GUI asks for a composed transform.
  */
 int dt_dev_distort_transform_gui(struct dt_develop_t *dev, const double iop_order,
                                  const int transf_direction, float *points, size_t points_count);
@@ -659,18 +657,18 @@ int dt_dev_distort_backtransform_gui(struct dt_develop_t *dev, const double iop_
 
 /**
  * @brief One module's own input and output rectangles at full resolution, from the geometry
- * service or, until it can answer, from the pixel-less pipe.
+ * service.
  *
- * Replaces resolving a piece and reading piece->buf_in / piece->buf_out. Returns FALSE when
- * neither source has them, leaving the out-params untouched -- a disabled or absent module has
- * no rectangles, and a caller that draws anyway draws somewhere arbitrary.
+ * Replaces resolving a piece and reading piece->buf_in / piece->buf_out. Returns FALSE when the
+ * service has none, leaving the out-params untouched -- a disabled or absent module has no
+ * rectangles, and a caller that draws anyway draws somewhere arbitrary.
  */
 gboolean dt_dev_module_geometry_gui(struct dt_develop_t *dev, struct dt_iop_module_t *module,
                                     dt_iop_roi_t *in, dt_iop_roi_t *out);
 
 /**
- * @brief The developed image's full-resolution size for a GUI caller: the geometry service, the
- * pixel-less pipe, or the published record, in that order of freshness. FALSE when none has one.
+ * @brief The developed image's full-resolution size for a GUI caller: the geometry service,
+ * then the published record, in that order of freshness. FALSE when neither has one.
  */
 gboolean dt_dev_processed_size_gui(struct dt_develop_t *dev, int *width, int *height);
 

--- a/src/develop/develop.h
+++ b/src/develop/develop.h
@@ -657,6 +657,17 @@ int dt_dev_distort_transform_gui(struct dt_develop_t *dev, const double iop_orde
 int dt_dev_distort_backtransform_gui(struct dt_develop_t *dev, const double iop_order,
                                      const int transf_direction, float *points, size_t points_count);
 
+/**
+ * @brief One module's own input and output rectangles at full resolution, from the geometry
+ * service or, until it can answer, from the pixel-less pipe.
+ *
+ * Replaces resolving a piece and reading piece->buf_in / piece->buf_out. Returns FALSE when
+ * neither source has them, leaving the out-params untouched -- a disabled or absent module has
+ * no rectangles, and a caller that draws anyway draws somewhere arbitrary.
+ */
+gboolean dt_dev_module_geometry_gui(struct dt_develop_t *dev, struct dt_iop_module_t *module,
+                                    dt_iop_roi_t *in, dt_iop_roi_t *out);
+
 /** get the iop_pixelpipe instance corresponding to the iop in the given pipe */
 struct dt_dev_pixelpipe_iop_t *dt_dev_distort_get_iop_pipe(struct dt_dev_pixelpipe_t *pipe,
                                                            struct dt_iop_module_t *module);

--- a/src/develop/geometry/geometry.c
+++ b/src/develop/geometry/geometry.c
@@ -338,7 +338,8 @@ void dt_geometry_clear_focus(dt_develop_t *dev)
   dev->geometry_chain->focus_active = FALSE;
 }
 
-void dt_geometry_shadow_check_size(dt_develop_t *dev, const int pipe_width, const int pipe_height)
+void dt_geometry_shadow_check(dt_develop_t *dev, const int pipe_width, const int pipe_height,
+                              const double chain_ms)
 {
   if(IS_NULL_PTR(dev) || IS_NULL_PTR(dev->geometry_chain)) return;
   if(!(dt_get_debug_flags() & DT_DEBUG_DEV)) return;
@@ -447,6 +448,11 @@ void dt_geometry_shadow_check_size(dt_develop_t *dev, const int pipe_width, cons
     dt_print(DT_DEBUG_DEV,
              "[geometry] agrees with the pipe: size %dx%d, 5/5 forward probes, 5/5 round-trips\n",
              chain->processed_width, chain->processed_height);
+
+  /* The cost, which is the reason this service exists. Compare against `-d perf's "pipeline
+   * resync with history ... for pipe virtual-preview" line: that is the same product, computed
+   * the way this replaces. */
+  dt_print(DT_DEBUG_DEV, "[geometry] chain rebuilt in %.2f ms\n", chain_ms);
 }
 
 // clang-format off

--- a/src/develop/geometry/geometry.c
+++ b/src/develop/geometry/geometry.c
@@ -71,9 +71,16 @@ struct dt_geometry_chain_t
    * reporting "not ready", which would be true and useless. */
   GList *missing;   /**< gchar*, owned */
 
-  /* Query-time GUI state, published by dt_geometry_set_focus(). */
-  const struct dt_iop_module_t *focused;
-  gboolean focus_editing;
+  /* Query-time GUI state, published by dt_geometry_set_focus(). Held BY VALUE, not as a
+   * dt_iop_module_t pointer: the focus outlives individual publications, and a module can be
+   * destroyed (instance removed, image changed, darkroom left) without anyone telling this
+   * chain. A stored pointer would then be dereferenced by the next query. The two things the
+   * exception needs -- who is focused, and what that module filters -- are both immutable for
+   * a given module, so copying them costs nothing and cannot dangle. */
+  char focus_op[32];
+  int focus_instance;
+  int focus_tags_filter;
+  gboolean focus_active;
 };
 
 static gboolean _on_roster(const char *op)
@@ -134,10 +141,9 @@ static gint _by_iop_order(gconstpointer a, gconstpointer b)
  */
 static gboolean _suppressed_by_focus(const dt_geometry_chain_t *chain, const dt_geometry_record_t *record)
 {
-  if(IS_NULL_PTR(chain->focused) || !chain->focus_editing) return FALSE;
-  if(!strcmp(chain->focused->op, record->op) && chain->focused->multi_priority == record->instance)
-    return FALSE;
-  return (chain->focused->operation_tags_filter() & record->operation_tags) != 0;
+  if(!chain->focus_active) return FALSE;
+  if(!strcmp(chain->focus_op, record->op) && chain->focus_instance == record->instance) return FALSE;
+  return (chain->focus_tags_filter & record->operation_tags) != 0;
 }
 
 /**
@@ -205,7 +211,6 @@ void dt_geometry_chain_rebuild(dt_develop_t *dev)
     record->iop_order = module->iop_order;
     record->enabled = TRUE;
     record->operation_tags = module->operation_tags();
-    record->operation_tags_filter = module->operation_tags_filter();
 
     /* A module that publishes nothing is identity, which is correct for the ~80 modules that
      * do not touch geometry -- their record exists only to carry dimensions. A ROSTER module
@@ -312,8 +317,24 @@ int dt_geometry_backtransform(dt_develop_t *dev, const double iop_order, const i
 void dt_geometry_set_focus(dt_develop_t *dev, const dt_iop_module_t *focused, const gboolean editing)
 {
   if(IS_NULL_PTR(dev) || IS_NULL_PTR(dev->geometry_chain)) return;
-  dev->geometry_chain->focused = focused;
-  dev->geometry_chain->focus_editing = editing;
+  dt_geometry_chain_t *chain = dev->geometry_chain;
+
+  if(IS_NULL_PTR(focused) || !editing)
+  {
+    chain->focus_active = FALSE;
+    return;
+  }
+
+  g_strlcpy(chain->focus_op, focused->op, sizeof(chain->focus_op));
+  chain->focus_instance = focused->multi_priority;
+  chain->focus_tags_filter = focused->operation_tags_filter();
+  chain->focus_active = TRUE;
+}
+
+void dt_geometry_clear_focus(dt_develop_t *dev)
+{
+  if(IS_NULL_PTR(dev) || IS_NULL_PTR(dev->geometry_chain)) return;
+  dev->geometry_chain->focus_active = FALSE;
 }
 
 void dt_geometry_shadow_check_size(dt_develop_t *dev, const int pipe_width, const int pipe_height)

--- a/src/develop/geometry/geometry.c
+++ b/src/develop/geometry/geometry.c
@@ -79,6 +79,32 @@ struct dt_geometry_chain_t
   dt_develop_t *dev;
 };
 
+/**
+ * @brief A/B switch for bisecting this service against the pipe it replaces.
+ *
+ * @details Every migrated consumer falls back to dev->virtual_pipe when the chain is not
+ * authoritative, so refusing authority puts the whole GUI back on the pipeline path without
+ * rebuilding or reverting anything. Set ANSEL_GEOMETRY_DISABLE=1: a symptom that persists is
+ * not this service's doing, one that disappears is.
+ *
+ * It clears the authority FLAG rather than intercepting the accessor, because the walkers and
+ * the shadow harness read that field directly -- an accessor-only switch would have left the
+ * transform paths live, which is exactly the half a bisection needs to move.
+ */
+static gboolean _geometry_disabled(void)
+{
+  static int disabled = -1;
+  if(disabled < 0)
+  {
+    const char *const env = g_getenv("ANSEL_GEOMETRY_DISABLE");
+    disabled = (!IS_NULL_PTR(env) && env[0] == '1') ? 1 : 0;
+    if(disabled)
+      fprintf(stderr, "[geometry] ANSEL_GEOMETRY_DISABLE=1: the chain declines every query; "
+                      "every consumer falls back to the pixel-less pipe\n");
+  }
+  return disabled == 1;
+}
+
 static gboolean _on_roster(const char *op)
 {
   if(IS_NULL_PTR(op)) return FALSE;
@@ -298,7 +324,7 @@ void dt_geometry_chain_rebuild(dt_develop_t *dev)
   dt_pthread_rwlock_unlock(&dev->history_mutex);
 
   _fold_sizes(chain);
-  chain->authoritative = complete && chain->sized;
+  chain->authoritative = complete && chain->sized && !_geometry_disabled();
 }
 
 gboolean dt_geometry_chain_authoritative(const dt_geometry_chain_t *chain)

--- a/src/develop/geometry/geometry.c
+++ b/src/develop/geometry/geometry.c
@@ -20,6 +20,7 @@
 
 #include "common/logging.h"
 #include "develop/dev_geometry.h"
+#include "develop/dev_history.h"
 #include "develop/develop.h"
 #include "develop/imageop.h"
 #include "system/mem_alloc.h"
@@ -184,6 +185,51 @@ static void _fold_sizes(dt_geometry_chain_t *chain)
   chain->sized = (chain->raw_width > 0 && chain->raw_height > 0);
 }
 
+/**
+ * @brief What will this module be committed with? Mirrors the pipe's own resolution.
+ *
+ * @details dt_dev_pixelpipe_change() decides a piece's parameters and its enabled state in two
+ * ways, and the chain has to reproduce both or it describes a geometry the pipes are not
+ * rendering:
+ *
+ *  - IOP_FLAGS_NO_HISTORY_STACK modules are committed from their DEFAULTS
+ *    (dt_dev_pixelpipe_sync_no_history), because they enable and disable themselves;
+ *  - every other module takes the last history item at or before history_end, falling back to
+ *    its defaults when it has none (_sync_pipe_nodes_from_history).
+ *
+ * What it must NOT read is module->params and module->enabled. Those are the GUI thread's live
+ * values, and dt_dev_add_history_item() is throttled, so between an edit and its commit they
+ * are ahead of what any pipe has been told -- which shadow mode caught as a size divergence
+ * while the crop module's piece was mid-transition.
+ *
+ * @param params out: the blob to hand geometry_record(). Borrowed, valid while history_mutex
+ * is held.
+ * @return the enabled state the pipe will use.
+ */
+static gboolean _resolve_from_history(dt_develop_t *dev, dt_iop_module_t *module,
+                                      const int32_t history_end, const void **params)
+{
+  if(module->flags() & IOP_FLAGS_NO_HISTORY_STACK)
+  {
+    *params = module->default_params;
+    return module->default_enabled;
+  }
+
+  *params = module->default_params;
+  gboolean enabled = module->default_enabled;
+
+  for(GList *item = g_list_nth(dev->history, history_end - 1); item; item = g_list_previous(item))
+  {
+    const dt_dev_history_item_t *const hist = (const dt_dev_history_item_t *)item->data;
+    if(IS_NULL_PTR(hist) || hist->module != module) continue;
+    *params = hist->params;
+    enabled = hist->enabled;
+    break;
+  }
+
+  return enabled;
+}
+
 void dt_geometry_chain_rebuild(dt_develop_t *dev)
 {
   if(IS_NULL_PTR(dev) || IS_NULL_PTR(dev->geometry_chain)) return;
@@ -199,10 +245,17 @@ void dt_geometry_chain_rebuild(dt_develop_t *dev)
 
   gboolean complete = TRUE;
 
+  /* Resolve each module the way the pipe will, from HISTORY -- see _resolve_from_history(). The
+   * read lock is what dt_dev_pixelpipe_change() takes for the same walk; it is same-thread
+   * recursive, so a caller that already holds it (a history commit republishing geometry) is
+   * fine. */
+  dt_pthread_rwlock_rdlock(&dev->history_mutex);
+  const int32_t history_end = dt_dev_get_history_end_ext(dev);
+
   for(GList *node = g_list_first(dev->iop); node; node = g_list_next(node))
   {
     dt_iop_module_t *module = (dt_iop_module_t *)node->data;
-    if(IS_NULL_PTR(module) || !module->enabled) continue;
+    if(IS_NULL_PTR(module)) continue;
 
     dt_geometry_record_t *record = (dt_geometry_record_t *)g_malloc0(sizeof(dt_geometry_record_t));
     if(IS_NULL_PTR(record)) continue;
@@ -210,16 +263,24 @@ void dt_geometry_chain_rebuild(dt_develop_t *dev)
     g_strlcpy(record->op, module->op, sizeof(record->op));
     record->instance = module->multi_priority;
     record->iop_order = module->iop_order;
-    record->enabled = TRUE;
     record->operation_tags = module->operation_tags();
 
-    /* A module that publishes nothing is identity, which is correct for the ~80 modules that
-     * do not touch geometry -- their record exists only to carry dimensions. A ROSTER module
-     * that publishes nothing is a gap, and the chain must not be trusted until it closes. */
-    const gboolean published = !IS_NULL_PTR(module->geometry_record)
-                               && module->geometry_record(module, record);
+    const void *params = NULL;
+    record->enabled = _resolve_from_history(dev, module, history_end, &params);
 
-    if(!published && _on_roster(module->op))
+    /* A record exists for EVERY module, enabled or not, because the fold this mirrors writes
+     * per-piece dimensions for disabled pieces too and consumers read them. A disabled module
+     * simply publishes nothing and is identity.
+     *
+     * A module that publishes nothing is also correct for the ~80 that do not touch geometry.
+     * A ROSTER module that publishes nothing is a gap, and the chain must not be trusted until
+     * it closes -- but only while it is ENABLED: a disabled lens owes this service nothing, and
+     * asking it for a record would build a lensfun modifier for a correction nobody applies. */
+    gboolean published = FALSE;
+    if(record->enabled && !IS_NULL_PTR(module->geometry_record))
+      published = module->geometry_record(module, params, record);
+
+    if(record->enabled && !published && _on_roster(module->op))
     {
       complete = FALSE;
       chain->missing = g_list_prepend(chain->missing,
@@ -228,6 +289,8 @@ void dt_geometry_chain_rebuild(dt_develop_t *dev)
 
     chain->records = g_list_insert_sorted(chain->records, record, _by_iop_order);
   }
+
+  dt_pthread_rwlock_unlock(&dev->history_mutex);
 
   _fold_sizes(chain);
   chain->authoritative = complete && chain->sized;

--- a/src/develop/geometry/geometry.c
+++ b/src/develop/geometry/geometry.c
@@ -1,0 +1,363 @@
+/*
+    This file is part of Ansel.
+    Copyright (C) 2026 Aurélien Pierre.
+
+    Ansel is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Ansel is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Ansel.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "develop/geometry/geometry.h"
+
+#include "common/logging.h"
+#include "develop/dev_geometry.h"
+#include "develop/develop.h"
+#include "develop/imageop.h"
+#include "system/mem_alloc.h"
+
+#include <string.h>
+
+/**
+ * THE ROSTER.
+ *
+ * Which modules owe this service a record. It is a hand-maintained list and cannot be anything
+ * else: dt_iop_module_t's geometry callbacks are bound through the DEFAULT() macros in
+ * common/module_api.h, so EVERY module has a non-NULL, no-op distort_transform() and an identity
+ * modify_roi_out(). There is no runtime predicate for "is this a geometry module" to test.
+ *
+ * Membership is by source audit (doc/geometry-service.md §1): the 15 modules that implement
+ * modify_roi_out plus the 11 that implement distort_transform, minus the two that implement
+ * neither in a way this service is concerned with.
+ *
+ * NOT on the roster, deliberately:
+ *   - retouch, spots: identity modify_roi_out and no point transform at all. Their
+ *     modify_roi_in expands the read window for source patches, which is a RENDERING concern --
+ *     it reads live dev->forms on the pipeline thread and exists so a clone source is inside
+ *     the tile. Nothing about it belongs to GUI geometry.
+ *   - initialscale, finalscale: no modify_roi_out whatsoever, so identity in a scale-1 fold,
+ *     and no point transform. finalscale's enabled state additionally depends on pipe type and
+ *     zoom, which is exactly the kind of per-pipe fact a pipe-less service must not try to own.
+ *   - useless: the module template, not built.
+ *
+ * A module added to this list without a geometry_record() implementation keeps the chain
+ * non-authoritative forever, which is the safe direction: consumers go on using the pipe.
+ */
+static const char *const _roster[] = {
+  "rawprepare", "basebuffer", "demosaic", "lens",     "ashift",  "liquify", "rotatepixels",
+  "scalepixels", "flip",      "clipping", "crop",     "borders",
+};
+
+struct dt_geometry_chain_t
+{
+  GList *records;   /**< dt_geometry_record_t*, ordered by iop_order, one per ENABLED module */
+
+  int32_t raw_width, raw_height;
+  int32_t processed_width, processed_height;
+  gboolean sized;
+
+  /** Every roster module that is enabled has published a record. See the header. */
+  gboolean authoritative;
+
+  /* What the last rebuild could not get. Kept so shadow mode can name it instead of just
+   * reporting "not ready", which would be true and useless. */
+  GList *missing;   /**< gchar*, owned */
+
+  /* Query-time GUI state, published by dt_geometry_set_focus(). */
+  const struct dt_iop_module_t *focused;
+  gboolean focus_editing;
+};
+
+static gboolean _on_roster(const char *op)
+{
+  if(IS_NULL_PTR(op)) return FALSE;
+  for(size_t i = 0; i < G_N_ELEMENTS(_roster); i++)
+    if(!strcmp(op, _roster[i])) return TRUE;
+  return FALSE;
+}
+
+static void _record_free(void *ptr)
+{
+  dt_geometry_record_t *record = (dt_geometry_record_t *)ptr;
+  if(IS_NULL_PTR(record)) return;
+  if(!IS_NULL_PTR(record->free_data) && !IS_NULL_PTR(record->data)) record->free_data(record->data);
+  dt_free(record);
+}
+
+static void _chain_clear(dt_geometry_chain_t *chain)
+{
+  g_list_free_full(chain->records, _record_free);
+  chain->records = NULL;
+  g_list_free_full(chain->missing, dt_free_gpointer);
+  chain->missing = NULL;
+  chain->authoritative = FALSE;
+  chain->sized = FALSE;
+  chain->processed_width = chain->processed_height = 0;
+}
+
+dt_geometry_chain_t *dt_geometry_chain_new(void)
+{
+  return (dt_geometry_chain_t *)g_malloc0(sizeof(dt_geometry_chain_t));
+}
+
+void dt_geometry_chain_free(dt_geometry_chain_t *chain)
+{
+  if(IS_NULL_PTR(chain)) return;
+  _chain_clear(chain);
+  dt_free(chain);
+}
+
+static gint _by_iop_order(gconstpointer a, gconstpointer b)
+{
+  const dt_geometry_record_t *ra = (const dt_geometry_record_t *)a;
+  const dt_geometry_record_t *rb = (const dt_geometry_record_t *)b;
+  if(ra->iop_order < rb->iop_order) return -1;
+  if(ra->iop_order > rb->iop_order) return 1;
+  return 0;
+}
+
+/**
+ * @brief Is this record disabled for the current query by the focused module?
+ *
+ * @details The chain's copy of dt_dev_pixelpipe_activemodule_disables_currentmodule(). It is
+ * evaluated HERE, per query, and never stored in a record: the inputs are the focused module's
+ * identity, its tag filter, and whether it is in editing mode -- all of which change with no
+ * history commit, which is precisely why records cannot carry them.
+ */
+static gboolean _suppressed_by_focus(const dt_geometry_chain_t *chain, const dt_geometry_record_t *record)
+{
+  if(IS_NULL_PTR(chain->focused) || !chain->focus_editing) return FALSE;
+  if(!strcmp(chain->focused->op, record->op) && chain->focused->multi_priority == record->instance)
+    return FALSE;
+  return (chain->focused->operation_tags_filter() & record->operation_tags) != 0;
+}
+
+/**
+ * @brief Fold every record's map_size in pipe order, at full resolution and scale 1.
+ *
+ * @details Reproduces dt_dev_pixelpipe_get_roi_out(): seed the input rect from the raw
+ * dimensions at scale 1, hand each enabled module its input and take its output as the next
+ * module's input, and record both on the way through. Those per-record rects are a product in
+ * their own right -- consumers read their own module's input/output dimensions off them, and
+ * not only the geometric modules do (graduatednd has no geometry callbacks and reads its output
+ * rect for its overlay).
+ *
+ * A record with no vtable, or one suppressed by the focused module, is identity. The suppression
+ * matters for SIZE and not only for coordinates: the fold this mirrors clears piece->enabled for
+ * such modules, so the developed size genuinely changes when the user enters crop's edit mode.
+ */
+static void _fold_sizes(dt_geometry_chain_t *chain)
+{
+  dt_iop_roi_t rect = (dt_iop_roi_t){ 0, 0, chain->raw_width, chain->raw_height, 1.0f };
+
+  for(GList *node = g_list_first(chain->records); node; node = g_list_next(node))
+  {
+    dt_geometry_record_t *record = (dt_geometry_record_t *)node->data;
+    record->in = rect;
+
+    if(!IS_NULL_PTR(record->vtable) && !IS_NULL_PTR(record->vtable->map_size)
+       && !_suppressed_by_focus(chain, record))
+      record->vtable->map_size(record->data, &rect, &record->out);
+    else
+      record->out = rect;
+
+    rect = record->out;
+  }
+
+  chain->processed_width = rect.width;
+  chain->processed_height = rect.height;
+  chain->sized = (chain->raw_width > 0 && chain->raw_height > 0);
+}
+
+void dt_geometry_chain_rebuild(dt_develop_t *dev)
+{
+  if(IS_NULL_PTR(dev) || IS_NULL_PTR(dev->geometry_chain)) return;
+
+  dt_geometry_chain_t *chain = dev->geometry_chain;
+  _chain_clear(chain);
+
+  int32_t raw_width = 0;
+  int32_t raw_height = 0;
+  if(!dt_dev_geometry_get_raw_size(dev, &raw_width, &raw_height)) return;
+  chain->raw_width = raw_width;
+  chain->raw_height = raw_height;
+
+  gboolean complete = TRUE;
+
+  for(GList *node = g_list_first(dev->iop); node; node = g_list_next(node))
+  {
+    dt_iop_module_t *module = (dt_iop_module_t *)node->data;
+    if(IS_NULL_PTR(module) || !module->enabled) continue;
+
+    dt_geometry_record_t *record = (dt_geometry_record_t *)g_malloc0(sizeof(dt_geometry_record_t));
+    if(IS_NULL_PTR(record)) continue;
+
+    g_strlcpy(record->op, module->op, sizeof(record->op));
+    record->instance = module->multi_priority;
+    record->iop_order = module->iop_order;
+    record->enabled = TRUE;
+    record->operation_tags = module->operation_tags();
+    record->operation_tags_filter = module->operation_tags_filter();
+
+    /* A module that publishes nothing is identity, which is correct for the ~80 modules that
+     * do not touch geometry -- their record exists only to carry dimensions. A ROSTER module
+     * that publishes nothing is a gap, and the chain must not be trusted until it closes. */
+    const gboolean published = !IS_NULL_PTR(module->geometry_record)
+                               && module->geometry_record(module, record);
+
+    if(!published && _on_roster(module->op))
+    {
+      complete = FALSE;
+      chain->missing = g_list_prepend(chain->missing,
+                                      g_strdup_printf("%s.%d", module->op, module->multi_priority));
+    }
+
+    chain->records = g_list_insert_sorted(chain->records, record, _by_iop_order);
+  }
+
+  _fold_sizes(chain);
+  chain->authoritative = complete && chain->sized;
+}
+
+gboolean dt_geometry_chain_authoritative(const dt_geometry_chain_t *chain)
+{
+  return !IS_NULL_PTR(chain) && chain->authoritative;
+}
+
+gboolean dt_geometry_chain_processed_size(const dt_geometry_chain_t *chain, int *width, int *height)
+{
+  if(IS_NULL_PTR(chain) || !chain->sized) return FALSE;
+  if(!IS_NULL_PTR(width)) *width = chain->processed_width;
+  if(!IS_NULL_PTR(height)) *height = chain->processed_height;
+  return TRUE;
+}
+
+const dt_geometry_record_t *dt_geometry_chain_find(const dt_geometry_chain_t *chain, const char *op,
+                                                   const int instance)
+{
+  if(IS_NULL_PTR(chain) || IS_NULL_PTR(op)) return NULL;
+  for(const GList *node = g_list_first(chain->records); node; node = g_list_next(node))
+  {
+    const dt_geometry_record_t *record = (const dt_geometry_record_t *)node->data;
+    if(!strcmp(record->op, op) && record->instance == instance) return record;
+  }
+  return NULL;
+}
+
+/**
+ * @brief Does this record fall inside the requested bound?
+ *
+ * @details The five modes are dt_dev_distort_transform_plus()'s, reproduced exactly. Every
+ * existing caller's bound has to keep meaning what it meant -- the mask GUI in particular
+ * composes BACK_EXCL up to a module, shifts, then FORW_INCL back out, and a bound that shifted
+ * by one module would move every clone source by that module's transform.
+ */
+static gboolean _in_bound(const dt_geometry_record_t *record, const double iop_order, const int direction)
+{
+  switch(direction)
+  {
+    case DT_DEV_TRANSFORM_DIR_FORW_INCL: return record->iop_order >= iop_order;
+    case DT_DEV_TRANSFORM_DIR_FORW_EXCL: return record->iop_order > iop_order;
+    case DT_DEV_TRANSFORM_DIR_BACK_INCL: return record->iop_order <= iop_order;
+    case DT_DEV_TRANSFORM_DIR_BACK_EXCL: return record->iop_order < iop_order;
+    case DT_DEV_TRANSFORM_DIR_ALL:
+    default: return TRUE;
+  }
+}
+
+int dt_geometry_transform(dt_develop_t *dev, const double iop_order, const int direction, float *points,
+                          const size_t points_count)
+{
+  if(IS_NULL_PTR(dev) || IS_NULL_PTR(dev->geometry_chain) || IS_NULL_PTR(points)) return 0;
+  dt_geometry_chain_t *chain = dev->geometry_chain;
+  if(!chain->authoritative) return 0;
+
+  for(GList *node = g_list_first(chain->records); node; node = g_list_next(node))
+  {
+    dt_geometry_record_t *record = (dt_geometry_record_t *)node->data;
+    if(IS_NULL_PTR(record->vtable) || IS_NULL_PTR(record->vtable->transform)) continue;
+    if(!_in_bound(record, iop_order, direction)) continue;
+    if(_suppressed_by_focus(chain, record)) continue;
+    record->vtable->transform(record->data, record, chain, points, points_count);
+  }
+  return 1;
+}
+
+int dt_geometry_backtransform(dt_develop_t *dev, const double iop_order, const int direction, float *points,
+                              const size_t points_count)
+{
+  if(IS_NULL_PTR(dev) || IS_NULL_PTR(dev->geometry_chain) || IS_NULL_PTR(points)) return 0;
+  dt_geometry_chain_t *chain = dev->geometry_chain;
+  if(!chain->authoritative) return 0;
+
+  for(GList *node = g_list_last(chain->records); node; node = g_list_previous(node))
+  {
+    dt_geometry_record_t *record = (dt_geometry_record_t *)node->data;
+    if(IS_NULL_PTR(record->vtable) || IS_NULL_PTR(record->vtable->backtransform)) continue;
+    if(!_in_bound(record, iop_order, direction)) continue;
+    if(_suppressed_by_focus(chain, record)) continue;
+    record->vtable->backtransform(record->data, record, chain, points, points_count);
+  }
+  return 1;
+}
+
+void dt_geometry_set_focus(dt_develop_t *dev, const dt_iop_module_t *focused, const gboolean editing)
+{
+  if(IS_NULL_PTR(dev) || IS_NULL_PTR(dev->geometry_chain)) return;
+  dev->geometry_chain->focused = focused;
+  dev->geometry_chain->focus_editing = editing;
+}
+
+void dt_geometry_shadow_check_size(dt_develop_t *dev, const int pipe_width, const int pipe_height)
+{
+  if(IS_NULL_PTR(dev) || IS_NULL_PTR(dev->geometry_chain)) return;
+  if(!(dt_get_debug_flags() & DT_DEBUG_DEV)) return;
+
+  const dt_geometry_chain_t *chain = dev->geometry_chain;
+
+  if(!chain->authoritative)
+  {
+    /* Name the gap. "Not ready" is true and useless; the list below is the actual, per-image
+     * work remaining, measured rather than taken from the source audit -- which is how a module
+     * that the audit missed, or one that only becomes enabled on some images, gets found. */
+    if(IS_NULL_PTR(chain->missing))
+    {
+      dt_print(DT_DEBUG_DEV, "[geometry] chain not authoritative: no usable raw geometry yet\n");
+      return;
+    }
+
+    gchar **names = (gchar **)g_malloc0((g_list_length(chain->missing) + 1) * sizeof(gchar *));
+    if(IS_NULL_PTR(names)) return;
+    int i = 0;
+    for(const GList *node = g_list_first(chain->missing); node; node = g_list_next(node))
+      names[i++] = (gchar *)node->data;
+    gchar *joined = g_strjoinv(", ", names);
+    dt_free(names);   // the strings belong to chain->missing; only the vector is ours
+
+    dt_print(DT_DEBUG_DEV, "[geometry] chain not authoritative: %d roster module(s) without a record: %s\n",
+             g_list_length(chain->missing), joined);
+    dt_free(joined);
+    return;
+  }
+
+  if(chain->processed_width != pipe_width || chain->processed_height != pipe_height)
+    dt_print(DT_DEBUG_DEV, "[geometry] SIZE DIVERGENCE: chain %dx%d, pipe %dx%d\n", chain->processed_width,
+             chain->processed_height, pipe_width, pipe_height);
+  else
+    dt_print(DT_DEBUG_DEV, "[geometry] size agrees with the pipe: %dx%d\n", chain->processed_width,
+             chain->processed_height);
+}
+
+// clang-format off
+// modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py
+// vim: shiftwidth=2 expandtab tabstop=2 cindent
+// kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;
+// clang-format on

--- a/src/develop/geometry/geometry.c
+++ b/src/develop/geometry/geometry.c
@@ -51,7 +51,12 @@
  *   - useless: the module template, not built.
  *
  * A module added to this list without a geometry_record() implementation keeps the chain
- * non-authoritative forever, which is the safe direction: consumers go on using the pipe.
+ * non-authoritative forever. That used to be the safe direction because consumers fell back to
+ * the pixel-less pipe; there is no fallback now, so it is instead the LOUD direction -- sizes
+ * come back FALSE and the darkroom cannot lay itself out, with the missing modules named under
+ * `-d dev'. Wholesale authority is still the rule it enforces: composing some modules from
+ * records and the rest from somewhere else interleaves two states, and the result is wrong in a
+ * way that looks plausible.
  */
 static const char *const _roster[] = {
   "rawprepare", "basebuffer", "demosaic", "lens",     "ashift",  "liquify", "rotatepixels",
@@ -78,32 +83,6 @@ struct dt_geometry_chain_t
    * at query time, from whatever the GUI currently is. */
   dt_develop_t *dev;
 };
-
-/**
- * @brief A/B switch for bisecting this service against the pipe it replaces.
- *
- * @details Every migrated consumer falls back to dev->virtual_pipe when the chain is not
- * authoritative, so refusing authority puts the whole GUI back on the pipeline path without
- * rebuilding or reverting anything. Set ANSEL_GEOMETRY_DISABLE=1: a symptom that persists is
- * not this service's doing, one that disappears is.
- *
- * It clears the authority FLAG rather than intercepting the accessor, because the walkers and
- * the shadow harness read that field directly -- an accessor-only switch would have left the
- * transform paths live, which is exactly the half a bisection needs to move.
- */
-static gboolean _geometry_disabled(void)
-{
-  static int disabled = -1;
-  if(disabled < 0)
-  {
-    const char *const env = g_getenv("ANSEL_GEOMETRY_DISABLE");
-    disabled = (!IS_NULL_PTR(env) && env[0] == '1') ? 1 : 0;
-    if(disabled)
-      fprintf(stderr, "[geometry] ANSEL_GEOMETRY_DISABLE=1: the chain declines every query; "
-                      "every consumer falls back to the pixel-less pipe\n");
-  }
-  return disabled == 1;
-}
 
 static gboolean _on_roster(const char *op)
 {
@@ -324,7 +303,7 @@ void dt_geometry_chain_rebuild(dt_develop_t *dev)
   dt_pthread_rwlock_unlock(&dev->history_mutex);
 
   _fold_sizes(chain);
-  chain->authoritative = complete && chain->sized && !_geometry_disabled();
+  chain->authoritative = complete && chain->sized;
 }
 
 gboolean dt_geometry_chain_authoritative(const dt_geometry_chain_t *chain)
@@ -450,8 +429,33 @@ int dt_geometry_backtransform(dt_develop_t *dev, const double iop_order, const i
   return 1;
 }
 
-void dt_geometry_shadow_check(dt_develop_t *dev, const int pipe_width, const int pipe_height,
-                              const double chain_ms)
+/**
+ * @brief What the shadow harness became once there was nothing left to shadow.
+ *
+ * @details It used to compare every answer against the pixel-less pipe, which was the right check
+ * while the pipe still owned them -- it is what caught the chain composing modules the pipe was
+ * suppressing, and it is why the focus exception is evaluated live. That reference is gone with
+ * the pipe, so what is left has to test the chain against ITSELF, and only identities that a
+ * wrong chain can actually fail are worth printing.
+ *
+ * Two of them are:
+ *
+ *   - the round trip. transform then backtransform over the whole chain must return the point it
+ *     started from. Every evaluator's inverse is exercised, and an inverse derived in the wrong
+ *     frame fails it -- which is the question flip's 90-degree orientations pose.
+ *
+ *   - the partition. The bounds are a cut of the same ordered list, so composing the two halves
+ *     must equal composing all of it: FORW_INCL(x) after BACK_EXCL(x) is DIR_ALL, and so is
+ *     FORW_EXCL(x) after BACK_INCL(x), for x at every module's own iop_order. This is the bound
+ *     bookkeeping the module GUIs depend on -- they ask for their own iop_order, never DIR_ALL --
+ *     and an off-by-one in _in_bound() drops or repeats exactly one module here.
+ *
+ * What it can no longer catch is a chain that is self-consistently wrong: both halves of a
+ * partition composing the same wrong subset still add up. That check needed a second
+ * implementation, and keeping a whole pipeline alive to be one was the cost this service exists
+ * to remove. Under `-d dev'; never changes behaviour.
+ */
+void dt_geometry_self_check(dt_develop_t *dev, const double chain_ms)
 {
   if(IS_NULL_PTR(dev) || IS_NULL_PTR(dev->geometry_chain)) return;
   if(!(dt_get_debug_flags() & DT_DEBUG_DEV)) return;
@@ -483,60 +487,17 @@ void dt_geometry_shadow_check(dt_develop_t *dev, const int pipe_width, const int
     return;
   }
 
-  if(chain->processed_width != pipe_width || chain->processed_height != pipe_height)
-  {
-    dt_print(DT_DEBUG_DEV, "[geometry] SIZE DIVERGENCE: chain %dx%d, pipe %dx%d\n", chain->processed_width,
-             chain->processed_height, pipe_width, pipe_height);
-    return;
-  }
-
-  /* The size fold only exercises map_size. Probe the point transforms too, or the evaluators
-   * that actually move overlays would go unverified until a consumer switched over and a user
-   * noticed a mask sitting in the wrong place.
-   *
-   * Five points spanning the raw frame, forward through everything (iop_order 0, DIR_ALL --
-   * what dt_dev_coordinates_raw_abs_to_image_abs() asks for), then the same through the pipe.
-   * The tolerance is half a pixel: both sides do the same arithmetic in the same order, so they
-   * should agree exactly, but the fold's rects reach the evaluators as ints on one side and
-   * through piece->buf_in on the other, and a rounding difference of that size is not a defect
-   * worth failing on. Anything larger is a real divergence and is printed with the point. */
+  /* Five points spanning the raw frame. The tolerance is half a pixel throughout: every identity
+   * below composes the same evaluators in the same order, so they should agree exactly, but the
+   * fold's rects reach them as ints and a rounding difference of that size is not a defect worth
+   * failing on. Anything larger is real and is printed with the point. */
   const float w = (float)chain->raw_width;
   const float h = (float)chain->raw_height;
-  float chain_points[10] = { 0.f, 0.f, w, 0.f, 0.f, h, w, h, 0.5f * w, 0.5f * h };
-  float pipe_points[10];
-  memcpy(pipe_points, chain_points, sizeof(pipe_points));
-
-  if(!dt_geometry_transform(dev, 0.0, DT_DEV_TRANSFORM_DIR_ALL, chain_points, 5)) return;
-  if(IS_NULL_PTR(dev->virtual_pipe)) return;
-  dt_dev_distort_transform_plus(dev->virtual_pipe, 0.0, DT_DEV_TRANSFORM_DIR_ALL, pipe_points, 5);
-
-  int diverged = 0;
-  for(int i = 0; i < 5; i++)
-  {
-    if(fabsf(chain_points[2 * i] - pipe_points[2 * i]) > 0.5f
-       || fabsf(chain_points[2 * i + 1] - pipe_points[2 * i + 1]) > 0.5f)
-    {
-      dt_print(DT_DEBUG_DEV,
-               "[geometry] TRANSFORM DIVERGENCE at probe %d: chain (%.2f, %.2f), pipe (%.2f, %.2f)\n", i,
-               chain_points[2 * i], chain_points[2 * i + 1], pipe_points[2 * i], pipe_points[2 * i + 1]);
-      diverged++;
-    }
-  }
-
-  /* And the inverse. Comparing forward against the pipe leaves every backtransform evaluator
-   * unverified -- they are only ever exercised by GUI consumers that have not switched over yet
-   * -- so round-trip the same probes through the chain and require the identity back.
-   *
-   * This is the check that decides a real question about flip, whose forward flips against the
-   * input dimensions and THEN swaps the axes. Its inverse un-swaps and unflips against those
-   * same dimensions, in the pre-swap frame where they are the right ones; swapping the
-   * dimensions as well -- which the neighbouring modify_roi_in helper legitimately does, in its
-   * own rectangle-mapping convention -- would break exactly the 90-degree orientations this
-   * probe covers. Composed here rather than argued. */
-  float roundtrip[10] = { 0.f, 0.f, w, 0.f, 0.f, h, w, h, 0.5f * w, 0.5f * h };
   const float origin[10] = { 0.f, 0.f, w, 0.f, 0.f, h, w, h, 0.5f * w, 0.5f * h };
 
-  dt_geometry_transform(dev, 0.0, DT_DEV_TRANSFORM_DIR_ALL, roundtrip, 5);
+  float roundtrip[10];
+  memcpy(roundtrip, origin, sizeof(roundtrip));
+  if(!dt_geometry_transform(dev, 0.0, DT_DEV_TRANSFORM_DIR_ALL, roundtrip, 5)) return;
   dt_geometry_backtransform(dev, 0.0, DT_DEV_TRANSFORM_DIR_ALL, roundtrip, 5);
 
   int not_identity = 0;
@@ -552,21 +513,13 @@ void dt_geometry_shadow_check(dt_develop_t *dev, const int pipe_width, const int
     }
   }
 
-  /* The bounds the module GUIs actually use.
-   *
-   * Everything above probes iop_order 0 and DIR_ALL, which is what the coordinate converters
-   * ask -- and nothing else does. A module GUI asks for its OWN iop_order with FORW_INCL,
-   * FORW_EXCL or BACK_EXCL, and those compose a different subset of the chain: a divergence
-   * confined to one of them is invisible to a DIR_ALL probe. That is exactly how a chain that
-   * never applied the focused-module exception passed every check here while drawing ashift's
-   * detected lines against the wrong module stack.
-   *
-   * So probe each roster record at its own iop_order, in the three bounds the GUIs use, against
-   * the pipe doing the same. Cheap -- one point, a handful of records -- and it covers the
-   * question the migrated call sites actually ask. */
-  static const int bounds[3] = { DT_DEV_TRANSFORM_DIR_FORW_INCL, DT_DEV_TRANSFORM_DIR_FORW_EXCL,
-                                 DT_DEV_TRANSFORM_DIR_BACK_EXCL };
-  static const char *const bound_names[3] = { "FORW_INCL", "FORW_EXCL", "BACK_EXCL" };
+  // The whole chain, once: what both halves of every partition below must add up to.
+  float whole[2] = { 0.37f * w, 0.61f * h };
+  dt_geometry_transform(dev, 0.0, DT_DEV_TRANSFORM_DIR_ALL, whole, 1);
+
+  static const int back[2] = { DT_DEV_TRANSFORM_DIR_BACK_EXCL, DT_DEV_TRANSFORM_DIR_BACK_INCL };
+  static const int forw[2] = { DT_DEV_TRANSFORM_DIR_FORW_INCL, DT_DEV_TRANSFORM_DIR_FORW_EXCL };
+  static const char *const cut_names[2] = { "BACK_EXCL|FORW_INCL", "BACK_INCL|FORW_EXCL" };
   int bound_diverged = 0;
 
   for(const GList *node = g_list_first(chain->records); node; node = g_list_next(node))
@@ -574,39 +527,32 @@ void dt_geometry_shadow_check(dt_develop_t *dev, const int pipe_width, const int
     const dt_geometry_record_t *const record = (const dt_geometry_record_t *)node->data;
     if(!record->enabled || IS_NULL_PTR(record->vtable)) continue;
 
-    for(int b = 0; b < 3; b++)
+    for(int c = 0; c < 2; c++)
     {
-      float cp[2] = { 0.37f * w, 0.61f * h };
-      float pp[2] = { cp[0], cp[1] };
+      float cut[2] = { 0.37f * w, 0.61f * h };
+      dt_geometry_transform(dev, record->iop_order, back[c], cut, 1);
+      dt_geometry_transform(dev, record->iop_order, forw[c], cut, 1);
 
-      dt_geometry_transform(dev, record->iop_order, bounds[b], cp, 1);
-      dt_dev_distort_transform_plus(dev->virtual_pipe, record->iop_order, bounds[b], pp, 1);
-
-      if(fabsf(cp[0] - pp[0]) > 0.5f || fabsf(cp[1] - pp[1]) > 0.5f)
+      if(fabsf(cut[0] - whole[0]) > 0.5f || fabsf(cut[1] - whole[1]) > 0.5f)
       {
         dt_print(DT_DEBUG_DEV,
-                 "[geometry] BOUND DIVERGENCE at %s.%d %s: chain (%.2f, %.2f), pipe (%.2f, %.2f)\n",
-                 record->op, record->instance, bound_names[b], cp[0], cp[1], pp[0], pp[1]);
+                 "[geometry] BOUND DIVERGENCE at %s.%d %s: cut (%.2f, %.2f), whole (%.2f, %.2f)\n",
+                 record->op, record->instance, cut_names[c], cut[0], cut[1], whole[0], whole[1]);
         bound_diverged++;
       }
     }
   }
 
-  if(bound_diverged)
-    dt_print(DT_DEBUG_DEV, "[geometry] %d module-relative bound probe(s) diverge\n", bound_diverged);
-
-  if(diverged || not_identity || bound_diverged)
-    dt_print(DT_DEBUG_DEV,
-             "[geometry] size agrees (%dx%d) but %d/5 forward, %d/5 round-trips, %d bounds diverge\n",
-             chain->processed_width, chain->processed_height, diverged, not_identity, bound_diverged);
+  if(not_identity || bound_diverged)
+    dt_print(DT_DEBUG_DEV, "[geometry] size %dx%d, %d/5 round-trips and %d bound cut(s) diverge\n",
+             chain->processed_width, chain->processed_height, not_identity, bound_diverged);
   else
-    dt_print(DT_DEBUG_DEV,
-             "[geometry] agrees with the pipe: size %dx%d, 5/5 forward, 5/5 round-trips, all bounds\n",
+    dt_print(DT_DEBUG_DEV, "[geometry] consistent: size %dx%d, 5/5 round-trips, all bound cuts\n",
              chain->processed_width, chain->processed_height);
 
-  /* The cost, which is the reason this service exists. Compare against `-d perf's "pipeline
-   * resync with history ... for pipe virtual-preview" line: that is the same product, computed
-   * the way this replaces. */
+  /* The cost, which is the reason this service exists. Its predecessor's counterpart is in the
+   * git history of this file and in doc/geometry-service.md: `-d perf's "pipeline resync with
+   * history ... for pipe virtual-preview", 0.10 to 0.33 s, on this same thread. */
   dt_print(DT_DEBUG_DEV, "[geometry] chain rebuilt in %.2f ms\n", chain_ms);
 }
 

--- a/src/develop/geometry/geometry.c
+++ b/src/develop/geometry/geometry.c
@@ -342,13 +342,11 @@ static gboolean _in_bound(const dt_geometry_record_t *record, const double iop_o
   }
 }
 
-int dt_geometry_transform(dt_develop_t *dev, const double iop_order, const int direction, float *points,
-                          const size_t points_count)
+/** @brief The forward fold over a chain, shared by the public entry point and by
+ *  dt_geometry_chain_compose(). Assumes the chain is usable; the callers check. */
+static int _compose_forward(dt_geometry_chain_t *chain, const double iop_order, const int direction,
+                            float *points, const size_t points_count)
 {
-  if(IS_NULL_PTR(dev) || IS_NULL_PTR(dev->geometry_chain) || IS_NULL_PTR(points)) return 0;
-  dt_geometry_chain_t *chain = dev->geometry_chain;
-  if(!chain->authoritative) return 0;
-
   for(GList *node = g_list_first(chain->records); node; node = g_list_next(node))
   {
     dt_geometry_record_t *record = (dt_geometry_record_t *)node->data;
@@ -358,6 +356,23 @@ int dt_geometry_transform(dt_develop_t *dev, const double iop_order, const int d
     record->vtable->transform(record->data, record, chain, points, points_count);
   }
   return 1;
+}
+
+int dt_geometry_chain_compose(dt_geometry_chain_t *chain, const double iop_order, const int direction,
+                              float *points, const size_t points_count)
+{
+  if(IS_NULL_PTR(chain) || IS_NULL_PTR(points)) return 0;
+  return _compose_forward(chain, iop_order, direction, points, points_count);
+}
+
+int dt_geometry_transform(dt_develop_t *dev, const double iop_order, const int direction, float *points,
+                          const size_t points_count)
+{
+  if(IS_NULL_PTR(dev) || IS_NULL_PTR(dev->geometry_chain) || IS_NULL_PTR(points)) return 0;
+  dt_geometry_chain_t *chain = dev->geometry_chain;
+  if(!chain->authoritative) return 0;
+
+  return _compose_forward(chain, iop_order, direction, points, points_count);
 }
 
 int dt_geometry_backtransform(dt_develop_t *dev, const double iop_order, const int direction, float *points,

--- a/src/develop/geometry/geometry.c
+++ b/src/develop/geometry/geometry.c
@@ -24,6 +24,7 @@
 #include "develop/imageop.h"
 #include "system/mem_alloc.h"
 
+#include <math.h>
 #include <string.h>
 
 /**
@@ -370,11 +371,51 @@ void dt_geometry_shadow_check_size(dt_develop_t *dev, const int pipe_width, cons
   }
 
   if(chain->processed_width != pipe_width || chain->processed_height != pipe_height)
+  {
     dt_print(DT_DEBUG_DEV, "[geometry] SIZE DIVERGENCE: chain %dx%d, pipe %dx%d\n", chain->processed_width,
              chain->processed_height, pipe_width, pipe_height);
+    return;
+  }
+
+  /* The size fold only exercises map_size. Probe the point transforms too, or the evaluators
+   * that actually move overlays would go unverified until a consumer switched over and a user
+   * noticed a mask sitting in the wrong place.
+   *
+   * Five points spanning the raw frame, forward through everything (iop_order 0, DIR_ALL --
+   * what dt_dev_coordinates_raw_abs_to_image_abs() asks for), then the same through the pipe.
+   * The tolerance is half a pixel: both sides do the same arithmetic in the same order, so they
+   * should agree exactly, but the fold's rects reach the evaluators as ints on one side and
+   * through piece->buf_in on the other, and a rounding difference of that size is not a defect
+   * worth failing on. Anything larger is a real divergence and is printed with the point. */
+  const float w = (float)chain->raw_width;
+  const float h = (float)chain->raw_height;
+  float chain_points[10] = { 0.f, 0.f, w, 0.f, 0.f, h, w, h, 0.5f * w, 0.5f * h };
+  float pipe_points[10];
+  memcpy(pipe_points, chain_points, sizeof(pipe_points));
+
+  if(!dt_geometry_transform(dev, 0.0, DT_DEV_TRANSFORM_DIR_ALL, chain_points, 5)) return;
+  if(IS_NULL_PTR(dev->virtual_pipe)) return;
+  dt_dev_distort_transform_plus(dev->virtual_pipe, 0.0, DT_DEV_TRANSFORM_DIR_ALL, pipe_points, 5);
+
+  int diverged = 0;
+  for(int i = 0; i < 5; i++)
+  {
+    if(fabsf(chain_points[2 * i] - pipe_points[2 * i]) > 0.5f
+       || fabsf(chain_points[2 * i + 1] - pipe_points[2 * i + 1]) > 0.5f)
+    {
+      dt_print(DT_DEBUG_DEV,
+               "[geometry] TRANSFORM DIVERGENCE at probe %d: chain (%.2f, %.2f), pipe (%.2f, %.2f)\n", i,
+               chain_points[2 * i], chain_points[2 * i + 1], pipe_points[2 * i], pipe_points[2 * i + 1]);
+      diverged++;
+    }
+  }
+
+  if(diverged)
+    dt_print(DT_DEBUG_DEV, "[geometry] size agrees (%dx%d) but %d/5 transform probes diverge\n",
+             chain->processed_width, chain->processed_height, diverged);
   else
-    dt_print(DT_DEBUG_DEV, "[geometry] size agrees with the pipe: %dx%d\n", chain->processed_width,
-             chain->processed_height);
+    dt_print(DT_DEBUG_DEV, "[geometry] agrees with the pipe: size %dx%d, all 5 transform probes\n",
+             chain->processed_width, chain->processed_height);
 }
 
 // clang-format off

--- a/src/develop/geometry/geometry.c
+++ b/src/develop/geometry/geometry.c
@@ -389,6 +389,32 @@ static int _compose_forward(dt_geometry_chain_t *chain, const double iop_order, 
   return 1;
 }
 
+int dt_geometry_module_transform(dt_develop_t *dev, const dt_iop_module_t *module, float *points,
+                                 const size_t points_count)
+{
+  if(IS_NULL_PTR(dev) || IS_NULL_PTR(module) || IS_NULL_PTR(points)) return 0;
+
+  dt_geometry_chain_t *const chain = dev->geometry_chain;
+  if(IS_NULL_PTR(chain) || !chain->authoritative) return 0;
+
+  dt_geometry_record_t *record = NULL;
+  for(GList *node = g_list_first(chain->records); node; node = g_list_next(node))
+  {
+    dt_geometry_record_t *const candidate = (dt_geometry_record_t *)node->data;
+    if(!strcmp(candidate->op, module->op) && candidate->instance == module->multi_priority)
+    {
+      record = candidate;
+      break;
+    }
+  }
+
+  if(IS_NULL_PTR(record) || !record->enabled) return 0;
+  if(IS_NULL_PTR(record->vtable) || IS_NULL_PTR(record->vtable->transform)) return 0;
+  if(_suppressed_by_focus(chain, record)) return 0;
+
+  return record->vtable->transform(record->data, record, chain, points, points_count);
+}
+
 int dt_geometry_chain_compose(dt_geometry_chain_t *chain, const double iop_order, const int direction,
                               float *points, const size_t points_count)
 {

--- a/src/develop/geometry/geometry.c
+++ b/src/develop/geometry/geometry.c
@@ -73,16 +73,10 @@ struct dt_geometry_chain_t
    * reporting "not ready", which would be true and useless. */
   GList *missing;   /**< gchar*, owned */
 
-  /* Query-time GUI state, published by dt_geometry_set_focus(). Held BY VALUE, not as a
-   * dt_iop_module_t pointer: the focus outlives individual publications, and a module can be
-   * destroyed (instance removed, image changed, darkroom left) without anyone telling this
-   * chain. A stored pointer would then be dereferenced by the next query. The two things the
-   * exception needs -- who is focused, and what that module filters -- are both immutable for
-   * a given module, so copying them costs nothing and cannot dangle. */
-  char focus_op[32];
-  int focus_instance;
-  int focus_tags_filter;
-  gboolean focus_active;
+  /* The dev this chain belongs to. Owned by it and freed with it, so it cannot dangle, and it
+   * is what lets the focus exception below be evaluated the way the pipe evaluates it: live,
+   * at query time, from whatever the GUI currently is. */
+  dt_develop_t *dev;
 };
 
 static gboolean _on_roster(const char *op)
@@ -143,9 +137,19 @@ static gint _by_iop_order(gconstpointer a, gconstpointer b)
  */
 static gboolean _suppressed_by_focus(const dt_geometry_chain_t *chain, const dt_geometry_record_t *record)
 {
-  if(!chain->focus_active) return FALSE;
-  if(!strcmp(chain->focus_op, record->op) && chain->focus_instance == record->instance) return FALSE;
-  return (chain->focus_tags_filter & record->operation_tags) != 0;
+  dt_develop_t *const dev = chain->dev;
+  if(IS_NULL_PTR(dev) || !dev->gui_attached) return FALSE;
+
+  dt_iop_module_t *const focused = dev->gui_module;
+  if(IS_NULL_PTR(focused)) return FALSE;
+
+  // the focused module never suppresses itself
+  if(!strcmp(focused->op, record->op) && focused->multi_priority == record->instance) return FALSE;
+
+  // cache bypass is the hint that the focused module is in an editing mode
+  if(!dt_iop_get_cache_bypass(focused)) return FALSE;
+
+  return (focused->operation_tags_filter() & record->operation_tags) != 0;
 }
 
 /**
@@ -236,6 +240,7 @@ void dt_geometry_chain_rebuild(dt_develop_t *dev)
 
   dt_geometry_chain_t *chain = dev->geometry_chain;
   _chain_clear(chain);
+  chain->dev = dev;
 
   int32_t raw_width = 0;
   int32_t raw_height = 0;
@@ -393,29 +398,6 @@ int dt_geometry_backtransform(dt_develop_t *dev, const double iop_order, const i
   return 1;
 }
 
-void dt_geometry_set_focus(dt_develop_t *dev, const dt_iop_module_t *focused, const gboolean editing)
-{
-  if(IS_NULL_PTR(dev) || IS_NULL_PTR(dev->geometry_chain)) return;
-  dt_geometry_chain_t *chain = dev->geometry_chain;
-
-  if(IS_NULL_PTR(focused) || !editing)
-  {
-    chain->focus_active = FALSE;
-    return;
-  }
-
-  g_strlcpy(chain->focus_op, focused->op, sizeof(chain->focus_op));
-  chain->focus_instance = focused->multi_priority;
-  chain->focus_tags_filter = focused->operation_tags_filter();
-  chain->focus_active = TRUE;
-}
-
-void dt_geometry_clear_focus(dt_develop_t *dev)
-{
-  if(IS_NULL_PTR(dev) || IS_NULL_PTR(dev->geometry_chain)) return;
-  dev->geometry_chain->focus_active = FALSE;
-}
-
 void dt_geometry_shadow_check(dt_develop_t *dev, const int pipe_width, const int pipe_height,
                               const double chain_ms)
 {
@@ -518,13 +500,56 @@ void dt_geometry_shadow_check(dt_develop_t *dev, const int pipe_width, const int
     }
   }
 
-  if(diverged || not_identity)
+  /* The bounds the module GUIs actually use.
+   *
+   * Everything above probes iop_order 0 and DIR_ALL, which is what the coordinate converters
+   * ask -- and nothing else does. A module GUI asks for its OWN iop_order with FORW_INCL,
+   * FORW_EXCL or BACK_EXCL, and those compose a different subset of the chain: a divergence
+   * confined to one of them is invisible to a DIR_ALL probe. That is exactly how a chain that
+   * never applied the focused-module exception passed every check here while drawing ashift's
+   * detected lines against the wrong module stack.
+   *
+   * So probe each roster record at its own iop_order, in the three bounds the GUIs use, against
+   * the pipe doing the same. Cheap -- one point, a handful of records -- and it covers the
+   * question the migrated call sites actually ask. */
+  static const int bounds[3] = { DT_DEV_TRANSFORM_DIR_FORW_INCL, DT_DEV_TRANSFORM_DIR_FORW_EXCL,
+                                 DT_DEV_TRANSFORM_DIR_BACK_EXCL };
+  static const char *const bound_names[3] = { "FORW_INCL", "FORW_EXCL", "BACK_EXCL" };
+  int bound_diverged = 0;
+
+  for(const GList *node = g_list_first(chain->records); node; node = g_list_next(node))
+  {
+    const dt_geometry_record_t *const record = (const dt_geometry_record_t *)node->data;
+    if(!record->enabled || IS_NULL_PTR(record->vtable)) continue;
+
+    for(int b = 0; b < 3; b++)
+    {
+      float cp[2] = { 0.37f * w, 0.61f * h };
+      float pp[2] = { cp[0], cp[1] };
+
+      dt_geometry_transform(dev, record->iop_order, bounds[b], cp, 1);
+      dt_dev_distort_transform_plus(dev->virtual_pipe, record->iop_order, bounds[b], pp, 1);
+
+      if(fabsf(cp[0] - pp[0]) > 0.5f || fabsf(cp[1] - pp[1]) > 0.5f)
+      {
+        dt_print(DT_DEBUG_DEV,
+                 "[geometry] BOUND DIVERGENCE at %s.%d %s: chain (%.2f, %.2f), pipe (%.2f, %.2f)\n",
+                 record->op, record->instance, bound_names[b], cp[0], cp[1], pp[0], pp[1]);
+        bound_diverged++;
+      }
+    }
+  }
+
+  if(bound_diverged)
+    dt_print(DT_DEBUG_DEV, "[geometry] %d module-relative bound probe(s) diverge\n", bound_diverged);
+
+  if(diverged || not_identity || bound_diverged)
     dt_print(DT_DEBUG_DEV,
-             "[geometry] size agrees (%dx%d) but %d/5 forward probes and %d/5 round-trips diverge\n",
-             chain->processed_width, chain->processed_height, diverged, not_identity);
+             "[geometry] size agrees (%dx%d) but %d/5 forward, %d/5 round-trips, %d bounds diverge\n",
+             chain->processed_width, chain->processed_height, diverged, not_identity, bound_diverged);
   else
     dt_print(DT_DEBUG_DEV,
-             "[geometry] agrees with the pipe: size %dx%d, 5/5 forward probes, 5/5 round-trips\n",
+             "[geometry] agrees with the pipe: size %dx%d, 5/5 forward, 5/5 round-trips, all bounds\n",
              chain->processed_width, chain->processed_height);
 
   /* The cost, which is the reason this service exists. Compare against `-d perf's "pipeline

--- a/src/develop/geometry/geometry.c
+++ b/src/develop/geometry/geometry.c
@@ -410,11 +410,42 @@ void dt_geometry_shadow_check_size(dt_develop_t *dev, const int pipe_width, cons
     }
   }
 
-  if(diverged)
-    dt_print(DT_DEBUG_DEV, "[geometry] size agrees (%dx%d) but %d/5 transform probes diverge\n",
-             chain->processed_width, chain->processed_height, diverged);
+  /* And the inverse. Comparing forward against the pipe leaves every backtransform evaluator
+   * unverified -- they are only ever exercised by GUI consumers that have not switched over yet
+   * -- so round-trip the same probes through the chain and require the identity back.
+   *
+   * This is the check that decides a real question about flip, whose forward flips against the
+   * input dimensions and THEN swaps the axes. Its inverse un-swaps and unflips against those
+   * same dimensions, in the pre-swap frame where they are the right ones; swapping the
+   * dimensions as well -- which the neighbouring modify_roi_in helper legitimately does, in its
+   * own rectangle-mapping convention -- would break exactly the 90-degree orientations this
+   * probe covers. Composed here rather than argued. */
+  float roundtrip[10] = { 0.f, 0.f, w, 0.f, 0.f, h, w, h, 0.5f * w, 0.5f * h };
+  const float origin[10] = { 0.f, 0.f, w, 0.f, 0.f, h, w, h, 0.5f * w, 0.5f * h };
+
+  dt_geometry_transform(dev, 0.0, DT_DEV_TRANSFORM_DIR_ALL, roundtrip, 5);
+  dt_geometry_backtransform(dev, 0.0, DT_DEV_TRANSFORM_DIR_ALL, roundtrip, 5);
+
+  int not_identity = 0;
+  for(int i = 0; i < 5; i++)
+  {
+    if(fabsf(roundtrip[2 * i] - origin[2 * i]) > 0.5f
+       || fabsf(roundtrip[2 * i + 1] - origin[2 * i + 1]) > 0.5f)
+    {
+      dt_print(DT_DEBUG_DEV,
+               "[geometry] ROUND-TRIP DIVERGENCE at probe %d: (%.2f, %.2f) came back as (%.2f, %.2f)\n", i,
+               origin[2 * i], origin[2 * i + 1], roundtrip[2 * i], roundtrip[2 * i + 1]);
+      not_identity++;
+    }
+  }
+
+  if(diverged || not_identity)
+    dt_print(DT_DEBUG_DEV,
+             "[geometry] size agrees (%dx%d) but %d/5 forward probes and %d/5 round-trips diverge\n",
+             chain->processed_width, chain->processed_height, diverged, not_identity);
   else
-    dt_print(DT_DEBUG_DEV, "[geometry] agrees with the pipe: size %dx%d, all 5 transform probes\n",
+    dt_print(DT_DEBUG_DEV,
+             "[geometry] agrees with the pipe: size %dx%d, 5/5 forward probes, 5/5 round-trips\n",
              chain->processed_width, chain->processed_height);
 }
 

--- a/src/develop/geometry/geometry.h
+++ b/src/develop/geometry/geometry.h
@@ -169,6 +169,22 @@ int dt_geometry_backtransform(struct dt_develop_t *dev, double iop_order, int di
                               size_t points_count);
 
 /**
+ * @brief Compose the chain over @p points, for a record evaluator that needs the transform
+ * stack around its own module.
+ *
+ * @details The nested case, and the reason ::dt_geometry_vtable_t hands every evaluator the
+ * chain. iop/liquify.c is the one that needs it: its warps are stored in RAW sensor
+ * coordinates, so before it can rasterise anything it has to push its own path nodes through
+ * everything upstream of itself. On the pixel pipe it does that by re-entering the pipe walker
+ * mid-walk; here it re-enters this.
+ *
+ * Bounded exactly like the walkers, so BACK_EXCL of the caller's own iop_order excludes the
+ * caller and the recursion terminates. Do not call it with a bound that includes the caller.
+ */
+int dt_geometry_chain_compose(dt_geometry_chain_t *chain, double iop_order, int direction, float *points,
+                              size_t points_count);
+
+/**
  * @brief Publish the focused module and its editing state, for the query-time GUI exception.
  *
  * @details dt_dev_pixelpipe_activemodule_disables_currentmodule() reads the focused module, its

--- a/src/develop/geometry/geometry.h
+++ b/src/develop/geometry/geometry.h
@@ -97,10 +97,10 @@ typedef struct dt_geometry_record_t
   double iop_order;        /**< position in the pipe; the walkers' ordering and bound */
   gboolean enabled;
 
-  /* Cached so the query-time GUI exception can be evaluated without touching dt_iop_module_t
-   * from a consumer. See dt_geometry_set_focus(). */
+  /* The candidate half of the query-time GUI exception: the FOCUSED module's tag filter is
+   * tested against this. The focused module's own filter is not stored per record -- it is one
+   * value for the whole query, and it lives on the chain. See dt_geometry_set_focus(). */
   int operation_tags;
-  int operation_tags_filter;
 
   const dt_geometry_vtable_t *vtable;   /**< NULL: this module is geometrically identity */
   void *data;                           /**< module-owned blob, freed by ::free_data */
@@ -171,6 +171,11 @@ int dt_geometry_backtransform(struct dt_develop_t *dev, double iop_order, int di
  */
 void dt_geometry_set_focus(struct dt_develop_t *dev, const struct dt_iop_module_t *focused,
                            gboolean editing);
+
+/** @brief Forget the focused module. Call before any module list teardown -- see the note on
+ *  dt_geometry_set_focus(): the chain keeps the focus by VALUE precisely so a stale publication
+ *  cannot dereference a destroyed module, but clearing it at teardown keeps the state honest. */
+void dt_geometry_clear_focus(struct dt_develop_t *dev);
 
 /**
  * @brief Shadow mode: compare the chain against the pipe that still owns the answer.

--- a/src/develop/geometry/geometry.h
+++ b/src/develop/geometry/geometry.h
@@ -184,23 +184,18 @@ int dt_geometry_backtransform(struct dt_develop_t *dev, double iop_order, int di
 int dt_geometry_chain_compose(dt_geometry_chain_t *chain, double iop_order, int direction, float *points,
                               size_t points_count);
 
-/**
- * @brief Publish the focused module and its editing state, for the query-time GUI exception.
+/* THE FOCUS EXCEPTION is not an entry point, deliberately. It used to be one -- a setter the GUI
+ * was supposed to call when the focused module or its editing state changed -- and nothing ever
+ * called it, so the chain composed every module while the pipe was skipping the ones the focused
+ * module's tag filter disables. The visible result was ashift's detected-lines overlay drawn
+ * against a different module stack than the image under it.
  *
- * @details dt_dev_pixelpipe_activemodule_disables_currentmodule() reads the focused module, its
- * operation_tags_filter() and its live cache-bypass flag, and disables matching modules for the
- * duration of a walk -- and, in the size fold, for the resulting processed size too. That is
- * view state: it changes when the user clicks into crop's edit mode, with no history commit
- * anywhere. It therefore cannot be baked into records; the chain reads it at query time, from
- * whatever the GUI last published here.
+ * A published copy of view state has to be refreshed to stay true and is wrong in between; that
+ * is the same lesson control/input.h records about the stored mouse-button state. So the chain
+ * now reads it where the pipe reads it -- dev->gui_module, its operation_tags_filter() and its
+ * live cache-bypass flag, at query time -- and the two cannot drift because there is nothing to
+ * keep in step. Do not reintroduce a setter for this.
  */
-void dt_geometry_set_focus(struct dt_develop_t *dev, const struct dt_iop_module_t *focused,
-                           gboolean editing);
-
-/** @brief Forget the focused module. Call before any module list teardown -- see the note on
- *  dt_geometry_set_focus(): the chain keeps the focus by VALUE precisely so a stale publication
- *  cannot dereference a destroyed module, but clearing it at teardown keeps the state honest. */
-void dt_geometry_clear_focus(struct dt_develop_t *dev);
 
 /**
  * @brief Shadow mode: compare the chain against the pipe that still owns the answer.

--- a/src/develop/geometry/geometry.h
+++ b/src/develop/geometry/geometry.h
@@ -1,0 +1,191 @@
+/*
+    This file is part of Ansel.
+    Copyright (C) 2026 Aurélien Pierre.
+
+    Ansel is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Ansel is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Ansel.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+/** @file develop/geometry/geometry.h
+ *
+ * @brief Where things are on the image, answered without a pipeline.
+ *
+ * @details The GUI constantly needs two geometric facts: how big the developed image is, and
+ * where a point on it lands after the distorting modules have had their say. Today both are
+ * answered by `dev->virtual_pipe' -- a complete, pixel-less clone of all ~95 IOP modules, their
+ * history committed into real pipeline nodes, resynchronised on the GUI thread at every history
+ * commit for 0.10 to 0.33 s. It renders nothing. It exists only to be walked.
+ *
+ * This module replaces that with the data the walk actually consumes. Each module that changes
+ * geometry publishes a small record -- its transform as values, not as a node -- and the GUI
+ * composes sizes and coordinates from the ordered list. See doc/geometry-service.md for the
+ * decision, the survey behind it, and the tranche plan; the traps section there is not
+ * optional reading.
+ *
+ * THREADING. This is GUI-thread state and takes no locks. Nothing else may touch it. The pixel
+ * pipelines keep their own piece-based modify_roi and distort callbacks for rendering, and the
+ * two must never be crossed: a worker that needs geometry asks its own pieces.
+ *
+ * STATUS: skeleton (tranche G2). No module publishes a record yet, so the chain is never
+ * authoritative and nothing consumes it; it runs beside the virtual pipe and reports what it
+ * would need in order to take over. Shadow mode is the whole point of this tranche.
+ */
+
+#ifndef DT_DEVELOP_GEOMETRY_GEOMETRY_H
+#define DT_DEVELOP_GEOMETRY_GEOMETRY_H
+
+#include <glib.h>
+#include <stdint.h>
+
+#include "develop/pixelpipe_hb.h"   // dt_iop_roi_t
+
+struct dt_develop_t;
+struct dt_iop_module_t;
+struct dt_geometry_record_t;
+struct dt_geometry_chain_t;
+
+/**
+ * @brief A module's geometry, evaluated. Pure functions of the record's own data.
+ *
+ * @details Every entry may be NULL, which means "identity for this operation": a module that
+ * resizes but does not move points (demosaic's downsample) has a map_size and no transform, and
+ * a module that is only ever asked for its dimensions (graduatednd) has neither.
+ *
+ * These evaluators are the SAME code the module's own distort_transform()/modify_roi_out() run
+ * on the pixel pipe -- one shared static helper per module, called from both sides. That rule is
+ * not stylistic: two derivations of the same geometry drift, and the drift shows up as an
+ * overlay that no longer sits on the thing it describes, months later, on one image.
+ */
+typedef struct dt_geometry_vtable_t
+{
+  /** @brief Full-resolution input rect -> output rect. Mirrors modify_roi_out() at scale 1. */
+  void (*map_size)(const void *data, const dt_iop_roi_t *const in, dt_iop_roi_t *out);
+
+  /** @brief Image coordinates in -> image coordinates out, in place, @p points_count pairs.
+   *  @p ctx composes the sub-chain upstream of this record, for the one module that needs it
+   *  (liquify's warps live in RAW coordinates). NULL for every other module. */
+  int (*transform)(const void *data, const struct dt_geometry_record_t *const record,
+                   struct dt_geometry_chain_t *chain, float *points, size_t points_count);
+
+  /** @brief The inverse of ::transform. */
+  int (*backtransform)(const void *data, const struct dt_geometry_record_t *const record,
+                       struct dt_geometry_chain_t *chain, float *points, size_t points_count);
+} dt_geometry_vtable_t;
+
+/**
+ * @brief One module instance's contribution, as data.
+ *
+ * @details There is a record for EVERY enabled module, not only the geometric ones: consumers
+ * ask this list for their own module's input and output dimensions, and `graduatednd' -- which
+ * has no geometry callbacks at all -- is one of them. A module with no geometry gets a record
+ * with a NULL vtable, which the size fold treats as identity and the walkers skip.
+ */
+typedef struct dt_geometry_record_t
+{
+  char op[32];             /**< module operation name */
+  int instance;            /**< multi_priority: which instance of that operation */
+  double iop_order;        /**< position in the pipe; the walkers' ordering and bound */
+  gboolean enabled;
+
+  /* Cached so the query-time GUI exception can be evaluated without touching dt_iop_module_t
+   * from a consumer. See dt_geometry_set_focus(). */
+  int operation_tags;
+  int operation_tags_filter;
+
+  const dt_geometry_vtable_t *vtable;   /**< NULL: this module is geometrically identity */
+  void *data;                           /**< module-owned blob, freed by ::free_data */
+  void (*free_data)(void *data);        /**< NULL when ::data needs no teardown */
+
+  /* Filled by the chain's own size fold, at full resolution and scale 1 -- the same numbers
+   * dt_dev_pixelpipe_get_roi_out() writes into piece->buf_in/buf_out today, which is what
+   * consumers actually read off the virtual pipe. */
+  dt_iop_roi_t in;
+  dt_iop_roi_t out;
+} dt_geometry_record_t;
+
+/** @brief The composed geometry of one image, for one dev. GUI thread only. */
+typedef struct dt_geometry_chain_t dt_geometry_chain_t;
+
+dt_geometry_chain_t *dt_geometry_chain_new(void);
+void dt_geometry_chain_free(dt_geometry_chain_t *chain);
+
+/**
+ * @brief Rebuild the chain from the dev's current modules and history. GUI thread only.
+ *
+ * @details Called wherever the virtual pipe is resynchronised today. Cheap by construction --
+ * a record is a small derivation of already-committed params, with no LUT, no colour transform
+ * and no disk access -- which is the point: it can run in the same step as the history write,
+ * where the virtual pipe's 0.1-0.3 s could not.
+ */
+void dt_geometry_chain_rebuild(struct dt_develop_t *dev);
+
+/**
+ * @brief Can this chain answer questions yet?
+ *
+ * @details TRUE only when every enabled module the roster names has published a record.
+ * Authority is WHOLESALE: composing some modules from records and the rest from pipeline
+ * pieces would interleave two states, and the result would be wrong in a way that looks
+ * plausible. Until the last roster module lands, this stays FALSE and every consumer keeps
+ * using the pipe.
+ */
+gboolean dt_geometry_chain_authoritative(const dt_geometry_chain_t *chain);
+
+/** @brief The developed image's full-resolution size, from the chain's own fold. */
+gboolean dt_geometry_chain_processed_size(const dt_geometry_chain_t *chain, int *width, int *height);
+
+/** @brief One module instance's record, or NULL. Use it for that module's own in/out dims. */
+const dt_geometry_record_t *dt_geometry_chain_find(const dt_geometry_chain_t *chain, const char *op,
+                                                   int instance);
+
+/* Direction modes, matching dt_dev_distort_transform_plus()'s DT_DEV_TRANSFORM_DIR_* exactly:
+ * the walkers this replaces are bounded folds, and every existing caller's bound has to keep
+ * meaning what it meant. */
+
+/** @brief Compose forward over the chain, in place. @p direction is a DT_DEV_TRANSFORM_DIR_*. */
+int dt_geometry_transform(struct dt_develop_t *dev, double iop_order, int direction, float *points,
+                          size_t points_count);
+
+/** @brief Compose backward over the chain, in place. */
+int dt_geometry_backtransform(struct dt_develop_t *dev, double iop_order, int direction, float *points,
+                              size_t points_count);
+
+/**
+ * @brief Publish the focused module and its editing state, for the query-time GUI exception.
+ *
+ * @details dt_dev_pixelpipe_activemodule_disables_currentmodule() reads the focused module, its
+ * operation_tags_filter() and its live cache-bypass flag, and disables matching modules for the
+ * duration of a walk -- and, in the size fold, for the resulting processed size too. That is
+ * view state: it changes when the user clicks into crop's edit mode, with no history commit
+ * anywhere. It therefore cannot be baked into records; the chain reads it at query time, from
+ * whatever the GUI last published here.
+ */
+void dt_geometry_set_focus(struct dt_develop_t *dev, const struct dt_iop_module_t *focused,
+                           gboolean editing);
+
+/**
+ * @brief Shadow mode: compare the chain against the pipe that still owns the answer.
+ *
+ * @details Called from the size path with whatever the virtual pipe just produced. While the
+ * roster is incomplete this reports exactly which enabled modules are still missing a record --
+ * measured per image, rather than assumed from a source audit -- and once it is complete it
+ * reports any divergence. Both under `-d dev'. It never changes behaviour.
+ */
+void dt_geometry_shadow_check_size(struct dt_develop_t *dev, int pipe_width, int pipe_height);
+
+#endif // DT_DEVELOP_GEOMETRY_GEOMETRY_H
+
+// clang-format off
+// modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py
+// vim: shiftwidth=2 expandtab tabstop=2 cindent
+// kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;
+// clang-format on

--- a/src/develop/geometry/geometry.h
+++ b/src/develop/geometry/geometry.h
@@ -169,6 +169,23 @@ int dt_geometry_backtransform(struct dt_develop_t *dev, double iop_order, int di
                               size_t points_count);
 
 /**
+ * @brief Apply ONE module's own transform, and nothing else.
+ *
+ * @details No direction bound expresses this: FORW_INCL at a module's own iop_order includes
+ * everything after it as well. iop/ashift.c wants exactly its own homography applied to the
+ * corners of its input, to work out where its output lands, and reached it by resolving its
+ * piece and calling its own distort_transform() through the module vtable.
+ *
+ * Honours the focused-module exception like every other composition here, so a module suppressed
+ * by whatever is being edited contributes nothing, exactly as it would in a full walk.
+ *
+ * @return 0 when the chain cannot answer -- not authoritative, no record, or that module has no
+ * transform -- in which case @p points is untouched and the caller should use the pipe.
+ */
+int dt_geometry_module_transform(struct dt_develop_t *dev, const struct dt_iop_module_t *module,
+                                 float *points, size_t points_count);
+
+/**
  * @brief Compose the chain over @p points, for a record evaluator that needs the transform
  * stack around its own module.
  *

--- a/src/develop/geometry/geometry.h
+++ b/src/develop/geometry/geometry.h
@@ -49,6 +49,15 @@
 
 #include "develop/pixelpipe_hb.h"   // dt_iop_roi_t
 
+/* C linkage: geometry.c is a C translation unit and iop/lens.cc -- the first module to publish
+ * a record -- is a C++ one. Without this its calls and its vtable would name mangled symbols
+ * nothing defines. Linux would still link the plugin (a shared object may carry undefined
+ * symbols and resolve them at dlopen time) and fail at runtime; macOS and Windows fail the
+ * build. Same reason control/user_message.h carries these guards. */
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 struct dt_develop_t;
 struct dt_iop_module_t;
 struct dt_geometry_record_t;
@@ -180,12 +189,23 @@ void dt_geometry_clear_focus(struct dt_develop_t *dev);
 /**
  * @brief Shadow mode: compare the chain against the pipe that still owns the answer.
  *
- * @details Called from the size path with whatever the virtual pipe just produced. While the
- * roster is incomplete this reports exactly which enabled modules are still missing a record --
- * measured per image, rather than assumed from a source audit -- and once it is complete it
- * reports any divergence. Both under `-d dev'. It never changes behaviour.
+ * @details Called from the size path with whatever the virtual pipe just produced, and with
+ * what each side cost. While the roster is incomplete this reports exactly which enabled
+ * modules are still missing a record -- measured per image, rather than assumed from a source
+ * audit -- and once it is complete it reports any divergence in size, in forward transforms and
+ * in round trips, together with the two costs. Both under `-d dev'. It never changes behaviour.
+ *
+ * @param chain_ms what the rebuild cost. The virtual pipe's counterpart is NOT measured here:
+ * its work is done in _sync_virtual_pipe(), off this path, and is already reported by `-d perf'
+ * as "pipeline resync with history ... for pipe virtual-preview". Timing it here would only ever
+ * catch a resync that had nothing to do, and report ~0 ms for the side that is expensive.
  */
-void dt_geometry_shadow_check_size(struct dt_develop_t *dev, int pipe_width, int pipe_height);
+void dt_geometry_shadow_check(struct dt_develop_t *dev, int pipe_width, int pipe_height,
+                              double chain_ms);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif // DT_DEVELOP_GEOMETRY_GEOMETRY_H
 

--- a/src/develop/geometry/geometry.h
+++ b/src/develop/geometry/geometry.h
@@ -21,24 +21,20 @@
  * @brief Where things are on the image, answered without a pipeline.
  *
  * @details The GUI constantly needs two geometric facts: how big the developed image is, and
- * where a point on it lands after the distorting modules have had their say. Today both are
- * answered by `dev->virtual_pipe' -- a complete, pixel-less clone of all ~95 IOP modules, their
- * history committed into real pipeline nodes, resynchronised on the GUI thread at every history
- * commit for 0.10 to 0.33 s. It renders nothing. It exists only to be walked.
+ * where a point on it lands after the distorting modules have had their say. Both used to be
+ * answered by a complete, pixel-less clone of all ~95 IOP modules -- their history committed
+ * into real pipeline nodes, resynchronised on the GUI thread at every history commit for 0.10 to
+ * 0.33 s. It rendered nothing. It existed only to be walked.
  *
- * This module replaces that with the data the walk actually consumes. Each module that changes
- * geometry publishes a small record -- its transform as values, not as a node -- and the GUI
- * composes sizes and coordinates from the ordered list. See doc/geometry-service.md for the
- * decision, the survey behind it, and the tranche plan; the traps section there is not
- * optional reading.
+ * This module is the data that walk actually consumed. Each module that changes geometry
+ * publishes a small record -- its transform as values, not as a node -- and the GUI composes
+ * sizes and coordinates from the ordered list. See doc/geometry-service.md for the decision, the
+ * survey behind it, and what each tranche moved; the traps section there is not optional reading.
  *
  * THREADING. This is GUI-thread state and takes no locks. Nothing else may touch it. The pixel
  * pipelines keep their own piece-based modify_roi and distort callbacks for rendering, and the
- * two must never be crossed: a worker that needs geometry asks its own pieces.
- *
- * STATUS: skeleton (tranche G2). No module publishes a record yet, so the chain is never
- * authoritative and nothing consumes it; it runs beside the virtual pipe and reports what it
- * would need in order to take over. Shadow mode is the whole point of this tranche.
+ * two must never be crossed: a worker that needs geometry asks its own pieces. That separation
+ * is the whole design: the GUI's copy of the module stack is gone, not shared.
  */
 
 #ifndef DT_DEVELOP_GEOMETRY_GEOMETRY_H
@@ -116,8 +112,8 @@ typedef struct dt_geometry_record_t
   void (*free_data)(void *data);        /**< NULL when ::data needs no teardown */
 
   /* Filled by the chain's own size fold, at full resolution and scale 1 -- the same numbers
-   * dt_dev_pixelpipe_get_roi_out() writes into piece->buf_in/buf_out today, which is what
-   * consumers actually read off the virtual pipe. */
+   * dt_dev_pixelpipe_get_roi_out() writes into a piece's buf_in/buf_out, which is what GUI
+   * consumers used to resolve a piece in order to read. */
   dt_iop_roi_t in;
   dt_iop_roi_t out;
 } dt_geometry_record_t;
@@ -131,10 +127,10 @@ void dt_geometry_chain_free(dt_geometry_chain_t *chain);
 /**
  * @brief Rebuild the chain from the dev's current modules and history. GUI thread only.
  *
- * @details Called wherever the virtual pipe is resynchronised today. Cheap by construction --
- * a record is a small derivation of already-committed params, with no LUT, no colour transform
- * and no disk access -- which is the point: it can run in the same step as the history write,
- * where the virtual pipe's 0.1-0.3 s could not.
+ * @details Called wherever the pixel-less pipe used to be resynchronised. Cheap by construction
+ * -- a record is a small derivation of already-committed params, with no LUT, no colour transform
+ * and no disk access -- which is the point: it runs in the same step as the history write, where
+ * its predecessor's 0.1-0.3 s could not.
  */
 void dt_geometry_chain_rebuild(struct dt_develop_t *dev);
 
@@ -142,10 +138,14 @@ void dt_geometry_chain_rebuild(struct dt_develop_t *dev);
  * @brief Can this chain answer questions yet?
  *
  * @details TRUE only when every enabled module the roster names has published a record.
- * Authority is WHOLESALE: composing some modules from records and the rest from pipeline
- * pieces would interleave two states, and the result would be wrong in a way that looks
- * plausible. Until the last roster module lands, this stays FALSE and every consumer keeps
- * using the pipe.
+ * Authority is WHOLESALE: composing some modules from records and the rest from pipeline pieces
+ * would interleave two states, and the result would be wrong in a way that looks plausible.
+ *
+ * There is no longer anything to fall back TO -- the pipe this replaced is deleted -- so a FALSE
+ * here is not a degraded mode, it is the GUI declining to answer: sizes come back FALSE, the
+ * transforms return 0 and leave their points untouched. Before an image is loaded that is simply
+ * the truth. After one is, it is a defect, and ::dt_geometry_self_check names which module owes
+ * a record.
  */
 gboolean dt_geometry_chain_authoritative(const dt_geometry_chain_t *chain);
 
@@ -180,7 +180,7 @@ int dt_geometry_backtransform(struct dt_develop_t *dev, double iop_order, int di
  * by whatever is being edited contributes nothing, exactly as it would in a full walk.
  *
  * @return 0 when the chain cannot answer -- not authoritative, no record, or that module has no
- * transform -- in which case @p points is untouched and the caller should use the pipe.
+ * transform -- in which case @p points is untouched.
  */
 int dt_geometry_module_transform(struct dt_develop_t *dev, const struct dt_iop_module_t *module,
                                  float *points, size_t points_count);
@@ -215,21 +215,17 @@ int dt_geometry_chain_compose(dt_geometry_chain_t *chain, double iop_order, int 
  */
 
 /**
- * @brief Shadow mode: compare the chain against the pipe that still owns the answer.
+ * @brief Check the chain against itself, and report what the rebuild cost.
  *
- * @details Called from the size path with whatever the virtual pipe just produced, and with
- * what each side cost. While the roster is incomplete this reports exactly which enabled
- * modules are still missing a record -- measured per image, rather than assumed from a source
- * audit -- and once it is complete it reports any divergence in size, in forward transforms and
- * in round trips, together with the two costs. Both under `-d dev'. It never changes behaviour.
+ * @details What the shadow harness became. It compared every answer against the pipe while the
+ * pipe still owned them; with the pipe gone the only checks left are identities the chain must
+ * satisfy on its own -- the round trip, and the bound partition. See the comment on the
+ * definition for what that does and does not still catch. Under `-d dev'; never changes
+ * behaviour.
  *
- * @param chain_ms what the rebuild cost. The virtual pipe's counterpart is NOT measured here:
- * its work is done in _sync_virtual_pipe(), off this path, and is already reported by `-d perf'
- * as "pipeline resync with history ... for pipe virtual-preview". Timing it here would only ever
- * catch a resync that had nothing to do, and report ~0 ms for the side that is expensive.
+ * @param chain_ms what the rebuild cost.
  */
-void dt_geometry_shadow_check(struct dt_develop_t *dev, int pipe_width, int pipe_height,
-                              double chain_ms);
+void dt_geometry_self_check(struct dt_develop_t *dev, double chain_ms);
 
 #ifdef __cplusplus
 }

--- a/src/develop/imageop.h
+++ b/src/develop/imageop.h
@@ -82,6 +82,12 @@ struct dt_dev_pixelpipe_iop_t;
 struct dt_develop_blend_params_t;
 struct dt_develop_tiling_t;
 struct dt_iop_color_picker_t;
+/* develop/geometry/geometry.h -- named by the geometry_record() vtable entry. Declared HERE,
+ * not only in iop_api.h: that header's forward declarations live inside its FULL_API_H block,
+ * which the struct-body expansion of the X-macro does not compile, so the first mention would
+ * otherwise be inside a function prototype -- C scopes that to the prototype and the resulting
+ * type is distinct from every other declaration of the same name. */
+struct dt_geometry_record_t;
 
 typedef enum dt_iop_module_header_icons_t
 {

--- a/src/develop/masks/brush.c
+++ b/src/develop/masks/brush.c
@@ -44,6 +44,7 @@
 #include "caches/pixelpipe_cache_alloc.h"
 #include "common/conf.h"
 #include "develop/imageop.h"
+#include "develop/masks/masks_distort.h"
 #include "develop/masks.h"
 #include "develop/masks_gui.h"
 #include "develop/masks/masks_functions.h"
@@ -717,7 +718,7 @@ static inline int _brush_cyclic_cursor(int n, int nb)
 // This means that it record the main line twice (up and down) while the border only once (around).
 static int _brush_get_pts_border(dt_develop_t *develop, dt_masks_form_t *mask_form,
                                  const double iop_order, const int transform_direction,
-                                 dt_dev_pixelpipe_t *pipe, float **point_buffer, int *point_count,
+                                 const dt_masks_distort_t *const dist, float **point_buffer, int *point_count,
                                  float **border_buffer, int *border_count, float **payload_buffer,
                                  int *payload_count, int use_source)
 {
@@ -732,12 +733,12 @@ static int _brush_get_pts_border(dt_develop_t *develop, dt_masks_form_t *mask_fo
   double start2 = 0.0;
   if(dt_get_debug_flags() & DT_DEBUG_PERF) start2 = dt_get_wtime();
 
-  const float iwd = pipe->iwidth;
-  const float iht = pipe->iheight;
+  const float iwd = dist->iwidth;
+  const float iht = dist->iheight;
   // How far apart consecutive samples of the outline may land, in image pixels. Decided by the
   // pipe, never here; see dt_dev_pixelpipe_t::mask_rasterization_step. Above 1 the samples
   // spread out and the radial spokes stamped from them leave gaps between each pair (#1116).
-  const int pixel_threshold = pipe->mask_rasterization_step;
+  const int pixel_threshold = dist->rasterization_step;
 
   dt_masks_dynbuf_t *dpoints = NULL, *dborder = NULL, *dpayload = NULL;
 
@@ -1033,14 +1034,14 @@ static int _brush_get_pts_border(dt_develop_t *develop, dt_masks_form_t *mask_fo
   {
     // we transform with all distortion that happen *before* the module
     // so we have now the TARGET points in module input reference
-    if(dt_dev_distort_transform_plus(pipe, iop_order, DT_DEV_TRANSFORM_DIR_BACK_EXCL,
+    if(dt_masks_distort_transform(dist, iop_order, DT_DEV_TRANSFORM_DIR_BACK_EXCL,
                                      *point_buffer, *point_count))
     {
       // now we move all the points by the shift
       // so we have now the SOURCE points in module input reference
       float pts[2] = { mask_form->source[0], mask_form->source[1] };
       dt_dev_coordinates_raw_norm_to_raw_abs(develop, pts, 1);
-      if(!dt_dev_distort_transform_plus(pipe, iop_order, DT_DEV_TRANSFORM_DIR_BACK_EXCL, pts, 1))
+      if(!dt_masks_distort_transform(dist, iop_order, DT_DEV_TRANSFORM_DIR_BACK_EXCL, pts, 1))
         goto fail;
 
       dx = pts[0] - (*point_buffer)[2];
@@ -1054,7 +1055,7 @@ static int _brush_get_pts_border(dt_develop_t *develop, dt_masks_form_t *mask_fo
 
       // we apply the rest of the distortions (those after the module)
       // so we have now the SOURCE points in final image reference
-      if(!dt_dev_distort_transform_plus(pipe, iop_order, DT_DEV_TRANSFORM_DIR_FORW_INCL,
+      if(!dt_masks_distort_transform(dist, iop_order, DT_DEV_TRANSFORM_DIR_FORW_INCL,
                                         *point_buffer, *point_count))
         goto fail;
     }
@@ -1065,11 +1066,11 @@ static int _brush_get_pts_border(dt_develop_t *develop, dt_masks_form_t *mask_fo
 
     return 0;
   }
-  else if(dt_dev_distort_transform_plus(pipe, iop_order, transform_direction,
+  else if(dt_masks_distort_transform(dist, iop_order, transform_direction,
                                         *point_buffer, *point_count))
   {
     if(!border_buffer
-       || dt_dev_distort_transform_plus(pipe, iop_order, transform_direction,
+       || dt_masks_distort_transform(dist, iop_order, transform_direction,
                                         *border_buffer, *border_count))
     {
       if(dt_get_debug_flags() & DT_DEBUG_PERF)
@@ -1242,8 +1243,9 @@ static int _brush_get_points_border(dt_develop_t *develop, dt_masks_form_t *mask
 {
   if(use_source && IS_NULL_PTR(module)) return 1;
   const double ioporder = (module) ? module->iop_order : 0.0f;
+  const dt_masks_distort_t gui_dist = dt_masks_distort_for_gui(develop);
   return _brush_get_pts_border(develop, mask_form, ioporder, DT_DEV_TRANSFORM_DIR_ALL,
-                               develop->virtual_pipe, point_buffer, point_count, border_buffer,
+                               &gui_dist, point_buffer, point_count, border_buffer,
                                border_count, NULL, NULL, use_source);
 }
 
@@ -2658,7 +2660,8 @@ static int _get_area(const dt_iop_module_t *const module, dt_dev_pixelpipe_t *pi
   // we get buffers for all points
   float *points = NULL, *border = NULL;
   int points_count, border_count;
-  if(_brush_get_pts_border(module->dev, mask_form, module->iop_order, DT_DEV_TRANSFORM_DIR_BACK_INCL, pipe,
+  const dt_masks_distort_t pipe_dist = dt_masks_distort_for_pipe(pipe, module->dev);
+  if(_brush_get_pts_border(module->dev, mask_form, module->iop_order, DT_DEV_TRANSFORM_DIR_BACK_INCL, &pipe_dist,
                            &points, &points_count, &border, &border_count, NULL, NULL, include_source) != 0)
   {
     dt_pixelpipe_cache_free_align(points);
@@ -2745,7 +2748,8 @@ static int _brush_get_mask(const dt_iop_module_t *const module, dt_dev_pixelpipe
   // we get buffers for all points
   float *points = NULL, *border = NULL, *payload = NULL;
   int points_count, border_count, payload_count;
-  if(_brush_get_pts_border(module->dev, mask_form, module->iop_order, DT_DEV_TRANSFORM_DIR_BACK_INCL, pipe,
+  const dt_masks_distort_t pipe_dist = dt_masks_distort_for_pipe(pipe, module->dev);
+  if(_brush_get_pts_border(module->dev, mask_form, module->iop_order, DT_DEV_TRANSFORM_DIR_BACK_INCL, &pipe_dist,
                            &points, &points_count,
                                &border, &border_count, &payload, &payload_count, 0) != 0)
   {
@@ -2933,7 +2937,8 @@ static int _brush_get_mask_roi(const dt_iop_module_t *const module, dt_dev_pixel
 
   int points_count, border_count, payload_count;
 
-  if(_brush_get_pts_border(module->dev, mask_form, module->iop_order, DT_DEV_TRANSFORM_DIR_BACK_INCL, pipe,
+  const dt_masks_distort_t pipe_dist = dt_masks_distort_for_pipe(pipe, module->dev);
+  if(_brush_get_pts_border(module->dev, mask_form, module->iop_order, DT_DEV_TRANSFORM_DIR_BACK_INCL, &pipe_dist,
                            &points, &points_count, &border, &border_count, &payload, &payload_count, 0) != 0)
   {
     dt_pixelpipe_cache_free_align(points);

--- a/src/develop/masks/circle.c
+++ b/src/develop/masks/circle.c
@@ -518,7 +518,7 @@ static int _circle_get_points_source(dt_develop_t *dev, float x, float y, float 
 
   // we transform with all distortion that happen *before* the module
   // so we have now the TARGET points in module input reference
-  if(!dt_dev_distort_transform_plus(dev->virtual_pipe, module->iop_order, DT_DEV_TRANSFORM_DIR_BACK_EXCL,
+  if(!dt_dev_distort_transform_gui(dev, module->iop_order, DT_DEV_TRANSFORM_DIR_BACK_EXCL,
                                     *points, *points_count))
     goto error;
 
@@ -526,7 +526,7 @@ static int _circle_get_points_source(dt_develop_t *dev, float x, float y, float 
   // so we have now the SOURCE points in module input reference
   float pts[2] = { xs, ys };
   dt_dev_coordinates_raw_norm_to_raw_abs(dev, pts, 1);
-  if(!dt_dev_distort_transform_plus(dev->virtual_pipe, module->iop_order, DT_DEV_TRANSFORM_DIR_BACK_EXCL,
+  if(!dt_dev_distort_transform_gui(dev, module->iop_order, DT_DEV_TRANSFORM_DIR_BACK_EXCL,
                                     pts, 1))
     goto error;
 
@@ -543,7 +543,7 @@ static int _circle_get_points_source(dt_develop_t *dev, float x, float y, float 
 
   // we apply the rest of the distortions (those after the module)
   // so we have now the SOURCE points in final image reference
-  if(!dt_dev_distort_transform_plus(dev->virtual_pipe, module->iop_order, DT_DEV_TRANSFORM_DIR_FORW_INCL,
+  if(!dt_dev_distort_transform_gui(dev, module->iop_order, DT_DEV_TRANSFORM_DIR_FORW_INCL,
                                     *points, *points_count))
     goto error;
 

--- a/src/develop/masks/ellipse.c
+++ b/src/develop/masks/ellipse.c
@@ -399,7 +399,7 @@ static int _ellipse_get_points_source(dt_develop_t *dev, float xx, float yy, flo
 
   // we transform with all distortion that happen *before* the module
   // so we have now the TARGET points in module input reference
-  if(!dt_dev_distort_transform_plus(dev->virtual_pipe, module->iop_order, DT_DEV_TRANSFORM_DIR_BACK_EXCL,
+  if(!dt_dev_distort_transform_gui(dev, module->iop_order, DT_DEV_TRANSFORM_DIR_BACK_EXCL,
                                     *points, *points_count))
     goto error;
 
@@ -407,7 +407,7 @@ static int _ellipse_get_points_source(dt_develop_t *dev, float xx, float yy, flo
   // so we have now the SOURCE points in module input reference
   float pts[2] = { xs, ys };
   dt_dev_coordinates_raw_norm_to_raw_abs(dev, pts, 1);
-  if(!dt_dev_distort_transform_plus(dev->virtual_pipe, module->iop_order, DT_DEV_TRANSFORM_DIR_BACK_EXCL,
+  if(!dt_dev_distort_transform_gui(dev, module->iop_order, DT_DEV_TRANSFORM_DIR_BACK_EXCL,
                                     pts, 1))
     goto error;
 
@@ -426,7 +426,7 @@ static int _ellipse_get_points_source(dt_develop_t *dev, float xx, float yy, flo
 
   // we apply the rest of the distortions (those after the module)
   // so we have now the SOURCE points in final image reference
-  if(!dt_dev_distort_transform_plus(dev->virtual_pipe, module->iop_order, DT_DEV_TRANSFORM_DIR_FORW_INCL,
+  if(!dt_dev_distort_transform_gui(dev, module->iop_order, DT_DEV_TRANSFORM_DIR_FORW_INCL,
                                     *points, *points_count))
     goto error;
 

--- a/src/develop/masks/masks_distort.h
+++ b/src/develop/masks/masks_distort.h
@@ -25,9 +25,10 @@
  * can grab; the pixel pipeline calls them, on a worker thread, to rasterise the mask a module
  * actually blends with. They are the same geometry either way, which is why they are one
  * function, and the difference between the two callers used to be expressed by handing them a
- * different `dt_dev_pixelpipe_t *`: the GUI passed `dev->virtual_pipe`, the worker passed its own.
+ * different `dt_dev_pixelpipe_t *`: the GUI passed a pixel-less clone of the pipeline, the worker
+ * passed its own.
  *
- * That stops working when the virtual pipe goes away, and the fix is not to give the GUI a
+ * That stopped working when the clone was deleted, and the fix was not to give the GUI a
  * different pipe but to name what the builders were reading out of one. It is three things: the
  * full-resolution image size, how finely to sample the outline, and a way to compose the module
  * stack around a given iop_order. This record supplies all three, and there are exactly two
@@ -38,7 +39,7 @@
  * -- not some other view of the same history.
  *
  * THE GUI SUPPLIER composes through develop/geometry/geometry.h, which answers from published
- * records and falls back to the pixel-less pipe until every geometry module has published one.
+ * records.
  *
  * Nothing else may implement this. Two suppliers are a seam; three are a fork.
  */
@@ -93,7 +94,7 @@ static inline dt_masks_distort_t dt_masks_distort_for_pipe(dt_dev_pixelpipe_t *p
  * @brief The GUI supplier: compose through the geometry service, at full resolution, one pixel
  * at a time.
  *
- * @details The step is 1 because that is what the GUI has always had: the virtual pipe this
+ * @details The step is 1 because that is what the GUI has always had: the pixel-less pipe this
  * replaces was never given a rasterisation step, so it kept the one its init set, and outlines
  * the user drags are drawn pixel-accurate. The size is the raw geometry, which is what that
  * pipe's input was set from.

--- a/src/develop/masks/masks_distort.h
+++ b/src/develop/masks/masks_distort.h
@@ -1,0 +1,140 @@
+/*
+    This file is part of Ansel.
+    Copyright (C) 2026 Aurélien Pierre.
+
+    Ansel is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Ansel is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Ansel.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+/** @file develop/masks/masks_distort.h
+ *
+ * @brief What a mask outline needs in order to place itself, and who supplies it.
+ *
+ * @details The shape outline builders -- `_brush_get_pts_border()`, `_polygon_get_pts_border()`
+ * -- are run from two entirely different places. The GUI calls them to draw an outline the user
+ * can grab; the pixel pipeline calls them, on a worker thread, to rasterise the mask a module
+ * actually blends with. They are the same geometry either way, which is why they are one
+ * function, and the difference between the two callers used to be expressed by handing them a
+ * different `dt_dev_pixelpipe_t *`: the GUI passed `dev->virtual_pipe`, the worker passed its own.
+ *
+ * That stops working when the virtual pipe goes away, and the fix is not to give the GUI a
+ * different pipe but to name what the builders were reading out of one. It is three things: the
+ * full-resolution image size, how finely to sample the outline, and a way to compose the module
+ * stack around a given iop_order. This record supplies all three, and there are exactly two
+ * suppliers.
+ *
+ * THE WORKER SUPPLIER keeps the piece-based machinery, unchanged and forever: mask rasterisation
+ * belongs to rendering, runs on the pipeline thread, and must compose the pipe it is rendering
+ * -- not some other view of the same history.
+ *
+ * THE GUI SUPPLIER composes through develop/geometry/geometry.h, which answers from published
+ * records and falls back to the pixel-less pipe until every geometry module has published one.
+ *
+ * Nothing else may implement this. Two suppliers are a seam; three are a fork.
+ */
+
+#ifndef DT_DEVELOP_MASKS_MASKS_DISTORT_H
+#define DT_DEVELOP_MASKS_MASKS_DISTORT_H
+
+#include <glib.h>
+#include <stdint.h>
+
+#include "develop/develop.h"
+#include "develop/pixelpipe_hb.h"
+
+/**
+ * @brief Where an outline builder gets its geometry from.
+ *
+ * @details Build one with ::dt_masks_distort_for_pipe or ::dt_masks_distort_for_gui; do not
+ * fill it by hand, so that the two suppliers stay the only two.
+ */
+typedef struct dt_masks_distort_t
+{
+  /** The pipe to compose, or NULL to compose through the geometry service. */
+  dt_dev_pixelpipe_t *pipe;
+  /** Needed by the GUI supplier, and harmless for the other. */
+  dt_develop_t *dev;
+
+  /** Full-resolution image size the outline's normalised coordinates scale against. */
+  int32_t iwidth, iheight;
+
+  /**
+   * How far apart consecutive samples of the outline may land, in image pixels. Above one, the
+   * samples spread out and the radial spokes stamped between them leave gaps (#1116), so a
+   * caller that wants a pixel-accurate outline asks for one.
+   */
+  int rasterization_step;
+} dt_masks_distort_t;
+
+/** @brief The rendering supplier: compose this pipe, sample as this pipe was told to. */
+static inline dt_masks_distort_t dt_masks_distort_for_pipe(dt_dev_pixelpipe_t *pipe, dt_develop_t *dev)
+{
+  dt_masks_distort_t d = { pipe, dev, 0, 0, 1 };
+  if(!IS_NULL_PTR(pipe))
+  {
+    d.iwidth = pipe->iwidth;
+    d.iheight = pipe->iheight;
+    d.rasterization_step = pipe->mask_rasterization_step;
+  }
+  return d;
+}
+
+/**
+ * @brief The GUI supplier: compose through the geometry service, at full resolution, one pixel
+ * at a time.
+ *
+ * @details The step is 1 because that is what the GUI has always had: the virtual pipe this
+ * replaces was never given a rasterisation step, so it kept the one its init set, and outlines
+ * the user drags are drawn pixel-accurate. The size is the raw geometry, which is what that
+ * pipe's input was set from.
+ */
+static inline dt_masks_distort_t dt_masks_distort_for_gui(dt_develop_t *dev)
+{
+  dt_masks_distort_t d = { NULL, dev, 0, 0, 1 };
+  int32_t raw_width = 0;
+  int32_t raw_height = 0;
+  if(dt_dev_geometry_get_raw_size(dev, &raw_width, &raw_height))
+  {
+    d.iwidth = raw_width;
+    d.iheight = raw_height;
+  }
+  return d;
+}
+
+/** @brief Compose forward, bounded exactly as dt_dev_distort_transform_plus() is. */
+static inline int dt_masks_distort_transform(const dt_masks_distort_t *const d, const double iop_order,
+                                             const int transf_direction, float *points,
+                                             size_t points_count)
+{
+  if(!IS_NULL_PTR(d->pipe))
+    return dt_dev_distort_transform_plus(d->pipe, iop_order, transf_direction, points, points_count);
+  return dt_dev_distort_transform_gui(d->dev, iop_order, transf_direction, points, points_count);
+}
+
+/** @brief Compose backward, same bounds. */
+static inline int dt_masks_distort_backtransform(const dt_masks_distort_t *const d, const double iop_order,
+                                                 const int transf_direction, float *points,
+                                                 size_t points_count)
+{
+  if(!IS_NULL_PTR(d->pipe))
+    return dt_dev_distort_backtransform_plus(d->pipe, iop_order, transf_direction, points, points_count);
+  return dt_dev_distort_backtransform_gui(d->dev, iop_order, transf_direction, points, points_count);
+}
+
+#endif // DT_DEVELOP_MASKS_MASKS_DISTORT_H
+
+// clang-format off
+// modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py
+// vim: shiftwidth=2 expandtab tabstop=2 cindent
+// kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;
+// clang-format on

--- a/src/develop/masks/polygon.c
+++ b/src/develop/masks/polygon.c
@@ -49,6 +49,7 @@
 #include "widgets/gdkkeys.h"
 #include "common/conf.h"
 #include "develop/imageop.h"
+#include "develop/masks/masks_distort.h"
 #include "develop/masks.h"
 #include "develop/masks_gui.h"
 #include "develop/masks/masks_functions.h"
@@ -712,7 +713,7 @@ static int _polygon_range_cmp(const void *a, const void *b)
  */
 static int _polygon_get_pts_border(dt_develop_t *develop, dt_masks_form_t *mask_form,
                                    const double iop_order, const int transform_direction,
-                                   dt_dev_pixelpipe_t *pipe, float **point_buffer, int *point_count,
+                                   const dt_masks_distort_t *const dist, float **point_buffer, int *point_count,
                                    float **border_buffer, int *border_count, gboolean source)
 {
   *point_buffer = NULL;
@@ -725,8 +726,8 @@ static int _polygon_get_pts_border(dt_develop_t *develop, dt_masks_form_t *mask_
   double start2 = 0.0;
   if(dt_get_debug_flags() & DT_DEBUG_PERF) start2 = dt_get_wtime();
 
-  const float input_width = pipe->iwidth;
-  const float input_height = pipe->iheight;
+  const float input_width = dist->iwidth;
+  const float input_height = dist->iheight;
   /* One pixel, always, and NOT dt_dev_pixelpipe_t::mask_rasterization_step.
    *
    * The border produced here is fed to _polygon_find_self_intersection(), which is a PIXEL-GRID
@@ -967,13 +968,13 @@ static int _polygon_get_pts_border(dt_develop_t *develop, dt_masks_form_t *mask_
   {
     // we transform with all distortion that happen *before* the module
     // so we have now the TARGET points in module input reference
-    if(dt_dev_distort_transform_plus(pipe, iop_order, DT_DEV_TRANSFORM_DIR_BACK_EXCL,
+    if(dt_masks_distort_transform(dist, iop_order, DT_DEV_TRANSFORM_DIR_BACK_EXCL,
                                      *point_buffer, *point_count))
     {
       // now we move all the points by the shift
       // so we have now the SOURCE points in module input reference
       float pts[2] = { mask_form->source[0] * input_width, mask_form->source[1] * input_height };
-      if(!dt_dev_distort_transform_plus(pipe, iop_order, DT_DEV_TRANSFORM_DIR_BACK_EXCL, pts, 1))
+      if(!dt_masks_distort_transform(dist, iop_order, DT_DEV_TRANSFORM_DIR_BACK_EXCL, pts, 1))
         goto fail;
 
       dx = pts[0] - (*point_buffer)[2];
@@ -987,7 +988,7 @@ static int _polygon_get_pts_border(dt_develop_t *develop, dt_masks_form_t *mask_
 
       // we apply the rest of the distortions (those after the module)
       // so we have now the SOURCE points in final image reference
-      if(!dt_dev_distort_transform_plus(pipe, iop_order, DT_DEV_TRANSFORM_DIR_FORW_INCL,
+      if(!dt_masks_distort_transform(dist, iop_order, DT_DEV_TRANSFORM_DIR_FORW_INCL,
                                         *point_buffer, *point_count))
         goto fail;
     }
@@ -1000,11 +1001,11 @@ static int _polygon_get_pts_border(dt_develop_t *develop, dt_masks_form_t *mask_
     dt_pixelpipe_cache_free_align(border_init);
     return 0;
   }
-  else if(dt_dev_distort_transform_plus(pipe, iop_order, transform_direction,
+  else if(dt_masks_distort_transform(dist, iop_order, transform_direction,
                                         *point_buffer, *point_count))
   {
     if(!border_buffer
-       || dt_dev_distort_transform_plus(pipe, iop_order, transform_direction,
+       || dt_masks_distort_transform(dist, iop_order, transform_direction,
                                         *border_buffer, *border_count))
     {
       if(dt_get_debug_flags() & DT_DEBUG_PERF)
@@ -1235,8 +1236,9 @@ static int _polygon_get_points_border(dt_develop_t *develop, dt_masks_form_t *ma
 {
   if(source && IS_NULL_PTR(module)) return 1;
   const double ioporder = (module) ? module->iop_order : 0.0f;
+  const dt_masks_distort_t gui_dist = dt_masks_distort_for_gui(develop);
   return _polygon_get_pts_border(develop, mask_form, ioporder, DT_DEV_TRANSFORM_DIR_ALL,
-                                 develop->virtual_pipe, point_buffer, point_count,
+                                 &gui_dist, point_buffer, point_count,
                                  border_buffer, border_count, source);
 }
 
@@ -2471,7 +2473,8 @@ static int _get_area(const dt_iop_module_t *const module, dt_dev_pixelpipe_t *pi
   int point_count = 0;
   int border_count = 0;
 
-  if(_polygon_get_pts_border(module->dev, mask_form, module->iop_order, DT_DEV_TRANSFORM_DIR_BACK_INCL, pipe,
+  const dt_masks_distort_t pipe_dist = dt_masks_distort_for_pipe(pipe, module->dev);
+  if(_polygon_get_pts_border(module->dev, mask_form, module->iop_order, DT_DEV_TRANSFORM_DIR_BACK_INCL, &pipe_dist,
                              &point_buffer, &point_count, &border_buffer, &border_count, get_source) != 0)
   {
     dt_pixelpipe_cache_free_align(point_buffer);
@@ -2547,8 +2550,9 @@ static int _polygon_get_mask(const dt_iop_module_t *const module, dt_dev_pixelpi
   float *border_buffer = NULL;
   int point_count = 0;
   int border_count = 0;
+  const dt_masks_distort_t pipe_dist = dt_masks_distort_for_pipe(pipe, module->dev);
   if(_polygon_get_pts_border(module->dev, mask_form, module->iop_order,
-                             DT_DEV_TRANSFORM_DIR_BACK_INCL, pipe, &point_buffer, &point_count,
+                             DT_DEV_TRANSFORM_DIR_BACK_INCL, &pipe_dist, &point_buffer, &point_count,
                              &border_buffer, &border_count, FALSE) != 0)
   {
     dt_pixelpipe_cache_free_align(point_buffer);
@@ -3179,8 +3183,9 @@ static int _polygon_get_mask_roi(const dt_iop_module_t *const module, dt_dev_pix
   // we get buffers for all points
   float *points = NULL, *border = NULL;
   int points_count = 0, border_count = 0;
+  const dt_masks_distort_t pipe_dist = dt_masks_distort_for_pipe(pipe, module->dev);
   if(_polygon_get_pts_border(module->dev, mask_form, module->iop_order,
-                             DT_DEV_TRANSFORM_DIR_BACK_INCL, pipe,
+                             DT_DEV_TRANSFORM_DIR_BACK_INCL, &pipe_dist,
                              &points, &points_count, &border, &border_count, FALSE) != 0)
   {
     dt_pixelpipe_cache_free_align(points);

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -1393,10 +1393,11 @@ static void _update_backbuf_cache_reference(dt_dev_pixelpipe_t *pipe, dt_iop_roi
     /* 4 bytes per pixel: this is the final, display-encoded backbuffer. */
     if(entry_size < pixels * 4)
       dt_print(DT_DEBUG_ALWAYS,
-               "[pixelpipe] BACKBUF TOO SMALL on pipe %s: roi %dx%d needs %zu bytes, cacheline holds "
-               "%zu; hash %" PRIu64 "\n",
-               dt_pixelpipe_get_pipe_name(pipe->type), roi.width, roi.height, pixels * 4, entry_size,
-               (uint64_t)entry_hash);
+               // %llu, not %zu: MinGW's printf does not implement the C99 length modifier.
+               "[pixelpipe] BACKBUF TOO SMALL on pipe %s: roi %dx%d needs %llu bytes, cacheline holds "
+               "%llu; hash %" PRIu64 "\n",
+               dt_pixelpipe_get_pipe_name(pipe->type), roi.width, roi.height,
+               (unsigned long long)(pixels * 4), (unsigned long long)entry_size, (uint64_t)entry_hash);
 
     /* And the shape itself. `roi' is what this run ASKED the pipe for; the pixels in the
      * cacheline are whatever the last node actually produced, which is its roi_out. Those are

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -1359,9 +1359,45 @@ static void _update_backbuf_cache_reference(dt_dev_pixelpipe_t *pipe, dt_iop_roi
     dt_dev_pixelpipe_cache_ref_count_entry(TRUE, entry);
   }
 
+  /* The backbuf advertises the ROI THIS RUN ASKED FOR, paired with whatever cacheline it
+   * resolved. Those two are supposed to describe the same image, and every consumer trusts that
+   * they do: the display paths compute a cairo stride from the width and walk the cacheline with
+   * it. When they disagree the picture is drawn with the wrong row length -- the diagonal
+   * striping of a stride error -- and nothing downstream can detect it, because a cacheline is
+   * just bytes and carries no shape of its own.
+   *
+   * They can disagree. Cache entries are reused in place by rekeying rather than reallocated
+   * (caches/pixelpipe_cache.c), so an entry produced at one ROI can be handed back under a key
+   * planned at another.
+   *
+   * The invariant worth checking is that the cacheline is BIG ENOUGH for the advertised
+   * dimensions -- not that it is exactly that size. Buffers come from an aligned allocator and
+   * from a reuse pool, so a cacheline is routinely larger than width x height x bpp: measured on
+   * an ordinary darkroom entry, the display buffers run about 0.2 % over and a thumbnail's can
+   * be several times over. That slack is why `bpp' below, a division by the requested pixel
+   * count, is not a pixel size and should not be read as one -- nothing does; the field exists
+   * for a consumer that no longer has one.
+   *
+   * Too SMALL is the dangerous direction, and the only one a consumer cannot survive: every
+   * display path computes a cairo stride from the width and walks that many rows, so a short
+   * cacheline is an out-of-bounds read, and a wrong width is the diagonal striping of a stride
+   * error. Report it; do not try to repair it here, where neither the true shape of the entry nor
+   * the reason it was selected is known. */
   int bpp = 0;
   if(roi.width > 0 && roi.height > 0)
-    bpp = (int)(dt_pixel_cache_entry_get_size(entry) / ((size_t)roi.width * (size_t)roi.height));
+  {
+    const size_t entry_size = dt_pixel_cache_entry_get_size(entry);
+    const size_t pixels = (size_t)roi.width * (size_t)roi.height;
+    bpp = (int)(entry_size / pixels);
+
+    /* 4 bytes per pixel: this is the final, display-encoded backbuffer. */
+    if(entry_size < pixels * 4)
+      dt_print(DT_DEBUG_ALWAYS,
+               "[pixelpipe] BACKBUF TOO SMALL on pipe %s: roi %dx%d needs %zu bytes, cacheline holds "
+               "%zu; hash %" PRIu64 "\n",
+               dt_pixelpipe_get_pipe_name(pipe->type), roi.width, roi.height, pixels * 4, entry_size,
+               (uint64_t)entry_hash);
+  }
 
   // Always refresh backbuf geometry/state, even when the cache key is unchanged.
   // Realtime drawing can update pixels in-place in the same cacheline, so width/height/history

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -1397,6 +1397,28 @@ static void _update_backbuf_cache_reference(dt_dev_pixelpipe_t *pipe, dt_iop_roi
                "%zu; hash %" PRIu64 "\n",
                dt_pixelpipe_get_pipe_name(pipe->type), roi.width, roi.height, pixels * 4, entry_size,
                (uint64_t)entry_hash);
+
+    /* And the shape itself. `roi' is what this run ASKED the pipe for; the pixels in the
+     * cacheline are whatever the last node actually produced, which is its roi_out. Those are
+     * supposed to be the same rectangle, and the backbuffer advertises the former while handing
+     * consumers the latter -- so if they differ, every display path computes its cairo stride
+     * from a width the data does not have, and draws the diagonal striping of a stride error.
+     *
+     * The cache cannot answer this on its own: an entry records how many BYTES it holds and not
+     * what shape they are in, so a cacheline reused at another size is indistinguishable from a
+     * correct one by size alone -- large-but-wrong passes every check a consumer can make. The
+     * last node's planned output is the only place the true shape survives. */
+    const GList *const last = g_list_last(pipe->nodes);
+    if(!IS_NULL_PTR(last))
+    {
+      const dt_dev_pixelpipe_iop_t *const tail = (const dt_dev_pixelpipe_iop_t *)last->data;
+      if(tail->roi_out.width != roi.width || tail->roi_out.height != roi.height)
+        dt_print(DT_DEBUG_ALWAYS,
+                 "[pixelpipe] BACKBUF SHAPE MISMATCH on pipe %s: advertising %dx%d but %s produced "
+                 "%dx%d; hash %" PRIu64 "\n",
+                 dt_pixelpipe_get_pipe_name(pipe->type), roi.width, roi.height, tail->module->op,
+                 tail->roi_out.width, tail->roi_out.height, (uint64_t)entry_hash);
+    }
   }
 
   // Always refresh backbuf geometry/state, even when the cache key is unchanged.

--- a/src/iop/ashift.c
+++ b/src/iop/ashift.c
@@ -3790,6 +3790,12 @@ if(!dt_dev_distort_transform_plus(self->dev, self->dev->virtual_pipe, self->prio
 static int call_distort_transform(dt_dev_pixelpipe_t *pipe, struct dt_iop_module_t *self,
                                   float *points, size_t points_count)
 {
+  /* This module's own transform and nothing else. The geometry service expresses that directly;
+   * the pipe cannot, which is why the piece has to be resolved and its callback invoked by hand
+   * below. Both honour the focused-module exception, so the two agree on when this contributes
+   * nothing at all. */
+  if(dt_geometry_module_transform(self->dev, self, points, points_count)) return 1;
+
   int ret = 0;
   dt_dev_pixelpipe_iop_t *piece = dt_dev_distort_get_iop_pipe(pipe, self);
   if(IS_NULL_PTR(piece)) return ret;

--- a/src/iop/ashift.c
+++ b/src/iop/ashift.c
@@ -2789,7 +2789,7 @@ static void _draw_save_lines_to_params(dt_iop_module_t *self)
     float pts[8] = { g->lines[0].p1[0], g->lines[0].p1[1], g->lines[0].p2[0],
                      g->lines[0].p2[1], g->lines[1].p1[0], g->lines[1].p1[1],
                      g->lines[1].p2[0], g->lines[1].p2[1] };
-    if(dt_dev_distort_backtransform_plus(self->dev->virtual_pipe, self->iop_order,
+    if(dt_dev_distort_backtransform_gui(self->dev, self->iop_order,
                                          DT_DEV_TRANSFORM_DIR_BACK_EXCL, pts, 4))
     {
       for(int i = 0; i < 8; i++) p->last_quad_lines[i] = pts[i];
@@ -2814,7 +2814,7 @@ static void _draw_save_lines_to_params(dt_iop_module_t *self)
         if(p->last_drawn_lines_count >= MAX_SAVED_LINES) break;
       }
     }
-    dt_dev_distort_backtransform_plus(self->dev->virtual_pipe, self->iop_order,
+    dt_dev_distort_backtransform_gui(self->dev, self->iop_order,
                                       DT_DEV_TRANSFORM_DIR_BACK_EXCL, p->last_drawn_lines,
                                       p->last_drawn_lines_count * 2);
   }
@@ -2840,7 +2840,7 @@ static gboolean _draw_retrieve_lines_from_params(dt_iop_module_t *self, dt_iop_a
                      p->last_quad_lines[2], p->last_quad_lines[3],
                      p->last_quad_lines[4], p->last_quad_lines[5],
                      p->last_quad_lines[6], p->last_quad_lines[7] };
-    if(dt_dev_distort_transform_plus(self->dev->virtual_pipe, self->iop_order,
+    if(dt_dev_distort_transform_gui(self->dev, self->iop_order,
                                      DT_DEV_TRANSFORM_DIR_BACK_EXCL, pts, 4))
     {
       if(g->lines)
@@ -2879,7 +2879,7 @@ static gboolean _draw_retrieve_lines_from_params(dt_iop_module_t *self, dt_iop_a
     for(int i = 0; i < p->last_drawn_lines_count * 4; i++)
       pts[i] = p->last_drawn_lines[i];
 
-    if(dt_dev_distort_transform_plus(self->dev->virtual_pipe, self->iop_order,
+    if(dt_dev_distort_transform_gui(self->dev, self->iop_order,
                                      DT_DEV_TRANSFORM_DIR_BACK_EXCL, pts, p->last_drawn_lines_count * 2))
     {
       if(g->lines)
@@ -3054,7 +3054,7 @@ static void _do_get_structure_quad(dt_iop_module_t *self)
     const float wd = geometry.processed_width;
     const float ht = geometry.processed_height;
     float pts[8] = { wd * 0.2, ht * 0.2, wd * 0.2, ht * 0.8, wd * 0.8, ht * 0.2, wd * 0.8, ht * 0.8 };
-    if(dt_dev_distort_backtransform_plus(self->dev->virtual_pipe, self->iop_order,
+    if(dt_dev_distort_backtransform_gui(self->dev, self->iop_order,
                                          DT_DEV_TRANSFORM_DIR_FORW_INCL, pts, 4))
     {
       g->current_structure_method = ASHIFT_METHOD_QUAD;
@@ -3718,9 +3718,9 @@ static int get_points(struct dt_iop_module_t *self, const dt_iop_ashift_line_t *
   }
 
   // third step: transform all points
-  if(!dt_dev_distort_transform_plus(dev->virtual_pipe, self->iop_order, DT_DEV_TRANSFORM_DIR_FORW_INCL, my_points, total_points))
+  if(!dt_dev_distort_transform_gui(dev, self->iop_order, DT_DEV_TRANSFORM_DIR_FORW_INCL, my_points, total_points))
     goto error;
-  if(!dt_dev_distort_transform_plus(dev->virtual_pipe, self->iop_order, DT_DEV_TRANSFORM_DIR_FORW_INCL,
+  if(!dt_dev_distort_transform_gui(dev, self->iop_order, DT_DEV_TRANSFORM_DIR_FORW_INCL,
                                     my_extremas, 2 * lines_count))
     goto error;
 
@@ -3976,10 +3976,10 @@ void gui_post_expose(struct dt_iop_module_t *self, cairo_t *cr, int32_t width, i
                     { xmin + p->cr * owd, ymin + p->ct * oht } };
 
   // convert clipping corners to final output image
-  if(!dt_dev_distort_transform_plus(self->dev->virtual_pipe, self->iop_order,
+  if(!dt_dev_distort_transform_gui(self->dev, self->iop_order,
                                     DT_DEV_TRANSFORM_DIR_FORW_EXCL, (float *)C, 4))
     return;
-  if(!dt_dev_distort_transform_plus(self->dev->virtual_pipe, self->iop_order,
+  if(!dt_dev_distort_transform_gui(self->dev, self->iop_order,
                                     DT_DEV_TRANSFORM_DIR_FORW_EXCL, (float *)V, 4))
     return;
 
@@ -4300,7 +4300,7 @@ int mouse_moved(struct dt_iop_module_t *self, double x, double y, double pressur
     const float pd_w = geometry.processed_width;
     const float pd_h = geometry.processed_height;
     float pts[2] = { pzx * pd_w, pzy * pd_h };
-    if(dt_dev_distort_backtransform_plus(self->dev->virtual_pipe, self->iop_order,
+    if(dt_dev_distort_backtransform_gui(self->dev, self->iop_order,
                                          DT_DEV_TRANSFORM_DIR_FORW_INCL, pts, 1))
     {
       // first we move the point
@@ -4367,7 +4367,7 @@ int mouse_moved(struct dt_iop_module_t *self, double x, double y, double pressur
     const float pd_w = geometry.processed_width;
     const float pd_h = geometry.processed_height;
     float pts[2] = { pzx * pd_w, pzy * pd_h };
-    if(dt_dev_distort_backtransform_plus(self->dev->virtual_pipe, self->iop_order,
+    if(dt_dev_distort_backtransform_gui(self->dev, self->iop_order,
                                          DT_DEV_TRANSFORM_DIR_FORW_INCL, pts, 1))
     {
       const float dx = (pts[0] - g->draw_pointmove_x);
@@ -4607,7 +4607,7 @@ int button_pressed(struct dt_iop_module_t *self, double x, double y, double pres
         const float pd_w = geometry.processed_width;
         const float pd_h = geometry.processed_height;
         float pts[2] = { pzx * pd_w, pzy * pd_h };
-        dt_dev_distort_backtransform_plus(self->dev->virtual_pipe, self->iop_order,
+        dt_dev_distort_backtransform_gui(self->dev, self->iop_order,
                                           DT_DEV_TRANSFORM_DIR_FORW_INCL, pts, 1);
         g->draw_line_move = n;
         g->draw_pointmove_x = pts[0];
@@ -4708,7 +4708,7 @@ int button_pressed(struct dt_iop_module_t *self, double x, double y, double pres
     const float pd_w = geometry.processed_width;
     const float pd_h = geometry.processed_height;
     float pts[2] = { pzx * pd_w, pzy * pd_h };
-    dt_dev_distort_backtransform_plus(self->dev->virtual_pipe, self->iop_order,
+    dt_dev_distort_backtransform_gui(self->dev, self->iop_order,
                                       DT_DEV_TRANSFORM_DIR_FORW_INCL, pts, 1);
     const int count = g->lines_count + 1;
     // if count > MAX_SAVED_LINES we alert that the next lines won't be saved in params
@@ -4780,7 +4780,7 @@ int button_released(struct dt_iop_module_t *self, double x, double y, int which,
     const float pd_w = geometry.processed_width;
     const float pd_h = geometry.processed_height;
     float pts[4] = { pzx * pd_w, pzy * pd_h, g->lastx * pd_w, g->lasty * pd_h };
-    dt_dev_distort_backtransform_plus(self->dev->virtual_pipe,
+    dt_dev_distort_backtransform_gui(self->dev,
                                       self->iop_order,
                                       DT_DEV_TRANSFORM_DIR_FORW_EXCL, pts, 2);
 

--- a/src/iop/ashift.c
+++ b/src/iop/ashift.c
@@ -67,6 +67,7 @@
 #include "common/opencl.h"
 #include "control/control.h"
 #include "develop/develop.h"
+#include "develop/geometry/geometry.h"
 #include "develop/imageop.h"
 #include "develop/imageop_gui.h"
 #include "widgets/button.h"
@@ -5555,14 +5556,25 @@ static void _event_process_after_ui_callback(gpointer instance, gpointer user_da
   dt_control_queue_redraw_center();
 }
 
-void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pixelpipe_t *pipe,
-                   dt_dev_pixelpipe_iop_t *piece)
+/* --- the shared geometry core ----------------------------------------------------------
+ *
+ * commit_params() below and the geometry service's record (develop/geometry/geometry.h) both go
+ * through _ashift_resolve(), and both evaluate through homography(), which is already a pure
+ * function of the resolved parameters and the input dimensions. So the correction the pipe
+ * applies and the one the GUI overlays are drawn against are the same one, expressed once.
+ *
+ * The edit-mode branch is why the record cannot be built from history alone: while the ashift
+ * GUI is editing, the effective parameters live in g->new_params -- which never reach history --
+ * and the crop is neutralised so the full transformed frame is visible. A record built from
+ * history would describe a crop nobody is rendering, exactly when the overlays matter most.
+ */
+static void _ashift_resolve(struct dt_iop_module_t *self, const dt_iop_ashift_params_t *const p1,
+                            dt_iop_ashift_data_t *d)
 {
-  dt_iop_ashift_data_t *d = (dt_iop_ashift_data_t *)piece->data;
   dt_iop_ashift_gui_data_t *g = (dt_iop_ashift_gui_data_t *)dt_iop_gui_data(self);
 
   const gboolean editing = !IS_NULL_PTR(g) && g->editing;
-  dt_iop_ashift_params_t *p = editing ? &g->new_params : (dt_iop_ashift_params_t *)p1;
+  const dt_iop_ashift_params_t *p = editing ? &g->new_params : p1;
 
   d->rotation = p->rotation;
   d->lensshift_v = p->lensshift_v;
@@ -5592,6 +5604,107 @@ void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pix
     d->ct = p->ct;
     d->cb = p->cb;
   }
+}
+
+void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pixelpipe_t *pipe,
+                   dt_dev_pixelpipe_iop_t *piece)
+{
+  _ashift_resolve(self, (const dt_iop_ashift_params_t *)p1, (dt_iop_ashift_data_t *)piece->data);
+}
+
+/* --- the geometry service's view of this module (develop/geometry/geometry.h) --------- */
+
+/** @brief Apply the homography plus the clipping offset, in whichever direction. */
+static int _ashift_geometry_apply(const void *data, const dt_geometry_record_t *const record, float *points,
+                                  size_t points_count, const int direction)
+{
+  const dt_iop_ashift_data_t *const d = (const dt_iop_ashift_data_t *)data;
+  if(isneutral(d)) return 1;
+
+  float DT_ALIGNED_ARRAY h[3][3];
+  homography((float *)h, d->rotation, d->lensshift_v, d->lensshift_h, d->shear, d->f_length_kb, d->orthocorr,
+             d->aspect, record->in.width, record->in.height, direction);
+
+  // clipping offset
+  const float fullwidth = (float)record->out.width / (d->cr - d->cl);
+  const float fullheight = (float)record->out.height / (d->cb - d->ct);
+  const float cx = fullwidth * d->cl;
+  const float cy = fullheight * d->ct;
+
+  const gboolean forward = (direction == ASHIFT_HOMOGRAPH_FORWARD);
+  for(size_t i = 0; i < points_count * 2; i += 2)
+  {
+    float DT_ALIGNED_PIXEL pi[3] = { points[i] + (forward ? 0.f : cx), points[i + 1] + (forward ? 0.f : cy),
+                                     1.0f };
+    float DT_ALIGNED_PIXEL po[3];
+    mat3mulv(po, (float *)h, pi);
+    points[i] = po[0] / po[2] - (forward ? cx : 0.f);
+    points[i + 1] = po[1] / po[2] - (forward ? cy : 0.f);
+  }
+  return 1;
+}
+
+static void _ashift_geometry_map_size(const void *data, const dt_iop_roi_t *const in, dt_iop_roi_t *out)
+{
+  const dt_iop_ashift_data_t *const d = (const dt_iop_ashift_data_t *)data;
+  *out = *in;
+  if(isneutral(d)) return;
+
+  float h[3][3];
+  homography((float *)h, d->rotation, d->lensshift_v, d->lensshift_h, d->shear, d->f_length_kb, d->orthocorr,
+             d->aspect, in->width, in->height, ASHIFT_HOMOGRAPH_FORWARD);
+
+  float xm = FLT_MAX, xM = -FLT_MAX, ym = FLT_MAX, yM = -FLT_MAX;
+
+  // the four vertices of the input rect, through the homograph, give the output bounding box
+  for(int y = 0; y < in->height; y += in->height - 1)
+    for(int x = 0; x < in->width; x += in->width - 1)
+    {
+      float pin[3] = { (in->x + x) / in->scale, (in->y + y) / in->scale, 1.0f };
+      float pout[3];
+      mat3mulv(pout, (float *)h, pin);
+      pout[0] = pout[0] / pout[2] * out->scale;
+      pout[1] = pout[1] / pout[2] * out->scale;
+      xm = MIN(xm, pout[0]);
+      xM = MAX(xM, pout[0]);
+      ym = MIN(ym, pout[1]);
+      yM = MAX(yM, pout[1]);
+    }
+
+  // clipping adjustments
+  out->width = floorf((xM - xm + 1) * (d->cr - d->cl));
+  out->height = floorf((yM - ym + 1) * (d->cb - d->ct));
+}
+
+static int _ashift_geometry_transform(const void *data, const dt_geometry_record_t *const record,
+                                      dt_geometry_chain_t *chain, float *points, size_t points_count)
+{
+  return _ashift_geometry_apply(data, record, points, points_count, ASHIFT_HOMOGRAPH_FORWARD);
+}
+
+static int _ashift_geometry_backtransform(const void *data, const dt_geometry_record_t *const record,
+                                          dt_geometry_chain_t *chain, float *points, size_t points_count)
+{
+  return _ashift_geometry_apply(data, record, points, points_count, ASHIFT_HOMOGRAPH_INVERTED);
+}
+
+static const dt_geometry_vtable_t _ashift_geometry_vtable = {
+  .map_size = _ashift_geometry_map_size,
+  .transform = _ashift_geometry_transform,
+  .backtransform = _ashift_geometry_backtransform,
+};
+
+gboolean geometry_record(struct dt_iop_module_t *self, const void *params, dt_geometry_record_t *record)
+{
+  dt_iop_ashift_data_t *data = (dt_iop_ashift_data_t *)g_malloc0(sizeof(dt_iop_ashift_data_t));
+  if(IS_NULL_PTR(data)) return FALSE;
+
+  _ashift_resolve(self, (const dt_iop_ashift_params_t *)params, data);
+
+  record->data = data;
+  record->free_data = dt_free_gpointer;
+  record->vtable = &_ashift_geometry_vtable;
+  return TRUE;
 }
 
 gboolean runtime_data_hash(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe,

--- a/src/iop/ashift.c
+++ b/src/iop/ashift.c
@@ -3196,8 +3196,22 @@ int process(struct dt_iop_module_t *self, const dt_dev_pixelpipe_t *pipe, const 
     float ivec[2] = { points[2] - points[0], points[3] - points[1] };
     float ivecl = sqrtf(ivec[0] * ivec[0] + ivec[1] * ivec[1]);
 
-    // where do they go?
-    dt_dev_distort_backtransform_plus(self->dev->virtual_pipe, self->iop_order,
+    /* Where do they go? Asked of THIS pipe, the one whose frame we are producing.
+     *
+     * This used to walk the GUI thread's pixel-less clone pipe: a worker thread reading
+     * another thread's node list with no lock, while the GUI can be
+     * resyncing it (dt_dev_pixelpipe_change() rebuilds pipe->nodes from dev->iop). The answer
+     * was also whatever history the virtual pipe happened to hold, not the history this frame
+     * is being rendered from.
+     *
+     * The running pipe answers the same question by construction: every distorting module
+     * downstream of ashift -- liquify, rotatepixels, scalepixels, flip, clipping, crop,
+     * borders -- commits identical params on every darkroom pipe (none of them is pipe-type
+     * dependent), and piece->buf_in/buf_out are full-resolution scale-1.0 dims on every pipe,
+     * because dt_dev_pixelpipe_get_roi_out() seeds its fold from pipe->iwidth/iheight at
+     * scale 1. So the geometry is the same, the ownership is correct, and the answer now
+     * describes the frame in hand. */
+    dt_dev_distort_backtransform_plus(pipe, self->iop_order,
                                       DT_DEV_TRANSFORM_DIR_FORW_EXCL, points, 2);
 
     float ovec[2] = { points[2] - points[0], points[3] - points[1] };
@@ -3336,8 +3350,22 @@ int process_cl(struct dt_iop_module_t *self, const dt_dev_pixelpipe_t *pipe, con
     const float ivec[2] = { points[2] - points[0], points[3] - points[1] };
     const float ivecl = sqrtf(ivec[0] * ivec[0] + ivec[1] * ivec[1]);
 
-    // where do they go?
-    dt_dev_distort_backtransform_plus(self->dev->virtual_pipe, self->iop_order,
+    /* Where do they go? Asked of THIS pipe, the one whose frame we are producing.
+     *
+     * This used to walk the GUI thread's pixel-less clone pipe: a worker thread reading
+     * another thread's node list with no lock, while the GUI can be
+     * resyncing it (dt_dev_pixelpipe_change() rebuilds pipe->nodes from dev->iop). The answer
+     * was also whatever history the virtual pipe happened to hold, not the history this frame
+     * is being rendered from.
+     *
+     * The running pipe answers the same question by construction: every distorting module
+     * downstream of ashift -- liquify, rotatepixels, scalepixels, flip, clipping, crop,
+     * borders -- commits identical params on every darkroom pipe (none of them is pipe-type
+     * dependent), and piece->buf_in/buf_out are full-resolution scale-1.0 dims on every pipe,
+     * because dt_dev_pixelpipe_get_roi_out() seeds its fold from pipe->iwidth/iheight at
+     * scale 1. So the geometry is the same, the ownership is correct, and the answer now
+     * describes the frame in hand. */
+    dt_dev_distort_backtransform_plus(pipe, self->iop_order,
                                       DT_DEV_TRANSFORM_DIR_FORW_EXCL, points, 2);
 
     const float ovec[2] = { points[2] - points[0], points[3] - points[1] };

--- a/src/iop/ashift.c
+++ b/src/iop/ashift.c
@@ -2550,11 +2550,11 @@ static void do_crop(dt_iop_module_t *self, dt_iop_ashift_params_t *p)
   // ashift's process() to populate g->buf. ashift's roi_in is crop-dependent, while buf_in is the
   // stable full input geometry required by the fit.
   int crop_width = 0, crop_height = 0;
-  const dt_dev_pixelpipe_iop_t *crop_piece = dt_dev_distort_get_iop_pipe(self->dev->virtual_pipe, self);
-  if(!IS_NULL_PTR(crop_piece) && crop_piece->buf_in.width > 0 && crop_piece->buf_in.height > 0)
+  dt_iop_roi_t crop_in;
+  if(dt_dev_module_geometry_gui(self->dev, self, &crop_in, NULL) && crop_in.width > 0 && crop_in.height > 0)
   {
-    crop_width = crop_piece->buf_in.width;
-    crop_height = crop_piece->buf_in.height;
+    crop_width = crop_in.width;
+    crop_height = crop_in.height;
   }
   else
   {
@@ -3011,14 +3011,17 @@ static void _do_get_structure_lines(dt_iop_module_t *self)
   // Manual line drawing only needs the module input geometry, never the pixel buffer (unlike
   // auto-detection). Tying it to g->buf used to block all manual input whenever the preview buffer
   // was momentarily unavailable, e.g. when the module already had parameters set (#710).
-  dt_dev_pixelpipe_iop_t *piece = dt_dev_distort_get_iop_pipe(self->dev->virtual_pipe, self);
-  if(IS_NULL_PTR(piece) || piece->iwidth <= 0 || piece->iheight <= 0) return;
+  /* piece->iwidth/iheight was the PIPE's input size, which is the raw geometry -- not anything
+   * this module derives -- so it is read from where that fact lives. */
+  int32_t raw_width = 0, raw_height = 0;
+  if(!dt_dev_geometry_get_raw_size(self->dev, &raw_width, &raw_height)) return;
+  if(raw_width <= 0 || raw_height <= 0) return;
 
   _do_clean_structure(self, p, TRUE);
 
   g->current_structure_method = ASHIFT_METHOD_LINES;
-  g->lines_in_width = piece->iwidth;
-  g->lines_in_height = piece->iheight;
+  g->lines_in_width = raw_width;
+  g->lines_in_height = raw_height;
   g->lines_x_off = 0;
   g->lines_y_off = 0;
 
@@ -3037,8 +3040,11 @@ static void _do_get_structure_quad(dt_iop_module_t *self)
 
   // The manual perspective rectangle only needs the module input geometry, never the pixel buffer
   // (unlike auto-detection), so it must not wait for the preview input buffer (#710).
-  dt_dev_pixelpipe_iop_t *piece = dt_dev_distort_get_iop_pipe(self->dev->virtual_pipe, self);
-  if(IS_NULL_PTR(piece) || piece->iwidth <= 0 || piece->iheight <= 0) return;
+  /* piece->iwidth/iheight was the PIPE's input size, which is the raw geometry -- not anything
+   * this module derives -- so it is read from where that fact lives. */
+  int32_t raw_width = 0, raw_height = 0;
+  if(!dt_dev_geometry_get_raw_size(self->dev, &raw_width, &raw_height)) return;
+  if(raw_width <= 0 || raw_height <= 0) return;
 
   _do_clean_structure(self, p, TRUE);
 
@@ -3073,8 +3079,8 @@ static void _do_get_structure_quad(dt_iop_module_t *self)
       // get real line type (they may be wrong due to image rotation)
       for(int i = 0; i < 4; i++) _draw_retrieve_line_type(&g->lines[i]);
 
-      g->lines_in_width = piece->iwidth;
-      g->lines_in_height = piece->iheight;
+      g->lines_in_width = raw_width;
+      g->lines_in_height = raw_height;
       g->lines_x_off = 0;
       g->lines_y_off = 0;
       g->vertical_count = 2;
@@ -3907,16 +3913,16 @@ void gui_post_expose(struct dt_iop_module_t *self, cairo_t *cr, int32_t width, i
   dt_dev_rescale_roi(dev, cr, width, height);
 
   // we draw the cropping area; use the input ROI from the virtual pipe piece
-  dt_dev_pixelpipe_iop_t *piece = dt_dev_distort_get_iop_pipe(self->dev->virtual_pipe, self);
-  if(IS_NULL_PTR(piece))
+  dt_iop_roi_t mod_in;
+  if(!dt_dev_module_geometry_gui(self->dev, self, &mod_in, NULL))
   {
     cairo_restore(cr);
     return;
   }
-  const float iwd = piece->buf_in.width;
-  const float iht = piece->buf_in.height;
-  const float ixo = piece->buf_in.x;
-  const float iyo = piece->buf_in.y;
+  const float iwd = mod_in.width;
+  const float iht = mod_in.height;
+  const float ixo = mod_in.x;
+  const float iyo = mod_in.y;
 
   // The four corners of the inner image polygon
   float V[4][2] = { { ixo,        iyo       },

--- a/src/iop/ashift.c
+++ b/src/iop/ashift.c
@@ -3797,6 +3797,7 @@ static int call_distort_transform(dt_dev_pixelpipe_t *pipe, struct dt_iop_module
   if(dt_geometry_module_transform(self->dev, self, points, points_count)) return 1;
 
   int ret = 0;
+  if(pipe == self->dev->virtual_pipe) dt_dev_virtual_pipe_ensure_synced(self->dev);
   dt_dev_pixelpipe_iop_t *piece = dt_dev_distort_get_iop_pipe(pipe, self);
   if(IS_NULL_PTR(piece)) return ret;
   if(piece->module == self && /*piece->enabled && */  //see note below

--- a/src/iop/ashift.c
+++ b/src/iop/ashift.c
@@ -2537,7 +2537,7 @@ static void do_crop(dt_iop_module_t *self, dt_iop_ashift_params_t *p)
     g->grid_hash = DT_PIXELPIPE_CACHE_HASH_INVALID;
     if(g->editing)
     {
-      dt_dev_pixelpipe_sync_virtual(self->dev, DT_DEV_PIPE_SYNCH);
+      dt_geometry_chain_rebuild(self->dev);
       dt_dev_get_thumbnail_size(self->dev);
       dt_dev_pixelpipe_resync_history_all(self->dev);
     }
@@ -2545,9 +2545,9 @@ static void do_crop(dt_iop_module_t *self, dt_iop_ashift_params_t *p)
   }
 
   // Auto-crop is a purely geometric fit: it only needs ashift's *full* (uncropped) input size, not
-  // pixel data. Read it from the virtual-pipe piece, which is synchronized on the GUI thread and
-  // remains available when the preview worker exact-hits downstream cache entries without running
-  // ashift's process() to populate g->buf. ashift's roi_in is crop-dependent, while buf_in is the
+  // pixel data. Read it from the geometry record, which is GUI-thread state and remains available
+  // when the preview worker exact-hits downstream cache entries without running ashift's process()
+  // to populate g->buf. ashift's roi_in is crop-dependent, while buf_in is the
   // stable full input geometry required by the fit.
   int crop_width = 0, crop_height = 0;
   dt_iop_roi_t crop_in;
@@ -2710,7 +2710,7 @@ static void do_crop(dt_iop_module_t *self, dt_iop_ashift_params_t *p)
 
   if(g->editing)
   {
-    dt_dev_pixelpipe_sync_virtual(self->dev, DT_DEV_PIPE_SYNCH);
+    dt_geometry_chain_rebuild(self->dev);
     dt_dev_get_thumbnail_size(self->dev);
     dt_dev_pixelpipe_resync_history_all(self->dev);
   }
@@ -2830,7 +2830,12 @@ static gboolean _draw_retrieve_lines_from_params(dt_iop_module_t *self, dt_iop_a
   dt_iop_ashift_params_t *p = _get_ashift_params(self);
   if(IS_NULL_PTR(g) || IS_NULL_PTR(p)) return FALSE;
 
-  dt_dev_pixelpipe_iop_t *piece = dt_dev_distort_get_iop_pipe(self->dev->virtual_pipe, self);
+  /* The saved lines are in the raw frame, and so is the size they are measured against -- what
+   * used to be read off a pipe piece's iwidth/iheight, which is the pipe's own input size. Ask
+   * the dev for it, the same way _do_get_structure_lines() below does. */
+  int32_t raw_width = 0;
+  int32_t raw_height = 0;
+  if(!dt_dev_geometry_get_raw_size(self->dev, &raw_width, &raw_height)) return FALSE;
 
   if(method == ASHIFT_METHOD_QUAD
      && p->last_quad_lines[0] > 0.0f && p->last_quad_lines[1] > 0.0f
@@ -2865,8 +2870,8 @@ static gboolean _draw_retrieve_lines_from_params(dt_iop_module_t *self, dt_iop_a
       g->horizontal_count = 2;
       g->vertical_weight = 2.0;
       g->horizontal_weight = 2.0;
-      g->lines_in_width = piece->iwidth;
-      g->lines_in_height = piece->iheight;
+      g->lines_in_width = raw_width;
+      g->lines_in_height = raw_height;
       g->current_structure_method = method;
       return TRUE;
     }
@@ -2909,8 +2914,8 @@ static gboolean _draw_retrieve_lines_from_params(dt_iop_module_t *self, dt_iop_a
       g->horizontal_count = hnb;
       g->vertical_weight = (float)vnb;
       g->horizontal_weight = (float)hnb;
-      g->lines_in_width = piece->iwidth;
-      g->lines_in_height = piece->iheight;
+      g->lines_in_width = raw_width;
+      g->lines_in_height = raw_height;
       g->current_structure_method = method;
       return TRUE;
     }
@@ -3783,34 +3788,21 @@ error:
   return FALSE;
 }
 
-/* this function replaces this sentence, it calls distort_transform() for this module on the pipe
-if(!dt_dev_distort_transform_plus(self->dev, self->dev->virtual_pipe, self->priority, self->priority + 1,
-      (float *)V, 4))
-*/
-static int call_distort_transform(dt_dev_pixelpipe_t *pipe, struct dt_iop_module_t *self,
-                                  float *points, size_t points_count)
+/* This module's own transform and nothing else -- no direction bound expresses that, since
+ * FORW_INCL at this module's own iop_order includes everything after it too.
+ *
+ * It used to be done by resolving this module's piece on the GUI's pixel-less pipe and invoking
+ * its distort_transform() by hand, with the focused-module exception applied around it. The
+ * geometry service expresses the whole thing directly and applies the same exception, so what is
+ * left is the call.
+ *
+ * The old hand-rolled version deliberately did NOT test piece->enabled: it is FALSE for exactly
+ * the first mouse_moved following a button_pressed while ASHIFT_CROP_ASPECT is active, which drew
+ * one frame of the centre image without the crop overlay. Records carry their enabled state from
+ * history rather than from a piece mid-commit, so that flicker has no equivalent here. */
+static int call_distort_transform(struct dt_iop_module_t *self, float *points, size_t points_count)
 {
-  /* This module's own transform and nothing else. The geometry service expresses that directly;
-   * the pipe cannot, which is why the piece has to be resolved and its callback invoked by hand
-   * below. Both honour the focused-module exception, so the two agree on when this contributes
-   * nothing at all. */
-  if(dt_geometry_module_transform(self->dev, self, points, points_count)) return 1;
-
-  int ret = 0;
-  if(pipe == self->dev->virtual_pipe) dt_dev_virtual_pipe_ensure_synced(self->dev);
-  dt_dev_pixelpipe_iop_t *piece = dt_dev_distort_get_iop_pipe(pipe, self);
-  if(IS_NULL_PTR(piece)) return ret;
-  if(piece->module == self && /*piece->enabled && */  //see note below
-     !dt_dev_pixelpipe_activemodule_disables_currentmodule(pipe->dev, piece->module))
-  {
-    if(piece->module->distort_transform)
-    ret = piece->module->distort_transform(piece->module, pipe, piece, points, points_count);
-  }
-  return ret;
-  //NOTE: piece->enabled is FALSE for exactly the first mouse_moved event following a button_pressed event
-  //  when ASHIFT_CROP_ASPECT is active, which causes the first gui_post_expose call on starting to resize
-  //  the crop box to draw the center image without the crop overlay, resulting in an annoying visual glitch.
-  //  Removing the check appears to have no adverse effects and eliminates the glitch.
+  return dt_geometry_module_transform(self->dev, self, points, points_count);
 }
 
 void gui_post_expose(struct dt_iop_module_t *self, cairo_t *cr, int32_t width, int32_t height,
@@ -3919,7 +3911,7 @@ void gui_post_expose(struct dt_iop_module_t *self, cairo_t *cr, int32_t width, i
   dt_dev_clip_roi(dev, cr, width, height);
   dt_dev_rescale_roi(dev, cr, width, height);
 
-  // we draw the cropping area; use the input ROI from the virtual pipe piece
+  // we draw the cropping area; use this module's own input rectangle
   dt_iop_roi_t mod_in;
   if(!dt_dev_module_geometry_gui(self->dev, self, &mod_in, NULL))
   {
@@ -3938,7 +3930,7 @@ void gui_post_expose(struct dt_iop_module_t *self, cairo_t *cr, int32_t width, i
                     { ixo + iwd,  iyo       } };
 
   // convert coordinates of corners to coordinates of this module's output
-  if(!call_distort_transform(self->dev->virtual_pipe, self, (float *)V, 4))
+  if(!call_distort_transform(self, (float *)V, 4))
     return;
 
   // get x/y-offset as well as width and height of output buffer
@@ -3955,10 +3947,10 @@ void gui_post_expose(struct dt_iop_module_t *self, cairo_t *cr, int32_t width, i
   // Paint black outside area when not in editing mode then returns.
   if(!g->editing)
   {
-    if(!dt_dev_distort_transform_plus(self->dev, self->dev->virtual_pipe, self->iop_order,
+    if(!dt_dev_distort_transform_gui(self->dev, self->iop_order,
                                     DT_DEV_TRANSFORM_DIR_FORW_EXCL, (float *)V, 4))
       return;
-    const float scale_factor = dt_dev_get_natural_scale(dev, dev->virtual_pipe);
+    const float scale_factor = dt_dev_get_natural_scale(dev, dev->preview_pipe);
     for(size_t i = 0; i < 4; i++)
     {
       V[i][0] *= scale_factor;
@@ -4053,12 +4045,10 @@ void gui_post_expose(struct dt_iop_module_t *self, cairo_t *cr, int32_t width, i
   // no structural data or visibility switched off? -> stop here
   if(g->fitting || IS_NULL_PTR(g->lines) || IS_NULL_PTR(g->buf) || !self->enabled) return;
 
-  // ensure virtual pipe params are in sync so distortions use current settings
-  if(dt_dev_pixelpipe_get_history_hash(dev->virtual_pipe) != dt_dev_get_history_hash(dev))
-    dt_dev_pixelpipe_sync_virtual(dev, DT_DEV_PIPE_TOP_CHANGED);
-
-  // get hash value that changes if distortions from here to the end of the pixelpipe changed
-  // virtual_pipe doesn't process pixels, so its hash isn't reliable for invalidation.
+  // get hash value that changes if distortions from here to the end of the pixelpipe changed.
+  // The composed geometry has no hash of its own -- it is rebuilt wherever a pipe flag is raised,
+  // so it cannot be stale here -- and the preview pipe's is what actually tracks the distortions
+  // these points are drawn against.
   const uint64_t hash = dt_dev_pixelpipe_get_hash(dev->preview_pipe);
   // get hash value that changes if coordinates of lines have changed
   const uint64_t lines_hash = _get_lines_hash(g->lines, g->lines_count);
@@ -5444,12 +5434,12 @@ static void _enter_edit_mode(GtkToggleButton* button, struct dt_iop_module_t *se
     gtk_widget_set_sensitive(g->commit_button, FALSE);
   }
 
-  // Entering or leaving edit mode changes ashift's runtime crop contract. Settle that contract on
-  // the virtual pipe first, then publish the resulting full-image dimensions before waking either
-  // pixel worker. Resyncing first and queuing separate ZOOMED updates afterwards let a worker start
+  // Entering or leaving edit mode changes ashift's runtime crop contract. Settle the composed
+  // geometry first, then publish the resulting full-image dimensions before waking either pixel
+  // worker. Resyncing first and queuing separate ZOOMED updates afterwards let a worker start
   // with the previous ROI, get killed by the next update, and repeatedly feed slightly different
   // preview dimensions back into the GUI geometry.
-  dt_dev_pixelpipe_sync_virtual(self->dev, DT_DEV_PIPE_SYNCH);
+  dt_geometry_chain_rebuild(self->dev);
   dt_dev_get_thumbnail_size(self->dev);
   dt_dev_pixelpipe_resync_history_all(self->dev);
 }

--- a/src/iop/basebuffer.c
+++ b/src/iop/basebuffer.c
@@ -27,6 +27,7 @@
 #include "common/module_versioning.h"
 #include "caches/mipmap_cache.h"
 #include "develop/develop.h"
+#include "develop/geometry/geometry.h"
 #include "develop/imageop.h"
 #include "iop/iop_api.h"
 
@@ -72,6 +73,31 @@ void modify_roi_out(dt_iop_module_t *self, const dt_dev_pixelpipe_t *pipe, dt_de
                     dt_iop_roi_t *roi_out, const dt_iop_roi_t *const roi_in)
 {
   *roi_out = (dt_iop_roi_t){ 0, 0, pipe->iwidth, pipe->iheight, 1.f };
+}
+
+/* --- the geometry service's view of this module (develop/geometry/geometry.h) ---------
+ *
+ * basebuffer is the first module in the pipe and asserts the full sensor frame at scale 1,
+ * ignoring whatever roi_in it is handed. The geometry chain seeds its fold with exactly that
+ * -- the raw dimensions at scale 1 -- so re-asserting the input rect here reproduces the
+ * callback above for every position this module can occupy. It moves no points.
+ */
+
+static void _basebuffer_geometry_map_size(const void *data, const dt_iop_roi_t *const in, dt_iop_roi_t *out)
+{
+  *out = (dt_iop_roi_t){ 0, 0, in->width, in->height, 1.f };
+}
+
+static const dt_geometry_vtable_t _basebuffer_geometry_vtable = {
+  .map_size = _basebuffer_geometry_map_size,
+  .transform = NULL,
+  .backtransform = NULL,
+};
+
+gboolean geometry_record(dt_iop_module_t *self, dt_geometry_record_t *record)
+{
+  record->vtable = &_basebuffer_geometry_vtable;
+  return TRUE;
 }
 
 

--- a/src/iop/basebuffer.c
+++ b/src/iop/basebuffer.c
@@ -94,7 +94,7 @@ static const dt_geometry_vtable_t _basebuffer_geometry_vtable = {
   .backtransform = NULL,
 };
 
-gboolean geometry_record(dt_iop_module_t *self, dt_geometry_record_t *record)
+gboolean geometry_record(dt_iop_module_t *self, const void *params, dt_geometry_record_t *record)
 {
   record->vtable = &_basebuffer_geometry_vtable;
   return TRUE;

--- a/src/iop/borders.c
+++ b/src/iop/borders.c
@@ -60,6 +60,7 @@
 #include "common/imagebuf.h"
 #include "common/opencl.h"
 #include "develop/develop.h"
+#include "develop/geometry/geometry.h"
 #include "develop/imageop.h"
 #include "develop/imageop_gui.h"
 #include "develop/imageop_gui.h"
@@ -239,15 +240,29 @@ int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, const dt
   return IOP_CS_RGB;
 }
 
+/* --- the shared geometry core ----------------------------------------------------------
+ *
+ * The border's offset is DERIVED, not a parameter: it is the difference between the output and
+ * input sizes, apportioned by pos_h/pos_v. Both the pixel pipe's distort callbacks and the
+ * geometry service's record (develop/geometry/geometry.h) go through the two helpers below, so
+ * the size map and the offset can never drift apart.
+ */
+
+/** @brief The translation the border applies, from the two rects it sits between. */
+static void _borders_offset(const dt_iop_borders_data_t *const d, const dt_iop_roi_t *const in,
+                            const dt_iop_roi_t *const out, int *left, int *top)
+{
+  *left = (out->width - in->width) * d->pos_h;
+  *top = (out->height - in->height) * d->pos_v;
+}
+
 int distort_transform(dt_iop_module_t *self, const dt_dev_pixelpipe_t *pipe, const dt_dev_pixelpipe_iop_t *piece,
                       float *const restrict points, size_t points_count)
 {
   dt_iop_borders_data_t *d = (dt_iop_borders_data_t *)piece->data;
 
-  const int border_tot_width = (piece->buf_out.width - piece->buf_in.width);
-  const int border_tot_height = (piece->buf_out.height - piece->buf_in.height);
-  const int border_size_t = border_tot_height * d->pos_v;
-  const int border_size_l = border_tot_width * d->pos_h;
+  int border_size_l = 0, border_size_t = 0;
+  _borders_offset(d, &piece->buf_in, &piece->buf_out, &border_size_l, &border_size_t);
 
   // nothing to be done if parameters are set to neutral values (no top/left border)
   if (border_size_l == 0 && border_size_t == 0) return 1;
@@ -265,10 +280,8 @@ int distort_backtransform(dt_iop_module_t *self, const dt_dev_pixelpipe_t *pipe,
 {
   dt_iop_borders_data_t *d = (dt_iop_borders_data_t *)piece->data;
 
-  const int border_tot_width = (piece->buf_out.width - piece->buf_in.width);
-  const int border_tot_height = (piece->buf_out.height - piece->buf_in.height);
-  const int border_size_t = border_tot_height * d->pos_v;
-  const int border_size_l = border_tot_width * d->pos_h;
+  int border_size_l = 0, border_size_t = 0;
+  _borders_offset(d, &piece->buf_in, &piece->buf_out, &border_size_l, &border_size_t);
 
   // nothing to be done if parameters are set to neutral values (no top/left border)
   if (border_size_l == 0 && border_size_t == 0) return 1;
@@ -311,12 +324,13 @@ void distort_mask(struct dt_iop_module_t *self, const struct dt_dev_pixelpipe_t 
 
 // 1st pass: how large would the output be, given this input roi?
 // this is always called with the full buffer before processing.
-void modify_roi_out(struct dt_iop_module_t *self, const struct dt_dev_pixelpipe_t *pipe,
-                    struct dt_dev_pixelpipe_iop_t *piece, dt_iop_roi_t *roi_out,
-                    const dt_iop_roi_t *roi_in)
+/** @brief Input rect -> output rect. THE size evaluator: modify_roi_out() below and the
+ *  geometry record both call it, so the frame the pipe renders and the frame the GUI
+ *  measures are the same frame. */
+static void _borders_map_size(const dt_iop_borders_data_t *const d, const dt_iop_roi_t *const roi_in,
+                              dt_iop_roi_t *roi_out)
 {
   *roi_out = *roi_in;
-  const dt_iop_borders_data_t *d = (dt_iop_borders_data_t *)piece->data;
   const float size = fabsf(d->size);
   if(size == 0.0f || size >= 1.0f) return;
 
@@ -361,6 +375,13 @@ void modify_roi_out(struct dt_iop_module_t *self, const struct dt_dev_pixelpipe_
       roi_out->width  = roi_out->height * aspect;
     }
   }
+}
+
+void modify_roi_out(struct dt_iop_module_t *self, const struct dt_dev_pixelpipe_t *pipe,
+                    struct dt_dev_pixelpipe_iop_t *piece, dt_iop_roi_t *roi_out,
+                    const dt_iop_roi_t *roi_in)
+{
+  _borders_map_size((const dt_iop_borders_data_t *)piece->data, roi_in, roi_out);
 }
 
 // 2nd pass: which roi would this operation need as input to fill the given output region?
@@ -696,6 +717,61 @@ void cleanup_global(dt_iop_module_so_t *module)
   dt_free(module->data);
 }
 
+
+/* --- the geometry service's view of this module (develop/geometry/geometry.h) --------- */
+
+static void _borders_geometry_map_size(const void *data, const dt_iop_roi_t *const in, dt_iop_roi_t *out)
+{
+  _borders_map_size((const dt_iop_borders_data_t *)data, in, out);
+}
+
+static int _borders_geometry_transform(const void *data, const dt_geometry_record_t *const record,
+                                       dt_geometry_chain_t *chain, float *points, size_t points_count)
+{
+  int left = 0, top = 0;
+  _borders_offset((const dt_iop_borders_data_t *)data, &record->in, &record->out, &left, &top);
+  if(left == 0 && top == 0) return 1;
+  for(size_t i = 0; i < points_count * 2; i += 2)
+  {
+    points[i] += left;
+    points[i + 1] += top;
+  }
+  return 1;
+}
+
+static int _borders_geometry_backtransform(const void *data, const dt_geometry_record_t *const record,
+                                           dt_geometry_chain_t *chain, float *points, size_t points_count)
+{
+  int left = 0, top = 0;
+  _borders_offset((const dt_iop_borders_data_t *)data, &record->in, &record->out, &left, &top);
+  if(left == 0 && top == 0) return 1;
+  for(size_t i = 0; i < points_count * 2; i += 2)
+  {
+    points[i] -= left;
+    points[i + 1] -= top;
+  }
+  return 1;
+}
+
+static const dt_geometry_vtable_t _borders_geometry_vtable = {
+  .map_size = _borders_geometry_map_size,
+  .transform = _borders_geometry_transform,
+  .backtransform = _borders_geometry_backtransform,
+};
+
+gboolean geometry_record(dt_iop_module_t *self, const void *params, dt_geometry_record_t *record)
+{
+  /* commit_params() is a straight copy of the parameters into the data struct -- the two are the
+   * same type -- so the record carries that copy and nothing is derived twice. */
+  dt_iop_borders_data_t *data = (dt_iop_borders_data_t *)g_malloc0(sizeof(dt_iop_borders_data_t));
+  if(IS_NULL_PTR(data)) return FALSE;
+  memcpy(data, params, sizeof(dt_iop_borders_params_t));
+
+  record->data = data;
+  record->free_data = dt_free_gpointer;
+  record->vtable = &_borders_geometry_vtable;
+  return TRUE;
+}
 
 void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pixelpipe_t *pipe,
                    dt_dev_pixelpipe_iop_t *piece)

--- a/src/iop/clipping.c
+++ b/src/iop/clipping.c
@@ -3072,8 +3072,8 @@ int mouse_moved(struct dt_iop_module_t *self, double x, double y, double pressur
 
       if(dt_dev_distort_backtransform_gui(self->dev, self->iop_order, DT_DEV_TRANSFORM_DIR_FORW_EXCL, points, 2))
       {
-        dt_dev_pixelpipe_iop_t *piece = dt_dev_distort_get_iop_pipe(self->dev->virtual_pipe, self);
-        if(!IS_NULL_PTR(piece))
+        dt_iop_roi_t mod_out;
+        if(dt_dev_module_geometry_gui(self->dev, self, NULL, &mod_out))
         {
           // only update the sliders, not the dt_iop_clipping_params_t structure, so that the call to
           // dt_control_queue_redraw_center below doesn't go rerun the pixelpipe because it thinks that
@@ -3212,13 +3212,13 @@ static void commit_box(dt_iop_module_t *self, dt_iop_clipping_gui_data_t *g, dt_
       = { g->clip_x * wd, g->clip_y * ht, (g->clip_x + g->clip_w) * wd, (g->clip_y + g->clip_h) * ht };
   if(dt_dev_distort_backtransform_gui(self->dev, self->iop_order, DT_DEV_TRANSFORM_DIR_FORW_EXCL, points, 2))
   {
-    dt_dev_pixelpipe_iop_t *piece = dt_dev_distort_get_iop_pipe(self->dev->virtual_pipe, self);
-    if(!IS_NULL_PTR(piece))
+    dt_iop_roi_t mod_out;
+    if(dt_dev_module_geometry_gui(self->dev, self, NULL, &mod_out))
     {
-      p->cx = CLAMPF(points[0] / (float)piece->buf_out.width, 0.0f, 0.9f);
-      p->cy = CLAMPF(points[1] / (float)piece->buf_out.height, 0.0f, 0.9f);
-      p->cw = copysignf(CLAMPF(points[2] / (float)piece->buf_out.width, 0.1f, 1.0f), p->cw);
-      p->ch = copysignf(CLAMPF(points[3] / (float)piece->buf_out.height, 0.1f, 1.0f), p->ch);
+      p->cx = CLAMPF(points[0] / (float)mod_out.width, 0.0f, 0.9f);
+      p->cy = CLAMPF(points[1] / (float)mod_out.height, 0.0f, 0.9f);
+      p->cw = copysignf(CLAMPF(points[2] / (float)mod_out.width, 0.1f, 1.0f), p->cw);
+      p->ch = copysignf(CLAMPF(points[3] / (float)mod_out.height, 0.1f, 1.0f), p->ch);
     }
   }
   g->applied = 1;

--- a/src/iop/clipping.c
+++ b/src/iop/clipping.c
@@ -695,10 +695,10 @@ static int _iop_clipping_set_max_clip(struct dt_iop_module_t *self)
   dt_iop_clipping_params_t *p = (dt_iop_clipping_params_t *)self->params;
 
   // we want to know the size of the actual buffer
-  dt_dev_pixelpipe_iop_t *piece = dt_dev_distort_get_iop_pipe(self->dev->virtual_pipe, self);
-  if(IS_NULL_PTR(piece)) return 0;
+  dt_iop_roi_t mod_out;
+  if(!dt_dev_module_geometry_gui(self->dev, self, NULL, &mod_out)) return 0;
 
-  float wp = piece->buf_out.width, hp = piece->buf_out.height;
+  float wp = mod_out.width, hp = mod_out.height;
   const float cx = CLAMPF(p->cx, 0.0f, 0.9f);
   const float cy = CLAMPF(p->cy, 0.0f, 0.9f);
   const float cw = CLAMPF(fabsf(p->cw), 0.1f, 1.0f);
@@ -1502,10 +1502,10 @@ static float _ratio_get_aspect(dt_iop_module_t *self, GtkWidget *combo)
   }
 
   // we want to know the size of the actual buffer
-  dt_dev_pixelpipe_iop_t *piece = dt_dev_distort_get_iop_pipe(self->dev->virtual_pipe, self);
-  if(IS_NULL_PTR(piece)) return 0.0f;
+  dt_iop_roi_t mod_in;
+  if(!dt_dev_module_geometry_gui(self->dev, self, &mod_in, NULL)) return 0.0f;
 
-  const int iwd = piece->buf_in.width, iht = piece->buf_in.height;
+  const int iwd = mod_in.width, iht = mod_in.height;
 
   // if we do not have yet computed the aspect ratio, let's do it now
   if(p->ratio_d == -2 && p->ratio_n == -2)
@@ -2597,10 +2597,10 @@ void gui_post_expose(struct dt_iop_module_t *self, cairo_t *cr, int32_t width, i
   if(g->k_show == 1 && p->k_type > 0)
   {
     // points in screen space
-    dt_dev_pixelpipe_iop_t *piece = dt_dev_distort_get_iop_pipe(self->dev->virtual_pipe, self);
-    if(IS_NULL_PTR(piece)) return;
+    dt_iop_roi_t mod_out;
+    if(!dt_dev_module_geometry_gui(self->dev, self, NULL, &mod_out)) return;
 
-    const float wp = piece->buf_out.width, hp = piece->buf_out.height;
+    const float wp = mod_out.width, hp = mod_out.height;
     float pts[8] = { p->kxa * wp, p->kya * hp, p->kxb * wp, p->kyb * hp,
                      p->kxc * wp, p->kyc * hp, p->kxd * wp, p->kyd * hp };
     if(dt_dev_distort_transform_gui(self->dev, self->iop_order, DT_DEV_TRANSFORM_DIR_FORW_EXCL, pts, 4))
@@ -2865,8 +2865,9 @@ int mouse_moved(struct dt_iop_module_t *self, double x, double y, double pressur
     {
       float pts[2] = { pzx * wd, pzy * ht };
       dt_dev_distort_backtransform_gui(self->dev, self->iop_order, DT_DEV_TRANSFORM_DIR_FORW_EXCL, pts, 1);
-      dt_dev_pixelpipe_iop_t *piece = dt_dev_distort_get_iop_pipe(self->dev->virtual_pipe, self);
-      const float xx = pts[0] / (float)piece->buf_out.width, yy = pts[1] / (float)piece->buf_out.height;
+      dt_iop_roi_t mod_out;
+      if(!dt_dev_module_geometry_gui(self->dev, self, NULL, &mod_out)) return FALSE;
+      const float xx = pts[0] / (float)mod_out.width, yy = pts[1] / (float)mod_out.height;
       if(g->k_selected == 0)
       {
         if(p->k_sym == 1 || p->k_sym == 3)
@@ -3139,8 +3140,9 @@ int mouse_moved(struct dt_iop_module_t *self, double x, double y, double pressur
     {
       float pts[2] = { pzx * wd, pzy * ht };
       dt_dev_distort_backtransform_gui(self->dev, self->iop_order, DT_DEV_TRANSFORM_DIR_FORW_EXCL, pts, 1);
-      dt_dev_pixelpipe_iop_t *piece = dt_dev_distort_get_iop_pipe(self->dev->virtual_pipe, self);
-      float xx = pts[0] / (float)piece->buf_out.width, yy = pts[1] / (float)piece->buf_out.height;
+      dt_iop_roi_t mod_out;
+      if(!dt_dev_module_geometry_gui(self->dev, self, NULL, &mod_out)) return FALSE;
+      float xx = pts[0] / (float)mod_out.width, yy = pts[1] / (float)mod_out.height;
       // are we near a keystone point ?
       g->k_selected = -1;
       g->k_selected_segment = -1;
@@ -3306,8 +3308,9 @@ int button_pressed(struct dt_iop_module_t *self, double x, double y, double pres
         float pzx = pzxpy[0];
         float pzy = pzxpy[1];
 
-        dt_dev_pixelpipe_iop_t *piece = dt_dev_distort_get_iop_pipe(dev->virtual_pipe, self);
-        const float wp = piece->buf_out.width, hp = piece->buf_out.height;
+        dt_iop_roi_t mod_out;
+        if(!dt_dev_module_geometry_gui(dev, self, NULL, &mod_out)) return 0;
+        const float wp = mod_out.width, hp = mod_out.height;
         float pts[8] = { p->kxa * wp, p->kya * hp, p->kxb * wp, p->kyb * hp,
                          p->kxc * wp, p->kyc * hp, p->kxd * wp, p->kyd * hp };
         dt_dev_distort_transform_gui(dev, self->iop_order, DT_DEV_TRANSFORM_DIR_FORW_EXCL, pts, 4);

--- a/src/iop/clipping.c
+++ b/src/iop/clipping.c
@@ -86,6 +86,7 @@
 #include "control/input.h"
 #include "control/control.h"
 #include "develop/develop.h"
+#include "develop/geometry/geometry.h"
 #include "develop/imageop.h"
 #include "develop/imageop_gui.h"
 
@@ -489,6 +490,11 @@ static inline void transform(float *x, float *o, const float *m, const float t_h
   o[0] *= (1.0f + o[1] * t_v);
 }
 
+/* Defined below, next to modify_roi_out() whose body it is: the distort callbacks need the
+ * size-dependent state it settles before they can use it. */
+static void _clipping_derive(dt_iop_clipping_data_t *d, const dt_iop_roi_t *const roi_in_orig,
+                             dt_iop_roi_t *roi_out);
+
 int distort_transform(dt_iop_module_t *self, const dt_dev_pixelpipe_t *pipe, const dt_dev_pixelpipe_iop_t *piece,
                       float *const restrict points, size_t points_count)
 {
@@ -498,13 +504,11 @@ int distort_transform(dt_iop_module_t *self, const dt_dev_pixelpipe_t *pipe, con
   if(dt_dev_pixelpipe_has_preview_output(self->dev, pipe, NULL)) factor = 100.0f;
   // we first need to be sure that all data values are computed
   // this is done in modify_roi_out fct, so we create tmp roi
-  dt_dev_pixelpipe_iop_t piece_copy = *piece;
+  dt_iop_clipping_data_t *d = (dt_iop_clipping_data_t *)piece->data;
   dt_iop_roi_t roi_out, roi_in;
   roi_in.width = piece->buf_in.width * factor;
   roi_in.height = piece->buf_in.height * factor;
-  self->modify_roi_out(self, pipe, &piece_copy, &roi_out, &roi_in);
-
-  dt_iop_clipping_data_t *d = (dt_iop_clipping_data_t *)piece->data;
+  _clipping_derive(d, &roi_in, &roi_out);
 
   const float rx = piece->buf_in.width;
   const float ry = piece->buf_in.height;
@@ -550,7 +554,7 @@ int distort_transform(dt_iop_module_t *self, const dt_dev_pixelpipe_t *pipe, con
   {
     roi_in.width = piece->buf_in.width;
     roi_in.height = piece->buf_in.height;
-    self->modify_roi_out(self, pipe, &piece_copy, &roi_out, &roi_in);
+    _clipping_derive(d, &roi_in, &roi_out);
   }
 
   return 1;
@@ -564,13 +568,11 @@ int distort_backtransform(dt_iop_module_t *self, const dt_dev_pixelpipe_t *pipe,
   if(dt_dev_pixelpipe_has_preview_output(self->dev, pipe, NULL)) factor = 100.0f;
   // we first need to be sure that all data values are computed
   // this is done in modify_roi_out fct, so we create tmp roi
-  dt_dev_pixelpipe_iop_t piece_copy = *piece;
+  dt_iop_clipping_data_t *d = (dt_iop_clipping_data_t *)piece->data;
   dt_iop_roi_t roi_out, roi_in;
   roi_in.width = piece->buf_in.width * factor;
   roi_in.height = piece->buf_in.height * factor;
-  self->modify_roi_out(self, pipe, &piece_copy, &roi_out, &roi_in);
-
-  dt_iop_clipping_data_t *d = (dt_iop_clipping_data_t *)piece->data;
+  _clipping_derive(d, &roi_in, &roi_out);
 
   const float rx = piece->buf_in.width;
   const float ry = piece->buf_in.height;
@@ -616,7 +618,7 @@ int distort_backtransform(dt_iop_module_t *self, const dt_dev_pixelpipe_t *pipe,
   {
     roi_in.width = piece->buf_in.width;
     roi_in.height = piece->buf_in.height;
-    self->modify_roi_out(self, pipe, &piece_copy, &roi_out, &roi_in);
+    _clipping_derive(d, &roi_in, &roi_out);
   }
 
   return 1;
@@ -723,14 +725,29 @@ static int _iop_clipping_set_max_clip(struct dt_iop_module_t *self)
 
 // 1st pass: how large would the output be, given this input roi?
 // this is always called with the full buffer before processing.
-void modify_roi_out(struct dt_iop_module_t *self, const struct dt_dev_pixelpipe_t *pipe,
-                    struct dt_dev_pixelpipe_iop_t *piece, dt_iop_roi_t *roi_out,
-                    const dt_iop_roi_t *roi_in_orig)
+/**
+ * @brief Derive this module's whole geometric state, and the output rect, from the committed
+ * parameters and the input dimensions. THE constructor and THE size evaluator at once.
+ *
+ * @details This is modify_roi_out()'s body, unchanged, with the one line that reached into a
+ * pipeline piece removed. It was already self-contained -- nothing else in those ~190 lines
+ * touched `piece', `self' or `pipe' -- which is what makes lifting it out safe.
+ *
+ * It WRITES into @p d: the rotation matrix and its inverse, the resolution-corrected keystone
+ * factors, the rotation centre, the crop window on the output, the enlargement and the flip are
+ * all functions of the input size and cannot be settled until that size is known. Callers who
+ * need those fields without planning a ROI -- the distort callbacks, and the geometry service's
+ * record (develop/geometry/geometry.h) -- must therefore run this first. They used to do it by
+ * calling modify_roi_out() through the module's own vtable on a SHALLOW COPY of the piece whose
+ * `data' pointer still aliased the real one, so the writes landed where they were wanted.
+ * Calling this directly says the same thing without the disguise.
+ */
+static void _clipping_derive(dt_iop_clipping_data_t *d, const dt_iop_roi_t *const roi_in_orig,
+                             dt_iop_roi_t *roi_out)
 {
   dt_iop_roi_t roi_in_d = *roi_in_orig;
   dt_iop_roi_t *roi_in = &roi_in_d;
 
-  dt_iop_clipping_data_t *d = (dt_iop_clipping_data_t *)piece->data;
 
   // use whole-buffer roi information to create matrix and inverse.
   float rt[] = { cosf(d->angle), sinf(d->angle), -sinf(d->angle), cosf(d->angle) };
@@ -910,6 +927,13 @@ void modify_roi_out(struct dt_iop_module_t *self, const struct dt_dev_pixelpipe_
   d->ciy = roi_out->y;
 }
 
+void modify_roi_out(struct dt_iop_module_t *self, const struct dt_dev_pixelpipe_t *pipe,
+                    struct dt_dev_pixelpipe_iop_t *piece, dt_iop_roi_t *roi_out,
+                    const dt_iop_roi_t *roi_in_orig)
+{
+  _clipping_derive((dt_iop_clipping_data_t *)piece->data, roi_in_orig, roi_out);
+}
+
 // 2nd pass: which roi would this operation need as input to fill the given output region?
 void modify_roi_in(struct dt_iop_module_t *self, const struct dt_dev_pixelpipe_t *pipe,
                    struct dt_dev_pixelpipe_iop_t *piece,
@@ -1061,11 +1085,25 @@ int process(struct dt_iop_module_t *self, const dt_dev_pixelpipe_t *pipe, const 
 }
 
 
-void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pixelpipe_t *pipe,
-                   dt_dev_pixelpipe_iop_t *piece)
+/**
+ * @brief Parameters -> committed data. THE constructor.
+ *
+ * @details commit_params()'s body, unchanged, minus the two lines that fetched the parameters
+ * and the piece. Like _clipping_derive() below it was already self-contained, and the geometry
+ * record needs it for the same reason: it has parameters and no pipeline piece to put them in.
+ *
+ * It reads ONE thing that is not a parameter: gui_has_focus(), which neutralises the crop while
+ * this module is the focused one so the darkroom shows the whole frame to drag the crop over.
+ * That is GUI state and never reaches history, which is why a record cannot be built from
+ * history alone and why this takes @p self.
+ *
+ * Note what this does NOT settle -- everything that depends on the input size (the matrices,
+ * the keystone factors corrected by resolution, the rotation centre, the crop on the output).
+ * That is _clipping_derive()'s job, and it has to run afterwards.
+ */
+static void _clipping_resolve(struct dt_iop_module_t *self, const dt_iop_clipping_params_t *const p,
+                              dt_iop_clipping_data_t *d)
 {
-  dt_iop_clipping_params_t *p = (dt_iop_clipping_params_t *)p1;
-  dt_iop_clipping_data_t *d = (dt_iop_clipping_data_t *)piece->data;
 
   // reset all values to be sure everything is initialized
   d->m[0] = d->m[3] = 1.0f;
@@ -1224,9 +1262,15 @@ void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pix
     if(d->cx != p->cx || d->cy != p->cy || d->cw != fabsf(p->cw) || d->ch != fabsf(p->ch))
     {
       fprintf(stderr, "[crop&rotate] invalid crop data for %d : x=%0.04f y=%0.04f w=%0.04f h=%0.04f\n",
-              pipe->dev->image_storage.id, p->cx, p->cy, p->cw, p->ch);
+              self->dev->image_storage.id, p->cx, p->cy, p->cw, p->ch);
     }
   }
+}
+
+void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pixelpipe_t *pipe,
+                   dt_dev_pixelpipe_iop_t *piece)
+{
+  _clipping_resolve(self, (const dt_iop_clipping_params_t *)p1, (dt_iop_clipping_data_t *)piece->data);
 }
 
 static void _event_preview_updated_callback(gpointer instance, dt_iop_module_t *self)
@@ -1287,6 +1331,144 @@ void gui_focus(struct dt_iop_module_t *self, gboolean in)
   dt_dev_get_thumbnail_size(self->dev);
 }
 
+
+/* --- the geometry service's view of this module (develop/geometry/geometry.h) ---------
+ *
+ * The record carries the PARAMETER-derived half of the state (what _clipping_resolve() settles)
+ * and re-derives the size-dependent half per call, into a local copy, because that half is a
+ * function of the rectangle it is handed and the chain hands a different one to the size fold
+ * than a consumer may ask a transform about. Deriving into a local keeps the evaluators pure
+ * and the record immutable, at the cost of running the derivation per query -- it is arithmetic
+ * on a dozen floats, and the alternative is a record that mutates while being read.
+ *
+ * Note the factor: the pipe's distort callbacks multiply the input size by 100 for preview
+ * pipes, to get around dt_iop_roi_t being integral. The chain does not, because the pipe the
+ * GUI walks today -- the virtual one -- is not the preview pipe by that test either, so factor
+ * 1 is what these coordinates are already computed with. Changing it would be an improvement to
+ * make deliberately, with shadow mode watching, not a side effect of this tranche.
+ */
+
+static void _clipping_geometry_map_size(const void *data, const dt_iop_roi_t *const in, dt_iop_roi_t *out)
+{
+  dt_iop_clipping_data_t local = *(const dt_iop_clipping_data_t *)data;
+  _clipping_derive(&local, in, out);
+}
+
+/** @brief The keystone matrix and the scaled quadrilateral, which both directions need. */
+static void _clipping_keystone(const dt_iop_clipping_data_t *const d, const float rx, const float ry,
+                               dt_boundingbox_t k_space, float *kxa, float *kya, float *ma, float *mb,
+                               float *md, float *me, float *mg, float *mh)
+{
+  k_space[0] = d->k_space[0] * rx;
+  k_space[1] = d->k_space[1] * ry;
+  k_space[2] = d->k_space[2] * rx;
+  k_space[3] = d->k_space[3] * ry;
+
+  *kxa = d->kxa * rx;
+  *kya = d->kya * ry;
+  if(d->k_apply == 1)
+    keystone_get_matrix(k_space, d->kxa * rx, d->kxb * rx, d->kxc * rx, d->kxd * rx, d->kya * ry,
+                        d->kyb * ry, d->kyc * ry, d->kyd * ry, ma, mb, md, me, mg, mh);
+}
+
+static int _clipping_geometry_transform(const void *data, const dt_geometry_record_t *const record,
+                                        dt_geometry_chain_t *chain, float *points, size_t points_count)
+{
+  dt_iop_clipping_data_t d = *(const dt_iop_clipping_data_t *)data;
+  dt_iop_roi_t out;
+  _clipping_derive(&d, &record->in, &out);
+
+  const float rx = record->in.width, ry = record->in.height;
+  dt_boundingbox_t k_space;
+  float kxa = 0.f, kya = 0.f, ma = 0.f, mb = 0.f, md = 0.f, me = 0.f, mg = 0.f, mh = 0.f;
+  _clipping_keystone(&d, rx, ry, k_space, &kxa, &kya, &ma, &mb, &md, &me, &mg, &mh);
+
+  for(size_t i = 0; i < points_count * 2; i += 2)
+  {
+    float pi[2] = { points[i], points[i + 1] }, po[2];
+
+    if(d.k_apply == 1) keystone_transform(pi, k_space, ma, mb, md, me, mg, mh, kxa, kya);
+
+    pi[0] -= d.tx;
+    pi[1] -= d.ty;
+    transform(pi, po, d.inv_m, d.k_h, d.k_v);
+
+    if(d.flip)
+    {
+      po[1] += d.tx;
+      po[0] += d.ty;
+    }
+    else
+    {
+      po[0] += d.tx;
+      po[1] += d.ty;
+    }
+
+    points[i] = po[0] - (d.cix - d.enlarge_x);
+    points[i + 1] = po[1] - (d.ciy - d.enlarge_y);
+  }
+  return 1;
+}
+
+static int _clipping_geometry_backtransform(const void *data, const dt_geometry_record_t *const record,
+                                            dt_geometry_chain_t *chain, float *points, size_t points_count)
+{
+  dt_iop_clipping_data_t d = *(const dt_iop_clipping_data_t *)data;
+  dt_iop_roi_t out;
+  _clipping_derive(&d, &record->in, &out);
+
+  const float rx = record->in.width, ry = record->in.height;
+  dt_boundingbox_t k_space;
+  float kxa = 0.f, kya = 0.f, ma = 0.f, mb = 0.f, md = 0.f, me = 0.f, mg = 0.f, mh = 0.f;
+  _clipping_keystone(&d, rx, ry, k_space, &kxa, &kya, &ma, &mb, &md, &me, &mg, &mh);
+
+  for(size_t i = 0; i < points_count * 2; i += 2)
+  {
+    float pi[2], po[2];
+    pi[0] = -(d.enlarge_x - d.cix) + points[i];
+    pi[1] = -(d.enlarge_y - d.ciy) + points[i + 1];
+
+    if(d.flip)
+    {
+      pi[1] -= d.tx;
+      pi[0] -= d.ty;
+    }
+    else
+    {
+      pi[0] -= d.tx;
+      pi[1] -= d.ty;
+    }
+
+    backtransform(pi, po, d.m, d.k_h, d.k_v);
+
+    po[0] += d.tx;
+    po[1] += d.ty;
+    if(d.k_apply == 1) keystone_backtransform(po, k_space, ma, mb, md, me, mg, mh, kxa, kya);
+
+    points[i] = po[0];
+    points[i + 1] = po[1];
+  }
+  return 1;
+}
+
+static const dt_geometry_vtable_t _clipping_geometry_vtable = {
+  .map_size = _clipping_geometry_map_size,
+  .transform = _clipping_geometry_transform,
+  .backtransform = _clipping_geometry_backtransform,
+};
+
+gboolean geometry_record(struct dt_iop_module_t *self, const void *params, dt_geometry_record_t *record)
+{
+  dt_iop_clipping_data_t *data = (dt_iop_clipping_data_t *)g_malloc0(sizeof(dt_iop_clipping_data_t));
+  if(IS_NULL_PTR(data)) return FALSE;
+
+  _clipping_resolve(self, (const dt_iop_clipping_params_t *)params, data);
+
+  record->data = data;
+  record->free_data = dt_free_gpointer;
+  record->vtable = &_clipping_geometry_vtable;
+  return TRUE;
+}
 
 void init_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
 {

--- a/src/iop/clipping.c
+++ b/src/iop/clipping.c
@@ -705,7 +705,7 @@ static int _iop_clipping_set_max_clip(struct dt_iop_module_t *self)
   const float ch = CLAMPF(fabsf(p->ch), 0.1f, 1.0f);
 
   float points[8] = { 0.0f, 0.0f, wp, hp, cx * wp, cy * hp, cw * wp, ch * hp };
-  if(!dt_dev_distort_transform_plus(self->dev->virtual_pipe, self->iop_order, DT_DEV_TRANSFORM_DIR_FORW_EXCL, points, 4))
+  if(!dt_dev_distort_transform_gui(self->dev, self->iop_order, DT_DEV_TRANSFORM_DIR_FORW_EXCL, points, 4))
     return 0;
   dt_dev_coordinates_preview_abs_to_image_norm(self->dev, points, 4);
 
@@ -2603,7 +2603,7 @@ void gui_post_expose(struct dt_iop_module_t *self, cairo_t *cr, int32_t width, i
     const float wp = piece->buf_out.width, hp = piece->buf_out.height;
     float pts[8] = { p->kxa * wp, p->kya * hp, p->kxb * wp, p->kyb * hp,
                      p->kxc * wp, p->kyc * hp, p->kxd * wp, p->kyd * hp };
-    if(dt_dev_distort_transform_plus(self->dev->virtual_pipe, self->iop_order, DT_DEV_TRANSFORM_DIR_FORW_EXCL, pts, 4))
+    if(dt_dev_distort_transform_gui(self->dev, self->iop_order, DT_DEV_TRANSFORM_DIR_FORW_EXCL, pts, 4))
     {
       if(p->k_type == 3)
       {
@@ -2864,7 +2864,7 @@ int mouse_moved(struct dt_iop_module_t *self, double x, double y, double pressur
     if(g->k_drag == TRUE && g->k_selected >= 0)
     {
       float pts[2] = { pzx * wd, pzy * ht };
-      dt_dev_distort_backtransform_plus(self->dev->virtual_pipe, self->iop_order, DT_DEV_TRANSFORM_DIR_FORW_EXCL, pts, 1);
+      dt_dev_distort_backtransform_gui(self->dev, self->iop_order, DT_DEV_TRANSFORM_DIR_FORW_EXCL, pts, 1);
       dt_dev_pixelpipe_iop_t *piece = dt_dev_distort_get_iop_pipe(self->dev->virtual_pipe, self);
       const float xx = pts[0] / (float)piece->buf_out.width, yy = pts[1] / (float)piece->buf_out.height;
       if(g->k_selected == 0)
@@ -3069,7 +3069,7 @@ int mouse_moved(struct dt_iop_module_t *self, double x, double y, double pressur
       float points[4]
           = { g->clip_x * wd, g->clip_y * ht, (g->clip_x + g->clip_w) * wd, (g->clip_y + g->clip_h) * ht };
 
-      if(dt_dev_distort_backtransform_plus(self->dev->virtual_pipe, self->iop_order, DT_DEV_TRANSFORM_DIR_FORW_EXCL, points, 2))
+      if(dt_dev_distort_backtransform_gui(self->dev, self->iop_order, DT_DEV_TRANSFORM_DIR_FORW_EXCL, points, 2))
       {
         dt_dev_pixelpipe_iop_t *piece = dt_dev_distort_get_iop_pipe(self->dev->virtual_pipe, self);
         if(!IS_NULL_PTR(piece))
@@ -3138,7 +3138,7 @@ int mouse_moved(struct dt_iop_module_t *self, double x, double y, double pressur
     if(g->k_show == 1 && g->k_drag == FALSE)
     {
       float pts[2] = { pzx * wd, pzy * ht };
-      dt_dev_distort_backtransform_plus(self->dev->virtual_pipe, self->iop_order, DT_DEV_TRANSFORM_DIR_FORW_EXCL, pts, 1);
+      dt_dev_distort_backtransform_gui(self->dev, self->iop_order, DT_DEV_TRANSFORM_DIR_FORW_EXCL, pts, 1);
       dt_dev_pixelpipe_iop_t *piece = dt_dev_distort_get_iop_pipe(self->dev->virtual_pipe, self);
       float xx = pts[0] / (float)piece->buf_out.width, yy = pts[1] / (float)piece->buf_out.height;
       // are we near a keystone point ?
@@ -3208,7 +3208,7 @@ static void commit_box(dt_iop_module_t *self, dt_iop_clipping_gui_data_t *g, dt_
   const float ht = dt_dev_roi_request_preview_height(self->dev);
   float points[4]
       = { g->clip_x * wd, g->clip_y * ht, (g->clip_x + g->clip_w) * wd, (g->clip_y + g->clip_h) * ht };
-  if(dt_dev_distort_backtransform_plus(self->dev->virtual_pipe, self->iop_order, DT_DEV_TRANSFORM_DIR_FORW_EXCL, points, 2))
+  if(dt_dev_distort_backtransform_gui(self->dev, self->iop_order, DT_DEV_TRANSFORM_DIR_FORW_EXCL, points, 2))
   {
     dt_dev_pixelpipe_iop_t *piece = dt_dev_distort_get_iop_pipe(self->dev->virtual_pipe, self);
     if(!IS_NULL_PTR(piece))
@@ -3235,7 +3235,7 @@ int button_released(struct dt_iop_module_t *self, double x, double y, int which,
   {
     // adjust the line with possible current angle and flip on this module
     dt_boundingbox_t pts = { x, y, g->button_down_x, g->button_down_y };
-    dt_dev_distort_backtransform_plus(self->dev->virtual_pipe, self->iop_order, DT_DEV_TRANSFORM_DIR_FORW_INCL, pts, 2);
+    dt_dev_distort_backtransform_gui(self->dev, self->iop_order, DT_DEV_TRANSFORM_DIR_FORW_INCL, pts, 2);
 
     float dx = pts[0] - pts[2];
     float dy = pts[1] - pts[3];
@@ -3310,7 +3310,7 @@ int button_pressed(struct dt_iop_module_t *self, double x, double y, double pres
         const float wp = piece->buf_out.width, hp = piece->buf_out.height;
         float pts[8] = { p->kxa * wp, p->kya * hp, p->kxb * wp, p->kyb * hp,
                          p->kxc * wp, p->kyc * hp, p->kxd * wp, p->kyd * hp };
-        dt_dev_distort_transform_plus(dev->virtual_pipe, self->iop_order, DT_DEV_TRANSFORM_DIR_FORW_EXCL, pts, 4);
+        dt_dev_distort_transform_gui(dev, self->iop_order, DT_DEV_TRANSFORM_DIR_FORW_EXCL, pts, 4);
 
         float point[2] = { pzx, pzy };
         dt_dev_coordinates_image_norm_to_preview_abs(dev, point, 1);

--- a/src/iop/colorequal.c
+++ b/src/iop/colorequal.c
@@ -152,7 +152,7 @@ typedef struct dt_iop_colorequal_global_data_t
 {
   // Truly global, read-only-after-init state only. Do NOT add a shared LUT/params cache
   // here: this struct is the same instance for every module instance, every piece, and
-  // every pipe (full/preview/thumbnail/export/virtual-preview) of colorequal in the whole
+  // every pipe (full/preview/thumbnail/export) of colorequal in the whole
   // application -- there is exactly one of it, not one per instance. A memoized LUT stored
   // here can only ever hold one instance's content at a time, and gets silently overwritten
   // by whichever piece/instance last committed -- including disabled instances, since

--- a/src/iop/colorout.c
+++ b/src/iop/colorout.c
@@ -108,7 +108,7 @@ typedef struct dt_iop_colorout_data_t
    * matrices, tone curves, extrapolation fits, or an lcms2 proofing transform. Built by
    * colorprofiles/conversion.c, which is where the lifetime and locking rules for the
    * profiles behind it are written down and enforced. NULL when the module is a nop
-   * (Lab output, or the virtual pipe, which never processes pixels). */
+   * (a Lab output). */
   dt_colorspaces_conversion_t *conversion;
 } dt_iop_colorout_data_t;
 
@@ -376,8 +376,7 @@ int process(struct dt_iop_module_t *self, const dt_dev_pixelpipe_t *pipe, const 
   const dt_iop_roi_t *const roi_out = &piece->roi_out;
   const dt_iop_colorout_data_t *const d = (dt_iop_colorout_data_t *)piece->data;
 
-  /* Lab output is a nop -- the pipe already carries Lab -- and so is the virtual pipe, which
-   * commits module contracts but never processes pixels. Both leave `conversion` NULL. */
+  /* Lab output is a nop -- the pipe already carries Lab -- and leaves `conversion` NULL. */
   if(d->type == DT_COLORSPACE_LAB || IS_NULL_PTR(d->conversion))
     dt_iop_image_copy_by_size(ovoid, ivoid, roi_out->width, roi_out->height, 4);
   else
@@ -424,8 +423,7 @@ void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pix
 
   dt_colorspaces_free_conversion(&d->conversion);
   /* Cleared here rather than beside each prepare below, so that every path which returns
-   * without building a conversion -- the virtual pipe, a Lab output -- leaves a hashed prefix
-   * that says so. */
+   * without building a conversion -- a Lab output -- leaves a hashed prefix that says so. */
   d->conversion_id = 0;
   piece->process_cl_ready = 1;
 
@@ -483,17 +481,6 @@ void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pix
   // when the output type is Lab then process is a nop, so we can avoid creating a transform
   // and the subsequent error messages
   d->type = out_type;
-  /* The virtual pipe mirrors history only for GUI geometry queries. It must
-   * still commit module contracts so ROI transforms see the same enabled
-   * modules, but creating an LCMS output transform for a pipe that will never
-   * process pixels only adds lifetime coupling to display/softproof profiles. */
-  if(!IS_NULL_PTR(pipe->dev) && pipe->dev->virtual_pipe == pipe)
-  {
-    d->type = DT_COLORSPACE_LAB;
-    piece->process_cl_ready = 0;
-    return;
-  }
-
   if(out_type == DT_COLORSPACE_LAB)
     return;
 

--- a/src/iop/colorprimaries.c
+++ b/src/iop/colorprimaries.c
@@ -118,7 +118,7 @@ typedef struct dt_iop_colorprimaries_global_data_t
 {
   // Truly global, read-only-after-init state only. Do NOT add a shared LUT/params cache
   // here: this struct is the same instance for every module instance, every piece, and
-  // every pipe (full/preview/thumbnail/export/virtual-preview) of colorprimaries in the
+  // every pipe (full/preview/thumbnail/export) of colorprimaries in the
   // whole application -- there is exactly one of it, not one per instance. A memoized LUT
   // stored here can only ever hold one instance's content at a time, and gets silently
   // overwritten by whichever piece/instance last committed -- including disabled instances,

--- a/src/iop/crop.c
+++ b/src/iop/crop.c
@@ -46,6 +46,7 @@
 #include "control/input.h"
 #include "control/control.h"
 #include "develop/develop.h"
+#include "develop/geometry/geometry.h"
 #include "develop/imageop.h"
 #include "develop/imageop_gui.h"
 
@@ -293,13 +294,71 @@ static gboolean _set_max_clip(dt_dev_pixelpipe_t *pipe, struct dt_iop_module_t *
   return TRUE;
 }
 
+/* --- the shared geometry core ----------------------------------------------------------
+ *
+ * These three are the ONLY place crop's geometry is expressed. commit_params() and the
+ * pipeline's distort/roi callbacks call them, and so does geometry_record() for the pixel-less
+ * geometry service (develop/geometry/geometry.h). One constructor and one evaluator per fact:
+ * a second derivation of the same crop would drift from this one, and the drift would show up
+ * as the crop overlay sitting somewhere the cropped image is not.
+ */
+
+/** @brief Resolve the effective crop rectangle. THE constructor -- see the note above. */
+static void _crop_resolve(dt_iop_module_t *self, const dt_iop_crop_params_t *const p,
+                          dt_iop_crop_data_t *out)
+{
+  const dt_iop_crop_gui_data_t *g = (dt_iop_crop_gui_data_t *)dt_iop_gui_data(self);
+
+  if(!IS_NULL_PTR(g) && g->editing)
+  {
+    // In editing mode, we need to see the full uncropped image to setup the frame.
+    out->cx = 0.0f;
+    out->cy = 0.0f;
+    out->cw = 1.0f;
+    out->ch = 1.0f;
+  }
+  else
+  {
+    out->cx = CLAMPF(p->cx, 0.0f, 0.9f);
+    out->cy = CLAMPF(p->cy, 0.0f, 0.9f);
+    out->cw = CLAMPF(p->cw, 0.1f, 1.0f);
+    out->ch = CLAMPF(p->ch, 0.1f, 1.0f);
+  }
+}
+
+/** @brief Input rect -> output rect. THE size evaluator. */
+static void _crop_map_size(const dt_iop_crop_data_t *const d, const dt_iop_roi_t *const roi_in,
+                           dt_iop_roi_t *roi_out)
+{
+  *roi_out = *roi_in;
+
+  roi_out->width = roi_in->width * (d->cw - d->cx);
+  roi_out->height = roi_in->height * (d->ch - d->cy);
+  roi_out->x = roi_in->width * d->cx;
+  roi_out->y = roi_in->height * d->cy;
+
+  // sanity check.
+  if(roi_out->x < 0) roi_out->x = 0;
+  if(roi_out->y < 0) roi_out->y = 0;
+  if(roi_out->width < 5) roi_out->width = 5;
+  if(roi_out->height < 5) roi_out->height = 5;
+}
+
+/** @brief The translation the crop applies, in the input rect's own pixels. */
+static void _crop_offset(const dt_iop_crop_data_t *const d, const dt_iop_roi_t *const roi_in, float *left,
+                         float *top)
+{
+  *left = roi_in->width * d->cx;
+  *top = roi_in->height * d->cy;
+}
+
 int distort_transform(dt_iop_module_t *self, const dt_dev_pixelpipe_t *pipe, const dt_dev_pixelpipe_iop_t *piece,
                       float *const restrict points, size_t points_count)
 {
   dt_iop_crop_data_t *d = (dt_iop_crop_data_t *)piece->data;
 
-  const float crop_top = piece->buf_in.height * d->cy;
-  const float crop_left = piece->buf_in.width * d->cx;
+  float crop_left = 0.f, crop_top = 0.f;
+  _crop_offset(d, &piece->buf_in, &crop_left, &crop_top);
 
   // nothing to be done if parameters are set to neutral values (no top/left border)
   if(crop_top == 0 && crop_left == 0) return 1;
@@ -318,8 +377,8 @@ int distort_backtransform(dt_iop_module_t *self, const dt_dev_pixelpipe_t *pipe,
 {
   dt_iop_crop_data_t *d = (dt_iop_crop_data_t *)piece->data;
 
-  const float crop_top = piece->buf_in.height * d->cy;
-  const float crop_left = piece->buf_in.width * d->cx;
+  float crop_left = 0.f, crop_top = 0.f;
+  _crop_offset(d, &piece->buf_in, &crop_left, &crop_top);
 
   // nothing to be done if parameters are set to neutral values (no top/left border)
   if(crop_top == 0 && crop_left == 0) return 1;
@@ -349,19 +408,7 @@ void modify_roi_out(struct dt_iop_module_t *self, const struct dt_dev_pixelpipe_
                     struct dt_dev_pixelpipe_iop_t *piece, dt_iop_roi_t *roi_out,
                     const dt_iop_roi_t *roi_in)
 {
-  *roi_out = *roi_in;
-  dt_iop_crop_data_t *d = (dt_iop_crop_data_t *)piece->data;
-
-  roi_out->width = roi_in->width * (d->cw - d->cx);
-  roi_out->height = roi_in->height * (d->ch - d->cy);
-  roi_out->x = roi_in->width * d->cx;
-  roi_out->y = roi_in->height * d->cy;
-
-  // sanity check.
-  if(roi_out->x < 0) roi_out->x = 0;
-  if(roi_out->y < 0) roi_out->y = 0;
-  if(roi_out->width < 5) roi_out->width = 5;
-  if(roi_out->height < 5) roi_out->height = 5;
+  _crop_map_size((dt_iop_crop_data_t *)piece->data, roi_in, roi_out);
 }
 
 // 2nd pass: which roi would this operation need as input to fill the given output region?
@@ -412,26 +459,64 @@ error:
 void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pixelpipe_t *pipe,
                    dt_dev_pixelpipe_iop_t *piece)
 {
-  dt_iop_crop_params_t *p = (dt_iop_crop_params_t *)p1;
-  dt_iop_crop_data_t *d = (dt_iop_crop_data_t *)piece->data;
-  dt_iop_crop_gui_data_t *g = (dt_iop_crop_gui_data_t *)dt_iop_gui_data(self);
+  _crop_resolve(self, (dt_iop_crop_params_t *)p1, (dt_iop_crop_data_t *)piece->data);
+}
 
-  if(!IS_NULL_PTR(g) && g->editing)
+/* --- the geometry service's view of this module (develop/geometry/geometry.h) --------- */
+
+static void _crop_geometry_map_size(const void *data, const dt_iop_roi_t *const in, dt_iop_roi_t *out)
+{
+  _crop_map_size((const dt_iop_crop_data_t *)data, in, out);
+}
+
+static int _crop_geometry_transform(const void *data, const dt_geometry_record_t *const record,
+                                    dt_geometry_chain_t *chain, float *points, size_t points_count)
+{
+  float left = 0.f, top = 0.f;
+  _crop_offset((const dt_iop_crop_data_t *)data, &record->in, &left, &top);
+  if(left == 0.f && top == 0.f) return 1;
+  for(size_t i = 0; i < points_count * 2; i += 2)
   {
-    // In editing mode, we need to see the full uncropped image
-    // to setup the frame.
-    d->cx = 0.0f;
-    d->cy = 0.0f;
-    d->cw = 1.0f;
-    d->ch = 1.0f;
+    points[i] -= left;
+    points[i + 1] -= top;
   }
-  else
+  return 1;
+}
+
+static int _crop_geometry_backtransform(const void *data, const dt_geometry_record_t *const record,
+                                        dt_geometry_chain_t *chain, float *points, size_t points_count)
+{
+  float left = 0.f, top = 0.f;
+  _crop_offset((const dt_iop_crop_data_t *)data, &record->in, &left, &top);
+  if(left == 0.f && top == 0.f) return 1;
+  for(size_t i = 0; i < points_count * 2; i += 2)
   {
-    d->cx = CLAMPF(p->cx, 0.0f, 0.9f);
-    d->cy = CLAMPF(p->cy, 0.0f, 0.9f);
-    d->cw = CLAMPF(p->cw, 0.1f, 1.0f);
-    d->ch = CLAMPF(p->ch, 0.1f, 1.0f);
+    points[i] += left;
+    points[i + 1] += top;
   }
+  return 1;
+}
+
+static const dt_geometry_vtable_t _crop_geometry_vtable = {
+  .map_size = _crop_geometry_map_size,
+  .transform = _crop_geometry_transform,
+  .backtransform = _crop_geometry_backtransform,
+};
+
+gboolean geometry_record(dt_iop_module_t *self, dt_geometry_record_t *record)
+{
+  /* Same constructor commit_params() uses, including the edit-mode neutralisation: while the
+   * crop GUI is in editing mode the pipe renders the full uncropped frame, and the overlays
+   * have to be told the same story or they would sit on a crop nobody is displaying. */
+  dt_iop_crop_data_t *data = (dt_iop_crop_data_t *)g_malloc0(sizeof(dt_iop_crop_data_t));
+  if(IS_NULL_PTR(data)) return FALSE;
+
+  _crop_resolve(self, (const dt_iop_crop_params_t *)self->params, data);
+
+  record->data = data;
+  record->free_data = dt_free_gpointer;
+  record->vtable = &_crop_geometry_vtable;
+  return TRUE;
 }
 
 gboolean runtime_data_hash(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe,

--- a/src/iop/crop.c
+++ b/src/iop/crop.c
@@ -209,11 +209,11 @@ static void _params_to_gui(dt_iop_crop_params_t *p, dt_iop_crop_gui_data_t *g)
 
 static void _commit_box(dt_iop_module_t *self, dt_iop_crop_gui_data_t *g, dt_iop_crop_params_t *p)
 {
-  dt_dev_pixelpipe_iop_t *piece = dt_dev_distort_get_iop_pipe(self->dev->virtual_pipe, self);
-  if(IS_NULL_PTR(piece)) return;
+  dt_iop_roi_t mod_out;
+  if(!dt_dev_module_geometry_gui(self->dev, self, NULL, &mod_out)) return;
   // we want value in iop space
-  const float wd = (float)piece->buf_out.width; //dt_dev_roi_request_preview_width(self->dev);
-  const float ht = (float)piece->buf_out.height; //dt_dev_roi_request_preview_height(self->dev);
+  const float wd = (float)mod_out.width;
+  const float ht = (float)mod_out.height;
 
   const float bbox_left   = g->clip_x * wd;
   const float bbox_top    = g->clip_y * ht;
@@ -230,7 +230,7 @@ static void _commit_box(dt_iop_module_t *self, dt_iop_crop_gui_data_t *g, dt_iop
     //{
       //fprintf(stderr, "buf_out size: %dx%d\n", piece->buf_out.width, piece->buf_out.height);
 
-      if(piece->buf_out.width < 1 || piece->buf_out.height < 1) return;
+      if(mod_out.width < 1 || mod_out.height < 1) return;
       /*p->cx = CLAMPF(points[0] / (float)piece->buf_out.width, 0.0f, 0.9f);
       p->cy = CLAMPF(points[1] / (float)piece->buf_out.height, 0.0f, 0.9f);
       p->cw = CLAMPF(points[2] / (float)piece->buf_out.width, 0.1f, 1.0f);
@@ -560,10 +560,10 @@ static float _aspect_ratio_get(dt_iop_module_t *self, GtkWidget *combo)
   }
 
   // we want to know the size of the actual buffer
-  dt_dev_pixelpipe_iop_t *piece = dt_dev_distort_get_iop_pipe(self->dev->virtual_pipe, self);
-  if(IS_NULL_PTR(piece)) return 0.0f;
+  dt_iop_roi_t mod_in;
+  if(!dt_dev_module_geometry_gui(self->dev, self, &mod_in, NULL)) return 0.0f;
 
-  const int iwd = piece->buf_in.width, iht = piece->buf_in.height;
+  const int iwd = mod_in.width, iht = mod_in.height;
 
   // if we do not have yet computed the aspect ratio, let's do it now
   if(p->ratio_d == -2 && p->ratio_n == -2)

--- a/src/iop/crop.c
+++ b/src/iop/crop.c
@@ -263,22 +263,24 @@ static void _commit_box(dt_iop_module_t *self, dt_iop_crop_gui_data_t *g, dt_iop
  * @param self the current module data
  * @return gboolean TRUE on success, FALSE otherwise 
  */
-static gboolean _set_max_clip(dt_dev_pixelpipe_t *pipe, struct dt_iop_module_t *self)
+/* Takes no pipe: both callers passed dev->virtual_pipe, so this was never the dual-use fold it
+ * resembled -- it is GUI-only, and asks the dev like every other GUI geometry query. */
+static gboolean _set_max_clip(struct dt_iop_module_t *self)
 {
   dt_iop_crop_gui_data_t *g = (dt_iop_crop_gui_data_t *)dt_iop_gui_data(self);
   dt_iop_crop_params_t *p = (dt_iop_crop_params_t *)self->params;
 
   // we want to know the size of the actual buffer
-  dt_dev_pixelpipe_iop_t *piece = dt_dev_distort_get_iop_pipe(pipe, self);
-  if(IS_NULL_PTR(piece)) return FALSE;
+  dt_iop_roi_t mod_out;
+  if(!dt_dev_module_geometry_gui(self->dev, self, NULL, &mod_out)) return FALSE;
 
-  float wp = piece->buf_out.width;
-  float hp = piece->buf_out.height;
+  float wp = mod_out.width;
+  float hp = mod_out.height;
   float points[8] = { 0.0f, 0.0f, wp, hp, p->cx * wp, p->cy * hp, p->cw * wp, p->ch * hp };
-  if(!dt_dev_distort_transform_plus(pipe, self->iop_order,
-                                    DT_DEV_TRANSFORM_DIR_FORW_EXCL, points, 4))
+  if(!dt_dev_distort_transform_gui(self->dev, self->iop_order,
+                                   DT_DEV_TRANSFORM_DIR_FORW_EXCL, points, 4))
     return FALSE;
-  dt_dev_coordinates_preview_abs_to_image_norm(pipe->dev, points, 4);
+  dt_dev_coordinates_preview_abs_to_image_norm(self->dev, points, 4);
 
   g->clip_max_x = fmaxf(points[0], 0.0f);
   g->clip_max_y = fmaxf(points[1], 0.0f);
@@ -1500,7 +1502,7 @@ void gui_post_expose(struct dt_iop_module_t *self, cairo_t *cr, int32_t width, i
   float pzy = pzxpy[1];
   cairo_set_line_width(cr, border_width);
 
-  if(_set_max_clip(self->dev->virtual_pipe, self))
+  if(_set_max_clip(self))
   {
     cairo_set_source_rgba(cr, .1, .1, .1, .8);
     cairo_set_fill_rule(cr, CAIRO_FILL_RULE_EVEN_ODD);
@@ -1612,7 +1614,7 @@ int mouse_moved(struct dt_iop_module_t *self, double x, double y, double pressur
 
   const _grab_region_t grab = _gui_get_grab(pzx, pzy, g, border, g->wd, g->ht);
 
-  _set_max_clip(self->dev->virtual_pipe, self);
+  _set_max_clip(self);
 
   if(g->dragging)
   {

--- a/src/iop/crop.c
+++ b/src/iop/crop.c
@@ -503,7 +503,7 @@ static const dt_geometry_vtable_t _crop_geometry_vtable = {
   .backtransform = _crop_geometry_backtransform,
 };
 
-gboolean geometry_record(dt_iop_module_t *self, dt_geometry_record_t *record)
+gboolean geometry_record(dt_iop_module_t *self, const void *params, dt_geometry_record_t *record)
 {
   /* Same constructor commit_params() uses, including the edit-mode neutralisation: while the
    * crop GUI is in editing mode the pipe renders the full uncropped frame, and the overlays
@@ -511,7 +511,7 @@ gboolean geometry_record(dt_iop_module_t *self, dt_geometry_record_t *record)
   dt_iop_crop_data_t *data = (dt_iop_crop_data_t *)g_malloc0(sizeof(dt_iop_crop_data_t));
   if(IS_NULL_PTR(data)) return FALSE;
 
-  _crop_resolve(self, (const dt_iop_crop_params_t *)self->params, data);
+  _crop_resolve(self, (const dt_iop_crop_params_t *)params, data);
 
   record->data = data;
   record->free_data = dt_free_gpointer;

--- a/src/iop/crop.c
+++ b/src/iop/crop.c
@@ -225,29 +225,12 @@ static void _commit_box(dt_iop_module_t *self, dt_iop_crop_gui_data_t *g, dt_iop
   if(dt_dev_distort_backtransform_gui(self->dev, self->iop_order,
                                        DT_DEV_TRANSFORM_DIR_FORW_EXCL, points, 2))
   {
-    //dt_dev_pixelpipe_iop_t *piece = dt_dev_distort_get_iop_pipe(self->dev->virtual_pipe, self);
-    //if(piece)
-    //{
-      //fprintf(stderr, "buf_out size: %dx%d\n", piece->buf_out.width, piece->buf_out.height);
+    if(mod_out.width < 1 || mod_out.height < 1) return;
 
-      if(mod_out.width < 1 || mod_out.height < 1) return;
-      /*p->cx = CLAMPF(points[0] / (float)piece->buf_out.width, 0.0f, 0.9f);
-      p->cy = CLAMPF(points[1] / (float)piece->buf_out.height, 0.0f, 0.9f);
-      p->cw = CLAMPF(points[2] / (float)piece->buf_out.width, 0.1f, 1.0f);
-      p->ch = CLAMPF(points[3] / (float)piece->buf_out.height, 0.1f, 1.0f);
-      */
-      p->cx = CLAMPF(points[0] / wd, 0.0f, 0.9f);
-      p->cy = CLAMPF(points[1] / ht, 0.0f, 0.9f);
-      p->cw = CLAMPF(points[2] / wd, 0.1f, 1.0f);
-      p->ch = CLAMPF(points[3] / ht, 0.1f, 1.0f);
-
-      /*fprintf(stderr, "Divisions: cx=%.1f/%d=%.4f, cy=%.1f/%d=%.4f, cw=%.1f/%d=%.4f, ch=%.1f/%d=%.4f\n",
-        points[0], piece->buf_out.width, p->cx,
-        points[1], piece->buf_out.height, p->cy,
-        points[2], piece->buf_out.width, p->cw,
-        points[3], piece->buf_out.height, p->ch);
-        */
-    //}
+    p->cx = CLAMPF(points[0] / wd, 0.0f, 0.9f);
+    p->cy = CLAMPF(points[1] / ht, 0.0f, 0.9f);
+    p->cw = CLAMPF(points[2] / wd, 0.1f, 1.0f);
+    p->ch = CLAMPF(points[3] / ht, 0.1f, 1.0f);
   }
 
   //fprintf(stderr, "_commit_box: cx:%.4f cy:%.4f cw:%.4f ch:%.4f\n", p->cx, p->cy, p->cw, p->ch);
@@ -263,8 +246,9 @@ static void _commit_box(dt_iop_module_t *self, dt_iop_crop_gui_data_t *g, dt_iop
  * @param self the current module data
  * @return gboolean TRUE on success, FALSE otherwise 
  */
-/* Takes no pipe: both callers passed dev->virtual_pipe, so this was never the dual-use fold it
- * resembled -- it is GUI-only, and asks the dev like every other GUI geometry query. */
+/* Takes no pipe: both callers passed the GUI's own pixel-less pipe, so this was never the
+ * dual-use fold it resembled -- it is GUI-only, and asks the dev like every other GUI geometry
+ * query. */
 static gboolean _set_max_clip(struct dt_iop_module_t *self)
 {
   dt_iop_crop_gui_data_t *g = (dt_iop_crop_gui_data_t *)dt_iop_gui_data(self);

--- a/src/iop/crop.c
+++ b/src/iop/crop.c
@@ -222,7 +222,7 @@ static void _commit_box(dt_iop_module_t *self, dt_iop_crop_gui_data_t *g, dt_iop
 
   dt_boundingbox_t points = { bbox_left, bbox_top, bbox_right, bbox_bottom };
 
-  if(dt_dev_distort_backtransform_plus(self->dev->virtual_pipe, self->iop_order,
+  if(dt_dev_distort_backtransform_gui(self->dev, self->iop_order,
                                        DT_DEV_TRANSFORM_DIR_FORW_EXCL, points, 2))
   {
     //dt_dev_pixelpipe_iop_t *piece = dt_dev_distort_get_iop_pipe(self->dev->virtual_pipe, self);

--- a/src/iop/demosaic.c
+++ b/src/iop/demosaic.c
@@ -77,6 +77,7 @@
 #include "develop/blend.h"
 #include "develop/develop.h"
 #include "pixel/format.h"
+#include "develop/geometry/geometry.h"
 #include "develop/imageop.h"
 #include "develop/imageop_math.h"
 #include "develop/imageop_gui.h"
@@ -933,14 +934,14 @@ void distort_mask(struct dt_iop_module_t *self, const struct dt_dev_pixelpipe_t 
   dt_interpolation_resample_roi_1c(itor, out, roi_out, in, roi_in);
 }
 
-void modify_roi_out(struct dt_iop_module_t *self, const struct dt_dev_pixelpipe_t *pipe,
-                    struct dt_dev_pixelpipe_iop_t *piece, dt_iop_roi_t *roi_out,
-                    const dt_iop_roi_t *const roi_in)
+/** @brief Input rect -> output rect. THE size evaluator: modify_roi_out() below and the
+ *  geometry service's record (develop/geometry/geometry.h) are its only two callers. */
+static void _demosaic_map_size(const gboolean downsamples, const dt_iop_roi_t *const roi_in,
+                               dt_iop_roi_t *roi_out)
 {
   *roi_out = *roi_in;
 
-  dt_iop_demosaic_data_t *data = (dt_iop_demosaic_data_t *)piece->data;
-  if(_is_downsample_method(data->demosaicing_method))
+  if(downsamples)
   {
     roi_out->width = (roi_in->width + 1) / 2;
     roi_out->height = (roi_in->height + 1) / 2;
@@ -949,6 +950,53 @@ void modify_roi_out(struct dt_iop_module_t *self, const struct dt_dev_pixelpipe_
   // snap to start of mosaic block:
   roi_out->x = 0; // MAX(0, roi_out->x & ~1);
   roi_out->y = 0; // MAX(0, roi_out->y & ~1);
+}
+
+void modify_roi_out(struct dt_iop_module_t *self, const struct dt_dev_pixelpipe_t *pipe,
+                    struct dt_dev_pixelpipe_iop_t *piece, dt_iop_roi_t *roi_out,
+                    const dt_iop_roi_t *const roi_in)
+{
+  dt_iop_demosaic_data_t *data = (dt_iop_demosaic_data_t *)piece->data;
+  _demosaic_map_size(_is_downsample_method(data->demosaicing_method), roi_in, roi_out);
+}
+
+/* --- the geometry service's view of this module (develop/geometry/geometry.h) ---------
+ *
+ * Demosaic is on the roster for its SIZE only: the downsampling methods halve the frame, and
+ * nothing downstream would otherwise know. It publishes no point transform because it has none
+ * -- consumers of coordinates work in the post-demosaic frame and normalise against the
+ * per-module dimensions the chain's fold records.
+ */
+
+typedef struct dt_iop_demosaic_geometry_t
+{
+  gboolean downsamples;
+} dt_iop_demosaic_geometry_t;
+
+static void _demosaic_geometry_map_size(const void *data, const dt_iop_roi_t *const in, dt_iop_roi_t *out)
+{
+  _demosaic_map_size(((const dt_iop_demosaic_geometry_t *)data)->downsamples, in, out);
+}
+
+static const dt_geometry_vtable_t _demosaic_geometry_vtable = {
+  .map_size = _demosaic_geometry_map_size,
+  .transform = NULL,
+  .backtransform = NULL,
+};
+
+gboolean geometry_record(dt_iop_module_t *self, dt_geometry_record_t *record)
+{
+  const dt_iop_demosaic_params_t *const p = (const dt_iop_demosaic_params_t *)self->params;
+
+  dt_iop_demosaic_geometry_t *data
+      = (dt_iop_demosaic_geometry_t *)g_malloc0(sizeof(dt_iop_demosaic_geometry_t));
+  if(IS_NULL_PTR(data)) return FALSE;
+  data->downsamples = _is_downsample_method(p->demosaicing_method);
+
+  record->data = data;
+  record->free_data = dt_free_gpointer;
+  record->vtable = &_demosaic_geometry_vtable;
+  return TRUE;
 }
 
 // which roi input is needed to process to this output?

--- a/src/iop/demosaic.c
+++ b/src/iop/demosaic.c
@@ -984,9 +984,9 @@ static const dt_geometry_vtable_t _demosaic_geometry_vtable = {
   .backtransform = NULL,
 };
 
-gboolean geometry_record(dt_iop_module_t *self, dt_geometry_record_t *record)
+gboolean geometry_record(dt_iop_module_t *self, const void *params, dt_geometry_record_t *record)
 {
-  const dt_iop_demosaic_params_t *const p = (const dt_iop_demosaic_params_t *)self->params;
+  const dt_iop_demosaic_params_t *const p = (const dt_iop_demosaic_params_t *)params;
 
   dt_iop_demosaic_geometry_t *data
       = (dt_iop_demosaic_geometry_t *)g_malloc0(sizeof(dt_iop_demosaic_geometry_t));

--- a/src/iop/drawlayer.c
+++ b/src/iop/drawlayer.c
@@ -365,32 +365,22 @@ static inline __attribute__((always_inline)) gboolean _resolve_layer_geometry(dt
   if(!IS_NULL_PTR(origin_x)) *origin_x = 0;
   if(!IS_NULL_PTR(origin_y)) *origin_y = 0;
   if(IS_NULL_PTR(self) || IS_NULL_PTR(self->dev)) return FALSE;
-  /* Layer geometry must follow authored image-space pixels at the current
-   * module stage, not merely the size of the working buffer currently attached
-   * to the pipe. Thumbnail/export pipes may start from a downscaled mipmap, so
-   * `piece->buf_out` alone is smaller than the layer canvas and must be
-   * lifted back through `roi_out.scale` to recover the full stage geometry. */
+  /* The canvas has the RAW image's dimensions, in this image's own orientation, and is centred
+   * on the module's frame -- the same for every pipe, every zoom and every crop, which is the
+   * point of anchoring to it: a crop changes which window of the canvas a render reads, not
+   * where the paint sits. See iop/drawlayer/coordinates.h.
+   *
+   * It used to be the module's own stage frame, lifted back through roi_out.scale. That size
+   * moves with every crop, and the authored raster was then fitted onto the new frame -- the
+   * paint moved and stretched with the crop.
+   *
+   * Thumbnail and export pipes may start from a downscaled mipmap; that shrinks the module's
+   * frame, not the canvas, and the placement's scale absorbs it. */
   int resolved_width = 0;
   int resolved_height = 0;
+  if(!dt_drawlayer_layer_canvas_for_pipe(self, pipe, &resolved_width, &resolved_height)) return FALSE;
 
-  if(!IS_NULL_PTR(piece) && piece->buf_out.width > 0 && piece->buf_out.height > 0 && piece->roi_out.scale > 0.0)
-  {
-    resolved_width = (int)lround((double)piece->buf_out.width * piece->roi_out.scale);
-    resolved_height = (int)lround((double)piece->buf_out.height * piece->roi_out.scale);
-  }
-  else if(!IS_NULL_PTR(pipe) && pipe->processed_width > 0 && pipe->processed_height > 0)
-  {
-    resolved_width = pipe->processed_width;
-    resolved_height = pipe->processed_height;
-  }
-  else if(!IS_NULL_PTR(pipe) || !IS_NULL_PTR(piece))
-  {
-    return FALSE;
-  }
-  else if(!dt_dev_processed_size_gui(self->dev, &resolved_width, &resolved_height))
-  {
-    return FALSE;
-  }
+  (void)piece;
 
   if(!IS_NULL_PTR(layer_width)) *layer_width = resolved_width;
   if(!IS_NULL_PTR(layer_height)) *layer_height = resolved_height;
@@ -553,21 +543,17 @@ static inline __attribute__((always_inline)) gboolean _refresh_piece_base_cache(
   int layer_height = 0;
   const gboolean have_pipe_geometry = _resolve_layer_geometry(self, pipe, piece, &layer_width, &layer_height, NULL, NULL);
 
-  /* Thumbnail/export pipes render a downscaled final image, but drawlayer
-   * sidecars stay authored in full image-space coordinates. Reinterpreting an
-   * existing TIFF page at thumbnail size recenters/crops it through the TIFF
-   * offset math and produces the apparent scale mismatch on first export. */
-  if(pipe->type == DT_DEV_PIXELPIPE_THUMBNAIL || pipe->type == DT_DEV_PIXELPIPE_EXPORT)
-  {
-    if(info.found && info.width > 0 && info.height > 0)
-    {
-      layer_width = (int)info.width;
-      layer_height = (int)info.height;
-    }
-    else if(!have_pipe_geometry)
-      return FALSE;
-  }
-  else if(!have_pipe_geometry)
+  /* The canvas is the raw frame in every pipe, so the stored page's own dimensions are no longer
+   * consulted to decide it -- they used to be, because a thumbnail or export pipe resolved a
+   * SMALLER canvas than the darkroom did (both followed the module's stage frame, and those pipes
+   * render downscaled), and reinterpreting the page at that size recentred it. Anchoring removes
+   * the divergence rather than papering over it: one canvas size for every pipe, and the pipe's
+   * own scale is absorbed by the placement.
+   *
+   * A page authored before this change was written in the post-crop frame and will be read as
+   * though it were raw, so it appears shifted until repainted. That was the agreed trade; the
+   * alternative was a versioned sidecar and a migration pass. */
+  if(!have_pipe_geometry)
   {
     if(info.found && info.width > 0 && info.height > 0)
     {
@@ -1591,7 +1577,7 @@ static inline __attribute__((always_inline)) gboolean _update_runtime_state(cons
 
   if(process && process->cache_valid && process->base_patch.pixels && process->cache_imgid == pipe->dev->image_storage.id)
   {
-    const dt_iop_roi_t process_roi = request->roi_out ? *request->roi_out : *request->roi_in;
+    dt_iop_roi_t process_roi = request->roi_out ? *request->roi_out : *request->roi_in;
     const dt_iop_roi_t source_full_roi = {
       .x = 0,
       .y = 0,
@@ -1599,6 +1585,31 @@ static inline __attribute__((always_inline)) gboolean _update_runtime_state(cons
       .height = process->base_patch.height,
       .scale = 1.0f,
     };
+
+    /* The canvas has the raw image's dimensions and this module's frame is a window into it, at
+     * the position the size fold gives that window (piece->buf_in.x/y -- a crop records itself
+     * there). So the window this render reads is the requested output window shifted by that
+     * origin -- and by nothing else. No scale: canvas and frame share the pixel pitch. No
+     * rotation: the flip is already in the canvas's orientation.
+     *
+     * dt_interpolation_resample() reads source pixel ((x + i) / scale) for output column i, and
+     * target_roi->x is in those same scaled units, which is why the offset is multiplied by the
+     * render's own scale here and by nothing else.
+     *
+     * Before this the canvas WAS the module's frame and target_roi indexed it directly -- so the
+     * canvas changed size with every crop and the authored raster was re-fitted onto the new
+     * frame. The paint moved and stretched with the crop; that is the bug this fixes.
+     *
+     * KNOWN LIMIT: when the frame is LARGER than the canvas (a perspective correction expands it)
+     * the offset goes negative and the resampler clamps to the canvas edge instead of reading
+     * transparency, so paint touching the very edge of the canvas smears outward into the added
+     * margin. Paint that does not reach the edge is unaffected. */
+    dt_drawlayer_raw_placement_t placement;
+    if(dt_drawlayer_raw_placement_for_frame(request->self, pipe, &request->piece->buf_in, &placement))
+    {
+      process_roi.x += (int)lroundf((float)placement.offset_x * process_roi.scale);
+      process_roi.y += (int)lroundf((float)placement.offset_y * process_roi.scale);
+    }
     source->kind = DT_DRAWLAYER_SOURCE_BASE_PATCH;
     source->pixels = process->base_patch.pixels;
     source->cache_entry = process->base_patch.cache_entry;

--- a/src/iop/drawlayer.c
+++ b/src/iop/drawlayer.c
@@ -387,17 +387,9 @@ static inline __attribute__((always_inline)) gboolean _resolve_layer_geometry(dt
   {
     return FALSE;
   }
-  else if(self->dev->virtual_pipe && self->dev->virtual_pipe->processed_width > 0
-          && self->dev->virtual_pipe->processed_height > 0)
+  else if(!dt_dev_processed_size_gui(self->dev, &resolved_width, &resolved_height))
   {
-    resolved_width = self->dev->virtual_pipe->processed_width;
-    resolved_height = self->dev->virtual_pipe->processed_height;
-  }
-  else
-  {
-    const dt_dev_image_geometry_t geometry = dt_dev_geometry_snapshot(self->dev);
-    resolved_width = geometry.processed_width;
-    resolved_height = geometry.processed_height;
+    return FALSE;
   }
 
   if(!IS_NULL_PTR(layer_width)) *layer_width = resolved_width;

--- a/src/iop/drawlayer/coordinates.c
+++ b/src/iop/drawlayer/coordinates.c
@@ -18,23 +18,151 @@
 
 #include "iop/drawlayer/coordinates.h"
 
-static gboolean _virtual_piece_layer_geometry(dt_iop_module_t *self, int *layer_width, int *layer_height)
+#include "develop/geometry/geometry.h"   // dt_geometry_chain_find(), dt_geometry_record_t
+
+#include <string.h>
+
+/* --- where the raw-anchored canvas sits in this module's frame ------------------------------
+ *
+ * One derivation, three callers -- the GUI placing a dab, the GUI drawing its overlays, and the
+ * pipe compositing. They MUST agree: a dab is placed by the first and rendered by the last, and a
+ * disagreement puts the paint somewhere other than where the cursor was.
+ */
+
+/**
+ * @brief Does the orientation flip.c settled on swap the axes?
+ *
+ * @details Asked of the SIZE FOLD, not of the EXIF tag: a raw's recorded orientation is not always
+ * right, and iop/flip.c exists precisely so the user can override it. Its _flip_resolve() merges
+ * the two, and what this reads -- the rect flip's own fold maps its input to -- is the consequence
+ * of that merge. So a corrected orientation is honoured with no access to flip's private data and
+ * no second copy of the merge rule.
+ *
+ * Read from flip's record on the GUI side and from flip's piece on a pipe, which are the same fold
+ * run by the two sides; nothing else in the pipe transposes. The focused-module exception cannot
+ * disturb it either: flip is tagged IOP_TAG_DISTORT and no module's operation_tags_filter()
+ * suppresses that tag -- crop filters DECORATION, ashift DECORATION|CLIPPING.
+ *
+ * A disabled flip folds its input to itself, so the answer is FALSE, which is what an orientation
+ * of NONE means. A square frame cannot express a swap, and does not need to: the canvas has the
+ * same dimensions either way.
+ */
+static gboolean _flip_swaps_axes(dt_iop_module_t *self, const dt_dev_pixelpipe_t *pipe)
 {
-  if(!IS_NULL_PTR(layer_width)) *layer_width = 0;
-  if(!IS_NULL_PTR(layer_height)) *layer_height = 0;
+  dt_iop_roi_t in = { 0 };
+  dt_iop_roi_t out = { 0 };
+  gboolean found = FALSE;
+
+  if(IS_NULL_PTR(pipe))
+  {
+    const dt_geometry_record_t *const record = dt_geometry_chain_find(self->dev->geometry_chain, "flip", 0);
+    if(!IS_NULL_PTR(record))
+    {
+      in = record->in;
+      out = record->out;
+      found = TRUE;
+    }
+  }
+  else
+  {
+    for(const GList *node = g_list_first(pipe->nodes); node; node = g_list_next(node))
+    {
+      const dt_dev_pixelpipe_iop_t *const piece = (const dt_dev_pixelpipe_iop_t *)node->data;
+      if(IS_NULL_PTR(piece) || IS_NULL_PTR(piece->module) || strcmp(piece->module->op, "flip")) continue;
+      in = piece->buf_in;
+      out = piece->buf_out;
+      found = TRUE;
+      break;
+    }
+  }
+
+  if(!found || in.width <= 0 || in.height <= 0) return FALSE;
+  return (out.width == in.height) && (out.height == in.width) && (in.width != in.height);
+}
+
+gboolean dt_drawlayer_layer_canvas_for_pipe(dt_iop_module_t *self, const dt_dev_pixelpipe_t *pipe, int *width,
+                                            int *height)
+{
+  if(!IS_NULL_PTR(width)) *width = 0;
+  if(!IS_NULL_PTR(height)) *height = 0;
   if(IS_NULL_PTR(self) || IS_NULL_PTR(self->dev)) return FALSE;
 
-  /* GUI coordinate mapping should prefer the composed geometry because it tracks
-   * the currently committed distortion stack even before the global darkroom ROI
-   * bookkeeping is fully refreshed. Falling back to `dev->roi` too early makes the
-   * first displayed layer appear stretched until the next display-pipe refresh
-   * catches up. */
-  int resolved_width = 0;
-  int resolved_height = 0;
-  dt_dev_processed_size_gui(self->dev, &resolved_width, &resolved_height);
-  if(!IS_NULL_PTR(layer_width)) *layer_width = resolved_width;
-  if(!IS_NULL_PTR(layer_height)) *layer_height = resolved_height;
-  return resolved_width > 0 && resolved_height > 0;
+  int32_t raw_width = 0;
+  int32_t raw_height = 0;
+  if(!dt_dev_geometry_get_raw_size(self->dev, &raw_width, &raw_height)) return FALSE;
+  if(raw_width <= 0 || raw_height <= 0) return FALSE;
+
+  /* A raw buffer is landscape; a portrait image is that buffer seen rotated a quarter turn, and
+   * the paint is rotated with it. Carried by transposing the canvas rather than by rotating
+   * pixels: the layer the user paints, and the page the sidecar holds, are both in the
+   * orientation they see. */
+  const gboolean swap = _flip_swaps_axes(self, pipe);
+
+  if(!IS_NULL_PTR(width)) *width = swap ? raw_height : raw_width;
+  if(!IS_NULL_PTR(height)) *height = swap ? raw_width : raw_height;
+  return TRUE;
+}
+
+gboolean dt_drawlayer_layer_canvas(dt_iop_module_t *self, int *width, int *height)
+{
+  return dt_drawlayer_layer_canvas_for_pipe(self, NULL, width, height);
+}
+
+gboolean dt_drawlayer_raw_placement_for_frame(dt_iop_module_t *self, const dt_dev_pixelpipe_t *pipe,
+                                              const dt_iop_roi_t *const frame,
+                                              dt_drawlayer_raw_placement_t *placement)
+{
+  if(IS_NULL_PTR(placement)) return FALSE;
+  *placement = (dt_drawlayer_raw_placement_t){ 0 };
+  if(IS_NULL_PTR(frame) || frame->width <= 0 || frame->height <= 0) return FALSE;
+
+  int canvas_width = 0;
+  int canvas_height = 0;
+  if(!dt_drawlayer_layer_canvas_for_pipe(self, pipe, &canvas_width, &canvas_height)) return FALSE;
+
+  /* The frame's ORIGIN, not the difference of the sizes.
+   *
+   * The size fold that produces this rect (dt_dev_pixelpipe_get_roi_out, and the chain's mirror of
+   * it) runs at scale 1 from the raw frame, and a crop records itself as an OFFSET in that frame:
+   * measured on a cropped NEF, crop maps in=(0,0,4016x6016) to out=(0,2802,2464x3213). So the
+   * frame's position inside the raw image is exactly frame->x/y, and translating the canvas by it
+   * is what makes the paint stay on the content -- for a crop that moves without resizing as much
+   * as for one that resizes.
+   *
+   * Centring on the sizes alone, which this did first, gets the uncropped case right and every
+   * moved crop wrong: two crops of equal size at different positions have the same size difference
+   * and therefore the same offset, so the layer followed the frame instead of the image. The
+   * uncropped case is still centre-on-centre, because there the origin is 0 and the extents match.
+   *
+   * A module that GROWS the frame (a perspective correction) leaves the origin at 0 while the
+   * extent exceeds the canvas, so the canvas anchors to the frame's corner rather than its centre.
+   * That is a consequence of being immune to that module -- there is no offset in this frame that
+   * both ignores the correction and re-centres against it. */
+  placement->offset_x = frame->x;
+  placement->offset_y = frame->y;
+  placement->valid = TRUE;
+  return TRUE;
+}
+
+gboolean dt_drawlayer_raw_placement_gui(dt_iop_module_t *self, dt_drawlayer_raw_placement_t *placement,
+                                        int *frame_width, int *frame_height)
+{
+  if(!IS_NULL_PTR(frame_width)) *frame_width = 0;
+  if(!IS_NULL_PTR(frame_height)) *frame_height = 0;
+  if(IS_NULL_PTR(self) || IS_NULL_PTR(self->dev) || IS_NULL_PTR(placement)) return FALSE;
+
+  dt_iop_roi_t frame;
+  if(!dt_dev_module_geometry_gui(self->dev, self, &frame, NULL)) return FALSE;
+  if(frame.width <= 0 || frame.height <= 0) return FALSE;
+
+  if(!IS_NULL_PTR(frame_width)) *frame_width = frame.width;
+  if(!IS_NULL_PTR(frame_height)) *frame_height = frame.height;
+  return dt_drawlayer_raw_placement_for_frame(self, NULL, &frame, placement);
+}
+
+static gboolean _virtual_piece_layer_geometry(dt_iop_module_t *self, int *layer_width, int *layer_height)
+{
+  return dt_drawlayer_layer_canvas(self, layer_width, layer_height);
 }
 
 gboolean dt_drawlayer_widget_points_to_layer_coords(dt_iop_module_t *self, float *pts, const int count)
@@ -48,15 +176,38 @@ gboolean dt_drawlayer_widget_points_to_layer_coords(dt_iop_module_t *self, float
                                         DT_DEV_TRANSFORM_DIR_FORW_EXCL, pts, count))
     return FALSE;
   dt_dev_coordinates_preview_abs_to_image_norm(self->dev, pts, count);
-  dt_dev_coordinates_image_norm_to_image_abs(self->dev, pts, count);
 
+  /* ...which lands in this module's own frame, normalised. Finish through the SAME placement the
+   * renderer uses: a dab has to be written where the composite will read it from. */
+  dt_drawlayer_raw_placement_t placement;
+  int frame_width = 0;
+  int frame_height = 0;
+  if(!dt_drawlayer_raw_placement_gui(self, &placement, &frame_width, &frame_height)) return FALSE;
+
+  for(int i = 0; i < count; i++)
+  {
+    pts[2 * i]     = (float)placement.offset_x + pts[2 * i]     * (float)frame_width;
+    pts[2 * i + 1] = (float)placement.offset_y + pts[2 * i + 1] * (float)frame_height;
+  }
   return TRUE;
 }
 
 gboolean dt_drawlayer_layer_points_to_widget_coords(dt_iop_module_t *self, float *pts, const int count)
 {
-  if(IS_NULL_PTR(pts) || count <= 0) return FALSE;
-  dt_dev_coordinates_image_abs_to_image_norm(self->dev, pts, count);
+  if(IS_NULL_PTR(self) || IS_NULL_PTR(self->dev) || IS_NULL_PTR(pts) || count <= 0) return FALSE;
+
+  // Canvas pixels back to this module's own frame, normalised. Inverse of the above.
+  dt_drawlayer_raw_placement_t placement;
+  int frame_width = 0;
+  int frame_height = 0;
+  if(!dt_drawlayer_raw_placement_gui(self, &placement, &frame_width, &frame_height)) return FALSE;
+
+  for(int i = 0; i < count; i++)
+  {
+    pts[2 * i]     = (pts[2 * i]     - (float)placement.offset_x) / (float)frame_width;
+    pts[2 * i + 1] = (pts[2 * i + 1] - (float)placement.offset_y) / (float)frame_height;
+  }
+
   dt_dev_coordinates_image_norm_to_preview_abs(self->dev, pts, count);
 
   if(!dt_dev_distort_transform_gui(self->dev, self->iop_order,

--- a/src/iop/drawlayer/coordinates.c
+++ b/src/iop/drawlayer/coordinates.c
@@ -24,11 +24,11 @@ static gboolean _virtual_piece_layer_geometry(dt_iop_module_t *self, int *layer_
   if(!IS_NULL_PTR(layer_height)) *layer_height = 0;
   if(IS_NULL_PTR(self) || IS_NULL_PTR(self->dev)) return FALSE;
 
-  /* GUI coordinate mapping should prefer the virtual pipe geometry because it
-   * tracks the currently committed distortion stack even before the global
-   * darkroom ROI bookkeeping is fully refreshed. Falling back to `dev->roi`
-   * too early makes the first displayed layer appear stretched until the next
-   * display-pipe refresh catches up. */
+  /* GUI coordinate mapping should prefer the composed geometry because it tracks
+   * the currently committed distortion stack even before the global darkroom ROI
+   * bookkeeping is fully refreshed. Falling back to `dev->roi` too early makes the
+   * first displayed layer appear stretched until the next display-pipe refresh
+   * catches up. */
   int resolved_width = 0;
   int resolved_height = 0;
   dt_dev_processed_size_gui(self->dev, &resolved_width, &resolved_height);

--- a/src/iop/drawlayer/coordinates.c
+++ b/src/iop/drawlayer/coordinates.c
@@ -31,18 +31,7 @@ static gboolean _virtual_piece_layer_geometry(dt_iop_module_t *self, int *layer_
    * display-pipe refresh catches up. */
   int resolved_width = 0;
   int resolved_height = 0;
-  if(self->dev->virtual_pipe && self->dev->virtual_pipe->processed_width > 0
-     && self->dev->virtual_pipe->processed_height > 0)
-  {
-    resolved_width = self->dev->virtual_pipe->processed_width;
-    resolved_height = self->dev->virtual_pipe->processed_height;
-  }
-  else
-  {
-    const dt_dev_image_geometry_t geometry = dt_dev_geometry_snapshot(self->dev);
-    resolved_width = geometry.processed_width;
-    resolved_height = geometry.processed_height;
-  }
+  dt_dev_processed_size_gui(self->dev, &resolved_width, &resolved_height);
   if(!IS_NULL_PTR(layer_width)) *layer_width = resolved_width;
   if(!IS_NULL_PTR(layer_height)) *layer_height = resolved_height;
   return resolved_width > 0 && resolved_height > 0;
@@ -50,7 +39,7 @@ static gboolean _virtual_piece_layer_geometry(dt_iop_module_t *self, int *layer_
 
 gboolean dt_drawlayer_widget_points_to_layer_coords(dt_iop_module_t *self, float *pts, const int count)
 {
-  if(IS_NULL_PTR(self) || IS_NULL_PTR(self->dev) || IS_NULL_PTR(self->dev->virtual_pipe) || IS_NULL_PTR(pts) || count <= 0) return FALSE;
+  if(IS_NULL_PTR(self) || IS_NULL_PTR(self->dev) || IS_NULL_PTR(pts) || count <= 0) return FALSE;
 
   dt_dev_coordinates_widget_to_image_norm(self->dev, pts, count);
   dt_dev_coordinates_image_norm_to_preview_abs(self->dev, pts, count);
@@ -137,7 +126,7 @@ gboolean dt_drawlayer_layer_bounds_to_widget_bounds(dt_iop_module_t *self, const
 float dt_drawlayer_widget_brush_radius(dt_iop_module_t *self, const dt_drawlayer_brush_dab_t *dab,
                                        const float fallback)
 {
-  if(IS_NULL_PTR(self) || IS_NULL_PTR(self->dev) || IS_NULL_PTR(self->dev->virtual_pipe) || IS_NULL_PTR(dab)) return fallback;
+  if(IS_NULL_PTR(self) || IS_NULL_PTR(self->dev) || IS_NULL_PTR(dab)) return fallback;
 
   float pts[6] = {
     dab->x, dab->y, dab->x + dab->radius, dab->y, dab->x, dab->y + dab->radius,

--- a/src/iop/drawlayer/coordinates.c
+++ b/src/iop/drawlayer/coordinates.c
@@ -55,7 +55,7 @@ gboolean dt_drawlayer_widget_points_to_layer_coords(dt_iop_module_t *self, float
   dt_dev_coordinates_widget_to_image_norm(self->dev, pts, count);
   dt_dev_coordinates_image_norm_to_preview_abs(self->dev, pts, count);
 
-  if(!dt_dev_distort_backtransform_plus(self->dev->virtual_pipe, self->iop_order,
+  if(!dt_dev_distort_backtransform_gui(self->dev, self->iop_order,
                                         DT_DEV_TRANSFORM_DIR_FORW_EXCL, pts, count))
     return FALSE;
   dt_dev_coordinates_preview_abs_to_image_norm(self->dev, pts, count);
@@ -70,7 +70,7 @@ gboolean dt_drawlayer_layer_points_to_widget_coords(dt_iop_module_t *self, float
   dt_dev_coordinates_image_abs_to_image_norm(self->dev, pts, count);
   dt_dev_coordinates_image_norm_to_preview_abs(self->dev, pts, count);
 
-  if(!dt_dev_distort_transform_plus(self->dev->virtual_pipe, self->iop_order,
+  if(!dt_dev_distort_transform_gui(self->dev, self->iop_order,
                                     DT_DEV_TRANSFORM_DIR_FORW_EXCL, pts, count))
     return FALSE;
 

--- a/src/iop/drawlayer/coordinates.h
+++ b/src/iop/drawlayer/coordinates.h
@@ -23,6 +23,60 @@ typedef struct drawlayer_view_patch_info_t
   float layer_y1;
 } drawlayer_view_patch_info_t;
 
+/**
+ * @brief Where the raw-anchored layer canvas sits in this module's own frame.
+ *
+ * @details The layer has the RAW image's dimensions and sits at the origin of the raw frame. The
+ * module's own frame is a window into it, at the position the size fold gives that window. That is
+ * the whole placement: an offset, never a scale, never a rotation.
+ *
+ * It follows from what the layer is FOR. Paint is authored on the sensor's frame, so it must not
+ * move when the frame around it changes -- crop it tighter, or move the crop without resizing it,
+ * and the same paint stays on the same content, cropped along with it. Uncropped, the two frames
+ * coincide and so do their centres.
+ *
+ * The layer is deliberately IMMUNE to perspective correction and to horizon rotation. Those change
+ * what the frame contains, not where the sensor's centre is, and following them would mean warping
+ * a four-channel raster through the upstream chain on every render.
+ *
+ * The one transform that does apply is the FLIP. A raw buffer is landscape, so a portrait image is
+ * a raw rotated 90 degrees, and the layer is rotated with it -- carried here by the canvas being
+ * stated in the module's own orientation (::dt_drawlayer_layer_canvas), which is what the user
+ * paints on and what the sidecar holds.
+ */
+typedef struct dt_drawlayer_raw_placement_t
+{
+  int offset_x, offset_y;   /**< canvas pixel under the frame's origin, at full resolution */
+  gboolean valid;
+} dt_drawlayer_raw_placement_t;
+
+/**
+ * @brief The layer canvas: the raw image's dimensions, in this image's own orientation.
+ *
+ * @details Transposed when the axes are swapped, because a portrait is a landscape raw seen rotated
+ * and the paint has to be rotated with it. WHETHER they are swapped is asked of iop/flip.c's own
+ * size fold, not of the EXIF tag -- a raw's recorded orientation is not always right, and flip is
+ * where the user corrects it. Everything else about the canvas is fixed: it does not move with a
+ * crop, a zoom, a pipe type or a mipmap level, which is what makes it something to anchor to.
+ *
+ * @p pipe selects which side's copy of that fold answers -- NULL for the GUI's records, a pipe for
+ * its own pieces. They are the same fold, so they agree.
+ */
+gboolean dt_drawlayer_layer_canvas_for_pipe(dt_iop_module_t *self, const struct dt_dev_pixelpipe_t *pipe,
+                                            int *width, int *height);
+
+/** @brief ::dt_drawlayer_layer_canvas_for_pipe for a GUI caller. */
+gboolean dt_drawlayer_layer_canvas(dt_iop_module_t *self, int *width, int *height);
+
+/** @brief Anchor the canvas against @p frame, this module's input rect from the size fold. */
+gboolean dt_drawlayer_raw_placement_for_frame(dt_iop_module_t *self, const struct dt_dev_pixelpipe_t *pipe,
+                                              const dt_iop_roi_t *frame,
+                                              dt_drawlayer_raw_placement_t *placement);
+
+/** @brief The placement against this module's frame, as the GUI sees it. */
+gboolean dt_drawlayer_raw_placement_gui(dt_iop_module_t *self, dt_drawlayer_raw_placement_t *placement,
+                                        int *frame_width, int *frame_height);
+
 gboolean dt_drawlayer_widget_points_to_layer_coords(dt_iop_module_t *self, float *pts, int count);
 gboolean dt_drawlayer_layer_points_to_widget_coords(dt_iop_module_t *self, float *pts, int count);
 gboolean dt_drawlayer_widget_to_layer_coords(dt_iop_module_t *self, double wx, double wy, float *lx, float *ly);

--- a/src/iop/flip.c
+++ b/src/iop/flip.c
@@ -61,6 +61,7 @@
 #include "imageio/imageio_core.h"
 #include "common/opencl.h"
 #include "develop/develop.h"
+#include "develop/geometry/geometry.h"
 #include "develop/imageop.h"
 #include "develop/imageop_gui.h"
 #include "develop/imageop_gui.h"
@@ -225,6 +226,40 @@ static void backtransform(const int32_t *x, int32_t *o, const dt_image_orientati
   }
 }
 
+/* --- the shared geometry core ----------------------------------------------------------
+ *
+ * The ONE place flip's orientation is resolved and the ONE place its size map is expressed.
+ * commit_params() and modify_roi_out() use them, and so does geometry_record() for the
+ * pixel-less geometry service (develop/geometry/geometry.h).
+ */
+
+/**
+ * @brief The orientation this module will actually apply.
+ *
+ * @details ORIENTATION_NULL means "whatever the file says", which is resolved from the image's
+ * EXIF here rather than stored in params -- so the resolution has to happen identically wherever
+ * the orientation is consumed, or a record would describe a rotation the pipe is not doing.
+ */
+static dt_image_orientation_t _flip_resolve(dt_iop_module_t *self, const dt_iop_flip_params_t *const p)
+{
+  if(p->orientation == ORIENTATION_NULL) return dt_image_orientation(&self->dev->image_storage);
+  return p->orientation;
+}
+
+/** @brief Input rect -> output rect: a swap, or nothing. */
+static void _flip_map_size(const dt_image_orientation_t orientation, const dt_iop_roi_t *const roi_in,
+                           dt_iop_roi_t *roi_out)
+{
+  *roi_out = *roi_in;
+
+  // transform whole buffer roi
+  if(orientation & ORIENTATION_SWAP_XY)
+  {
+    roi_out->width = roi_in->height;
+    roi_out->height = roi_in->width;
+  }
+}
+
 int distort_transform(dt_iop_module_t *self, const dt_dev_pixelpipe_t *pipe, const dt_dev_pixelpipe_iop_t *piece,
                       float *const restrict points, size_t points_count)
 {
@@ -305,14 +340,7 @@ void modify_roi_out(struct dt_iop_module_t *self, const struct dt_dev_pixelpipe_
                     const dt_iop_roi_t *roi_in)
 {
   const dt_iop_flip_data_t *d = (dt_iop_flip_data_t *)piece->data;
-  *roi_out = *roi_in;
-
-  // transform whole buffer roi
-  if(d->orientation & ORIENTATION_SWAP_XY)
-  {
-    roi_out->width = roi_in->height;
-    roi_out->height = roi_in->width;
-  }
+  _flip_map_size(d->orientation, roi_in, roi_out);
 }
 
 // 2nd pass: which roi would this operation need as input to fill the given output region?
@@ -423,12 +451,92 @@ void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pix
   const dt_iop_flip_params_t *p = (dt_iop_flip_params_t *)p1;
   dt_iop_flip_data_t *d = (dt_iop_flip_data_t *)piece->data;
 
-  if(p->orientation == ORIENTATION_NULL)
-    d->orientation = dt_image_orientation(&self->dev->image_storage);
-  else
-    d->orientation = p->orientation;
+  d->orientation = _flip_resolve(self, p);
 
   if(d->orientation == ORIENTATION_NONE) piece->enabled = 0;
+}
+
+/* --- the geometry service's view of this module (develop/geometry/geometry.h) --------- */
+
+typedef struct dt_iop_flip_geometry_t
+{
+  dt_image_orientation_t orientation;
+} dt_iop_flip_geometry_t;
+
+static void _flip_geometry_map_size(const void *data, const dt_iop_roi_t *const in, dt_iop_roi_t *out)
+{
+  _flip_map_size(((const dt_iop_flip_geometry_t *)data)->orientation, in, out);
+}
+
+static int _flip_geometry_transform(const void *data, const dt_geometry_record_t *const record,
+                                    dt_geometry_chain_t *chain, float *points, size_t points_count)
+{
+  const dt_image_orientation_t orientation = ((const dt_iop_flip_geometry_t *)data)->orientation;
+  for(size_t i = 0; i < points_count * 2; i += 2)
+  {
+    float x = points[i];
+    float y = points[i + 1];
+    if(orientation & ORIENTATION_FLIP_X) x = record->in.width - points[i];
+    if(orientation & ORIENTATION_FLIP_Y) y = record->in.height - points[i + 1];
+    if(orientation & ORIENTATION_SWAP_XY)
+    {
+      const float yy = y;
+      y = x;
+      x = yy;
+    }
+    points[i] = x;
+    points[i + 1] = y;
+  }
+  return 1;
+}
+
+static int _flip_geometry_backtransform(const void *data, const dt_geometry_record_t *const record,
+                                        dt_geometry_chain_t *chain, float *points, size_t points_count)
+{
+  const dt_image_orientation_t orientation = ((const dt_iop_flip_geometry_t *)data)->orientation;
+  for(size_t i = 0; i < points_count * 2; i += 2)
+  {
+    float x = points[i];
+    float y = points[i + 1];
+    if(orientation & ORIENTATION_SWAP_XY)
+    {
+      const float yy = y;
+      y = x;
+      x = yy;
+    }
+    if(orientation & ORIENTATION_FLIP_X) x = record->in.width - x;
+    if(orientation & ORIENTATION_FLIP_Y) y = record->in.height - y;
+    points[i] = x;
+    points[i + 1] = y;
+  }
+  return 1;
+}
+
+static const dt_geometry_vtable_t _flip_geometry_vtable = {
+  .map_size = _flip_geometry_map_size,
+  .transform = _flip_geometry_transform,
+  .backtransform = _flip_geometry_backtransform,
+};
+
+gboolean geometry_record(dt_iop_module_t *self, dt_geometry_record_t *record)
+{
+  const dt_image_orientation_t orientation
+      = _flip_resolve(self, (const dt_iop_flip_params_t *)self->params);
+
+  /* ORIENTATION_NONE is how commit_params() clears piece->enabled: an enabled flip module whose
+   * resolved orientation is a no-op contributes nothing to the pipe, and must contribute nothing
+   * here either. Published (so the roster is satisfied) with no vtable, which the chain reads as
+   * identity -- the same thing a disabled piece is. */
+  if(orientation == ORIENTATION_NONE) return TRUE;
+
+  dt_iop_flip_geometry_t *data = (dt_iop_flip_geometry_t *)g_malloc0(sizeof(dt_iop_flip_geometry_t));
+  if(IS_NULL_PTR(data)) return FALSE;
+  data->orientation = orientation;
+
+  record->data = data;
+  record->free_data = dt_free_gpointer;
+  record->vtable = &_flip_geometry_vtable;
+  return TRUE;
 }
 
 void init_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)

--- a/src/iop/flip.c
+++ b/src/iop/flip.c
@@ -518,10 +518,10 @@ static const dt_geometry_vtable_t _flip_geometry_vtable = {
   .backtransform = _flip_geometry_backtransform,
 };
 
-gboolean geometry_record(dt_iop_module_t *self, dt_geometry_record_t *record)
+gboolean geometry_record(dt_iop_module_t *self, const void *params, dt_geometry_record_t *record)
 {
   const dt_image_orientation_t orientation
-      = _flip_resolve(self, (const dt_iop_flip_params_t *)self->params);
+      = _flip_resolve(self, (const dt_iop_flip_params_t *)params);
 
   /* ORIENTATION_NONE is how commit_params() clears piece->enabled: an enabled flip module whose
    * resolved orientation is a no-op contributes nothing to the pipe, and must contribute nothing

--- a/src/iop/graduatednd.c
+++ b/src/iop/graduatednd.c
@@ -291,7 +291,7 @@ static int set_grad_from_points(struct dt_iop_module_t *self, const grad_point_t
   // we want absolute preview positions
   float pts[4] = { a->x, a->y, b->x, b->y };
   dt_dev_coordinates_image_norm_to_image_abs(self->dev, pts, 2);
-  dt_dev_distort_backtransform_plus(self->dev->virtual_pipe, self->iop_order, DT_DEV_TRANSFORM_DIR_FORW_EXCL, pts, 2);
+  dt_dev_distort_backtransform_gui(self->dev, self->iop_order, DT_DEV_TRANSFORM_DIR_FORW_EXCL, pts, 2);
   dt_dev_pixelpipe_iop_t *piece = dt_dev_distort_get_iop_pipe(self->dev->virtual_pipe, self);
   pts[0] /= (float)piece->buf_out.width;
   pts[2] /= (float)piece->buf_out.width;
@@ -389,7 +389,7 @@ static int set_points_from_grad(struct dt_iop_module_t *self, grad_point_t *a, g
   }
   // now we want that points to take care of distort modules
 
-  if(!dt_dev_distort_transform_plus(self->dev->virtual_pipe, self->iop_order, DT_DEV_TRANSFORM_DIR_FORW_EXCL, pts, 2))
+  if(!dt_dev_distort_transform_gui(self->dev, self->iop_order, DT_DEV_TRANSFORM_DIR_FORW_EXCL, pts, 2))
     return 0;
   dt_dev_coordinates_image_abs_to_image_norm(self->dev, pts, 2);
   a->x = pts[0];

--- a/src/iop/graduatednd.c
+++ b/src/iop/graduatednd.c
@@ -292,11 +292,12 @@ static int set_grad_from_points(struct dt_iop_module_t *self, const grad_point_t
   float pts[4] = { a->x, a->y, b->x, b->y };
   dt_dev_coordinates_image_norm_to_image_abs(self->dev, pts, 2);
   dt_dev_distort_backtransform_gui(self->dev, self->iop_order, DT_DEV_TRANSFORM_DIR_FORW_EXCL, pts, 2);
-  dt_dev_pixelpipe_iop_t *piece = dt_dev_distort_get_iop_pipe(self->dev->virtual_pipe, self);
-  pts[0] /= (float)piece->buf_out.width;
-  pts[2] /= (float)piece->buf_out.width;
-  pts[1] /= (float)piece->buf_out.height;
-  pts[3] /= (float)piece->buf_out.height;
+  dt_iop_roi_t mod_out;
+  if(!dt_dev_module_geometry_gui(self->dev, self, NULL, &mod_out)) return 0;
+  pts[0] /= (float)mod_out.width;
+  pts[2] /= (float)mod_out.width;
+  pts[1] /= (float)mod_out.height;
+  pts[3] /= (float)mod_out.height;
 
   // directly compute the line angle from segment AB and keep one representative modulo PI
   const float eps = .0001f;
@@ -326,9 +327,9 @@ static int set_points_from_grad(struct dt_iop_module_t *self, grad_point_t *a, g
   const float eps = 1e-6f;
   dt_boundingbox_t pts;
 
-  dt_dev_pixelpipe_iop_t *piece = dt_dev_distort_get_iop_pipe(self->dev->virtual_pipe, self);
-  if(IS_NULL_PTR(piece)) return 0;
-  float wp = piece->buf_out.width, hp = piece->buf_out.height;
+  dt_iop_roi_t mod_out;
+  if(!dt_dev_module_geometry_gui(self->dev, self, NULL, &mod_out)) return 0;
+  float wp = mod_out.width, hp = mod_out.height;
 
   const float off = offset / 100.0f;
 

--- a/src/iop/iop_api.h
+++ b/src/iop/iop_api.h
@@ -204,13 +204,20 @@ DEFAULT(gboolean, runtime_data_hash, struct dt_iop_module_t *self, struct dt_dev
  *  pixel-less virtual pipe -- see doc/geometry-service.md).
  *
  *  Fill @p record's vtable/data and return TRUE; return FALSE (the default) for a module that
- *  does not change geometry. Called on the GUI thread, after params are committed.
+ *  does not change geometry. Called on the GUI thread.
+ *
+ *  @p params is THE SAME BLOB commit_params() is handed for this module -- resolved from the
+ *  history stack, or the module's defaults where the pipe would use those. It is not
+ *  self->params: those are the GUI thread's live values, and dt_dev_add_history_item() is
+ *  throttled, so between an edit and its commit they describe a geometry the pipes are not
+ *  rendering. Read this argument, exactly as commit_params() reads its own.
  *
  *  THE ONE-CONSTRUCTOR RULE: whatever commit_params() derives for geometry and whatever the
  *  record carries must come from ONE shared helper, and the record's evaluators must be the
  *  same code distort_transform()/modify_roi_out() run. Two derivations of the same geometry
  *  drift, and the drift surfaces as an overlay that no longer sits on what it describes. */
-OPTIONAL(gboolean, geometry_record, struct dt_iop_module_t *self, struct dt_geometry_record_t *record);
+OPTIONAL(gboolean, geometry_record, struct dt_iop_module_t *self, const void *params,
+                                    struct dt_geometry_record_t *record);
 
 /** called after the image has changed in darkroom */
 OPTIONAL(void, change_image, struct dt_iop_module_t *self);

--- a/src/iop/iop_api.h
+++ b/src/iop/iop_api.h
@@ -200,8 +200,8 @@ DEFAULT(gboolean, has_defaults, struct dt_iop_module_t *self);
 DEFAULT(gboolean, runtime_data_hash, struct dt_iop_module_t *self, struct dt_dev_pixelpipe_t *pipe,
                                      const struct dt_dev_pixelpipe_iop_t *piece);
 
-/** Publish this module's geometry as data, for develop/geometry (the service replacing the
- *  pixel-less virtual pipe -- see doc/geometry-service.md).
+/** Publish this module's geometry as data, for develop/geometry (the service that replaced the
+ *  GUI's pixel-less clone of the pipeline -- see doc/geometry-service.md).
  *
  *  Fill @p record's vtable/data and return TRUE; return FALSE (the default) for a module that
  *  does not change geometry. Called on the GUI thread.

--- a/src/iop/iop_api.h
+++ b/src/iop/iop_api.h
@@ -58,6 +58,7 @@ struct dt_iop_module_so_t;
 struct dt_iop_module_t;
 struct dt_dev_pixelpipe_t;
 struct dt_dev_pixelpipe_iop_t;
+struct dt_geometry_record_t;
 struct dt_iop_roi_t;
 struct dt_develop_tiling_t;
 struct dt_iop_buffer_dsc_t;
@@ -198,6 +199,18 @@ DEFAULT(gboolean, has_defaults, struct dt_iop_module_t *self);
  *  (dt_colorspaces_conversion_identity()) and hash THAT. */
 DEFAULT(gboolean, runtime_data_hash, struct dt_iop_module_t *self, struct dt_dev_pixelpipe_t *pipe,
                                      const struct dt_dev_pixelpipe_iop_t *piece);
+
+/** Publish this module's geometry as data, for develop/geometry (the service replacing the
+ *  pixel-less virtual pipe -- see doc/geometry-service.md).
+ *
+ *  Fill @p record's vtable/data and return TRUE; return FALSE (the default) for a module that
+ *  does not change geometry. Called on the GUI thread, after params are committed.
+ *
+ *  THE ONE-CONSTRUCTOR RULE: whatever commit_params() derives for geometry and whatever the
+ *  record carries must come from ONE shared helper, and the record's evaluators must be the
+ *  same code distort_transform()/modify_roi_out() run. Two derivations of the same geometry
+ *  drift, and the drift surfaces as an overlay that no longer sits on what it describes. */
+OPTIONAL(gboolean, geometry_record, struct dt_iop_module_t *self, struct dt_geometry_record_t *record);
 
 /** called after the image has changed in darkroom */
 OPTIONAL(void, change_image, struct dt_iop_module_t *self);

--- a/src/iop/lens.cc
+++ b/src/iop/lens.cc
@@ -2668,26 +2668,16 @@ void gui_update(struct dt_iop_module_t *self)
   // Which corrections are actually available/applied only depends on the current camera+lens+params
   // combo, not on process() having just run -- so don't gate the label on the pixel pipe having
   // (re)executed (it may not: a pixelpipe cache hit skips process() entirely, e.g. after undo/redo
-  // to a recently-rendered history state, leaving the label blank forever otherwise). commit_params()
-  // already wrote this exact lensfun data into the synced piece regardless of that; read it back the
-  // same GUI-thread-safe way ashift reads piece->buf_in from the virtual pipe.
+  // to a recently-rendered history state, leaving the label blank forever otherwise).
   /* The geometry record IS this data -- geometry_record() builds it with the same constructor
-   * commit_params() uses -- so ask the service for it, and the synced piece only while the
-   * service cannot answer. This is the one consumer in the migration that wants a module's
-   * committed state rather than a rectangle. */
+   * commit_params() uses -- so ask the service for it. This is the one consumer in the migration
+   * that wants a module's committed state rather than a rectangle. */
   const dt_iop_lensfun_data_t *lens_d = NULL;
   const dt_geometry_record_t *const lens_record
       = dt_geometry_chain_find(self->dev->geometry_chain, self->op, self->multi_priority);
   if(dt_geometry_chain_authoritative(self->dev->geometry_chain) && !IS_NULL_PTR(lens_record)
      && !IS_NULL_PTR(lens_record->data))
     lens_d = &((const dt_iop_lens_geometry_t *)lens_record->data)->data;
-  else
-  {
-    dt_dev_virtual_pipe_ensure_synced(self->dev);
-    const dt_dev_pixelpipe_iop_t *const lens_piece
-        = dt_dev_distort_get_iop_pipe(self->dev->virtual_pipe, self);
-    if(!IS_NULL_PTR(lens_piece)) lens_d = (const dt_iop_lensfun_data_t *)lens_piece->data;
-  }
 
   dt_iop_roi_t lens_in;
   const gboolean have_dims = dt_dev_module_geometry_gui(self->dev, self, &lens_in, NULL);

--- a/src/iop/lens.cc
+++ b/src/iop/lens.cc
@@ -2671,16 +2671,33 @@ void gui_update(struct dt_iop_module_t *self)
   // to a recently-rendered history state, leaving the label blank forever otherwise). commit_params()
   // already wrote this exact lensfun data into the synced piece regardless of that; read it back the
   // same GUI-thread-safe way ashift reads piece->buf_in from the virtual pipe.
-  const dt_dev_pixelpipe_iop_t *lens_piece = dt_dev_distort_get_iop_pipe(self->dev->virtual_pipe, self);
-  const dt_iop_lensfun_data_t *lens_d
-      = (!IS_NULL_PTR(lens_piece)) ? (const dt_iop_lensfun_data_t *)lens_piece->data : NULL;
+  /* The geometry record IS this data -- geometry_record() builds it with the same constructor
+   * commit_params() uses -- so ask the service for it, and the synced piece only while the
+   * service cannot answer. This is the one consumer in the migration that wants a module's
+   * committed state rather than a rectangle. */
+  const dt_iop_lensfun_data_t *lens_d = NULL;
+  const dt_geometry_record_t *const lens_record
+      = dt_geometry_chain_find(self->dev->geometry_chain, self->op, self->multi_priority);
+  if(dt_geometry_chain_authoritative(self->dev->geometry_chain) && !IS_NULL_PTR(lens_record)
+     && !IS_NULL_PTR(lens_record->data))
+    lens_d = &((const dt_iop_lens_geometry_t *)lens_record->data)->data;
+  else
+  {
+    const dt_dev_pixelpipe_iop_t *const lens_piece
+        = dt_dev_distort_get_iop_pipe(self->dev->virtual_pipe, self);
+    if(!IS_NULL_PTR(lens_piece)) lens_d = (const dt_iop_lensfun_data_t *)lens_piece->data;
+  }
+
+  dt_iop_roi_t lens_in;
+  const gboolean have_dims = dt_dev_module_geometry_gui(self->dev, self, &lens_in, NULL);
+
   if(!IS_NULL_PTR(lens_d) && !IS_NULL_PTR(lens_d->lens) && !IS_NULL_PTR(lens_d->lens->Maker) && lens_d->crop > 0.0f
-     && lens_piece->buf_in.width > 0 && lens_piece->buf_in.height > 0)
+     && have_dims && lens_in.width > 0 && lens_in.height > 0)
   {
     const gboolean raw_monochrome = dt_image_is_monochrome(&self->dev->image_storage);
     const int used_lf_mask = raw_monochrome ? (LF_MODIFY_ALL & ~LF_MODIFY_TCA) : LF_MODIFY_ALL;
     int modflags = 0;
-    lfModifier *modifier = get_modifier(&modflags, lens_piece->buf_in.width, lens_piece->buf_in.height,
+    lfModifier *modifier = get_modifier(&modflags, lens_in.width, lens_in.height,
                                         lens_d, used_lf_mask, FALSE);
     delete modifier;
 

--- a/src/iop/lens.cc
+++ b/src/iop/lens.cc
@@ -103,6 +103,8 @@
 #include "widgets/widget_style.h"
 #include "control/signal.h"
 
+#include "develop/geometry/geometry.h"
+
 extern "C" {
 
 #if LF_VERSION < ((0 << 24) | (2 << 16) | (9 << 8) | 0)
@@ -1175,28 +1177,41 @@ void modify_roi_in(struct dt_iop_module_t *self, const struct dt_dev_pixelpipe_t
   delete modifier;
 }
 
-void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pixelpipe_t *pipe,
-                   dt_dev_pixelpipe_iop_t *piece)
+/* --- the shared geometry core ----------------------------------------------------------
+ *
+ * lens resolves its effective parameters and then builds a lensfun state out of them, and both
+ * halves are needed twice: once for the pixel pipe, once for the record the geometry service
+ * composes GUI coordinates from (develop/geometry/geometry.h). Expressed once here.
+ *
+ * Note what lens does NOT contribute: modify_roi_out() is the identity, so this module changes
+ * no dimensions. It is on the geometry roster purely for its point transforms.
+ */
+
+/**
+ * @brief Which parameters are actually in force.
+ *
+ * @details p->modified == 0 means "auto": the user never touched the GUI after autodetection,
+ * and the parameters that describe the correction are the module's DEFAULTS, filled in by
+ * reload_defaults() from the image's EXIF -- not the ones in history. A record built from
+ * history alone would describe a correction the pipe is not applying, on exactly the images
+ * where lens correction is automatic, which is most of them.
+ */
+static const dt_iop_lensfun_params_t *_lens_effective_params(dt_iop_module_t *self,
+                                                             const dt_iop_lensfun_params_t *const p)
 {
-  dt_iop_lensfun_params_t *p = (dt_iop_lensfun_params_t *)p1;
+  return (p->modified == 0) ? (const dt_iop_lensfun_params_t *)self->default_params : p;
+}
 
-  // FIXME: this is utter shit and should be made into a GUI "mode".
-  // If p->modified == 0, mode = auto and hide all controls
-  // if p->modidified == 1, mode = manual and show all controls.
-  if(p->modified == 0)
-  {
-    /*
-     * user did not modify anything in gui after autodetection - let's
-     * use current default_params as params - for presets and mass-export
-     */
-    p = (dt_iop_lensfun_params_t *)self->default_params;
-
-    // Temporary fix pending GUI unfucking
-    dt_iop_compute_module_hash(self, self->dev->forms);
-  }
-
-  dt_iop_lensfun_data_t *d = (dt_iop_lensfun_data_t *)piece->data;
-
+/**
+ * @brief Build the lensfun state from resolved parameters. THE constructor.
+ *
+ * @details @p d is zeroed or already owns a lens; either way it owns a fresh deep copy of the
+ * database's lfLens on return, and the caller must delete it (see _lens_free_data() and
+ * cleanup_pipe()). The database lookups take the plugin mutex, as they always have.
+ */
+static void _lens_build_data(dt_iop_module_t *self, const dt_iop_lensfun_params_t *const p,
+                             dt_iop_lensfun_data_t *d)
+{
   dt_iop_lensfun_global_data_t *gd = (dt_iop_lensfun_global_data_t *)self->global_data;
   lfDatabase *dt_iop_lensfun_db = (lfDatabase *)gd->db;
   const lfCamera *camera = NULL;
@@ -1284,8 +1299,120 @@ void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pix
   {
     d->do_nan_checks = FALSE;
   }
+}
+
+/** @brief The lensfun modify mask this image allows: monochrome sensors get no TCA correction. */
+static int _lens_used_mask(dt_iop_module_t *self)
+{
+  return dt_image_is_monochrome(&self->dev->image_storage) ? (LF_MODIFY_ALL & ~LF_MODIFY_TCA)
+                                                           : LF_MODIFY_ALL;
+}
+
+void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pixelpipe_t *pipe,
+                   dt_dev_pixelpipe_iop_t *piece)
+{
+  const dt_iop_lensfun_params_t *p = _lens_effective_params(self, (dt_iop_lensfun_params_t *)p1);
+
+  // FIXME: this is utter shit and should be made into a GUI "mode".
+  // If p->modified == 0, mode = auto and hide all controls
+  // if p->modidified == 1, mode = manual and show all controls.
+  if(((dt_iop_lensfun_params_t *)p1)->modified == 0)
+  {
+    // Temporary fix pending GUI unfucking
+    dt_iop_compute_module_hash(self, self->dev->forms);
+  }
+
+  _lens_build_data(self, p, (dt_iop_lensfun_data_t *)piece->data);
 
   piece->cache_output_on_ram = TRUE;
+}
+
+/* --- the geometry service's view of this module (develop/geometry/geometry.h) ---------
+ *
+ * The one record in the service whose payload is not plain data: evaluating a lens correction
+ * needs a live lfLens, a C++ object with heap-allocated calibration lists, so the record owns a
+ * deep copy and frees it. That is what dt_geometry_record_t::free_data exists for.
+ */
+
+typedef struct dt_iop_lens_geometry_t
+{
+  dt_iop_lensfun_data_t data;   /**< owns its own lfLens, exactly like a pipe piece does */
+  int used_lf_mask;
+} dt_iop_lens_geometry_t;
+
+static void _lens_free_data(void *ptr)
+{
+  dt_iop_lens_geometry_t *g = (dt_iop_lens_geometry_t *)ptr;
+  if(!g) return;
+  if(g->data.lens) delete g->data.lens;
+  free(g);
+}
+
+/** @brief Apply the correction to points. @p inverse selects the direction, as get_modifier()
+ *  means it: distort_transform() passes TRUE, distort_backtransform() passes FALSE. */
+static int _lens_geometry_apply(const void *data, const dt_geometry_record_t *const record,
+                                float *points, size_t points_count, gboolean inverse)
+{
+  const dt_iop_lens_geometry_t *const g = (const dt_iop_lens_geometry_t *)data;
+  const dt_iop_lensfun_data_t *const d = &g->data;
+
+  if(!d->lens || !d->lens->Maker || d->crop <= 0.0f) return 0;
+  if(record->in.width <= 0 || record->in.height <= 0) return 0;
+
+  int modflags = 0;
+  const lfModifier *modifier
+      = get_modifier(&modflags, record->in.width, record->in.height, d, g->used_lf_mask, inverse);
+  if(!modifier) return 0;
+
+  if(modflags & (LF_MODIFY_TCA | LF_MODIFY_DISTORTION | LF_MODIFY_GEOMETRY | LF_MODIFY_SCALE))
+  {
+    for(size_t i = 0; i < points_count * 2; i += 2)
+    {
+      float DT_ALIGNED_ARRAY buf[6];
+      modifier->ApplySubpixelGeometryDistortion(points[i], points[i + 1], 1, 1, buf);
+      // green channel, like distort_transform() and distort_mask() do, so x and y come from the
+      // same colour channel's distortion field instead of mixing red's x with green's y.
+      points[i] = buf[2];
+      points[i + 1] = buf[3];
+    }
+  }
+
+  delete modifier;
+  return 1;
+}
+
+static int _lens_geometry_transform(const void *data, const dt_geometry_record_t *const record,
+                                    dt_geometry_chain_t *chain, float *points, size_t points_count)
+{
+  return _lens_geometry_apply(data, record, points, points_count, TRUE);
+}
+
+static int _lens_geometry_backtransform(const void *data, const dt_geometry_record_t *const record,
+                                        dt_geometry_chain_t *chain, float *points, size_t points_count)
+{
+  return _lens_geometry_apply(data, record, points, points_count, FALSE);
+}
+
+static const dt_geometry_vtable_t _lens_geometry_vtable = {
+  /* .map_size = */ NULL,   // modify_roi_out() is the identity: lens changes no dimensions
+  /* .transform = */ _lens_geometry_transform,
+  /* .backtransform = */ _lens_geometry_backtransform,
+};
+
+gboolean geometry_record(dt_iop_module_t *self, dt_geometry_record_t *record)
+{
+  dt_iop_lens_geometry_t *g = (dt_iop_lens_geometry_t *)calloc(1, sizeof(dt_iop_lens_geometry_t));
+  if(!g) return FALSE;
+
+  const dt_iop_lensfun_params_t *p
+      = _lens_effective_params(self, (const dt_iop_lensfun_params_t *)self->params);
+  _lens_build_data(self, p, &g->data);
+  g->used_lf_mask = _lens_used_mask(self);
+
+  record->data = g;
+  record->free_data = _lens_free_data;
+  record->vtable = &_lens_geometry_vtable;
+  return TRUE;
 }
 
 void init_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)

--- a/src/iop/lens.cc
+++ b/src/iop/lens.cc
@@ -2683,6 +2683,7 @@ void gui_update(struct dt_iop_module_t *self)
     lens_d = &((const dt_iop_lens_geometry_t *)lens_record->data)->data;
   else
   {
+    dt_dev_virtual_pipe_ensure_synced(self->dev);
     const dt_dev_pixelpipe_iop_t *const lens_piece
         = dt_dev_distort_get_iop_pipe(self->dev->virtual_pipe, self);
     if(!IS_NULL_PTR(lens_piece)) lens_d = (const dt_iop_lensfun_data_t *)lens_piece->data;

--- a/src/iop/lens.cc
+++ b/src/iop/lens.cc
@@ -1399,13 +1399,13 @@ static const dt_geometry_vtable_t _lens_geometry_vtable = {
   /* .backtransform = */ _lens_geometry_backtransform,
 };
 
-gboolean geometry_record(dt_iop_module_t *self, dt_geometry_record_t *record)
+gboolean geometry_record(dt_iop_module_t *self, const void *params, dt_geometry_record_t *record)
 {
   dt_iop_lens_geometry_t *g = (dt_iop_lens_geometry_t *)calloc(1, sizeof(dt_iop_lens_geometry_t));
   if(!g) return FALSE;
 
   const dt_iop_lensfun_params_t *p
-      = _lens_effective_params(self, (const dt_iop_lensfun_params_t *)self->params);
+      = _lens_effective_params(self, (const dt_iop_lensfun_params_t *)params);
   _lens_build_data(self, p, &g->data);
   g->used_lf_mask = _lens_used_mask(self);
 

--- a/src/iop/liquify.c
+++ b/src/iop/liquify.c
@@ -3026,9 +3026,9 @@ static void get_point_scale(struct dt_iop_module_t *module, float x, float y, fl
   float pts[2] = { (float)x, (float)y };
   dt_dev_coordinates_widget_to_image_norm(module->dev, pts, 1);
   dt_dev_coordinates_image_norm_to_image_abs(module->dev, pts, 1);
-  dt_dev_distort_backtransform_plus(module->dev->virtual_pipe,
+  dt_dev_distort_backtransform_gui(module->dev,
                                     module->iop_order,DT_DEV_TRANSFORM_DIR_FORW_EXCL, pts, 1);
-  dt_dev_distort_backtransform_plus(module->dev->virtual_pipe,
+  dt_dev_distort_backtransform_gui(module->dev,
                                     module->iop_order,DT_DEV_TRANSFORM_DIR_BACK_EXCL, pts, 1);
 
   *scale = get_zoom_scale(module->dev);

--- a/src/iop/liquify.c
+++ b/src/iop/liquify.c
@@ -2966,10 +2966,16 @@ void gui_post_expose(struct dt_iop_module_t *module,
   memcpy(&copy_params, &g->params, sizeof(dt_iop_liquify_params_t));
   dt_iop_gui_leave_critical_section(module);
 
-  // distort all points
-  if(dt_dev_pixelpipe_get_history_hash(develop->virtual_pipe) != dt_dev_get_history_hash(develop))
-    dt_dev_pixelpipe_sync_virtual(develop, DT_DEV_PIPE_TOP_CHANGED);
-  const distort_params_t d_params = { develop, develop->virtual_pipe, NULL, 1.0, 1.0, DT_DEV_TRANSFORM_DIR_ALL, FALSE };
+  /* Distort all points, through the geometry service. Nothing is resynchronised first: the
+   * chain is rebuilt wherever a pipe flag is raised, and this fold excludes the module itself
+   * (BACK_EXCL then FORW_EXCL), so the live params being dragged are not what it reads. If the
+   * chain cannot answer, its compose leaves the points in RAW coordinates -- which would draw
+   * the whole path in the wrong place -- so draw nothing instead. */
+  if(!dt_geometry_chain_authoritative(develop->geometry_chain))
+    return;
+
+  const distort_params_t d_params = { develop, NULL, develop->geometry_chain, 1.0, 1.0,
+                                      DT_DEV_TRANSFORM_DIR_ALL, FALSE };
   _distort_paths(module, &d_params, &copy_params);
 
   // You're not supposed to understand this

--- a/src/iop/liquify.c
+++ b/src/iop/liquify.c
@@ -60,6 +60,7 @@
 #include "common/collection.h"
 #include "common/conf.h"
 #include "control/control.h"
+#include "develop/geometry/geometry.h"
 #include "develop/imageop.h"
 #include "develop/imageop_gui.h"
 #include "develop/develop.h"
@@ -560,10 +561,23 @@ static void path_delete(dt_iop_liquify_params_t *p, dt_liquify_path_data_t *this
  *
  */
 
+/** @brief What the geometry service's record carries: the parameters, and the module whose
+ *  iop_order bounds the nested composition. */
+typedef struct
+{
+  dt_iop_liquify_params_t params;
+  dt_iop_module_t *self;
+} dt_iop_liquify_geometry_t;
+
 typedef struct
 {
   dt_develop_t *develop;
   const dt_dev_pixelpipe_t *pipe;
+  /* When set, compose through the geometry service instead of a pixel pipe. Exactly one of
+   * `pipe' and `chain' is used: the pipe when a piece is being processed, the chain when the
+   * GUI asks the pixel-less service (develop/geometry/geometry.h). The paths are the same
+   * fold in both cases -- see _distort_paths(). */
+  dt_geometry_chain_t *chain;
   float from_scale;
   float to_scale;
   int transf_direction;
@@ -629,7 +643,21 @@ static void _distort_paths(const struct dt_iop_module_t *module,
       break;
     }
   }
-  if(params->from_distort_transform)
+  if(!IS_NULL_PTR(params->chain))
+  {
+    /* The geometry service's equivalent of the two branches below. The bound is the caller's
+     * own iop_order, exclusive, so this module is not re-entered and the recursion ends. */
+    if(params->transf_direction == DT_DEV_TRANSFORM_DIR_ALL)
+    {
+      dt_geometry_chain_compose(params->chain, module->iop_order, DT_DEV_TRANSFORM_DIR_BACK_EXCL, buffer,
+                                len);
+      dt_geometry_chain_compose(params->chain, module->iop_order, DT_DEV_TRANSFORM_DIR_FORW_EXCL, buffer,
+                                len);
+    }
+    else
+      dt_geometry_chain_compose(params->chain, module->iop_order, params->transf_direction, buffer, len);
+  }
+  else if(params->from_distort_transform)
   {
     if(params->transf_direction == DT_DEV_TRANSFORM_DIR_ALL)
     {
@@ -694,7 +722,17 @@ static void distort_paths_raw_to_piece(const struct dt_iop_module_t *module,
                                         dt_iop_liquify_params_t *p,
                                         const gboolean from_distort_transform)
 {
-  const distort_params_t params = { module->dev, pipe, 1.f, roi_in_scale, DT_DEV_TRANSFORM_DIR_BACK_EXCL, from_distort_transform };
+  const distort_params_t params = { module->dev, pipe, NULL, 1.f, roi_in_scale, DT_DEV_TRANSFORM_DIR_BACK_EXCL, from_distort_transform };
+  _distort_paths(module, &params, p);
+}
+
+/** @brief distort_paths_raw_to_piece() for the geometry service: same fold, no pipe. */
+static void distort_paths_raw_to_piece_chain(const struct dt_iop_module_t *module,
+                                             dt_geometry_chain_t *chain, const float roi_in_scale,
+                                             dt_iop_liquify_params_t *p)
+{
+  const distort_params_t params = { module->dev, NULL, chain, 1.f, roi_in_scale,
+                                    DT_DEV_TRANSFORM_DIR_BACK_EXCL, TRUE };
   _distort_paths(module, &params, p);
 }
 
@@ -1366,10 +1404,20 @@ void modify_roi_in(struct dt_iop_module_t *module, const struct dt_dev_pixelpipe
   cairo_region_destroy(roi_in_region);
 }
 
-static int _distort_xtransform(dt_iop_module_t *self, const dt_dev_pixelpipe_t *pipe,
-                               const dt_dev_pixelpipe_iop_t *piece,
-                               float *const restrict points, const size_t points_count,
-                               const gboolean inverted)
+/**
+ * @brief Warp @p points, given this module's parameters brought into its own input space.
+ *
+ * @details The whole of the transform, minus where the parameters come from and minus how the
+ * path nodes are composed out of RAW coordinates. Those two are the caller's: the pixel pipe
+ * takes them from a piece and folds through the pipe, the geometry service takes them from a
+ * record and folds through the chain. Everything after that -- interpolating the paths,
+ * rasterising the warp map over the points' extent, inverting it for the forward direction --
+ * is the same code either way, which is the point.
+ */
+static int _liquify_warp_points(const dt_iop_liquify_params_t *const params_in,
+                                dt_iop_module_t *self, const dt_dev_pixelpipe_t *pipe,
+                                dt_geometry_chain_t *chain, float *const restrict points,
+                                const size_t points_count, const gboolean inverted)
 {
 
   // compute the extent of all points (all computations are done in RAW coordinate)
@@ -1392,9 +1440,12 @@ static int _distort_xtransform(dt_iop_module_t *self, const dt_dev_pixelpipe_t *
   {
     // copy params
     dt_iop_liquify_params_t copy_params;
-    memcpy(&copy_params, (dt_iop_liquify_params_t *)piece->data, sizeof(dt_iop_liquify_params_t));
+    memcpy(&copy_params, params_in, sizeof(dt_iop_liquify_params_t));
 
-    distort_paths_raw_to_piece(self, pipe, 1.f, &copy_params, TRUE);
+    if(!IS_NULL_PTR(chain))
+      distort_paths_raw_to_piece_chain(self, chain, 1.f, &copy_params);
+    else
+      distort_paths_raw_to_piece(self, pipe, 1.f, &copy_params, TRUE);
 
     // create the distortion map for this extent
 
@@ -1463,13 +1514,69 @@ int distort_transform(dt_iop_module_t *self, const dt_dev_pixelpipe_t *pipe, con
 {
   // Recurse on the caller pipe so we reuse the same node list and piece data in preview, export,
   // thumbnail, and mask evaluation paths.
-  return _distort_xtransform(self, pipe, piece, points, points_count, TRUE);
+  return _liquify_warp_points((const dt_iop_liquify_params_t *)piece->data, self, pipe, NULL, points,
+                              points_count, TRUE);
 }
 
 int distort_backtransform(dt_iop_module_t *self, const dt_dev_pixelpipe_t *pipe, const dt_dev_pixelpipe_iop_t *piece,
                           float *const restrict points, size_t points_count)
 {
-  return _distort_xtransform(self, pipe, piece, points, points_count, FALSE);
+  return _liquify_warp_points((const dt_iop_liquify_params_t *)piece->data, self, pipe, NULL, points,
+                              points_count, FALSE);
+}
+
+/* --- the geometry service's view of this module (develop/geometry/geometry.h) ---------
+ *
+ * modify_roi_out() is the identity, so there is no size map: liquify moves pixels without
+ * changing how many there are. What it does need is the one thing no other record needs -- the
+ * chain composed around it. Its warps are stored in RAW sensor coordinates, so before it can
+ * rasterise anything it has to push its own path nodes through every module upstream of itself,
+ * which on the pixel pipe means re-entering the pipe walker mid-walk and here means re-entering
+ * the chain (dt_geometry_chain_compose(), bounded BACK_EXCL of this module's own iop_order so
+ * the recursion terminates).
+ *
+ * The cost is inherited, not introduced: each query rasterises a warp map over the extent of
+ * the points it was given, so it is O(area), not O(points), exactly as the pipe's own
+ * distort_transform() has always been.
+ */
+
+static int _liquify_geometry_transform(const void *data, const dt_geometry_record_t *const record,
+                                       dt_geometry_chain_t *chain, float *points, size_t points_count)
+{
+  const dt_iop_liquify_geometry_t *const g = (const dt_iop_liquify_geometry_t *)data;
+  return _liquify_warp_points(&g->params, g->self, NULL, chain, points, points_count, TRUE);
+}
+
+static int _liquify_geometry_backtransform(const void *data, const dt_geometry_record_t *const record,
+                                           dt_geometry_chain_t *chain, float *points, size_t points_count)
+{
+  const dt_iop_liquify_geometry_t *const g = (const dt_iop_liquify_geometry_t *)data;
+  return _liquify_warp_points(&g->params, g->self, NULL, chain, points, points_count, FALSE);
+}
+
+static const dt_geometry_vtable_t _liquify_geometry_vtable = {
+  .map_size = NULL,   // modify_roi_out() is the identity: liquify changes no dimensions
+  .transform = _liquify_geometry_transform,
+  .backtransform = _liquify_geometry_backtransform,
+};
+
+gboolean geometry_record(struct dt_iop_module_t *self, const void *params, dt_geometry_record_t *record)
+{
+  dt_iop_liquify_geometry_t *g
+      = (dt_iop_liquify_geometry_t *)g_malloc0(sizeof(dt_iop_liquify_geometry_t));
+  if(IS_NULL_PTR(g)) return FALSE;
+
+  /* commit_params() is a straight copy of the parameters, so the record carries that copy. The
+   * module pointer is kept because the fold needs its iop_order to bound the recursion and its
+   * dev to reach the paths; it is the same module the chain is being built from, so it cannot
+   * outlive the record. */
+  memcpy(&g->params, params, sizeof(dt_iop_liquify_params_t));
+  g->self = self;
+
+  record->data = g;
+  record->free_data = dt_free_gpointer;
+  record->vtable = &_liquify_geometry_vtable;
+  return TRUE;
 }
 
 void distort_mask(struct dt_iop_module_t *self, const struct dt_dev_pixelpipe_t *pipe, struct dt_dev_pixelpipe_iop_t *piece,
@@ -2862,7 +2969,7 @@ void gui_post_expose(struct dt_iop_module_t *module,
   // distort all points
   if(dt_dev_pixelpipe_get_history_hash(develop->virtual_pipe) != dt_dev_get_history_hash(develop))
     dt_dev_pixelpipe_sync_virtual(develop, DT_DEV_PIPE_TOP_CHANGED);
-  const distort_params_t d_params = { develop, develop->virtual_pipe, 1.0, 1.0, DT_DEV_TRANSFORM_DIR_ALL, FALSE };
+  const distort_params_t d_params = { develop, develop->virtual_pipe, NULL, 1.0, 1.0, DT_DEV_TRANSFORM_DIR_ALL, FALSE };
   _distort_paths(module, &d_params, &copy_params);
 
   // You're not supposed to understand this

--- a/src/iop/rawprepare.c
+++ b/src/iop/rawprepare.c
@@ -998,9 +998,9 @@ static const dt_geometry_vtable_t _rawprepare_geometry_vtable = {
   .backtransform = _rawprepare_geometry_backtransform,
 };
 
-gboolean geometry_record(dt_iop_module_t *self, dt_geometry_record_t *record)
+gboolean geometry_record(dt_iop_module_t *self, const void *params, dt_geometry_record_t *record)
 {
-  const dt_iop_rawprepare_params_t *const p = (const dt_iop_rawprepare_params_t *)self->params;
+  const dt_iop_rawprepare_params_t *const p = (const dt_iop_rawprepare_params_t *)params;
 
   dt_iop_rawprepare_geometry_t *data
       = (dt_iop_rawprepare_geometry_t *)g_malloc0(sizeof(dt_iop_rawprepare_geometry_t));

--- a/src/iop/rawprepare.c
+++ b/src/iop/rawprepare.c
@@ -49,6 +49,7 @@
 #include "common/opencl.h"
 #include "common/imagebuf.h"
 #include "common/image.h"
+#include "develop/geometry/geometry.h"
 #include "develop/imageop.h"
 #include "develop/imageop_gui.h"
 #include "caches/image_cache.h"
@@ -268,6 +269,40 @@ static void _update_output_cfa_descriptor(const dt_dev_pixelpipe_t *pipe,
   }
 }
 
+/* --- the shared geometry core ----------------------------------------------------------
+ *
+ * rawprepare's geometry is the fixed sensor border trim: a translation by the top/left margin,
+ * and an output shrunk by the total margin. Expressed once here for the pipeline callbacks and
+ * for geometry_record() (develop/geometry/geometry.h) alike.
+ */
+
+typedef struct dt_iop_rawprepare_geometry_t
+{
+  int32_t x, y, width, height;   /**< the four crop fields, verbatim from params */
+} dt_iop_rawprepare_geometry_t;
+
+/** @brief The translation the trim applies, at @p scale. */
+static void _rawprepare_offset(const int32_t crop_x, const int32_t crop_y, const double scale, double *dx,
+                               double *dy)
+{
+  *dx = (double)crop_x * scale;
+  *dy = (double)crop_y * scale;
+}
+
+/** @brief Input rect -> output rect, shrunk by the total margin at the input's own scale. */
+static void _rawprepare_map_size(const dt_iop_rawprepare_geometry_t *const g,
+                                 const dt_iop_roi_t *const roi_in, dt_iop_roi_t *roi_out)
+{
+  *roi_out = *roi_in;
+  roi_out->x = roi_out->y = 0;
+
+  const double x = g->x + g->width;
+  const double y = g->y + g->height;
+  const double scale = roi_in->scale;
+  roi_out->width = (int)round((double)roi_out->width - x * scale);
+  roi_out->height = (int)round((double)roi_out->height - y * scale);
+}
+
 int distort_transform(dt_iop_module_t *self, const dt_dev_pixelpipe_t *pipe, const dt_dev_pixelpipe_iop_t *piece,
                       float *const restrict points, size_t points_count)
 {
@@ -278,9 +313,8 @@ int distort_transform(dt_iop_module_t *self, const dt_dev_pixelpipe_t *pipe, con
   // nothing to be done if parameters are set to neutral values (no top/left crop)
   if (d->x == 0 && d->y == 0) return 1;
 
-  const double scale = piece->buf_in.scale;
-  const double x = (double)d->x * scale;
-  const double y = (double)d->y * scale;
+  double x = 0.0, y = 0.0;
+  _rawprepare_offset(d->x, d->y, piece->buf_in.scale, &x, &y);
   __OMP_PARALLEL_FOR_SIMD__(aligned(points:64) if(points_count > 100))
   for(size_t i = 0; i < points_count * 2; i += 2)
   {
@@ -302,9 +336,8 @@ int distort_backtransform(dt_iop_module_t *self, const dt_dev_pixelpipe_t *pipe,
   // nothing to be done if parameters are set to neutral values (no top/left crop)
   if (d->x == 0 && d->y == 0) return 1;
 
-  const double scale = piece->buf_in.scale;
-  const double x = (double)d->x * scale;
-  const double y = (double)d->y * scale;
+  double x = 0.0, y = 0.0;
+  _rawprepare_offset(d->x, d->y, piece->buf_in.scale, &x, &y);
   __OMP_PARALLEL_FOR_SIMD__(aligned(points:64) if(points_count > 100))
   for(size_t i = 0; i < points_count * 2; i += 2)
   {
@@ -332,16 +365,10 @@ void modify_roi_out(dt_iop_module_t *self, const dt_dev_pixelpipe_t *pipe, dt_de
                     dt_iop_roi_t *roi_out,
                     const dt_iop_roi_t *const roi_in)
 {
-  *roi_out = *roi_in;
   dt_iop_rawprepare_data_t *d = (dt_iop_rawprepare_data_t *)piece->data;
 
-  roi_out->x = roi_out->y = 0;
-
-  const double x = d->x + d->width;
-  const double y = d->y + d->height;
-  const double scale = roi_in->scale;
-  roi_out->width = (int)round((double)roi_out->width - x * scale);
-  roi_out->height = (int)round((double)roi_out->height - y * scale);
+  const dt_iop_rawprepare_geometry_t geo = { d->x, d->y, d->width, d->height };
+  _rawprepare_map_size(&geo, roi_in, roi_out);
 
   /* Rawprepare changes the CFA phase according to the effective crop on the current ROI scale.
    * That contract cannot be authored at history resync time because `piece->roi_in` is not known yet.
@@ -924,6 +951,71 @@ void init_pipe(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe
 {
   piece->data = dt_calloc_align(sizeof(dt_iop_rawprepare_data_t));
   piece->data_size = sizeof(dt_iop_rawprepare_data_t);
+}
+
+/* --- the geometry service's view of this module (develop/geometry/geometry.h) --------- */
+
+static void _rawprepare_geometry_map_size(const void *data, const dt_iop_roi_t *const in, dt_iop_roi_t *out)
+{
+  _rawprepare_map_size((const dt_iop_rawprepare_geometry_t *)data, in, out);
+}
+
+static int _rawprepare_geometry_transform(const void *data, const dt_geometry_record_t *const record,
+                                          dt_geometry_chain_t *chain, float *points, size_t points_count)
+{
+  const dt_iop_rawprepare_geometry_t *const g = (const dt_iop_rawprepare_geometry_t *)data;
+  if(g->x == 0 && g->y == 0) return 1;
+
+  double x = 0.0, y = 0.0;
+  _rawprepare_offset(g->x, g->y, record->in.scale, &x, &y);
+  for(size_t i = 0; i < points_count * 2; i += 2)
+  {
+    points[i] -= x;
+    points[i + 1] -= y;
+  }
+  return 1;
+}
+
+static int _rawprepare_geometry_backtransform(const void *data, const dt_geometry_record_t *const record,
+                                              dt_geometry_chain_t *chain, float *points, size_t points_count)
+{
+  const dt_iop_rawprepare_geometry_t *const g = (const dt_iop_rawprepare_geometry_t *)data;
+  if(g->x == 0 && g->y == 0) return 1;
+
+  double x = 0.0, y = 0.0;
+  _rawprepare_offset(g->x, g->y, record->in.scale, &x, &y);
+  for(size_t i = 0; i < points_count * 2; i += 2)
+  {
+    points[i] += x;
+    points[i + 1] += y;
+  }
+  return 1;
+}
+
+static const dt_geometry_vtable_t _rawprepare_geometry_vtable = {
+  .map_size = _rawprepare_geometry_map_size,
+  .transform = _rawprepare_geometry_transform,
+  .backtransform = _rawprepare_geometry_backtransform,
+};
+
+gboolean geometry_record(dt_iop_module_t *self, dt_geometry_record_t *record)
+{
+  const dt_iop_rawprepare_params_t *const p = (const dt_iop_rawprepare_params_t *)self->params;
+
+  dt_iop_rawprepare_geometry_t *data
+      = (dt_iop_rawprepare_geometry_t *)g_malloc0(sizeof(dt_iop_rawprepare_geometry_t));
+  if(IS_NULL_PTR(data)) return FALSE;
+
+  /* commit_params() copies these four verbatim; nothing else about them is derived. */
+  data->x = p->x;
+  data->y = p->y;
+  data->width = p->width;
+  data->height = p->height;
+
+  record->data = data;
+  record->free_data = dt_free_gpointer;
+  record->vtable = &_rawprepare_geometry_vtable;
+  return TRUE;
 }
 
 void cleanup_pipe(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)

--- a/src/iop/rotatepixels.c
+++ b/src/iop/rotatepixels.c
@@ -40,6 +40,7 @@
 #include "pixel/interpolation.h"
 #include "math/math.h"
 #include "develop/develop.h"
+#include "develop/geometry/geometry.h"
 #include "develop/imageop.h"
 #include "iop/iop_api.h"
 
@@ -116,12 +117,17 @@ const char **description(struct dt_iop_module_t *self)
 }
 
 
+/* --- the shared geometry core ----------------------------------------------------------
+ *
+ * These take the committed data rather than a pipeline piece, so the pixel pipe's distort
+ * callbacks and the geometry service's record (develop/geometry/geometry.h) run the same
+ * arithmetic instead of two copies of it.
+ */
+
 __OMP_DECLARE_SIMD__()
-static void transform(const dt_dev_pixelpipe_iop_t *const piece, const float scale, const float *const x,
+static void transform(const dt_iop_rotatepixels_data_t *const d, const float scale, const float *const x,
                       float *o)
 {
-  dt_iop_rotatepixels_data_t *d = (dt_iop_rotatepixels_data_t *)piece->data;
-
   float pi[2] = { x[0] - d->rx * scale, x[1] - d->ry * scale };
 
   mul_mat_vec_2(d->m, pi, o);
@@ -129,16 +135,43 @@ static void transform(const dt_dev_pixelpipe_iop_t *const piece, const float sca
 
 
 __OMP_DECLARE_SIMD__()
-static void backtransform(const dt_dev_pixelpipe_iop_t *const piece, const float scale, const float *const x,
+static void backtransform(const dt_iop_rotatepixels_data_t *const d, const float scale, const float *const x,
                           float *o)
 {
-  dt_iop_rotatepixels_data_t *d = (dt_iop_rotatepixels_data_t *)piece->data;
-
   float rt[] = { d->m[0], -d->m[1], -d->m[2], d->m[3] };
   mul_mat_vec_2(rt, x, o);
 
   o[0] += d->rx * scale;
   o[1] += d->ry * scale;
+}
+
+/**
+ * @brief Input rect -> output rect: the inner rectangle of the 45-degree rotation.
+ *
+ * @details NOTE the non-parameter input: the output size depends on the user's interpolator
+ * preference, because the margin this trims is the interpolation kernel's width. A record
+ * captures it at publish time, which is correct as long as changing that preference
+ * re-publishes -- it forces a pipeline rebuild, which republishes the geometry.
+ */
+static void _rotatepixels_map_size(const dt_iop_rotatepixels_data_t *const d,
+                                   const dt_iop_roi_t *const roi_in, dt_iop_roi_t *roi_out)
+{
+  *roi_out = *roi_in;
+
+  const float scale = roi_in->scale;
+  const float T = (float)d->ry * scale;
+
+  const float y = sqrtf(2.0f * T * T),
+              x = sqrtf(2.0f * ((float)roi_in->width - T) * ((float)roi_in->width - T));
+
+  const struct dt_interpolation *interpolation = dt_interpolation_new(DT_INTERPOLATION_USERPREF);
+  const float IW = (float)interpolation->width * scale;
+
+  roi_out->width = y - IW;
+  roi_out->height = x - IW;
+
+  roi_out->width = MAX(0, roi_out->width & ~1);
+  roi_out->height = MAX(0, roi_out->height & ~1);
 }
 
 int distort_transform(dt_iop_module_t *self, const dt_dev_pixelpipe_t *pipe, const dt_dev_pixelpipe_iop_t *piece,
@@ -153,7 +186,7 @@ int distort_transform(dt_iop_module_t *self, const dt_dev_pixelpipe_t *pipe, con
     pi[0] = points[i];
     pi[1] = points[i + 1];
 
-    transform(piece, scale, pi, po);
+    transform((const dt_iop_rotatepixels_data_t *)piece->data, scale, pi, po);
 
     points[i] = po[0];
     points[i + 1] = po[1];
@@ -174,7 +207,7 @@ int distort_backtransform(dt_iop_module_t *self, const dt_dev_pixelpipe_t *pipe,
     pi[0] = points[i];
     pi[1] = points[i + 1];
 
-    backtransform(piece, scale, pi, po);
+    backtransform((const dt_iop_rotatepixels_data_t *)piece->data, scale, pi, po);
 
     points[i] = po[0];
     points[i + 1] = po[1];
@@ -199,44 +232,7 @@ void modify_roi_out(dt_iop_module_t *self, const dt_dev_pixelpipe_t *pipe, dt_de
                     dt_iop_roi_t *roi_out,
                     const dt_iop_roi_t *const roi_in)
 {
-  dt_iop_rotatepixels_data_t *d = (dt_iop_rotatepixels_data_t *)piece->data;
-
-  *roi_out = *roi_in;
-
-  /*
-   * Think of input image as:
-   * 1. Square, containing:
-   * 3. 4x Right triangles (two pairs), located in the Edges of square
-   * 2. Rectangle (rotated 45 degrees), located in between triangles.
-   *
-   * Therefore, output image dimensions, that are sizes of inner Rectangle
-   * can be found using Pythagorean theorem.
-   *
-   * Not precise pseudographics: (width == height + 1)
-   *         height
-   *     _  -------
-   *     |  |1 /\2|
-   * ty  |  | y  \|
-   *     _  |/   /| width
-   *        |\x / |
-   *        |2\/ 1|
-   *        -------
-   */
-
-  const float scale = roi_in->scale;
-  const float T = (float)d->ry * scale;
-
-  const float y = sqrtf(2.0f * T * T),
-              x = sqrtf(2.0f * ((float)roi_in->width - T) * ((float)roi_in->width - T));
-
-  const struct dt_interpolation *interpolation = dt_interpolation_new(DT_INTERPOLATION_USERPREF);
-  const float IW = (float)interpolation->width * scale;
-
-  roi_out->width = y - IW;
-  roi_out->height = x - IW;
-
-  roi_out->width = MAX(0, roi_out->width & ~1);
-  roi_out->height = MAX(0, roi_out->height & ~1);
+  _rotatepixels_map_size((const dt_iop_rotatepixels_data_t *)piece->data, roi_in, roi_out);
 }
 
 // 2nd pass: which roi would this operation need as input to fill the given output region?
@@ -259,7 +255,7 @@ void modify_roi_in(dt_iop_module_t *self, const dt_dev_pixelpipe_t *pipe, dt_dev
     // get corner points of roi_out
     get_corner(aabb, c, p);
 
-    backtransform(piece, scale, p, o);
+    backtransform((const dt_iop_rotatepixels_data_t *)piece->data, scale, p, o);
 
     // transform to roi_in space, get aabb.
     adjust_aabb(o, aabb_in);
@@ -311,7 +307,7 @@ int process(dt_iop_module_t *self, const dt_dev_pixelpipe_t *pipe, const dt_dev_
       pi[0] = roi_out->x + i;
       pi[1] = roi_out->y + j;
 
-      backtransform(piece, scale, pi, po);
+      backtransform((const dt_iop_rotatepixels_data_t *)piece->data, scale, pi, po);
 
       po[0] -= roi_in->x;
       po[1] -= roi_in->y;
@@ -323,23 +319,96 @@ int process(dt_iop_module_t *self, const dt_dev_pixelpipe_t *pipe, const dt_dev_
   return 0;
 }
 
+/** @brief Params -> committed data. THE constructor, shared with geometry_record(). */
+static void _rotatepixels_resolve(const dt_iop_rotatepixels_params_t *const p,
+                                  dt_iop_rotatepixels_data_t *d)
+{
+  d->rx = p->rx;
+  d->ry = p->ry;
+
+  const float angle = p->angle * M_PI / 180.0f;
+
+  const float rt[] = { cosf(angle), sinf(angle), -sinf(angle), cosf(angle) };
+  for(int k = 0; k < 4; k++) d->m[k] = rt[k];
+}
+
 void commit_params(dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pixelpipe_t *pipe,
                    dt_dev_pixelpipe_iop_t *piece)
 {
   dt_iop_rotatepixels_params_t *p = (dt_iop_rotatepixels_params_t *)p1;
   dt_iop_rotatepixels_data_t *d = (dt_iop_rotatepixels_data_t *)piece->data;
 
-  d->rx = p->rx;
-  d->ry = p->ry;
-
-  const float angle = p->angle * M_PI / 180.0f;
-
-  float rt[] = { cosf(angle), sinf(angle), -sinf(angle), cosf(angle) };
-  for(int k = 0; k < 4; k++) d->m[k] = rt[k];
+  _rotatepixels_resolve(p, d);
 
   // this should not be used for normal images
   // (i.e. for those, when this iop is off by default)
   if((d->rx == 0u) && (d->ry == 0u)) piece->enabled = 0;
+}
+
+/* --- the geometry service's view of this module (develop/geometry/geometry.h) --------- */
+
+static void _rotatepixels_geometry_map_size(const void *data, const dt_iop_roi_t *const in, dt_iop_roi_t *out)
+{
+  _rotatepixels_map_size((const dt_iop_rotatepixels_data_t *)data, in, out);
+}
+
+static int _rotatepixels_geometry_transform(const void *data, const dt_geometry_record_t *const record,
+                                            dt_geometry_chain_t *chain, float *points, size_t points_count)
+{
+  const dt_iop_rotatepixels_data_t *const d = (const dt_iop_rotatepixels_data_t *)data;
+  for(size_t i = 0; i < points_count * 2; i += 2)
+  {
+    const float pi[2] = { points[i], points[i + 1] };
+    float po[2];
+    transform(d, record->in.scale, pi, po);
+    points[i] = po[0];
+    points[i + 1] = po[1];
+  }
+  return 1;
+}
+
+static int _rotatepixels_geometry_backtransform(const void *data, const dt_geometry_record_t *const record,
+                                                dt_geometry_chain_t *chain, float *points,
+                                                size_t points_count)
+{
+  const dt_iop_rotatepixels_data_t *const d = (const dt_iop_rotatepixels_data_t *)data;
+  for(size_t i = 0; i < points_count * 2; i += 2)
+  {
+    const float pi[2] = { points[i], points[i + 1] };
+    float po[2];
+    backtransform(d, record->in.scale, pi, po);
+    points[i] = po[0];
+    points[i + 1] = po[1];
+  }
+  return 1;
+}
+
+static const dt_geometry_vtable_t _rotatepixels_geometry_vtable = {
+  .map_size = _rotatepixels_geometry_map_size,
+  .transform = _rotatepixels_geometry_transform,
+  .backtransform = _rotatepixels_geometry_backtransform,
+};
+
+gboolean geometry_record(dt_iop_module_t *self, const void *params, dt_geometry_record_t *record)
+{
+  dt_iop_rotatepixels_data_t *data
+      = (dt_iop_rotatepixels_data_t *)g_malloc0(sizeof(dt_iop_rotatepixels_data_t));
+  if(IS_NULL_PTR(data)) return FALSE;
+
+  _rotatepixels_resolve((const dt_iop_rotatepixels_params_t *)params, data);
+
+  /* A zero rotation centre is how commit_params() clears piece->enabled: the module is in the
+   * pipe but does nothing. Published with no vtable, which the chain reads as identity. */
+  if(data->rx == 0u && data->ry == 0u)
+  {
+    g_free(data);
+    return TRUE;
+  }
+
+  record->data = data;
+  record->free_data = dt_free_gpointer;
+  record->vtable = &_rotatepixels_geometry_vtable;
+  return TRUE;
 }
 
 void init_pipe(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)

--- a/src/iop/scalepixels.c
+++ b/src/iop/scalepixels.c
@@ -38,6 +38,7 @@
 #include "common/module_versioning.h"
 #include "system/target_clones.h"
 #include "pixel/interpolation.h"
+#include "develop/geometry/geometry.h"
 #include "develop/imageop.h"
 #include "develop/tiling.h"
 
@@ -115,17 +116,44 @@ static void transform(const dt_dev_pixelpipe_iop_t *const piece, float *p)
   }
 }
 
+/**
+ * @brief The axis scales this module applies, from its one parameter. THE constructor.
+ *
+ * @details These used to be obtained by calling modify_roi_in() on a SHALLOW COPY of the piece
+ * with roi_out set to the full input size -- a copy whose `data' pointer still aliased the real
+ * one, so the callback's writes landed in the real piece. Working the algebra through shows the
+ * dimensions cancel and the result is a pure function of the pixel aspect ratio:
+ *
+ *   hw = { H, W } transformed  ->  par < 1 : { H, W/par },  par >= 1 : { H*par, W }
+ *   reduction    = max(hw[0]/H, hw[1]/W)  ->  par < 1 : 1/par,  par >= 1 : par
+ *   both divided by reduction ->  par < 1 : { H*par, W },  par >= 1 : { H, W/par }
+ *   x_scale = width/W, y_scale = height/H
+ *
+ * so x_scale = 1, y_scale = par below one, and x_scale = 1/par, y_scale = 1 at or above it.
+ * Same numbers, no aliased copy, and one place that says what the scaling is -- which is what
+ * the geometry record needs, having no piece to fake.
+ */
+static void _scalepixels_scales(const float pixel_aspect_ratio, float *x_scale, float *y_scale)
+{
+  if(pixel_aspect_ratio < 1.0f)
+  {
+    *x_scale = 1.0f;
+    *y_scale = pixel_aspect_ratio;
+  }
+  else
+  {
+    *x_scale = 1.0f / pixel_aspect_ratio;
+    *y_scale = 1.0f;
+  }
+}
+
 static void precalculate_scale(dt_iop_module_t *self, const dt_dev_pixelpipe_t *pipe,
                                const dt_dev_pixelpipe_iop_t *piece)
 {
-  // Since the scaling is calculated by modify_roi_in use that to get them
-  // This doesn't seem strictly needed but since clipping.c also does it we try
-  // and avoid breaking any assumptions elsewhere in the code
-  dt_dev_pixelpipe_iop_t piece_copy = *piece;
-  dt_iop_roi_t roi_out, roi_in;
-  roi_out.width = piece->buf_in.width;
-  roi_out.height = piece->buf_in.height;
-  self->modify_roi_in(self, pipe, &piece_copy, &roi_out, &roi_in);
+  /* Writes into the piece, as it always has: process() reads these two fields, and the distort
+   * callbacks below deliberately reset them to the full-frame values before using them. */
+  dt_iop_scalepixels_data_t *d = (dt_iop_scalepixels_data_t *)piece->data;
+  _scalepixels_scales(d->pixel_aspect_ratio, &d->x_scale, &d->y_scale);
 }
 
 int distort_transform(dt_iop_module_t *self, const dt_dev_pixelpipe_t *pipe, const dt_dev_pixelpipe_iop_t *piece,
@@ -261,6 +289,84 @@ void commit_params(dt_iop_module_t *self, dt_iop_params_t *params, dt_dev_pixelp
 
   if(isnan(p->pixel_aspect_ratio) || p->pixel_aspect_ratio <= 0.0f || p->pixel_aspect_ratio == 1.0f)
     piece->enabled = 0;
+}
+
+/* --- the geometry service's view of this module (develop/geometry/geometry.h) --------- */
+
+typedef struct dt_iop_scalepixels_geometry_t
+{
+  float x_scale, y_scale;
+} dt_iop_scalepixels_geometry_t;
+
+static void _scalepixels_geometry_map_size(const void *data, const dt_iop_roi_t *const in, dt_iop_roi_t *out)
+{
+  const dt_iop_scalepixels_geometry_t *const g = (const dt_iop_scalepixels_geometry_t *)data;
+  *out = *in;
+
+  /* modify_roi_out() runs the aspect transform on the origin and on the size; expressed through
+   * the scales, that is a division, since transform() maps input to output and the scales are
+   * the input-over-output ratio. */
+  out->x = (int)floorf(in->x / g->x_scale);
+  out->y = (int)floorf(in->y / g->y_scale);
+  out->width = (int)ceilf(in->width / g->x_scale);
+  out->height = (int)ceilf(in->height / g->y_scale);
+
+  // sanity check.
+  if(out->x < 0) out->x = 0;
+  if(out->y < 0) out->y = 0;
+  if(out->width < 1) out->width = 1;
+  if(out->height < 1) out->height = 1;
+}
+
+static int _scalepixels_geometry_transform(const void *data, const dt_geometry_record_t *const record,
+                                           dt_geometry_chain_t *chain, float *points, size_t points_count)
+{
+  const dt_iop_scalepixels_geometry_t *const g = (const dt_iop_scalepixels_geometry_t *)data;
+  for(size_t i = 0; i < points_count * 2; i += 2)
+  {
+    points[i] /= g->x_scale;
+    points[i + 1] /= g->y_scale;
+  }
+  return 1;
+}
+
+static int _scalepixels_geometry_backtransform(const void *data, const dt_geometry_record_t *const record,
+                                               dt_geometry_chain_t *chain, float *points,
+                                               size_t points_count)
+{
+  const dt_iop_scalepixels_geometry_t *const g = (const dt_iop_scalepixels_geometry_t *)data;
+  for(size_t i = 0; i < points_count * 2; i += 2)
+  {
+    points[i] *= g->x_scale;
+    points[i + 1] *= g->y_scale;
+  }
+  return 1;
+}
+
+static const dt_geometry_vtable_t _scalepixels_geometry_vtable = {
+  .map_size = _scalepixels_geometry_map_size,
+  .transform = _scalepixels_geometry_transform,
+  .backtransform = _scalepixels_geometry_backtransform,
+};
+
+gboolean geometry_record(dt_iop_module_t *self, const void *params, dt_geometry_record_t *record)
+{
+  const dt_iop_scalepixels_params_t *const p = (const dt_iop_scalepixels_params_t *)params;
+
+  /* The same disabling condition commit_params() applies: a ratio of one, or a nonsensical one,
+   * means this module does nothing. Published as identity. */
+  if(isnan(p->pixel_aspect_ratio) || p->pixel_aspect_ratio <= 0.0f || p->pixel_aspect_ratio == 1.0f)
+    return TRUE;
+
+  dt_iop_scalepixels_geometry_t *data
+      = (dt_iop_scalepixels_geometry_t *)g_malloc0(sizeof(dt_iop_scalepixels_geometry_t));
+  if(IS_NULL_PTR(data)) return FALSE;
+  _scalepixels_scales(p->pixel_aspect_ratio, &data->x_scale, &data->y_scale);
+
+  record->data = data;
+  record->free_data = dt_free_gpointer;
+  record->vtable = &_scalepixels_geometry_vtable;
+  return TRUE;
 }
 
 void init_pipe(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)

--- a/src/libs/navigation.c
+++ b/src/libs/navigation.c
@@ -48,6 +48,7 @@
 #include "common/module_versioning.h"
 #include "common/times.h"
 #include "control/control.h"
+#include "caches/pixelpipe_cache.h"
 #include "develop/dev_pixelpipe.h"
 #include "develop/develop.h"
 
@@ -277,8 +278,29 @@ static gboolean _lib_navigation_draw_callback(GtkWidget *widget, cairo_t *crf, g
 
     wd = dev->preview_pipe->backbuf.width;
     ht = dev->preview_pipe->backbuf.height;
-    scale = fminf(width / (float)wd, height / (float)ht);
     const int stride = cairo_format_stride_for_width(CAIRO_FORMAT_RGB24, wd);
+
+    /* Can this cacheline hold an image of those dimensions at all?
+     *
+     * The centre view asks the same question before it paints (dt_dev_lock_pipe_surface); this
+     * widget did not, and handed cairo a buffer to walk with a stride computed from a width the
+     * data need not have. When they disagree the thumbnail is striped diagonally, and the read
+     * runs past the allocation whenever the recorded dimensions are the larger pair -- the
+     * buffer and its dimensions are fetched separately here, from state a worker owns and can
+     * republish at a new size in between.
+     *
+     * Keep the previous thumbnail and come back on the next expose rather than draw garbage.
+     * This does not FIX a mismatch -- only the pipe that published it can -- but it stops this
+     * widget turning one into an out-of-bounds read. */
+    const size_t required_size = (size_t)stride * (size_t)ht;
+    if(wd <= 0 || ht <= 0 || dt_pixel_cache_entry_get_size(cache_entry) < required_size
+       || dt_pixel_cache_entry_get_data(cache_entry) != data)
+    {
+      dt_dev_pixelpipe_cache_rdlock_entry(FALSE, cache_entry);
+      return TRUE;
+    }
+
+    scale = fminf(width / (float)wd, height / (float)ht);
     cairo_surface_t *tmp_surface = cairo_image_surface_create_for_data(data, CAIRO_FORMAT_RGB24, wd, ht, stride);
 
     image_hash = dt_dev_backbuf_get_hash(&dev->preview_pipe->backbuf);

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -1968,7 +1968,6 @@ void leave(dt_view_t *self)
   dev->exit = 1;
   dt_atomic_set_int(&dev->pipe->shutdown, TRUE);
   dt_atomic_set_int(&dev->preview_pipe->shutdown, TRUE);
-  if(dev->virtual_pipe) dt_atomic_set_int(&dev->virtual_pipe->shutdown, TRUE);
   dev->pipelines_started = FALSE;
 
   /* dev->exit / the shutdown atomics above are only checked by the darkroom worker thread
@@ -2050,13 +2049,6 @@ void leave(dt_view_t *self)
   dt_dev_set_backbuf(&dev->preview_pipe->backbuf, 0, 0, 0, DT_PIXELPIPE_CACHE_HASH_INVALID,
                      DT_PIXELPIPE_CACHE_HASH_INVALID);
   dt_pthread_mutex_unlock(&dev->preview_pipe->busy_mutex);
-
-  dt_pthread_mutex_lock(&dev->virtual_pipe->busy_mutex);
-  dt_dev_pixelpipe_cleanup_nodes(dev->virtual_pipe);
-  dt_dev_pixelpipe_cache_unref_hash(dt_dev_backbuf_get_hash(&dev->virtual_pipe->backbuf));
-  dt_dev_set_backbuf(&dev->virtual_pipe->backbuf, 0, 0, 0, DT_PIXELPIPE_CACHE_HASH_INVALID,
-                     DT_PIXELPIPE_CACHE_HASH_INVALID);
-  dt_pthread_mutex_unlock(&dev->virtual_pipe->busy_mutex);
 
   /* Device-side cache payloads are only an acceleration layer. Once darkroom
    * leaves, drop the cl_mem objects these pipes produced -- but only on the

--- a/src/views/studio_capture.c
+++ b/src/views/studio_capture.c
@@ -298,7 +298,6 @@ static void _studio_dev_teardown(dt_studio_capture_t *d)
   dev->exit = 1;
   dt_atomic_set_int(&dev->pipe->shutdown, TRUE);
   dt_atomic_set_int(&dev->preview_pipe->shutdown, TRUE);
-  if(dev->virtual_pipe) dt_atomic_set_int(&dev->virtual_pipe->shutdown, TRUE);
   dev->pipelines_started = FALSE;
 
   // Stop module background threads before freeing the nodes/history they read.
@@ -321,16 +320,6 @@ static void _studio_dev_teardown(dt_studio_capture_t *d)
   dt_dev_set_backbuf(&dev->preview_pipe->backbuf, 0, 0, 0, DT_PIXELPIPE_CACHE_HASH_INVALID,
                      DT_PIXELPIPE_CACHE_HASH_INVALID);
   dt_pthread_mutex_unlock(&dev->preview_pipe->busy_mutex);
-
-  if(dev->virtual_pipe)
-  {
-    dt_pthread_mutex_lock(&dev->virtual_pipe->busy_mutex);
-    dt_dev_pixelpipe_cleanup_nodes(dev->virtual_pipe);
-    dt_dev_pixelpipe_cache_unref_hash(dt_dev_backbuf_get_hash(&dev->virtual_pipe->backbuf));
-    dt_dev_set_backbuf(&dev->virtual_pipe->backbuf, 0, 0, 0, DT_PIXELPIPE_CACHE_HASH_INVALID,
-                       DT_PIXELPIPE_CACHE_HASH_INVALID);
-    dt_pthread_mutex_unlock(&dev->virtual_pipe->busy_mutex);
-  }
 
   dt_dev_pixelpipe_cache_flush_clmem_for_pipe(dev->pipe->last_devid);
   if(dev->preview_pipe->last_devid != dev->pipe->last_devid)


### PR DESCRIPTION
Replaces the sixteen stacked PRs (#1164–#1184), which were unreviewable for the reason you gave:
stacked bases never fired the CI matrix, and several lines were rewritten more than once across
the series. This is the same work as one branch off `master`, so the Files-changed tab **is** the
final diff and CI builds it.

Plan and rationale: `doc/geometry-service.md` (already on master, #1163). This description is the
summary; that file is the record.

---

## What this removes

`dev->virtual_pipe` — a complete, pixel-less clone of all ~95 IOP modules, their history committed
into real pipeline nodes, resynchronised **on the GUI thread at every history commit**. It rendered
nothing. It existed only to be walked, to answer two questions: how big is the developed image, and
where does a point on it land.

**Measured, per darkroom entry: 5 resyncs at 0.104–0.141 s on the GUI thread → 0 at 0.000 s.**

## What replaces it

`src/develop/geometry/` — each geometry module publishes a small record (its transform as values,
not as a node) and the GUI composes sizes and coordinates from the ordered list. A rebuild is small
derivations of already-committed parameters: no LUT, no colour transform, no disk. It runs in the
same step as the history write, where 0.1–0.3 s could not.

Twelve modules publish records: `rawprepare`, `basebuffer`, `demosaic`, `lens`, `ashift`,
`liquify`, `rotatepixels`, `scalepixels`, `flip`, `clipping`, `crop`, `borders`.

Three rules the design rests on, each of which killed a simpler version:

- **One constructor.** A module's `commit_params()` and its `geometry_record()` call the same static
  helper. Two derivations of the same geometry drift, and the drift surfaces months later as an
  overlay that no longer sits on the thing it describes.
- **Query-time GUI state.** The focused module's tag filter is a *composition parameter*, read live
  from `dev->gui_module`, never stored. The first version had a setter nothing called, and the chain
  composed modules the pipe was suppressing — ashift's detected-lines overlay drawn against a
  different module stack than the image under it. There is deliberately no setter.
- **Wholesale authority.** The chain refuses every query unless *every* enabled roster module has
  published. Composing some modules from records and the rest from somewhere else interleaves two
  states, and the result is wrong in a way that looks plausible.

## Also in here

- **A bug the combination surfaced.** G1 moved `ashift`'s `process()`/`process_cl()` off the GUI's
  pipe — a worker thread was reading another thread's node list with no lock. G10's later sweep
  converted every bounded GUI fold to the service, and because G1 sat on a *sibling* branch rather
  than in the chain, that sweep silently reverted those two sites. Combining the branches put the
  conflict on screen; resolved in favour of G1's worker-safe call. Neither stack would have caught
  it, which is a fair argument for the way you asked for this.
- **drawlayer anchored on raw coordinates** (your report). The canvas was the module's *stage*
  frame — post-crop, since `crop` is `iop_order` 29, `drawlayer` 44 and everything between is
  colour-only. Change the crop and the authored raster was re-fitted onto the new frame: the paint
  moved and stretched. The canvas is now the raw frame, placed by an offset and a scale read off
  the back-transformed corners of the module's own frame. Exact for crop (offset, scale 1) and for
  a downscaled export mipmap (scale); a keystone or lens correction is neither and the paint stays
  where it was authored — the trade you chose. Layers painted before this appear shifted until
  repainted, also as agreed.
- Two `distort_transform`/`modify_roi_out` families that derived state inside their ROI callbacks
  (`clipping`, `scalepixels`) became pure constructors; `scalepixels` turned out to need no piece
  at all.
- Records resolve from **history**, not from `self->params` — a mid-series fix from shadow mode
  catching the chain and the pipe disagreeing across the 200 ms commit throttle.

## Verification

- Release, `build-nofeatures` (the `USE_OPENCL=OFF` CI mirror) and Debug (`-Werror`) all build
  clean; 8/8 unit tests pass.
- `tools/check_export_pixels.sh origin/master HEAD <NEF>`: both variants (output profile chosen by
  colorout, and forced to sRGB) **3 217 408 pixels identical** on `_DSC9410.NEF`.
- `pragma_once` verify clean, include-graph cycles 0, `check_module_boundaries.sh` all baselines
  held, no include added inside a conditional block, 0 unused includes introduced (11 files
  checked).
- Ratchet: `virtual_pipe` / `sync_virtual` / `ensure_synced` / `ANSEL_GEOMETRY_DISABLE` → **0**.

**What no automated check covers**, stated plainly: from G9 onward the migrated consumers are
GUI-side and an export never calls them, so the bit-identical export says only that nothing *else*
regressed. Every regression in this series was found by you in the darkroom and by nothing else —
the ashift overlay against the wrong module stack, the stride error on ashift edit re-entry, the
detected lines missing an existing transform. You validated crop, ashift and drawn masks at G10 and
drawlayer/liquify at G13; the size path, the deletion and the drawlayer anchoring have not had a
session yet.

**Related, kept separate** (both already target `master`, so both get CI):
#1185 — the backbuffer stride error (`hash` and the shape read as separate facts); needed for the
zebra you reported, independent of this branch.
#1168 — the darkroom's startup configure disagreeing with GTK by 16 px.
