### PR TITLE
Fix #1158: mask outlines were cached against a pixel identity, not a geometric one

### DIFF
--- a/src/develop/geometry/geometry.c
+++ b/src/develop/geometry/geometry.c
@@ -74,6 +74,9 @@ struct dt_geometry_chain_t
   /** Every roster module that is enabled has published a record. See the header. */
   gboolean authoritative;
 
+  /** Advanced once per rebuild. See dt_geometry_chain_generation(). */
+  uint64_t generation;
+
   /* What the last rebuild could not get. Kept so shadow mode can name it instead of just
    * reporting "not ready", which would be true and useless. */
   GList *missing;   /**< gchar*, owned */
@@ -109,6 +112,8 @@ static void _chain_clear(dt_geometry_chain_t *chain)
   chain->authoritative = FALSE;
   chain->sized = FALSE;
   chain->processed_width = chain->processed_height = 0;
+  // `generation' is deliberately NOT reset here: clearing is a change like any other, and a
+  // consumer holding the old number must see a different one afterwards, not the same one again.
 }
 
 dt_geometry_chain_t *dt_geometry_chain_new(void)
@@ -304,6 +309,16 @@ void dt_geometry_chain_rebuild(dt_develop_t *dev)
 
   _fold_sizes(chain);
   chain->authoritative = complete && chain->sized;
+
+  /* Last, so a consumer that samples the generation and then reads the chain cannot pair a new
+   * number with geometry still being folded -- this all runs on the GUI thread, but the ordering
+   * is what makes the key mean "everything below is settled". */
+  chain->generation++;
+}
+
+uint64_t dt_geometry_chain_generation(const dt_geometry_chain_t *chain)
+{
+  return IS_NULL_PTR(chain) ? 0 : chain->generation;
 }
 
 gboolean dt_geometry_chain_authoritative(const dt_geometry_chain_t *chain)

--- a/src/develop/geometry/geometry.h
+++ b/src/develop/geometry/geometry.h
@@ -149,6 +149,32 @@ void dt_geometry_chain_rebuild(struct dt_develop_t *dev);
  */
 gboolean dt_geometry_chain_authoritative(const dt_geometry_chain_t *chain);
 
+/**
+ * @brief How many times this chain has been rebuilt. A GUI cache key for anything derived from
+ * the composed geometry.
+ *
+ * @details A consumer that caches something it composed through this service -- a mask outline in
+ * image coordinates, say -- needs to know when to throw that cache away. The answer is "when the
+ * geometry moved", and this counter is that, cheaply: it advances once per rebuild, and a rebuild
+ * happens exactly where a pipe flag is raised, i.e. where the module stack or the history changed.
+ *
+ * It is deliberately NOT a content hash. A rebuild that lands on identical geometry still advances
+ * it, which costs a consumer one redundant recompute; the alternative -- hashing each record's
+ * module-owned data blob, whose size this service does not know -- would have to guess, and a
+ * missed change here is an overlay drawn in the wrong place. Over-invalidating is the safe
+ * direction for a key.
+ *
+ * What it must NOT be replaced by is a PIXEL identity. Keying an outline cache on a pipe's
+ * backbuffer hash, which is what iop/masks did before, ties a geometric fact to a rendering event:
+ * every republished preview frame -- continuous while a brush is being dragged -- then invalidates
+ * outlines whose inputs did not change. Measured on the report in #1158: 566 rebuilds of two brush
+ * outlines in 80 seconds, ~2 s of coordinate transform, gravity centres recomputed bit-identical
+ * every time, and a darkroom expose growing from 23 ms to 137 ms as strokes accumulated.
+ *
+ * @return 0 for a chain that has never been built, which no live generation can equal.
+ */
+uint64_t dt_geometry_chain_generation(const dt_geometry_chain_t *chain);
+
 /** @brief The developed image's full-resolution size, from the chain's own fold. */
 gboolean dt_geometry_chain_processed_size(const dt_geometry_chain_t *chain, int *width, int *height);
 

--- a/src/develop/masks/brush.c
+++ b/src/develop/masks/brush.c
@@ -2160,11 +2160,35 @@ static void _brush_draw_shape(struct dt_develop_t *dev, cairo_t *cr, const float
 
     // We don't want to draw the plain line twice, adapt the end index accordingly
     const int end_idx = border ? points_count : 0.5 * points_count;
-    
+
+    /* One line_to per point sampled at RAW resolution is several per device pixel; emit at the
+     * resolution the context can actually show. See dt_draw_min_emit_step(). */
+    const double min_step = dt_draw_min_emit_step(cr);
+    const double min_step2 = min_step * min_step;
+    double last_x = points[start_idx * 2];
+    double last_y = points[start_idx * 2 + 1];
+
     for(int i = start_idx + 1; i < end_idx; i++)
     {
-      if(!isnan(points[i * 2]) && !isnan(points[i * 2 + 1]))
-        cairo_line_to(cr, points[i * 2], points[i * 2 + 1]);
+      const double x = points[i * 2];
+      const double y = points[i * 2 + 1];
+      if(isnan(x) || isnan(y)) continue;
+
+      const double step_x = x - last_x;
+      const double step_y = y - last_y;
+      if((step_x * step_x + step_y * step_y) < min_step2) continue;
+
+      cairo_line_to(cr, x, y);
+      last_x = x;
+      last_y = y;
+    }
+
+    // the last point always lands, so the outline closes where the shape does
+    if(end_idx > start_idx + 1)
+    {
+      const double x = points[(end_idx - 1) * 2];
+      const double y = points[(end_idx - 1) * 2 + 1];
+      if(!isnan(x) && !isnan(y) && (x != last_x || y != last_y)) cairo_line_to(cr, x, y);
     }
   }
 }

--- a/src/develop/masks/group.c
+++ b/src/develop/masks/group.c
@@ -31,6 +31,7 @@
     You should have received a copy of the GNU General Public License
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
+#include "common/hash.h"   // dt_hash()
 #include "system/macros.h"
 #include "system/openmp.h"
 #include "system/mem_alloc.h"
@@ -597,6 +598,52 @@ __OMP_FOR_SIMD__(aligned(dest, newmask : 64)  if(npixels > 10000)
   }
 }
 
+/**
+ * @brief Identity of the group mask after folding the first @p count shapes, at this ROI.
+ *
+ * @details The fold below is a left fold: the result after k shapes is a pure function of the
+ * result after k-1 and of shape k. So every PREFIX of it is a cacheable value, and the one that
+ * matters is the longest one: drawing a new stroke appends a shape and leaves every earlier
+ * prefix untouched.
+ *
+ * What has to be in the key is everything the fold reads:
+ *
+ *   - each shape's own content, via dt_masks_form_get_own_hash() -- for a brush that is every
+ *     node's position, border, hardness and density, which is exactly what its rasterisation is
+ *     a function of;
+ *   - each membership's state and opacity, which decide the combine operator and its weight;
+ *   - the ROI, which decides the pixels;
+ *   - the module's own input and output rects, which is how a geometry change upstream (a crop
+ *     moved, a keystone) reaches the rasterisation without changing any form. Deliberately NOT
+ *     the pipe's history hash: that changes on every commit, including the stroke being drawn,
+ *     which would make the cache miss exactly when it is worth having.
+ */
+static uint64_t _group_prefix_hash(const dt_masks_form_t *const form, GList *masks,
+                                   const dt_dev_pixelpipe_iop_t *const piece, const dt_iop_roi_t *const roi,
+                                   const int count)
+{
+  uint64_t hash = 5381;
+  hash = dt_hash(hash, (const char *)roi, sizeof(dt_iop_roi_t));
+  if(!IS_NULL_PTR(piece))
+  {
+    hash = dt_hash(hash, (const char *)&piece->buf_in, sizeof(dt_iop_roi_t));
+    hash = dt_hash(hash, (const char *)&piece->buf_out, sizeof(dt_iop_roi_t));
+  }
+
+  int i = 0;
+  for(const GList *fpts = form->points; fpts && i < count; fpts = g_list_next(fpts), i++)
+  {
+    const dt_masks_form_group_t *const fpt = (const dt_masks_form_group_t *)fpts->data;
+    const dt_masks_form_t *const sel = dt_masks_get_from_id_ext(masks, fpt->formid);
+    if(IS_NULL_PTR(sel)) return 0;   // cannot describe this prefix; refuse to key on it
+
+    hash = dt_hash(hash, (const char *)&fpt->state, sizeof(int));
+    hash = dt_hash(hash, (const char *)&fpt->opacity, sizeof(float));
+    hash = dt_masks_form_get_own_hash(hash, masks, sel);
+  }
+  return hash ? hash : 1;
+}
+
 static int _group_get_mask_roi(const dt_iop_module_t *const restrict module, dt_dev_pixelpipe_t *pipe,
                                const dt_dev_pixelpipe_iop_t *const restrict piece,
                                dt_masks_form_t *const form, const dt_iop_roi_t *const roi,
@@ -610,10 +657,54 @@ static int _group_get_mask_roi(const dt_iop_module_t *const restrict module, dt_
   const int height = roi->height;
   const size_t npixels = (size_t)width * height;
 
+  /* Resume from the longest cached prefix.
+   *
+   * Without this every shape is rasterised and combined from scratch on every render, so drawing
+   * the tenth stroke costs ten shapes and drawing the first costs one -- measured on #1158 at
+   * ~9 ms to rasterise and ~21 ms to combine per shape, on the preview pipe and the full pipe
+   * both, growing `render all masks' from 205 ms to 260 ms across one session. Appending a stroke
+   * leaves every earlier prefix identical, so the work that actually has to be redone is one
+   * shape's.
+   *
+   * Shapes are walked newest-first: the append case hits on the first probe. The forms come from
+   * pipe->forms, the refcounted snapshot this run owns -- never dev->forms, which the GUI thread
+   * is mutating while this runs on a worker. */
+  GList *const masks = !IS_NULL_PTR(pipe) && !IS_NULL_PTR(pipe->forms) ? pipe->forms : module->dev->forms;
+  const int shape_count = g_list_length(form->points);
+  int resume_from = 0;
+
+  for(int count = shape_count - 1; count > 0; count--)
+  {
+    const uint64_t prefix = _group_prefix_hash(form, masks, piece, roi, count);
+    if(prefix == 0) break;
+
+    void *cached = NULL;
+    dt_pixel_cache_entry_t *entry = NULL;
+    if(dt_dev_pixelpipe_cache_peek(prefix, &cached, &entry, -1, NULL) && !IS_NULL_PTR(cached))
+    {
+      dt_dev_pixelpipe_cache_rdlock_entry(TRUE, entry);
+      memcpy(buffer, cached, npixels * sizeof(float));
+      dt_dev_pixelpipe_cache_rdlock_entry(FALSE, entry);
+      dt_dev_pixelpipe_cache_ref_count_entry(FALSE, entry);
+      resume_from = count;
+      nb_ok = count;
+      if(dt_get_debug_flags() & DT_DEBUG_PERF)
+        dt_print(DT_DEBUG_MASKS, "[masks] group fold resumed from cached prefix of %d/%d shapes\n", count,
+                 shape_count);
+      break;
+    }
+  }
+
   // we need to allocate a zeroed temporary buffer for intermediate creation of individual shapes
   float *const restrict bufs = dt_pixelpipe_cache_alloc_align_float_cache(npixels, 0);
   if(IS_NULL_PTR(bufs)) return 1;
   int err = 0;
+
+  /* Somewhere to hold the fold minus its last shape. Only needed when there is something new to
+   * publish; a failure to allocate simply means this render publishes nothing. */
+  float *publishable = NULL;
+  if(shape_count > 1 && resume_from < shape_count - 1)
+    publishable = dt_pixelpipe_cache_alloc_align_float_cache(npixels, 0);
 
   int i = 0;
   // and we get all masks
@@ -622,8 +713,20 @@ static int _group_get_mask_roi(const dt_iop_module_t *const restrict module, dt_
     dt_masks_form_group_t *fpt = (dt_masks_form_group_t *)fpts->data;
     dt_masks_form_t *sel = dt_masks_get_from_id(module->dev, fpt->formid);
 
+    if(sel && i < resume_from)
+    {
+      // already folded into `buffer' by the cached prefix above
+      i++;
+      continue;
+    }
+
     if(sel)
     {
+      /* Snapshot the fold before the LAST shape goes in: that is what gets published, and it is
+       * the only state a later render can start from without redoing the shape being edited. */
+      if(i == shape_count - 1 && !IS_NULL_PTR(publishable))
+        memcpy(publishable, buffer, npixels * sizeof(float));
+
       // ensure that we start with a zeroed buffer regardless of what was previously written into 'bufs'
       memset(bufs, 0, npixels*sizeof(float));
       const int err_child = dt_masks_get_mask_roi(module, pipe, piece, sel, roi, bufs);
@@ -678,8 +781,49 @@ static int _group_get_mask_roi(const dt_iop_module_t *const restrict module, dt_
   // and we free the intermediate buffer
   dt_pixelpipe_cache_free_align(bufs);
 
+
   if(nb_ok == 0)
     memset(buffer, 0, npixels * sizeof(float));
+
+  /* Publish the fold WITHOUT the last shape, never the complete one.
+   *
+   * The last shape is the one being edited: while a stroke is dragged its content changes on every
+   * frame, so the complete fold's key changes on every frame too. Publishing that would leave one
+   * full-ROI cacheline per rendered frame behind, each dead the moment it is written -- memory
+   * pressure that evicts the pipeline's own outputs and costs more than the fold ever saved.
+   * Measured: publishing the complete fold flattened `render all masks' as intended (205-260 ms
+   * down to 32-100 ms) while the darkroom redraw grew from 5 ms to 416 ms over one session.
+   *
+   * The fold minus its last shape is stable across every frame of a stroke, so it is published
+   * once and hit on every later frame -- and when the next shape is appended the resume covers all
+   * but two. Nothing is published when the resume already came from that prefix: it is what we
+   * would be writing back.
+   *
+   * Only on a complete, error-free fold: a prefix that describes fewer shapes than its key claims
+   * is not a wrong-looking mask, it is a mask. */
+  if(!err && shape_count > 1 && nb_ok == shape_count && resume_from < shape_count - 1
+     && !IS_NULL_PTR(publishable))
+  {
+    const uint64_t prefix = _group_prefix_hash(form, masks, piece, roi, shape_count - 1);
+    if(prefix != 0)
+    {
+      void *slot = NULL;
+      dt_pixel_cache_entry_t *entry = NULL;
+      const int created = dt_dev_pixelpipe_cache_get(prefix, npixels * sizeof(float), "masks group prefix",
+                                                    IS_NULL_PTR(pipe) ? -1 : pipe->type, TRUE, &slot, &entry);
+      if(!IS_NULL_PTR(slot))
+      {
+        if(created)
+        {
+          memcpy(slot, publishable, npixels * sizeof(float));
+          dt_dev_pixelpipe_cache_wrlock_entry(FALSE, entry);
+        }
+        dt_dev_pixelpipe_cache_ref_count_entry(FALSE, entry);
+      }
+    }
+  }
+
+  dt_pixelpipe_cache_free_align(publishable);
 
   return err;
 }

--- a/src/develop/masks/group.c
+++ b/src/develop/masks/group.c
@@ -133,8 +133,29 @@ static void _group_events_post_expose_draw(cairo_t *cr, float zoom_scale, dt_mas
   dt_masks_form_t *selected_form = _group_get_child_at(gui->dev, form, pos, NULL);
   if(selected_form && selected_form->functions && selected_form->functions->post_expose)
   {
+    /* Timed per shape, with the size of what is being stroked.
+     *
+     * The overlay redraw is the expensive half of a mask-heavy darkroom and nothing measured it:
+     * on the #1158 logs the darkroom expose runs 270-390 ms with only ~15 ms of it accounted for
+     * by the outline rebuilds around it, and the unaccounted time falls BETWEEN consecutive
+     * shapes -- which is this call. Whether that is the cairo stroking, and whether it scales
+     * with the point count or with the node count (dt_masks_draw_path_seg_by_seg() strokes once
+     * per node), is exactly what these two numbers separate. */
+    const dt_times_t start = { 0 };
+    dt_get_times((dt_times_t *)&start);
+
     gui->type = selected_form->type;
     selected_form->functions->post_expose(cr, zoom_scale, gui, pos, g_list_length(selected_form->points));
+
+    if(dt_get_debug_flags() & DT_DEBUG_MASKS)
+    {
+      const dt_masks_form_gui_points_t *const gui_points
+          = (const dt_masks_form_gui_points_t *)g_list_nth_data(gui->points, pos);
+      dt_show_times_f(&start, "[masks]", "shape %d (%s) drawn: %d outline points, %d border points, %d nodes",
+                      pos, selected_form->name, IS_NULL_PTR(gui_points) ? -1 : gui_points->points_count,
+                      IS_NULL_PTR(gui_points) ? -1 : gui_points->border_count,
+                      g_list_length(selected_form->points));
+    }
   }
 }
 

--- a/src/develop/masks/masks_gui.c
+++ b/src/develop/masks/masks_gui.c
@@ -3323,6 +3323,7 @@ static void _masks_draw_creation_session_forms(dt_develop_t *develop, dt_iop_mod
 void dt_masks_events_post_expose(dt_develop_t *dev, struct dt_iop_module_t *module, cairo_t *cr, int32_t width, int32_t height,
                                  int32_t pointerx, int32_t pointery)
 {
+  const double post_expose_start = dt_get_wtime();
   dt_develop_t *develop = dev;
   if(IS_NULL_PTR(develop)) return;
   dt_masks_form_t *mask_form = dt_masks_get_visible_form(develop);
@@ -3337,17 +3338,27 @@ void dt_masks_events_post_expose(dt_develop_t *dev, struct dt_iop_module_t *modu
   if(buffer_width < 1.0 || buffer_height < 1.0) return;
   const float zoom_scale = dt_dev_get_zoom_level(develop);
 
-  // Create a surface to draw the mask, so that we can apply
-  // operation that does not affect the main context
-  cairo_surface_t *overlay = NULL;
-  cairo_t *mask_draw = NULL;
-  cairo_surface_t *target = cairo_get_target(cr);
-  double sx = 1.0, sy = 1.0;
-  cairo_surface_get_device_scale(target, &sx, &sy);
-  overlay = cairo_surface_create_similar(target, CAIRO_CONTENT_COLOR_ALPHA, (int)ceil(width * sx),
-                                         (int)ceil(height * sy));
-  cairo_surface_set_device_scale(overlay, sx, sy);
-  mask_draw = cairo_create(overlay);
+  /* Draw into an isolated group, so that overlapping shapes composite once against the view
+   * instead of once each.
+   *
+   * This used to allocate a full-window ARGB surface with cairo_surface_create_similar() on EVERY
+   * expose and destroy it again at the end -- at ppd 2 that is a four-byte-per-pixel buffer of
+   * four times the window's area, created, cleared, composited and freed per frame, and on an
+   * X11 or GL target it is a server-side pixmap each time. Measured on #1158: the expose stage
+   * that contains it costs 0.44 s while the mask drawing inside it costs 0.0014 s, and it grows
+   * across a session -- 11 ms, 137, 221, 310 -- which is what repeated large allocation and
+   * release looks like.
+   *
+   * cairo_push_group() is the same isolation with none of that: cairo sizes the group to the
+   * current CLIP rather than the window, and takes it from its own scratch pool instead of
+   * allocating. Every path out of here must pop what it pushed. */
+  const double group_start = dt_get_wtime();
+  if(dt_get_debug_flags() & DT_DEBUG_PERF)
+    dt_print(DT_DEBUG_MASKS, "[masks] overlay preamble took %0.04f sec\n", group_start - post_expose_start);
+  cairo_push_group(cr);
+  cairo_t *const mask_draw = cr;
+  if(dt_get_debug_flags() & DT_DEBUG_PERF)
+    dt_print(DT_DEBUG_MASKS, "[masks] overlay group pushed in %0.04f sec\n", dt_get_wtime() - group_start);
 
   // Apply the same transformation to the mask drawing context
   /*cairo_matrix_t m;
@@ -3360,8 +3371,7 @@ void dt_masks_events_post_expose(dt_develop_t *dev, struct dt_iop_module_t *modu
   if(dt_dev_rescale_roi_to_input(develop, mask_draw, width, height))
   {
     cairo_restore(mask_draw);
-    cairo_destroy(mask_draw);
-    cairo_surface_destroy(overlay);
+    cairo_pattern_destroy(cairo_pop_group(cr));   // discard: nothing was drawn
     return;
   }
 
@@ -3376,7 +3386,11 @@ void dt_masks_events_post_expose(dt_develop_t *dev, struct dt_iop_module_t *modu
   if(dt_get_debug_flags() & DT_DEBUG_MASKS)
     dt_show_times(&rebuild_start, "[masks] overlay outline refresh");
 
+  const double session_start = dt_get_wtime();
   _masks_draw_creation_session_forms(develop, module, mask_draw, zoom_scale, mask_gui);
+  if(dt_get_debug_flags() & DT_DEBUG_PERF)
+    dt_print(DT_DEBUG_MASKS, "[masks] creation session (%d shapes) drawn in %0.04f sec\n",
+             g_list_length(mask_gui->creation_formids), dt_get_wtime() - session_start);
 
   // Draw form
   const dt_times_t draw_start = { 0 };
@@ -3395,15 +3409,15 @@ void dt_masks_events_post_expose(dt_develop_t *dev, struct dt_iop_module_t *modu
   if(dt_get_debug_flags() & DT_DEBUG_MASKS)
     dt_show_times(&draw_start, "[masks] overlay drawn");
 
-  // Draw the overlay with the same transformation as the main context
-  cairo_save(cr);
-  cairo_identity_matrix(cr);
-  cairo_set_source_surface(cr, overlay, 0.0, 0.0);
+  /* Composite the group. pop_group_to_source() hands back a pattern already carrying the matrix
+   * that was in effect at push time, so a plain paint reproduces exactly what the explicit
+   * full-window surface did -- the save/restore pair above balances the one taken after the
+   * push. */
+  const double composite_start = dt_get_wtime();
+  cairo_pop_group_to_source(cr);
   cairo_paint(cr);
-  cairo_restore(cr);
-
-  cairo_destroy(mask_draw);
-  cairo_surface_destroy(overlay);
+  if(dt_get_debug_flags() & DT_DEBUG_PERF)
+    dt_print(DT_DEBUG_MASKS, "[masks] overlay composited in %0.04f sec\n", dt_get_wtime() - composite_start);
 }
 
 void dt_masks_clear_form_gui(dt_develop_t *develop)

--- a/src/develop/masks/masks_gui.c
+++ b/src/develop/masks/masks_gui.c
@@ -3168,6 +3168,23 @@ void dt_masks_draw_path_seg_by_seg(cairo_t *cr, dt_masks_form_gui_t *mask_gui, c
   int current_segment_index = 0;
   cairo_move_to(cr, points[node_count * 6], points[node_count * 6 + 1]);
 
+  /* Emit at screen resolution, not at the resolution the outline was built with.
+   *
+   * The outline is sampled one point per RAW pixel along the path -- measured on #1158, a mean of
+   * 89 150 points per shape and a maximum of 208 095, for a mean of 11.9 nodes -- while the view
+   * it is drawn into is a fraction of that: at the zoom in those logs, roughly four outline points
+   * land inside every device pixel. Issuing a cairo_line_to() for each of them costs 93 ms per
+   * shape and draws a curve indistinguishable from the one below, which is 14.87 s of a 30.45 s
+   * session spent on segments shorter than a pixel.
+   *
+   * Points nearer than half a device pixel to the last EMITTED one are dropped -- not skipped in
+   * the walk: every point is still tested for a segment boundary below, and a boundary always
+   * emits, so the strokes still start and end exactly where the nodes are. */
+  const double min_step = dt_draw_min_emit_step(cr);
+  const double min_step2 = min_step * min_step;
+  double last_x = points[node_count * 6];
+  double last_y = points[node_count * 6 + 1];
+
   for(int point_index = node_count * 3; point_index < points_count; point_index++)
   {
     const int coord_index = point_index * 2;
@@ -3175,7 +3192,16 @@ void dt_masks_draw_path_seg_by_seg(cairo_t *cr, dt_masks_form_gui_t *mask_gui, c
 
     const double coord_x = points[coord_index];
     const double coord_y = points[coord_index + 1];
-    cairo_line_to(cr, coord_x, coord_y);
+
+    const double step_x = coord_x - last_x;
+    const double step_y = coord_y - last_y;
+    const gboolean far_enough = (step_x * step_x + step_y * step_y) >= min_step2;
+    if(far_enough)
+    {
+      cairo_line_to(cr, coord_x, coord_y);
+      last_x = coord_x;
+      last_y = coord_y;
+    }
 
     const int segment_coord_index = show_segment_index * 6;
     if((segment_coord_index + 3) >= total_coords) continue;
@@ -3184,6 +3210,15 @@ void dt_masks_draw_path_seg_by_seg(cairo_t *cr, dt_masks_form_gui_t *mask_gui, c
     const double segment_y = points[segment_coord_index + 3];
     if(coord_x == segment_x && coord_y == segment_y)
     {
+      // a segment ends exactly on a node: emit it even when it was too near to the last one,
+      // or the stroke would stop short of the handle it belongs to
+      if(!far_enough)
+      {
+        cairo_line_to(cr, coord_x, coord_y);
+        last_x = coord_x;
+        last_y = coord_y;
+      }
+
       const gboolean seg_is_selected = group_selected
                                        && (dt_masks_gui_selected_segment_index(mask_gui)
                                            == current_segment_index);
@@ -3199,6 +3234,9 @@ void dt_masks_draw_path_seg_by_seg(cairo_t *cr, dt_masks_form_gui_t *mask_gui, c
 
       show_segment_index = (show_segment_index + 1) % node_count;
       current_segment_index++;
+
+      // dt_draw_stroke_line() consumed the path; the next one starts here
+      cairo_move_to(cr, coord_x, coord_y);
     }
 
     if(mask_gui->creation && current_segment_index >= node_count - 1) break;

--- a/src/develop/masks/masks_gui.c
+++ b/src/develop/masks/masks_gui.c
@@ -1848,8 +1848,20 @@ void dt_masks_gui_form_create(dt_masks_form_t *mask_form, dt_masks_form_gui_t *m
 
   dt_masks_form_gui_points_t *gui_points
       = (dt_masks_form_gui_points_t *)g_list_nth_data(mask_gui->points, form_index);
-  if(dt_masks_get_points_border(mask_gui->dev, mask_form, &gui_points->points, &gui_points->points_count,
-                                &gui_points->border, &gui_points->border_count, 0, NULL) == 0)
+  const int border_status
+      = dt_masks_get_points_border(mask_gui->dev, mask_form, &gui_points->points, &gui_points->points_count,
+                                   &gui_points->border, &gui_points->border_count, 0, NULL);
+
+  /* A shape that fails here leaves the cache key UNSET, so the next expose rebuilds the whole
+   * group again -- and the one after that, forever. An empty shape mid-creation is the obvious
+   * candidate and it is invisible in a log otherwise: say so. */
+  if(border_status != 0 && (dt_get_debug_flags() & DT_DEBUG_MASKS))
+    dt_print(DT_DEBUG_MASKS,
+             "[masks] outline build FAILED for %s (index %d, %d nodes): the cache key stays unset,"
+             " so every later expose rebuilds this whole group\n",
+             mask_form->name, form_index, g_list_length(mask_form->points));
+
+  if(border_status == 0)
   {
     if(mask_form->type & DT_MASKS_CLONE)
     {
@@ -2302,9 +2314,17 @@ void dt_masks_gui_form_test_create(dt_masks_form_t *mask_form, dt_masks_form_gui
                                    dt_iop_module_t *module)
 {
   // we test if the geometry the cached outlines were built against has moved
+  const uint64_t live_generation = dt_geometry_chain_generation(mask_gui->dev->geometry_chain);
+  if(dt_get_debug_flags() & DT_DEBUG_MASKS)
+    dt_print(DT_DEBUG_MASKS, "[masks] outline cache: held for geometry %lu, live %lu -> %s\n",
+             (unsigned long)mask_gui->geometry_generation, (unsigned long)live_generation,
+             (mask_gui->geometry_generation == 0)
+                 ? "REBUILD (nothing cached)"
+                 : ((mask_gui->geometry_generation != live_generation) ? "REBUILD (geometry moved)" : "reuse"));
+
   if(mask_gui->geometry_generation != 0)
   {
-    if(mask_gui->geometry_generation != dt_geometry_chain_generation(mask_gui->dev->geometry_chain))
+    if(mask_gui->geometry_generation != live_generation)
     {
       mask_gui->geometry_generation = 0;
       mask_gui->formid = 0;
@@ -2636,7 +2656,23 @@ static void _dt_masks_events_set_current_pos(const double x, const double y, dt_
   dt_dev_coordinates_image_abs_to_raw_abs(mask_gui->dev, mask_gui->raw_pos, 1);
 }
 
+static int _dt_masks_events_mouse_moved(dt_develop_t *dev, struct dt_iop_module_t *module, double x,
+                                       double y, double pressure, int which);
+
 int dt_masks_events_mouse_moved(dt_develop_t *dev, struct dt_iop_module_t *module, double x, double y, double pressure, int which)
+{
+  /* Timed because it is the other thing that scales with the number of shapes and is not part of
+   * the expose: hit-testing walks every shape in the group and, for a brush, every point of it.
+   * The #1158 logs show the darkroom redraw growing to 400 ms with only 1.5 ms of mask overlay in
+   * it, so whatever grows is either here or in the expose's earlier stages -- both are now timed. */
+  dt_times_t moved_start = { 0 };
+  dt_get_times(&moved_start);
+  const int moved_result = _dt_masks_events_mouse_moved(dev, module, x, y, pressure, which);
+  if(dt_get_debug_flags() & DT_DEBUG_PERF) dt_show_times(&moved_start, "[masks] mouse moved");
+  return moved_result;
+}
+
+static int _dt_masks_events_mouse_moved(dt_develop_t *dev, struct dt_iop_module_t *module, double x, double y, double pressure, int which)
 {
   // This assume that if this event is generated, the mouse is over the center window.
   // record mouse position even if there are no masks visible
@@ -3252,7 +3288,9 @@ static void _masks_draw_creation_session_forms(dt_develop_t *develop, dt_iop_mod
 
     /* Built at `index', not at 0: one slot per shape, so they can all be kept. The old loop wrote
      * every shape into slot 0 and freed it again, which is why none of them could be cached. */
+    const double shape_start = dt_get_wtime();
     if(rebuild) dt_masks_gui_form_create(session_form, &_session_gui, index, module);
+    const double built = dt_get_wtime();
 
     if(session_form->functions && session_form->functions->post_expose)
     {
@@ -3260,6 +3298,14 @@ static void _masks_draw_creation_session_forms(dt_develop_t *develop, dt_iop_mod
       _session_gui.type = session_form->type;
       session_form->functions->post_expose(cr, zoom_scale, &_session_gui, index, point_count);
     }
+
+    /* Which half costs: rebuilding an outline, or stroking it. The session is 15.9 ms of a 25.7 ms
+     * redraw, about 5 ms per shape, while the shape being drawn -- same stroker, cached outline --
+     * costs 1.4 ms. Either the cache is not holding here or the draw is genuinely dearer, and
+     * those want opposite fixes. */
+    if(dt_get_debug_flags() & DT_DEBUG_PERF)
+      dt_print(DT_DEBUG_MASKS, "[masks] session shape %d: %s %0.04f sec, drawn %0.04f sec\n", index,
+               rebuild ? "rebuilt in" : "cached,", built - shape_start, dt_get_wtime() - built);
 
     // Keep the saved-session shape path from being connected to the active
     // creation cursor drawn right after this loop.
@@ -3321,12 +3367,21 @@ void dt_masks_events_post_expose(dt_develop_t *dev, struct dt_iop_module_t *modu
 
   // We update the form if needed
   // Add preview when creating a circle, ellipse and gradient
+  const dt_times_t rebuild_start = { 0 };
+  dt_get_times((dt_times_t *)&rebuild_start);
+
   if(!((mask_form->type & DT_MASKS_IS_PRIMITIVE_SHAPE) && mask_gui->creation))
     dt_masks_gui_form_test_create(mask_form, mask_gui, module);
+
+  if(dt_get_debug_flags() & DT_DEBUG_MASKS)
+    dt_show_times(&rebuild_start, "[masks] overlay outline refresh");
 
   _masks_draw_creation_session_forms(develop, module, mask_draw, zoom_scale, mask_gui);
 
   // Draw form
+  const dt_times_t draw_start = { 0 };
+  dt_get_times((dt_times_t *)&draw_start);
+
   if(mask_form->type & DT_MASKS_GROUP)
     dt_group_events_post_expose(mask_draw, zoom_scale, mask_form, mask_gui);
   else if(mask_form->functions && mask_form->functions->post_expose)
@@ -3336,6 +3391,9 @@ void dt_masks_events_post_expose(dt_develop_t *dev, struct dt_iop_module_t *modu
     mask_form->functions->post_expose(mask_draw, zoom_scale, mask_gui, 0, point_count);
   }
   cairo_restore(mask_draw);
+
+  if(dt_get_debug_flags() & DT_DEBUG_MASKS)
+    dt_show_times(&draw_start, "[masks] overlay drawn");
 
   // Draw the overlay with the same transformation as the main context
   cairo_save(cr);

--- a/src/develop/masks/masks_gui.c
+++ b/src/develop/masks/masks_gui.c
@@ -32,6 +32,7 @@
 #include "control/control.h"
 #include "system/macros.h"
 #include "system/mem_alloc.h"
+#include "develop/geometry/geometry.h"   // dt_geometry_chain_generation()
 #include "develop/masks.h"
 #include "develop/masks_gui.h"
 #include "develop/masks/masks_functions.h"
@@ -1305,7 +1306,7 @@ void dt_masks_gui_init(dt_develop_t *dev)
 
   dt_masks_clear_form_gui(dev);
   dt_masks_set_visible_form(dev, NULL);
-  dev->form_gui->pipe_hash = DT_PIXELPIPE_CACHE_HASH_INVALID;
+  dev->form_gui->geometry_generation = 0;
   dev->form_gui->formid = 0;
 }
 
@@ -1857,7 +1858,7 @@ void dt_masks_gui_form_create(dt_masks_form_t *mask_form, dt_masks_form_gui_t *m
          != 0)
         return;
     }
-    mask_gui->pipe_hash = dt_dev_backbuf_get_hash(&mask_gui->dev->preview_pipe->backbuf);
+    mask_gui->geometry_generation = dt_geometry_chain_generation(mask_gui->dev->geometry_chain);
     mask_gui->formid = mask_form->formid;
     mask_gui->type = mask_form->type;
 
@@ -1882,9 +1883,13 @@ gboolean dt_masks_gui_form_create_throttled(dt_masks_form_t *mask_form, dt_masks
   const double now = dt_get_wtime();
   const double min_delta_time = 1.0 / 60.0;
   const float min_dist2 = 4.0f;
+  /* Bypass the throttle only when the GEOMETRY moved -- the outlines would then be drawn in the
+   * wrong place, which no amount of throttling makes acceptable. It used to bypass on the preview
+   * pipe's backbuffer hash instead, so a republished frame counted as a reason: dragging a brush
+   * republishes continuously, the clause was therefore true on essentially every mouse move, and
+   * the throttle below never ran. #1158. */
   const gboolean force_rebuild
-      = (develop->preview_pipe
-         && mask_gui->pipe_hash != dt_dev_backbuf_get_hash(&develop->preview_pipe->backbuf));
+      = (mask_gui->geometry_generation != dt_geometry_chain_generation(develop->geometry_chain));
 
   if(!force_rebuild && mask_gui->last_rebuild_ts > 0.0)
   {
@@ -2278,7 +2283,7 @@ void dt_masks_gui_form_remove(dt_masks_form_t *mask_form, dt_masks_form_gui_t *m
 {
   dt_masks_form_gui_points_t *gui_points
       = (dt_masks_form_gui_points_t *)g_list_nth_data(mask_gui->points, form_index);
-  mask_gui->pipe_hash = DT_PIXELPIPE_CACHE_HASH_INVALID;
+  mask_gui->geometry_generation = 0;
   mask_gui->formid = 0;
 
   if(!IS_NULL_PTR(gui_points))
@@ -2296,12 +2301,12 @@ void dt_masks_gui_form_remove(dt_masks_form_t *mask_form, dt_masks_form_gui_t *m
 void dt_masks_gui_form_test_create(dt_masks_form_t *mask_form, dt_masks_form_gui_t *mask_gui,
                                    dt_iop_module_t *module)
 {
-  // we test if the image has changed
-  if(mask_gui->pipe_hash != DT_PIXELPIPE_CACHE_HASH_INVALID)
+  // we test if the geometry the cached outlines were built against has moved
+  if(mask_gui->geometry_generation != 0)
   {
-    if(mask_gui->pipe_hash != dt_dev_backbuf_get_hash(&mask_gui->dev->preview_pipe->backbuf))
+    if(mask_gui->geometry_generation != dt_geometry_chain_generation(mask_gui->dev->geometry_chain))
     {
-      mask_gui->pipe_hash = DT_PIXELPIPE_CACHE_HASH_INVALID;
+      mask_gui->geometry_generation = 0;
       mask_gui->formid = 0;
       g_list_free_full(mask_gui->points, dt_masks_form_gui_points_free);
       mask_gui->points = NULL;
@@ -2309,7 +2314,7 @@ void dt_masks_gui_form_test_create(dt_masks_form_t *mask_form, dt_masks_form_gui
   }
 
   // we create the form if needed
-  if(mask_gui->pipe_hash == DT_PIXELPIPE_CACHE_HASH_INVALID)
+  if(mask_gui->geometry_generation == 0)
   {
     if(mask_form->type & DT_MASKS_GROUP)
     {
@@ -2464,7 +2469,7 @@ void dt_masks_gui_form_save_creation(dt_develop_t *develop, dt_iop_module_t *mod
     dt_masks_dynbuf_free(mask_gui->guipoints_payload);
     mask_gui->guipoints_payload = NULL;
     mask_gui->guipoints_count = 0;
-    mask_gui->pipe_hash = DT_PIXELPIPE_CACHE_HASH_INVALID;
+    mask_gui->geometry_generation = 0;
     mask_gui->formid = 0;
     mask_gui->creation_closing_form = FALSE;
     dt_masks_soft_reset_form_gui(mask_gui);
@@ -3172,41 +3177,100 @@ void dt_masks_draw_path_seg_by_seg(cairo_t *cr, dt_masks_form_gui_t *mask_gui, c
  * stored in creation_formids are therefore drawn explicitly here, so only the
  * shapes created in this session stay visible until creation mode is exited.
  */
+/* The creation session's own outline cache.
+ *
+ * GUI-thread state, like every other dt_masks_form_gui_t. It is static because the shapes it
+ * describes outlive a single expose and nothing else owns them: `creation_formids' is a list of
+ * ids, and the outlines built from them used to live in a STACK LOCAL that was initialised fresh
+ * every expose, with its cache key forced to zero after each shape. That defeated the cache by
+ * construction -- every shape drawn since creation mode was entered was re-derived and thrown away
+ * on every frame.
+ *
+ * Measured on #1158, with the list length as the variable: 0 shapes 0.0000 s, 1 shape 0.1141 s,
+ * 2 shapes 0.2431 s, 3 shapes 0.3189 s, 4 shapes 0.4444 s -- about 110 ms per shape per expose,
+ * while the mask GROUP, whose outlines ARE cached, drew all of its shapes in 0.0020 s. Everything
+ * else in that stage measured zero: the predicates, the preamble, the group push, the outline
+ * refresh, the composite, the hit test.
+ */
+static dt_masks_form_gui_t _session_gui = { 0 };
+static gboolean _session_gui_inited = FALSE;
+static uint64_t _session_gui_generation = 0;
+static int _session_gui_count = 0;
+
+/** @brief Drop the session outlines. Safe to call when nothing is cached. */
+static void _session_gui_reset(void)
+{
+  if(!_session_gui_inited) return;
+  g_list_free_full(_session_gui.points, dt_masks_form_gui_points_free);
+  _session_gui.points = NULL;
+  _session_gui_generation = 0;
+  _session_gui_count = 0;
+}
+
 static void _masks_draw_creation_session_forms(dt_develop_t *develop, dt_iop_module_t *module,
                                                cairo_t *cr, const float zoom_scale,
                                                const dt_masks_form_gui_t *creation_gui)
 {
-  if(!creation_gui->creation || IS_NULL_PTR(creation_gui->creation_formids)) return;
+  if(!creation_gui->creation || IS_NULL_PTR(creation_gui->creation_formids))
+  {
+    _session_gui_reset();
+    return;
+  }
 
-  dt_masks_form_gui_t draw_gui;
-  dt_masks_init_form_gui(develop, &draw_gui);
-  draw_gui.edit_mode = creation_gui->edit_mode;
-  draw_gui.group_selected = -1;
-  draw_gui.pipe_hash = DT_PIXELPIPE_CACHE_HASH_INVALID;
+  const int count = g_list_length(creation_gui->creation_formids);
+  const uint64_t live_generation = dt_geometry_chain_generation(develop->geometry_chain);
+
+  if(!_session_gui_inited)
+  {
+    dt_masks_init_form_gui(develop, &_session_gui);
+    _session_gui_inited = TRUE;
+    _session_gui_generation = 0;
+    _session_gui_count = 0;
+  }
+  _session_gui.dev = develop;
+  _session_gui.edit_mode = creation_gui->edit_mode;
+  _session_gui.group_selected = -1;
+
+  /* Rebuild only when the composed geometry moved or the session gained a shape -- the same rule
+   * the mask group's outlines follow. A shape's own content changing commits history, which
+   * rebuilds the chain, which advances the generation. */
+  const gboolean rebuild = (_session_gui_generation != live_generation) || (_session_gui_count != count);
+  if(rebuild)
+  {
+    g_list_free_full(_session_gui.points, dt_masks_form_gui_points_free);
+    _session_gui.points = NULL;
+  }
 
   // Iterate over the ids saved in this creation session. Other masks stay
   // hidden while creation is active, even if they belong to the same module.
+  int index = 0;
   for(GList *formid_node = creation_gui->creation_formids; formid_node; formid_node = g_list_next(formid_node))
   {
     const int formid = GPOINTER_TO_INT(formid_node->data);
     dt_masks_form_t *session_form = dt_masks_get_from_id(develop, formid);
     if(IS_NULL_PTR(session_form)) continue;
 
-    dt_masks_gui_form_test_create(session_form, &draw_gui, module);
+    /* Built at `index', not at 0: one slot per shape, so they can all be kept. The old loop wrote
+     * every shape into slot 0 and freed it again, which is why none of them could be cached. */
+    if(rebuild) dt_masks_gui_form_create(session_form, &_session_gui, index, module);
+
     if(session_form->functions && session_form->functions->post_expose)
     {
       const guint point_count = g_list_length(session_form->points);
-      draw_gui.type = session_form->type;
-      session_form->functions->post_expose(cr, zoom_scale, &draw_gui, 0, point_count);
+      _session_gui.type = session_form->type;
+      session_form->functions->post_expose(cr, zoom_scale, &_session_gui, index, point_count);
     }
 
     // Keep the saved-session shape path from being connected to the active
     // creation cursor drawn right after this loop.
     cairo_new_path(cr);
-    g_list_free_full(draw_gui.points, dt_masks_form_gui_points_free);
-    draw_gui.points = NULL;
-    draw_gui.pipe_hash = DT_PIXELPIPE_CACHE_HASH_INVALID;
-    draw_gui.formid = 0;
+    index++;
+  }
+
+  if(rebuild)
+  {
+    _session_gui_generation = live_generation;
+    _session_gui_count = count;
   }
 }
 
@@ -3286,6 +3350,7 @@ void dt_masks_events_post_expose(dt_develop_t *dev, struct dt_iop_module_t *modu
 
 void dt_masks_clear_form_gui(dt_develop_t *develop)
 {
+  _session_gui_reset();
   if(IS_NULL_PTR(develop->form_gui)) return;
   g_list_free_full(develop->form_gui->points, dt_masks_form_gui_points_free);
   develop->form_gui->points = NULL;
@@ -3294,7 +3359,7 @@ void dt_masks_clear_form_gui(dt_develop_t *develop)
   dt_masks_dynbuf_free(develop->form_gui->guipoints_payload);
   develop->form_gui->guipoints_payload = NULL;
   develop->form_gui->guipoints_count = 0;
-  develop->form_gui->pipe_hash = DT_PIXELPIPE_CACHE_HASH_INVALID;
+  develop->form_gui->geometry_generation = 0;
   develop->form_gui->formid = 0;
   develop->form_gui->delta[0] = develop->form_gui->delta[1] = 0.0f;
   develop->form_gui->scrollx = develop->form_gui->scrolly = 0.0f;

--- a/src/develop/masks/masks_gui.c
+++ b/src/develop/masks/masks_gui.c
@@ -3271,9 +3271,181 @@ static gboolean _session_gui_inited = FALSE;
 static uint64_t _session_gui_generation = 0;
 static int _session_gui_count = 0;
 
+/* The shapes already saved in this session, rendered.
+ *
+ * They do not change while a new stroke is being drawn -- that is what makes them "already saved"
+ * -- so re-stroking them on every frame is redrawing a still image. Measured: 8.8 ms per shape per
+ * frame with the outline cached and decimated, 15.9 ms of a 25.7 ms redraw, and it is rasterisation
+ * rather than geometry (only the path is stroked for these; borders, nodes and handles all sit
+ * behind `group_selected == index', which is never true here).
+ *
+ * A cairo pattern from cairo_pop_group() is that rendering, kept. Painting it costs one composite
+ * whatever the shape count, and cairo owns the surface behind it so there is nothing to size or
+ * free by hand.
+ *
+ * The key has to include the MATRIX: a group's pattern carries the transform in effect when it was
+ * pushed, so painting it under a different one would put the shapes somewhere else. Panning or
+ * zooming therefore re-renders, which is correct and is not a per-frame cost while drawing. */
+static cairo_pattern_t *_session_pattern = NULL;
+static uint64_t _session_pattern_key = 0;
+
+/* The area those shapes actually occupy, in the same coordinates they are drawn in.
+ *
+ * Both halves of this cost the whole window otherwise: the group is sized to the CLIP at push
+ * time, and painting its pattern fills the clip. Measured with no clip: a cache HIT still costs
+ * 7.5 ms -- compositing a device-scaled full-frame ARGB surface -- and a miss 19.3 ms, together
+ * 3.13 s of a 5.77 s redraw total. Shapes that cover a fifth of the frame should cost a fifth of
+ * that, and clipping to their union is what says so to cairo. */
+static gboolean _session_bbox_valid = FALSE;
+static double _session_bbox[4] = { 0.0, 0.0, 0.0, 0.0 };   /**< x0, y0, x1, y1 */
+
+/* Did the outlines actually move?
+ *
+ * The rendering is keyed on the geometry GENERATION, which is deliberately a version and not a
+ * content hash -- over-invalidating is the safe direction for the geometry service, whose consumers
+ * mostly recompute something cheap. Here it is not cheap: committing a stroke advances the
+ * generation, and re-rendering costs ~18 ms per shape in the session, 218 ms at twelve of them.
+ * That is the whole of the tail.
+ *
+ * But a generation bump does not mean the outlines moved. This asks whether they did, from the
+ * outlines themselves: the point count and the two endpoints of every shape. Anything that moves an
+ * outline -- a crop, a rotation, a scale, a keystone -- shifts every coordinate in it, endpoints
+ * included, and a shape edited into a different path changes its point count or its ends. What it
+ * cannot see is a change that preserves both endpoints AND the exact point count while moving
+ * points in between; no geometry module does that, and an edit that did would have committed a
+ * different point count on the way.
+ *
+ * Cheap on purpose: three numbers per shape, against hashing 89 000 points each. */
+typedef struct _session_outline_sig_t
+{
+  int points_count;
+  float first[2];
+  float last[2];
+} _session_outline_sig_t;
+
+static _session_outline_sig_t *_session_sigs = NULL;
+static int _session_sigs_count = 0;
+
+static void _session_sigs_reset(void)
+{
+  dt_free(_session_sigs);
+  _session_sigs = NULL;
+  _session_sigs_count = 0;
+}
+
+/** @brief Take the signature of every cached outline. @return the number taken. */
+static int _session_sigs_take(const dt_masks_form_gui_t *gui, _session_outline_sig_t *out, const int max)
+{
+  int taken = 0;
+  for(const GList *node = gui->points; node && taken < max; node = g_list_next(node))
+  {
+    const dt_masks_form_gui_points_t *const pts = (const dt_masks_form_gui_points_t *)node->data;
+    if(IS_NULL_PTR(pts)) continue;
+
+    out[taken].points_count = pts->points_count;
+    if(!IS_NULL_PTR(pts->points) && pts->points_count > 0)
+    {
+      out[taken].first[0] = pts->points[0];
+      out[taken].first[1] = pts->points[1];
+      out[taken].last[0] = pts->points[2 * (pts->points_count - 1)];
+      out[taken].last[1] = pts->points[2 * (pts->points_count - 1) + 1];
+    }
+    else
+      out[taken].first[0] = out[taken].first[1] = out[taken].last[0] = out[taken].last[1] = 0.0f;
+    taken++;
+  }
+  return taken;
+}
+
+/** @brief Union of the cached outlines, or FALSE when there is nothing to bound. */
+static gboolean _session_bbox_from_points(const dt_masks_form_gui_t *gui, double bbox[4])
+{
+  gboolean any = FALSE;
+  for(const GList *node = gui->points; node; node = g_list_next(node))
+  {
+    const dt_masks_form_gui_points_t *const pts = (const dt_masks_form_gui_points_t *)node->data;
+    if(IS_NULL_PTR(pts) || IS_NULL_PTR(pts->points) || pts->points_count <= 0) continue;
+
+    for(int i = 0; i < pts->points_count; i++)
+    {
+      const double x = pts->points[2 * i];
+      const double y = pts->points[2 * i + 1];
+      if(isnan(x) || isnan(y)) continue;
+
+      if(!any)
+      {
+        bbox[0] = bbox[2] = x;
+        bbox[1] = bbox[3] = y;
+        any = TRUE;
+      }
+      else
+      {
+        bbox[0] = fmin(bbox[0], x);
+        bbox[1] = fmin(bbox[1], y);
+        bbox[2] = fmax(bbox[2], x);
+        bbox[3] = fmax(bbox[3], y);
+      }
+    }
+  }
+  return any;
+}
+
+/** @brief Clip to the session's area, with room for the stroke's own width. */
+static gboolean _session_clip(cairo_t *cr, const float zoom_scale)
+{
+  if(!_session_bbox_valid) return FALSE;
+
+  const double margin = (zoom_scale > 1e-6f) ? (16.0 / zoom_scale) : 0.0;
+  cairo_save(cr);
+  cairo_rectangle(cr, _session_bbox[0] - margin, _session_bbox[1] - margin,
+                  (_session_bbox[2] - _session_bbox[0]) + 2.0 * margin,
+                  (_session_bbox[3] - _session_bbox[1]) + 2.0 * margin);
+  cairo_clip(cr);
+  cairo_new_path(cr);
+  return TRUE;
+}
+
 /** @brief Drop the session outlines. Safe to call when nothing is cached. */
+static void _session_pattern_reset(void)
+{
+  if(!IS_NULL_PTR(_session_pattern)) cairo_pattern_destroy(_session_pattern);
+  _session_pattern = NULL;
+  _session_pattern_key = 0;
+}
+
+static void _session_bbox_invalidate(void)
+{
+  _session_bbox_valid = FALSE;
+}
+
+/** @brief What the cached rendering is a rendering OF. */
+static uint64_t _session_pattern_hash(cairo_t *cr, const dt_masks_form_gui_t *creation_gui,
+                                      const uint64_t generation, const int count)
+{
+  cairo_matrix_t matrix;
+  cairo_get_matrix(cr, &matrix);
+
+  /* No generation here: whether the geometry MOVED is asked of the outlines themselves
+   * (_session_sigs_take), because the generation advances on every history commit -- including the
+   * one that saves the stroke being drawn -- without shifting any of these shapes. What remains in
+   * the key is what genuinely describes this rendering: where it was drawn, and which shapes. */
+  (void)generation;
+  uint64_t hash = 5381;
+  hash = dt_hash(hash, (const char *)&matrix, sizeof(matrix));
+  hash = dt_hash(hash, (const char *)&count, sizeof(count));
+  for(const GList *node = creation_gui->creation_formids; node; node = g_list_next(node))
+  {
+    const int formid = GPOINTER_TO_INT(node->data);
+    hash = dt_hash(hash, (const char *)&formid, sizeof(formid));
+  }
+  return hash ? hash : 1;
+}
+
 static void _session_gui_reset(void)
 {
+  _session_pattern_reset();
+  _session_bbox_invalidate();
+  _session_sigs_reset();
   if(!_session_gui_inited) return;
   g_list_free_full(_session_gui.points, dt_masks_form_gui_points_free);
   _session_gui.points = NULL;
@@ -3285,13 +3457,31 @@ static void _masks_draw_creation_session_forms(dt_develop_t *develop, dt_iop_mod
                                                cairo_t *cr, const float zoom_scale,
                                                const dt_masks_form_gui_t *creation_gui)
 {
-  if(!creation_gui->creation || IS_NULL_PTR(creation_gui->creation_formids))
+  /* Nothing to draw and nothing to forget.
+   *
+   * `creation' goes false between strokes -- a shape is committed, then the next one begins -- and
+   * resetting on that threw the session's rendering away every time: 46 of 78 cache misses in one
+   * log had no reason to report beyond the pattern having been destroyed, at ~21 ms each. The
+   * shapes it describes are still there, and will be drawn again the moment creation resumes.
+   *
+   * What ends the session is the LIST emptying, which is the only thing reset on here now. */
+  if(IS_NULL_PTR(creation_gui->creation_formids))
   {
     _session_gui_reset();
     return;
   }
 
   const int count = g_list_length(creation_gui->creation_formids);
+
+  if(!creation_gui->creation)
+  {
+    // Nothing to draw between strokes. Said out loud so a log reader does not count it as a cache
+    // miss: the outer timer around this call fires either way.
+    if(dt_get_debug_flags() & DT_DEBUG_PERF)
+      dt_print(DT_DEBUG_MASKS, "[masks] creation session idle (%d shapes kept)\n", count);
+    return;
+  }
+
   const uint64_t live_generation = dt_geometry_chain_generation(develop->geometry_chain);
 
   if(!_session_gui_inited)
@@ -3314,6 +3504,63 @@ static void _masks_draw_creation_session_forms(dt_develop_t *develop, dt_iop_mod
     g_list_free_full(_session_gui.points, dt_masks_form_gui_points_free);
     _session_gui.points = NULL;
   }
+
+  /* The outlines are current from here on. Ask whether they actually MOVED before deciding the
+   * rendering is stale: the generation advances when a stroke is committed, which does not shift a
+   * single point of the shapes already saved. */
+  gboolean outlines_moved = TRUE;
+  if(rebuild)
+  {
+    _session_outline_sig_t *const sigs
+        = (_session_outline_sig_t *)dt_alloc_align(sizeof(_session_outline_sig_t) * MAX(count, 1));
+    const int taken = IS_NULL_PTR(sigs) ? 0 : _session_sigs_take(&_session_gui, sigs, count);
+
+    outlines_moved = IS_NULL_PTR(_session_sigs) || taken != _session_sigs_count
+                     || IS_NULL_PTR(sigs)
+                     || memcmp(sigs, _session_sigs, sizeof(_session_outline_sig_t) * taken) != 0;
+
+    if(!IS_NULL_PTR(sigs))
+    {
+      dt_free(_session_sigs);
+      _session_sigs = sigs;
+      _session_sigs_count = taken;
+    }
+  }
+  else
+    outlines_moved = FALSE;
+
+  /* Nothing about these shapes changed: paint the rendering we already have. */
+  const uint64_t pattern_key = _session_pattern_hash(cr, creation_gui, live_generation, count);
+
+  if((dt_get_debug_flags() & DT_DEBUG_PERF) && (outlines_moved || pattern_key != _session_pattern_key))
+  {
+    cairo_matrix_t matrix;
+    cairo_get_matrix(cr, &matrix);
+    dt_print(DT_DEBUG_MASKS,
+             "[masks] session re-render: rebuild=%d moved=%d generation %lu->%lu count %d->%d"
+             " matrix (%.4f %.4f %.4f %.4f %.2f %.2f)\n",
+             rebuild, outlines_moved, (unsigned long)_session_gui_generation,
+             (unsigned long)live_generation, _session_gui_count, count, matrix.xx, matrix.yx,
+             matrix.xy, matrix.yy, matrix.x0, matrix.y0);
+  }
+  if(!outlines_moved && !IS_NULL_PTR(_session_pattern) && pattern_key == _session_pattern_key)
+  {
+    const gboolean clipped = _session_clip(cr, zoom_scale);
+    cairo_set_source(cr, _session_pattern);
+    cairo_paint(cr);
+    if(clipped) cairo_restore(cr);
+    if(dt_get_debug_flags() & DT_DEBUG_PERF)
+      dt_print(DT_DEBUG_MASKS, "[masks] creation session (%d shapes) painted from cache\n", count);
+    return;
+  }
+
+  _session_pattern_reset();
+
+  /* Bound the group to what the previous render occupied. The outlines are already built by the
+   * time this matters -- the very first render of a session has no bbox yet and takes the whole
+   * clip, once. */
+  const gboolean clipped = _session_clip(cr, zoom_scale);
+  cairo_push_group(cr);
 
   // Iterate over the ids saved in this creation session. Other masks stay
   // hidden while creation is active, even if they belong to the same module.
@@ -3350,6 +3597,19 @@ static void _masks_draw_creation_session_forms(dt_develop_t *develop, dt_iop_mod
     cairo_new_path(cr);
     index++;
   }
+
+  /* Keep the rendering, and paint it -- this frame included, so the first frame after a change
+   * costs the same as it did before and every later one costs a composite. */
+  _session_pattern = cairo_pop_group(cr);
+  _session_pattern_key = pattern_key;
+  cairo_set_source(cr, _session_pattern);
+  cairo_paint(cr);
+  if(clipped) cairo_restore(cr);
+
+  /* The bbox is a function of the OUTLINES, so it is recomputed when they are and not when the
+   * matrix moved under them -- walking every point of every shape is not free (measured: doing it
+   * on every render took the miss path from 19.3 ms to 25.1 ms, more than the clip saved). */
+  if(rebuild) _session_bbox_valid = _session_bbox_from_points(&_session_gui, _session_bbox);
 
   if(rebuild)
   {
@@ -3460,7 +3720,19 @@ void dt_masks_events_post_expose(dt_develop_t *dev, struct dt_iop_module_t *modu
 
 void dt_masks_clear_form_gui(dt_develop_t *develop)
 {
-  _session_gui_reset();
+  /* Deliberately NOT resetting the creation session's cache here.
+   *
+   * dt_masks_change_form_gui() calls this every time the visible form changes, which during a
+   * creation session is once per stroke -- and the shapes already saved in that session are
+   * unaffected by which form is currently being edited. Tying the two together threw away their
+   * rendering AND their outlines on every stroke: 37 of 77 cache misses in one log came from the
+   * pattern having been destroyed rather than from anything about the shapes changing, each
+   * costing a 20 ms re-render.
+   *
+   * What ends the session cache is the session ending, which
+   * _masks_draw_creation_session_forms() handles at its top, and any change to what it describes,
+   * which its key covers: the geometry generation, the shape count, the shape ids and the
+   * matrix. */
   if(IS_NULL_PTR(develop->form_gui)) return;
   g_list_free_full(develop->form_gui->points, dt_masks_form_gui_points_free);
   develop->form_gui->points = NULL;

--- a/src/develop/masks_gui.h
+++ b/src/develop/masks_gui.h
@@ -169,7 +169,15 @@ typedef struct dt_masks_form_gui_t
 
   // ids
   int formid;
-  uint64_t pipe_hash;
+  /* Which composed geometry the cached outlines in ::points were built against
+   * (dt_geometry_chain_generation()). Zero means "nothing cached".
+   *
+   * This used to be the PREVIEW PIPE'S BACKBUFFER HASH, which made it a pixel identity standing in
+   * for a geometric one: every republished preview frame invalidated outlines whose inputs had not
+   * changed, and while a brush is dragged the preview republishes continuously. That is #1158 --
+   * the outlines of every shape in the group rebuilt on every mouse move, and the 1/60 s throttle
+   * in dt_masks_gui_form_create_throttled() bypassed by its own force_rebuild clause. */
+  uint64_t geometry_generation;
 } dt_masks_form_gui_t;
 
 /** Reset a form GUI state and bind it to its owning develop instance (gui->dev). */

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -842,7 +842,16 @@ void expose(
   const uint64_t zoom_hash = _darkroom_zoom_hash(dev);
   const gboolean roi_changed = !_darkroom_locked_main_valid_for_zoom(&expose_state, zoom_hash);
 
+  /* The expose is timed as a whole and nothing inside it is, which is why a redraw that grows
+   * from 11 ms to 400 ms across a drawing session cannot be attributed: the mask overlay reports
+   * 1.5 ms of it and the rest is dark. Three stages, so the next log says which. */
+  dt_times_t stage = { 0 };
+  dt_get_times(&stage);
+
   _darkroom_prepare_image_surface(dev, width, height, &expose_state);
+
+  if(dt_get_debug_flags() & DT_DEBUG_PERF) dt_show_times(&stage, "[darkroom] surface prepared");
+  dt_get_times(&stage);
 
   cairo_t *cr = cairo_create(dev->image_surface);
   const int full_width = dt_dev_roi_request_preview_width(dev);
@@ -1076,6 +1085,9 @@ void expose(
     cairo_restore(cri);
   }
 
+  if(dt_get_debug_flags() & DT_DEBUG_PERF) dt_show_times(&stage, "[darkroom] image painted");
+  dt_get_times(&stage);
+
   const gboolean picker_active = dt_iop_color_picker_is_visible(dev);
 
   // draw colorpicker for in focus module or execute module callback hook
@@ -1094,9 +1106,17 @@ void expose(
     if(dt_masks_get_visible_form(dev) && display_masks)
       dt_masks_events_post_expose(dev, dev->gui_module, cri, width, height, pointerx, pointery);
       
+    if(dt_get_debug_flags() & DT_DEBUG_PERF) dt_show_times(&stage, "[darkroom] overlays drawn");
+    dt_get_times(&stage);
+
     // module
     if(dev->gui_module && dev->gui_module->enabled && dev->gui_module->gui_post_expose)
+    {
       dev->gui_module->gui_post_expose(dev->gui_module, cri, width, height, pointerx, pointery);
+
+      if(dt_get_debug_flags() & DT_DEBUG_PERF)
+        dt_show_times_f(&stage, "[darkroom]", "module %s gui_post_expose", dev->gui_module->op);
+    }
   }
 
   // indicate if we are in gamut check or softproof mode

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -1103,6 +1103,8 @@ void expose(
     const gboolean display_masks = (dev->gui_module && dev->gui_module->enabled)
                                  || dt_lib_gui_get_expanded(dt_lib_get_module("masks"));
 
+    if(dt_get_debug_flags() & DT_DEBUG_PERF) dt_show_times(&stage, "[darkroom] overlay predicates");
+
     if(dt_masks_get_visible_form(dev) && display_masks)
       dt_masks_events_post_expose(dev, dev->gui_module, cri, width, height, pointerx, pointery);
       

--- a/src/widgets/draw.h
+++ b/src/widgets/draw.h
@@ -835,6 +835,27 @@ static inline void dt_draw_shape_lines(struct dt_develop_t *dev, const dt_draw_d
  * @param selected TRUE if the shape is selected
  * @param zoom_scale the current zoom scale of the image
  */
+/**
+ * @brief The shortest user-space step worth emitting into @p cr, in user units.
+ *
+ * @details Outlines are sampled at the resolution they were BUILT at -- for a mask, one point per
+ * raw image pixel along the path -- and drawn into a view that is a fraction of that. Measured on
+ * ansel#1158: a mean of 89 150 points per brush shape (max 208 095) for a mean of 11.9 nodes, with
+ * roughly four of them landing inside every device pixel, costing 93 ms per shape per frame to
+ * stroke a curve indistinguishable from the decimated one.
+ *
+ * Half a device pixel, converted through the context's own matrix rather than through a zoom
+ * factor a caller happens to know: that picks up the device scale (HiDPI) and any transform in
+ * effect, and needs nothing passed in. Returns 0 for a degenerate matrix, which decimates nothing.
+ */
+static inline double dt_draw_min_emit_step(cairo_t *cr)
+{
+  double dx = 0.5, dy = 0.5;
+  cairo_device_to_user_distance(cr, &dx, &dy);
+  const double step = fmin(fabs(dx), fabs(dy));
+  return isfinite(step) ? step : 0.0;
+}
+
 static inline void dt_draw_stroke_line(const dt_draw_dash_type_t dash_type, const gboolean source, cairo_t *cr,
                           const gboolean selected, const float zoom_scale, const cairo_line_cap_t line_cap)
 {


### PR DESCRIPTION
Fixes #1158 — brushing gets slower with every stroke.

Diagnosed from the reporter's `-d masks -d perf` log rather than from the source, because the
source reads as though a throttle already handles this.

### What the log says

Over 80 seconds of brushing:

- **566 rebuilds** of two brush outlines;
- **~2 s** in coordinate transform alone (`brush_points transform`, mean 3.5 ms, max 21 ms);
- `render all masks` growing **21 → 46 ms**;
- the darkroom expose growing **23 ms → 137 ms** — 7 fps, which is the reported jitter.

And every one of those rebuilds recomputes each form's gravity centre and gets the same answer to
six decimals — form `0x62e791786df0` reports centre `(0.627190, 0.660384)` area `0.038440` at
t=78.7, 79.5 and 88.3. Nothing about those outlines had changed.

### Why

`dt_masks_gui_form_test_create()` threw the cached outlines away whenever

```c
mask_gui->pipe_hash != dt_dev_backbuf_get_hash(&dev->preview_pipe->backbuf)
```

and `dt_masks_gui_form_create_throttled()` bypassed its own 1/60 s + 2 px throttle on the same
condition.

That is a **pixel identity standing in for a geometric one**. An outline is a function of the
form's points and of the composed distortion — never of what the preview pipe last painted — and
dragging a brush makes the preview republish continuously, so the key changed on essentially every
mouse move. The throttle was dead code exactly when it was needed, and each event rebuilt every
shape in the group: O(shapes × points). That is why the first stroke is fine and the fifth is not.

The key predates the module split — `git log -S` dates it to `masks : base implementation` — but
the replacement did not exist until the geometry service landed.

### Fix

`develop/geometry` gains a generation counter, advanced once per chain rebuild — and a rebuild
happens where a pipe flag is raised, i.e. where the module stack or the history changed, not where
a frame was published. The mask GUI keys its outline cache on that, and the field is renamed
`geometry_generation` so the old meaning cannot come back.

Deliberately **not** a content hash: a rebuild landing on identical geometry still advances it,
costing one redundant recompute, whereas hashing each record's module-owned blob would mean
guessing at a size the service does not know — and a missed change draws an overlay in the wrong
place. Over-invalidating is the safe direction for a cache key, and it is still bounded by the
throttle, which now actually runs.

### Verification

Builds clean. **Not measured end-to-end** — reproducing needs a brush session in the darkroom, so
that is where this should be confirmed before the issue is closed. The thing to watch is whether
`brush_points transform` still fires per mouse move under `-d masks -d perf`.
