### PR TITLE
Link IOP modules into the binary instead of dlopen'ing 91 shared objects

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,6 +90,19 @@ jobs:
           - nofeatures
         generator:
           - Ninja
+        # One Release build per OS. Release is the ONLY configuration that turns LTO on
+        # (CMakeLists.txt disables IPO for Debug), and LTO is what the nightlies ship, so a
+        # Debug-only matrix never exercises the configuration users actually run. It also
+        # cannot catch what LTO changes: with LTO the linker localises module-internal
+        # symbols, so a duplicate-definition clash shows up in Debug and NOT in Release --
+        # and cross-TU inlining, which moves pixels under -ffast-math, only exists here.
+        # See doc/static-iop.md.
+        include:
+          - os: { label: ubuntu-24.04, code: noble }
+            compiler: { compiler: GNU14, CC: gcc-14, CXX: g++-14, GCC_VER: "14", LLVM_VER: "" }
+            btype: Release
+            target: skiptest
+            generator: Ninja
     env:
       CC: ${{ matrix.compiler.CC }}
       CXX: ${{ matrix.compiler.CXX }}
@@ -213,13 +226,15 @@ jobs:
           ./run.sh --no-opencl --no-deltae --fast-fail
 
   Win64:
-    name: Win64.${{ matrix.msystem }}.${{ matrix.target }}.${{ matrix.btype }}.${{ matrix.generator }}
+    name: Win64.${{ matrix.msystem }}.${{ matrix.compiler.compiler }}.${{ matrix.target }}.${{ matrix.btype }}.${{ matrix.generator }}
     runs-on: windows-latest
     strategy:
       fail-fast: true
       matrix:
         btype:
           - Debug
+        compiler:
+          - { compiler: GNU, CC: gcc, CXX: g++ }
         eco: [-DUSE_XMLLINT=OFF]
         target:
           - skiptest
@@ -228,6 +243,23 @@ jobs:
           - Ninja
         msystem:
           - UCRT64
+        # One Release build per OS. Release is the ONLY configuration that turns LTO on
+        # (CMakeLists.txt disables IPO for Debug), and LTO is what the nightlies ship, so a
+        # Debug-only matrix never exercises the configuration users actually run. It also
+        # cannot catch what LTO changes: with LTO the linker localises module-internal
+        # symbols, so a duplicate-definition clash shows up in Debug and NOT in Release --
+        # and cross-TU inlining, which moves pixels under -ffast-math, only exists here.
+        # See doc/static-iop.md.
+        # On Windows LTO needs clang and lld: CMakeLists.txt disables IPO outright for
+        # WIN32 with the GNU toolchain, because GNU ld cannot do it. Both are already in
+        # packaging/install-deps-windows-msys2.sh, and this is what win-nightly.yml ships.
+        include:
+          - btype: Release
+            compiler: { compiler: LLVM, CC: clang, CXX: clang++ }
+            eco: -DUSE_XMLLINT=OFF
+            target: skiptest
+            generator: Ninja
+            msystem: UCRT64
     defaults:
       run:
         shell: msys2 {0}
@@ -235,6 +267,8 @@ jobs:
       SRC_DIR: ${{ github.workspace }}/src
       BUILD_DIR: ${{ github.workspace }}/build
       INSTALL_PREFIX: ${{ github.workspace }}/install
+      CC: ${{ matrix.compiler.CC }}
+      CXX: ${{ matrix.compiler.CXX }}
       ECO: ${{ matrix.eco }}
       CMAKE_BUILD_TYPE: ${{ matrix.btype }}
       TARGET: ${{ matrix.target }}
@@ -292,6 +326,20 @@ jobs:
         generator:
           - Ninja
         eco: [-DUSE_GRAPHICSMAGICK=ON -DUSE_IMAGEMAGICK=OFF]
+        # One Release build per OS. Release is the ONLY configuration that turns LTO on
+        # (CMakeLists.txt disables IPO for Debug), and LTO is what the nightlies ship, so a
+        # Debug-only matrix never exercises the configuration users actually run. It also
+        # cannot catch what LTO changes: with LTO the linker localises module-internal
+        # symbols, so a duplicate-definition clash shows up in Debug and NOT in Release --
+        # and cross-TU inlining, which moves pixels under -ffast-math, only exists here.
+        # See doc/static-iop.md.
+        include:
+          - build: { os: macos-15, xcode: 26.3, deployment: 15.0 }
+            compiler: { compiler: XCode, CC: cc, CXX: c++ }
+            btype: Release
+            target: skiptest
+            generator: Ninja
+            eco: -DUSE_GRAPHICSMAGICK=ON -DUSE_IMAGEMAGICK=OFF
     env:
       DEVELOPER_DIR: /Applications/Xcode_${{ matrix.build.xcode }}.app/Contents/Developer
       CC: ${{ matrix.compiler.CC }}

--- a/doc/lensfun-cost.md
+++ b/doc/lensfun-cost.md
@@ -37,9 +37,15 @@ modules in (see `static-iop.md`), which is the other half of the number:
 |---|---|---|---|
 | startup | 0.293–0.340 s | 0.206–0.211 s | **0.097–0.112 s** |
 
-The 90-odd ms does not disappear, it moves to the first image that needs a lens — where a raw
-decode already dwarfs it. If that hitch ever matters, the next step is to warm the database on
-a background thread at startup; the accessor is already thread-safe, so that is a few lines.
+The 90-odd ms does not disappear, but it is not left on the critical path either:
+`init_global()` starts `_lensfun_db_warm()` on a background thread, so the parse overlaps the
+rest of startup and is normally done before any image asks. Whoever arrives first builds it
+and the other waits on the same lock — there is one construction either way, and the accessor
+was already thread-safe. The thread is **joined** in `cleanup_global()`, not detached: it must
+not still be parsing when the database it is writing gets freed.
+
+Measured with the pre-warm in place, 5 interleaved runs: startup 0.109–0.115 s against
+master's 0.345–0.356 s — i.e. the background parse costs the startup path nothing.
 
 ## 2. The same lookup was repeated on every pipe resync
 

--- a/doc/lensfun-cost.md
+++ b/doc/lensfun-cost.md
@@ -1,0 +1,93 @@
+# What lensfun actually costs, and what was done about it
+
+Measured on lensfun 0.3.4, a stock Fedora database (`/usr/share/lensfun/version_1`, 4.5 MB,
+57 files) plus the user's own updates (3.9 MB), against a microbenchmark linked straight to
+`liblensfun` — no Ansel in the loop, so none of this is confounded by pipeline machinery.
+
+| operation | cost |
+|---|---|
+| `new lfDatabase` | 0.02 ms |
+| `lfDatabase::Load()` — parse the whole database | **89–102 ms**, +4 MB RSS |
+| what that yields | 1051 cameras, 1562 lenses |
+| `FindCamerasExt()` | **0.35–0.42 ms** |
+| `FindLenses()`, hit | 0.055 ms |
+| `FindLenses()`, miss | **0.84 ms** (a miss scans everything) |
+| `new lfModifier` + `Initialize()` | 0.0007 ms — free |
+| `ApplySubpixelGeometryDistortion()`, 6016×4016 | 278 ms single-threaded (87 Mpx/s) |
+
+Three things follow, and only the first two are about *profiles*.
+
+## 1. The database was parsed at startup, in every session
+
+`init_global()` called `Load()`, so every launch paid 89–102 ms and 4 MB to parse XML —
+including every lighttable-only session that never corrects a lens. Nothing can need it that
+early: `reload_defaults()` sets `workflow_enabled` per image, so the first possible consumer
+is an image being loaded.
+
+**Fixed**: the database is built on first use, behind `_lensfun_db()` (`iop/lens.cc`). Every
+consumer goes through that accessor; `init_global()` only creates OpenCL kernels now.
+`db_tried` makes a failed load final, so a broken installation stays broken instead of
+becoming slow. The construction lock is never held while the plugin mutex is taken, so the two
+cannot deadlock.
+
+Measured, headless startup, 5 interleaved runs of each — this on top of linking the IOP
+modules in (see `static-iop.md`), which is the other half of the number:
+
+| | master | + static IOP | + lazy lensfun |
+|---|---|---|---|
+| startup | 0.293–0.340 s | 0.206–0.211 s | **0.097–0.112 s** |
+
+The 90-odd ms does not disappear, it moves to the first image that needs a lens — where a raw
+decode already dwarfs it. If that hitch ever matters, the next step is to warm the database on
+a background thread at startup; the accessor is already thread-safe, so that is a few lines.
+
+## 2. The same lookup was repeated on every pipe resync
+
+`commit_params()` → `_lens_build_data()` resolved the camera and the lens from the database on
+**every resync, for every pipe**, taking the global plugin mutex to do it. That is 0.4–1.3 ms
+of fuzzy string scanning to re-answer a question whose answer cannot change: the camera and
+lens of an open image are fixed.
+
+**Fixed**: `_lensfun_find_camera()` / `_lensfun_find_lens()` memoise the resolved pointers,
+keyed on the strings that were searched for. Misses are cached too — a miss is the *expensive*
+case to establish and it will not change. The results are pointers into the database, which is
+built once and never reloaded, so they stay valid for the process's life; the memos are
+destroyed before the database in `cleanup_global()`. Both are read under the plugin mutex the
+lookups already took, so no new lock and no new lock order.
+
+An uncontended hash lookup replaces 0.4 ms of scanning per resync. `reload_defaults()` keeps
+the array-returning API — it walks the whole candidate list to pick a fixed-lens camera's
+shortest model name — and runs once per image load, not per resync.
+
+## 3. What is NOT a profile problem
+
+The module's ~0.9 s in a full-resolution export is **not** database work. It is
+`ApplySubpixelGeometryDistortion()` building the coordinate map — 278 ms of lensfun's own
+polynomial maths per full frame, single-threaded, before any resampling — plus Ansel's
+interpolation over the result. No amount of profile caching touches it. Reducing that means
+caching the coordinate map across frames, or not asking lensfun for per-pixel maths, and both
+are a different project.
+
+## The `lens` slowdown under static linking is code placement, not code quality
+
+Linking the modules into `lib_ansel` made `Lens correction` consistently slower: +10.7%
+(p = 0.003, n = 13), reproduced across three separate sessions. It is the only module that
+moved significantly. Chased to the end, because it looked like the one real cost of that
+change:
+
+* Disabling LTO for the `lens` target alone did **not** help (+11.7%). Not inlining in the
+  module's own objects.
+* Profiling put the cost in `dt_interpolation_compute_sample` — which lives in `lib_ansel` in
+  *both* builds, and which lens leans on for resampling. Absolute cycles: 10.05 G → 10.82 G,
+  +7.6%, matching the module delta.
+* **Its disassembly is identical.** 883 instructions in both, same 15 `ymm`, same 50 FMA, byte
+  for byte the same except addresses. Only its placement changed: `0x350de0` (32-byte aligned)
+  in a 32 MB library, `0x725290` (16-byte aligned) in a 42 MB one.
+* Whole-process counters confirm the front-end: the static build retires **4% fewer
+  instructions** at **lower IPC**, takes **9.3% fewer µops from the DSB** (µop-cache coverage
+  58.3% → 55.3%), leans more on legacy decode, and eats **11.8% more `icache_64b.iftag_stall`**.
+
+So this is the alignment/µop-cache lottery, not a regression in anything anyone wrote. It
+would reshuffle on a different link order, and total pipeline cycles moved +0.8% — i.e. not at
+all. `-falign-functions=64`, PGO or BOLT are the levers if it is ever worth reclaiming; a
+per-module workaround is not.

--- a/doc/static-iop.md
+++ b/doc/static-iop.md
@@ -1,0 +1,170 @@
+# IOP modules are linked in, not dlopen'd
+
+## Why this changed
+
+`src/iop` was loaded the same way `src/libs` and `src/views` are: one shared object per
+module, installed into `lib/ansel/plugins`, discovered by scanning that directory, bound
+with `g_module_symbol()`. For libs and views that is defensible — a user may genuinely not
+want a panel, and the set is small. For IOP modules it bought nothing and cost three things.
+
+**It bought nothing, because the module set is not discoverable.** Every one of the 90
+`add_iop()` calls in `src/iop/CMakeLists.txt` is unconditional; the only `if()` in that file
+switches lut3d's *sources*. More importantly, the application already carries a hardcoded
+census of module names that a module on disk cannot join:
+
+* the five order tables in `src/develop/iop_order.c` and `dt_ioppr_insert_missing_modules()`,
+* the `_roster[]` in `src/develop/geometry/geometry.c`, which decides who may publish a
+  geometry record,
+* the `@@_NEW_MODULE` markers that tie the two together.
+
+A module without an entry in those is not a working module. So a genuinely third-party IOP
+was never possible without recompiling the core, and the directory scan could only ever
+discover a *disagreement* with the tables.
+
+**It cost a hard failure at startup.** `dt_ioppr_check_so_iop_order()` aborts
+initialisation — GUI included — when a loaded module has no iop-order entry:
+
+```
+[dt_ioppr_check_so_iop_order] missing iop_order for module experimental
+ERROR: iop order looks bad, aborting.
+```
+
+One `.so` left behind by an experimental branch was enough. `DT_MODULE_VERSION` is a
+hand-bumped constant, so any build sharing its value loads. The quiet variant is worse: a
+stale module whose op name *does* have an order loads fine and reads a struct whose layout
+has since shifted.
+
+**It cost two thirds of startup.** Measured headless (`ansel-cltest -d control`, 3 runs,
+warm cache): startup 0.373–0.388 s total, of which the IOP load span was 253–260 ms. 108 ms
+of that is `lens` alone (lensfun's database, in `init_global`, and unaffected by any of
+this). The remaining ~136 ms for 90 modules is almost entirely the dynamic loader: an
+isolated benchmark of 91 `dlopen()`s of the same files with `libansel.so` preloaded costs
+120 ms lazy / 122 ms bound, so symbol binding is not the expense — mapping and relocating 91
+objects is.
+
+## What replaced it
+
+The constraint that shaped the design: **the API must not change.** Every module defines
+`process`, `name`, `commit_params` with those exact names, and that sameness is the point —
+it is what makes a module read as an implementation of an abstract class. No module source
+was touched.
+
+### Symbol namespacing by asm label
+
+`common/module_api.h`'s `FULL_API_H` branch attaches an asm label to each declaration when
+`DT_MODULE_SYMBOL_PREFIX` is defined:
+
+```c
+#define OPTIONAL(return_type, function_name, ...) \
+    return_type function_name(__VA_ARGS__) DT_MODULE_SYM(function_name)
+```
+
+so `iop/exposure.c` still writes `int process(...)` and emits `dt_iop_exposure__process`.
+An asm label renames the *symbol* and leaves the *identifier* alone, which a
+`#define process ...` could not: struct members, locals and `->name` are untouched by
+construction. The label attaches to the first declaration and the later definition inherits
+it; re-declaring it identically is fine, which matters because `iop_api.h` has no include
+guard and most modules include it again themselves.
+
+Verified on GCC and Clang, with and without `-flto`, through a static archive. It is a
+compiler feature, so it needs nothing from the linker — which is what makes it work on the
+Windows nightly, where clang drives **lld** in COFF mode: there is no `-r` partial link and
+COFF has no symbol visibility, so the `objcopy --localize-hidden` / `--redefine-sym` route
+that works on ELF is unavailable.
+
+`DT_MODULE_SYMBOL_PREFIX` is set per module by `add_iop()`. It is undefined for `src/libs`
+and `src/views`, which are still one shared object each and still dlopen'd, so nothing there
+changes.
+
+**macOS:** an asm label is emitted verbatim and Mach-O prefixes symbols with an underscore,
+so `DT_MODULE_SYM` adds it under `__APPLE__`. ELF and PE/COFF x86-64 do not.
+
+### Answering what `g_module_symbol()` used to answer
+
+Binding needs to know, per module, which entry points it actually defines — `OPTIONAL` ones
+legitimately absent, `DEFAULT` ones falling back to `default_<fn>`. `tools/generate_iop_static.py`
+answers it by running the **real compiler's preprocessor** over the module's real sources
+with the module's real flags, and emitting `DT_MODULE_HAS_<fn>` as 0 or 1 for every name in
+the API.
+
+It has to be the preprocessor, not a regex. A regex over the raw sources gets 90 of the 91
+modules right and then meets `iop/censorize.c`, which parks four functions behind
+`#if FALSE` and writes `name()` with its return type on the previous line. Preprocessed
+output, filtered by line marker to the module's own files, matches `nm -D` on all 91 of the
+previously shipped `.so`s exactly.
+
+The presence header defines a macro for *every* API name, so a name the generator did not
+consider is a compile error in `DT_MODULE_PICK()`, never a silently NULL function pointer.
+`REQUIRED` entries are bound unconditionally: a module missing one fails to link.
+
+### Two halves, and why they cannot be merged
+
+`<module>_static.c` is generated into the module's own object library, because that is the
+only translation unit where the plain API names resolve to *that* module's symbols. It fills
+everything the module defines and leaves NULL elsewhere.
+
+The `DEFAULT` fallbacks are applied afterwards, in `develop/imageop.c`, because
+`default_process`, `default_group` and the rest are `static` to that file. Hence the two
+X-macro branches, `INCLUDE_API_FROM_MODULE_STATIC` and
+`INCLUDE_API_FROM_MODULE_STATIC_DEFAULTS`.
+
+### Where the objects live
+
+Each module is an `OBJECT` library whose objects are added to `lib_ansel` via
+`target_sources`. They cannot go in the executable: `lib_ansel` is a shared library, and on
+Windows a DLL may not leave symbols for its executable to resolve. The generated
+`iop_registry.c` — also compiled into `lib_ansel` — names every module's binder, which is
+what pulls the objects into the link.
+
+The object libraries link `ansel_deps` and OpenMP directly rather than `lib_ansel`; naming
+`lib_ansel` would be a dependency cycle, and its symbols need no linking now that the
+objects are inside it.
+
+## Latent bugs this surfaced
+
+One link instead of 91 turns "each `.so` gets its own copy" into "duplicate definition".
+The linker found 30 such symbols, and nearly all of them are the defect `CLAUDE.md` already
+warns about — a header that *defines* rather than declares. Each was given internal linkage,
+which is exactly the lifetime they had before (one copy per shared object) and so is not a
+behaviour change:
+
+* `common/colorchecker.h` — 24 of the 30. Ten `dt_colorchecker_*` functions and fourteen
+  built-in chart tables (`spyder_*`, `xrite_*`, `CGATS_types`,
+  `colorchecker_material_types`), all defined at file scope in a header included by both
+  `common/colorchecker.c` and `iop/channelmixerrgb.c`. Now `static inline` / `static`.
+  **The properly correct fix is to move these into `common/colorchecker.c`, which already
+  exists and already defines the header's other functions.** That is a separate cleanup and
+  deliberately not done here.
+* `pixel/chromatic_adaptation.h` defined eight `const dt_colormatrix_t` matrices at file
+  scope, alongside four siblings that were already `static const`. Now all twelve are.
+* `pixel/locallaplacian.h` defined `local_laplacian()` — a one-line wrapper — at file scope,
+  among neighbours that are declarations. Now `static inline`.
+* `pixel/illuminants.h` defined `pair_min()` at file scope. Now `static inline`.
+* `iop/initialscale.c`, `iop/finalscale.c` and `iop/rotatepixels.c` each had a file-scope
+  `dummy`. Now `static`.
+* `iop/channelmixerrgb_shared.c` was `#include`d textually into two modules, with a comment
+  saying it had to be, "to avoid duplicate globals from a separate compiled object". That
+  constraint is exactly what this change reverses, so it is a translation unit again,
+  compiled once.
+
+A note on finding these: counting duplicate symbol names across the *pre-LTO* object files
+of a partial build undercounts badly — it reported 37 names, mostly the shared-implementation
+file, and missed `common/colorchecker.h` entirely. The link is the only reliable census.
+
+## What this costs
+
+Editing one module used to relink one small `.so`. It now relinks `lib_ansel`, which takes
+34–42 s with LTO. That is the real price, it is a developer-workflow price rather than a
+runtime one, and it is the thing to revisit if it becomes painful — giving the IOP objects
+their own non-LTO target would recover most of it at the cost of cross-module inlining.
+
+## Things that follow from this
+
+* The 91 `plugins/<name>/enable` conf keys are gone. They were written on first run by
+  `dt_module_load_modules()`, read by nothing, exposed in no preferences page, and made up
+  91 of the 155 lines of a fresh `anselrc`.
+* `dt_module_dt_version` / `dt_module_mod_version` still exist and are still per-module, but
+  the ABI check they served is now structural: a module and its application are compiled
+  together or not at all.
+* Module order in `darktable.iop` is the registry's, which is alphabetical and stable, rather
+  than `readdir()`'s. Pipe order comes from `iop_order` and never depended on it.

--- a/doc/static-iop.md
+++ b/doc/static-iop.md
@@ -151,6 +151,16 @@ A note on finding these: counting duplicate symbol names across the *pre-LTO* ob
 of a partial build undercounts badly — it reported 37 names, mostly the shared-implementation
 file, and missed `common/colorchecker.h` entirely. The link is the only reliable census.
 
+**And the Release link is not census enough either.** Giving a header-defined object internal
+linkage silences the duplicate but creates an *unused* one in every translation unit that does
+not read it, which `-Werror=unused-variable` rejects — and `-Werror` is on in Debug only, where
+LTO is off. Three dead `dummy` variables (`initialscale`, `finalscale`, `rotatepixels`) turned
+out to be referenced by nothing at all, since `IOP_GUI_ALLOC()` only takes `sizeof` of the type,
+and were deleted; `CGATS_types` and `colorchecker_material_types` had exactly one consumer each
+and moved into `common/colorchecker.c`, which is where they should have been. **Build BOTH
+configurations before pushing**: Release is the only one with LTO, Debug the only one with
+`-Werror`, and each hides a different half of this.
+
 ## Does it make pixel processing faster? No.
 
 The interesting hypothesis was that folding the modules into `lib_ansel` lets LTO inline

--- a/doc/static-iop.md
+++ b/doc/static-iop.md
@@ -151,6 +151,57 @@ A note on finding these: counting duplicate symbol names across the *pre-LTO* ob
 of a partial build undercounts badly — it reported 37 names, mostly the shared-implementation
 file, and missed `common/colorchecker.h` entirely. The link is the only reliable census.
 
+## Does it make pixel processing faster? No.
+
+The interesting hypothesis was that folding the modules into `lib_ansel` lets LTO inline
+across a boundary it could not cross before. Measured, `ansel-cli` full-resolution export,
+`--disable-opencl -t 8`, master and this branch interleaved run-by-run to cancel thermal
+drift, `-d perf` for the pipeline's own timing (no startup, no I/O):
+
+**Default pipeline, 15 runs per side** (medians, Mann-Whitney two-sided p):
+
+| | master | static | delta | p |
+|---|---|---|---|---|
+| **TOTAL pipeline** | 6.738 s | 6.524 s | **-3.2%** | **0.59** |
+| Highlight reconstruction | 2.917 | 2.807 | -3.8% | 0.19 |
+| Filmic | 1.478 | 1.404 | -5.0% | 0.007 |
+| Lens correction | 0.797 | 0.863 | +8.3% | 0.004 |
+| Color calibration | 0.563 | 0.565 | +0.4% | 0.84 |
+| Demosaic | 0.187 | 0.178 | -4.8% | 0.04 |
+
+**Heavy sidecar, 3 runs per side** (a different module set):
+
+| | master | static | delta |
+|---|---|---|---|
+| **TOTAL pipeline** | 70.48 s | 71.23 s | **+1.1%** |
+| Diffuse or sharpen | 64.71 | 65.65 | +1.4% |
+| Color calibration | 0.613 | 0.490 | -20.1% |
+| Horizon and perspective | 0.314 | 0.259 | -17.5% |
+| Color calibration 1 | 0.541 | 0.475 | -12.2% |
+| Color balance | 1.794 | 1.631 | -9.1% |
+| Filmic | 0.871 | 0.802 | -7.9% |
+| Lens correction | 0.972 | 1.017 | +4.6% |
+
+**The whole-pipeline number does not move.** -3.2% on one workload with p = 0.59 is noise;
++1.1% on the other. Individual modules move by real amounts in *both* directions, and they
+cancel — and in each workload the total is dominated by one module (`highlights`, then
+`diffuse`) that barely moved.
+
+The likely reason there is nothing to win: this codebase already inlines the hot paths
+through headers. `pixel/colorspaces_inline_conversions.h`, `math/*.h`, `pixel/*.h` are full
+of `static inline`, so a module's pixel loop had already inlined everything it calls before
+LTO was ever asked. What crossing the boundary newly exposes is mostly cold glue.
+
+Two caveats on reading the per-module rows. First, this branch also changed the linkage of a
+few shared helpers (`pair_min`, `local_laplacian`, `channelmixerrgb_shared.c` becoming a real
+translation unit), so a per-module delta is this branch's net effect and not attributable to
+LTO alone. Second, **`lens` is consistently slower** — +8.3% (p = 0.004, n = 15) and +4.6% on
+the other workload. It is the C++ module; nobody has looked at why. On the default pipeline
+that is about 66 ms of a 6.5 s export.
+
+So: take this change for the startup time, the failure mode it removes and the honesty of the
+module boundary. Do not take it expecting faster pixels.
+
 ## What this costs
 
 Editing one module used to relink one small `.so`. It now relinks `lib_ansel`, which takes

--- a/src/common/colorchecker.c
+++ b/src/common/colorchecker.c
@@ -87,6 +87,21 @@ typedef struct cht_box_F_t {
 
 #define TWO_SQRT2f 2.8284271247461900976f // sqrt(2) * 2
 
+/* The only consumers of these two tables live in this file. They used to be defined in
+ * common/colorchecker.h, i.e. once per translation unit that included it -- which was
+ * invisible while every IOP was its own shared object, and a duplicate definition once
+ * the modules were linked into lib_ansel. A header declares; it does not define. */
+static const char *CGATS_types[CGATS_TYPE_UNKOWN] = {
+  "IT8.7/1", // transparent 
+  "IT8.7/2", // opaque
+  "CTI3"     // opaque
+};
+
+static const char *colorchecker_material_types[COLOR_CHECKER_MATERIAL_UNKNOWN] = {
+  "Transparent",
+  "Opaque"
+};
+
 static void _dt_colorchecker_copy_patch(dt_color_checker_patch *dest, const dt_color_checker_patch *src)
 {
   if(IS_NULL_PTR(dest) || IS_NULL_PTR(src)) return;

--- a/src/common/colorchecker.h
+++ b/src/common/colorchecker.h
@@ -410,23 +410,12 @@ typedef enum dt_colorchecker_CGATS_types
   CGATS_TYPE_UNKOWN  = 3
 } dt_colorchecker_CGATS_types;
 
-static const char *CGATS_types[CGATS_TYPE_UNKOWN] = {
-  "IT8.7/1", // transparent 
-  "IT8.7/2", // opaque
-  "CTI3"     // opaque
-};
-
 typedef enum dt_colorchecker_material_types
 {
   COLOR_CHECKER_MATERIAL_TRANSPARENT = 0,
   COLOR_CHECKER_MATERIAL_OPAQUE = 1,
   COLOR_CHECKER_MATERIAL_UNKNOWN = 2
 } dt_colorchecker_material_types;
-
-static const char *colorchecker_material_types[COLOR_CHECKER_MATERIAL_UNKNOWN] = {
-  "Transparent",
-  "Opaque"
-};
 
 typedef struct dt_colorchecker_CGATS_label_make_name_t 
 {

--- a/src/common/colorchecker.h
+++ b/src/common/colorchecker.h
@@ -83,7 +83,7 @@ typedef struct dt_color_checker_t
   gboolean finished;               // whether the color checker is loaded or not
 } dt_color_checker_t;
 
-dt_color_checker_patch xrite_24_2000_patches[] = {
+static dt_color_checker_patch xrite_24_2000_patches[] = {
                                               { "A1", { 37.986,  13.555,  14.059 }, { 0.087, 0.125}},
                                               { "A2", { 65.711,  18.13,   17.81  }, { 0.250, 0.125}},
                                               { "A3", { 49.927, -04.88,  -21.905 }, { 0.417, 0.125}},
@@ -109,7 +109,7 @@ dt_color_checker_patch xrite_24_2000_patches[] = {
                                               { "D5", { 35.656,  -0.421,  -1.231 }, { 0.751, 0.875}},
                                               { "D6", { 20.461,  -0.079,  -0.973 }, { 0.918, 0.875}} };
 
-dt_color_checker_t xrite_24_2000 = { .name = "Xrite ColorChecker 24 before 2014",
+static dt_color_checker_t xrite_24_2000 = { .name = "Xrite ColorChecker 24 before 2014",
                                     .author = "X-Rite",
                                     .date = "3/27/2000",
                                     .manufacturer = "X-Rite/Gretag Macbeth",
@@ -123,7 +123,7 @@ dt_color_checker_t xrite_24_2000 = { .name = "Xrite ColorChecker 24 before 2014"
                                     .black = 23,
                                     .values = xrite_24_2000_patches };
                                     
-dt_color_checker_patch xrite_24_2014_patches[] = {
+static dt_color_checker_patch xrite_24_2014_patches[] = {
                                               { "A1", { 37.54,   14.37,   14.92 }, { 0.087, 0.125}},
                                               { "A2", { 64.66,   19.27,   17.50 }, { 0.250, 0.125}},
                                               { "A3", { 49.32,  -03.82,  -22.54 }, { 0.417, 0.125}},
@@ -149,7 +149,7 @@ dt_color_checker_patch xrite_24_2014_patches[] = {
                                               { "D5", { 35.63,  -00.46,  -00.48 }, { 0.751, 0.875}},
                                               { "D6", { 20.64,   00.07,  -00.46 }, { 0.918, 0.875}} };
 
-dt_color_checker_t xrite_24_2014 = { .name = "Xrite ColorChecker 24 after 2014",
+static dt_color_checker_t xrite_24_2014 = { .name = "Xrite ColorChecker 24 after 2014",
                                     .author = "X-Rite",
                                     .date = "3/28/2015",
                                     .manufacturer = "X-Rite/Gretag Macbeth",
@@ -169,7 +169,7 @@ dt_color_checker_t xrite_24_2014 = { .name = "Xrite ColorChecker 24 after 2014",
 // outer gutter : 8 mm
 // internal gutters (gap between patches) : 5 mm
 
-dt_color_checker_patch spyder_24_patches[] = {
+static dt_color_checker_patch spyder_24_patches[] = {
                                               { "A1", { 96.04,	 2.16,	 2.60 }, { 0.107, 0.844 } },
                                               { "A2", { 80.44,	 1.17,	 2.05 }, { 0.264, 0.844 } },
                                               { "A3", { 65.52,	 0.69,	 1.86 }, { 0.421, 0.844 } },
@@ -195,7 +195,7 @@ dt_color_checker_patch spyder_24_patches[] = {
                                               { "D5", { 65.10,	18.14,	18.68 }, { 0.736, 0.155 } },
                                               { "D6", { 36.13,	14.15,	15.78 }, { 0.893, 0.155 } } };
 
-dt_color_checker_t spyder_24 = {  .name = "Datacolor SpyderCheckr 24 before 2018",
+static dt_color_checker_t spyder_24 = {  .name = "Datacolor SpyderCheckr 24 before 2018",
                                   .author = "Aur\303\251lien PIERRE",
                                   .date = "dec, 9 2016",
                                   .manufacturer = "DataColor",
@@ -215,7 +215,7 @@ dt_color_checker_t spyder_24 = {  .name = "Datacolor SpyderCheckr 24 before 2018
 // outer gutter : 8 mm
 // internal gutters (gap between patches) : 5 mm
 
-dt_color_checker_patch spyder_24_v2_patch[] = {{ "A1", { 96.04,   2.16,   2.60 }, { 0.107, 0.844 } },
+static dt_color_checker_patch spyder_24_v2_patch[] = {{ "A1", { 96.04,   2.16,   2.60 }, { 0.107, 0.844 } },
                                         { "A2", { 80.44,   1.17,   2.05 }, { 0.264, 0.844 } },
                                         { "A3", { 65.52,   0.69,   1.86 }, { 0.421, 0.844 } },
                                         { "A4", { 49.62,   0.58,   1.56 }, { 0.579, 0.844 } },
@@ -240,7 +240,7 @@ dt_color_checker_patch spyder_24_v2_patch[] = {{ "A1", { 96.04,   2.16,   2.60 }
                                         { "D5", { 65.10,  18.14,  18.68 }, { 0.736, 0.155 } },
                                         { "D6", { 36.13,  14.15,  15.78 }, { 0.893, 0.155 } } };
 
-dt_color_checker_t spyder_24_v2 = {  .name = "Datacolor SpyderCheckr 24 after 2018",
+static dt_color_checker_t spyder_24_v2 = {  .name = "Datacolor SpyderCheckr 24 after 2018",
                                   .author = "Aur\303\251lien PIERRE",
                                   .date = "dec, 9 2016",
                                   .manufacturer = "DataColor",
@@ -260,7 +260,7 @@ dt_color_checker_t spyder_24_v2 = {  .name = "Datacolor SpyderCheckr 24 after 20
 // outer gutter : 8 mm
 // internal gutters (gap between patches) : 5 mm
 
-dt_color_checker_patch spyder_48_patches[] = { { "A1", { 61.35,  34.81,  18.38 }, { 0.071, 0.107 } },
+static dt_color_checker_patch spyder_48_patches[] = { { "A1", { 61.35,  34.81,  18.38 }, { 0.071, 0.107 } },
                                               { "A2", { 75.50 ,  5.84,  50.42 }, { 0.071, 0.264 } },
                                               { "A3", { 66.82,	-25.1,	23.47 }, { 0.071, 0.421 } },
                                               { "A4", { 60.53,	-22.6, -20.40 }, { 0.071, 0.579 } },
@@ -309,7 +309,7 @@ dt_color_checker_patch spyder_48_patches[] = { { "A1", { 61.35,  34.81,  18.38 }
                                               { "H5", { 65.10,	18.14,	18.68 }, { 0.929, 0.736 } },
                                               { "H6", { 36.13,	14.15,	15.78 }, { 0.929, 0.893 } } };
 
-dt_color_checker_t spyder_48 = {  .name = "Datacolor SpyderCheckr 48 before 2018",
+static dt_color_checker_t spyder_48 = {  .name = "Datacolor SpyderCheckr 48 before 2018",
                                   .author = "Aur\303\251lien PIERRE",
                                   .date = "dec, 9 2016",
                                   .manufacturer = "DataColor",
@@ -329,7 +329,7 @@ dt_color_checker_t spyder_48 = {  .name = "Datacolor SpyderCheckr 48 before 2018
 // outer gutter : 8 mm
 // internal gutters (gap between patches) : 5 mm
 
-dt_color_checker_patch spyder_48_v2_patch[] = { { "A1", { 61.35,  34.81,  18.38 }, { 0.071, 0.107 } },
+static dt_color_checker_patch spyder_48_v2_patch[] = { { "A1", { 61.35,  34.81,  18.38 }, { 0.071, 0.107 } },
                                               { "A2", { 75.50 ,  5.84,  50.42 }, { 0.071, 0.264 } },
                                               { "A3", { 66.82,  -25.1,  23.47 }, { 0.071, 0.421 } },
                                               { "A4", { 60.53, -22.62, -20.40 }, { 0.071, 0.579 } },
@@ -378,7 +378,7 @@ dt_color_checker_patch spyder_48_v2_patch[] = { { "A1", { 61.35,  34.81,  18.38 
                                               { "H5", { 65.10,  18.14,  18.68 }, { 0.929, 0.736 } },
                                               { "H6", { 36.13,  14.15,  15.78 }, { 0.929, 0.893 } } };
 
-dt_color_checker_t spyder_48_v2 = {  .name = "Datacolor SpyderCheckr 48 after 2018",
+static dt_color_checker_t spyder_48_v2 = {  .name = "Datacolor SpyderCheckr 48 after 2018",
                                   .author = "Aur\303\251lien PIERRE",
                                   .date = "dec, 9 2016",
                                   .manufacturer = "DataColor",
@@ -410,7 +410,7 @@ typedef enum dt_colorchecker_CGATS_types
   CGATS_TYPE_UNKOWN  = 3
 } dt_colorchecker_CGATS_types;
 
-const char *CGATS_types[CGATS_TYPE_UNKOWN] = {
+static const char *CGATS_types[CGATS_TYPE_UNKOWN] = {
   "IT8.7/1", // transparent 
   "IT8.7/2", // opaque
   "CTI3"     // opaque
@@ -423,7 +423,7 @@ typedef enum dt_colorchecker_material_types
   COLOR_CHECKER_MATERIAL_UNKNOWN = 2
 } dt_colorchecker_material_types;
 
-const char *colorchecker_material_types[COLOR_CHECKER_MATERIAL_UNKNOWN] = {
+static const char *colorchecker_material_types[COLOR_CHECKER_MATERIAL_UNKNOWN] = {
   "Transparent",
   "Opaque"
 };
@@ -459,7 +459,7 @@ typedef struct dt_colorchecker_chart_spec_t
 
 } dt_colorchecker_chart_spec_t;
 
-dt_colorchecker_label_t *dt_colorchecker_label_init(const char *label, const dt_color_checker_targets type, const char *path, const int patch_nb)
+static inline dt_colorchecker_label_t *dt_colorchecker_label_init(const char *label, const dt_color_checker_targets type, const char *path, const int patch_nb)
 {
   dt_colorchecker_label_t *checker_label = malloc(sizeof(dt_colorchecker_label_t));
   if(!checker_label) return NULL;
@@ -472,7 +472,7 @@ dt_colorchecker_label_t *dt_colorchecker_label_init(const char *label, const dt_
   return checker_label;
 }
 
-dt_color_checker_patch *dt_colorchecker_patch_array_init(const size_t num_patches)
+static inline dt_color_checker_patch *dt_colorchecker_patch_array_init(const size_t num_patches)
 {
   dt_color_checker_patch *patches = (dt_color_checker_patch *)dt_alloc_align(num_patches * sizeof(dt_color_checker_patch));
   if(!patches) return NULL;
@@ -490,7 +490,7 @@ dt_color_checker_patch *dt_colorchecker_patch_array_init(const size_t num_patche
   return patches;
 }
 
-void dt_colorchecker_patch_cleanup(dt_color_checker_patch *patch)
+static inline void dt_colorchecker_patch_cleanup(dt_color_checker_patch *patch)
 {
   if(!patch) return;
   if(!patch->name) return;
@@ -499,7 +499,7 @@ void dt_colorchecker_patch_cleanup(dt_color_checker_patch *patch)
 }
 
 // This one is to fully free GSList of dt_color_checker_patch
-void dt_colorchecker_patch_cleanup_list(void *_patch)
+static inline void dt_colorchecker_patch_cleanup_list(void *_patch)
 {
   dt_color_checker_patch *patch = (dt_color_checker_patch *)_patch;
   if(!patch) return;
@@ -510,7 +510,7 @@ void dt_colorchecker_patch_cleanup_list(void *_patch)
   dt_free(patch);
 }
 
-dt_color_checker_t *dt_colorchecker_init()
+static inline dt_color_checker_t *dt_colorchecker_init()
 {                  
   dt_color_checker_t *checker = (dt_color_checker_t*)malloc(sizeof(dt_color_checker_t));
   if(!checker) return NULL;
@@ -525,7 +525,7 @@ dt_color_checker_t *dt_colorchecker_init()
   return checker;
 }
 
-void dt_colorchecker_cleanup(dt_color_checker_t *checker)
+static inline void dt_colorchecker_cleanup(dt_color_checker_t *checker)
 {
   if (!checker) return;
 
@@ -547,7 +547,7 @@ void dt_colorchecker_cleanup(dt_color_checker_t *checker)
   checker = NULL;
 }
 
-void dt_colorchecker_label_free(gpointer data)
+static inline void dt_colorchecker_label_free(gpointer data)
 {
   dt_colorchecker_label_t *checker_label = (dt_colorchecker_label_t *)data;
   if(!checker_label) return;
@@ -557,7 +557,7 @@ void dt_colorchecker_label_free(gpointer data)
   dt_free(checker_label);
 }
 
-void dt_colorchecker_label_list_cleanup(GList **colorcheckers)
+static inline void dt_colorchecker_label_list_cleanup(GList **colorcheckers)
 {
   if(!colorcheckers) return;
 
@@ -721,7 +721,7 @@ static inline const dt_color_checker_patch *dt_color_checker_get_patch_by_name(c
  * @param colorcheckers_label the NULL GList that will be populated with found .cht.
  * @return int Number of found colorcheckers.
  */
-int dt_colorchecker_find(GList **colorcheckers_label)
+static inline int dt_colorchecker_find(GList **colorcheckers_label)
 {
   int total = dt_colorchecker_find_builtin(colorcheckers_label);
   dt_print(DT_DEBUG_VERBOSE, _("dt_colorchecker_find: found %d builtin colorcheckers\n"), total);
@@ -738,7 +738,7 @@ int dt_colorchecker_find(GList **colorcheckers_label)
  * @param color_label A NULL GList that will be populated with found .CGATS files.
  * @return int The number of found .cht files.
  */
-int dt_colorchecker_find_color(GList **color_label)
+static inline int dt_colorchecker_find_color(GList **color_label)
 {
   if(!color_label) return 0;
 

--- a/src/common/module_api.h
+++ b/src/common/module_api.h
@@ -76,6 +76,39 @@ skip_error:
   #define DEFAULT(return_type, function_name, ...) return_type (*function_name)(__VA_ARGS__)
   int (*version)();
   #undef INCLUDE_API_FROM_MODULE_H
+#elif defined(INCLUDE_API_FROM_MODULE_STATIC)
+  /* Statically-linked modules: bind the module's own entry points into its
+   * dt_..._module_so_t. Expanded INSIDE the module's own translation unit, where the
+   * plain API names are in scope and carry this module's asm label (see FULL_API_H
+   * below), so `module->process = process` stores the address of THIS module's process.
+   *
+   * DT_MODULE_HAS_<fn> answers what g_module_symbol() used to answer at dlopen time:
+   * whether the module defines this entry point at all. The generated presence header
+   * defines one for EVERY name in the API, 0 or 1 -- a missing one is a compile error
+   * (DT_MODULE_PICK_DT_MODULE_HAS_foo is not a macro), never a silent NULL.
+   *
+   * DEFAULT's fallback is NOT applied here: the default_<fn> implementations are static
+   * to develop/imageop.c. INCLUDE_API_FROM_MODULE_STATIC_DEFAULTS, expanded there, fills
+   * them in afterwards. REQUIRED takes the symbol unconditionally, so a module missing
+   * one fails to link instead of failing to load. */
+  #define DT_MODULE_PICK_0(fn, fb) fb
+  #define DT_MODULE_PICK_1(fn, fb) fn
+  #define DT_MODULE_PICK_C(h, fn, fb) DT_MODULE_PICK_ ## h(fn, fb)
+  #define DT_MODULE_PICK_B(h, fn, fb) DT_MODULE_PICK_C(h, fn, fb)
+  #define DT_MODULE_PICK(fn, fb) DT_MODULE_PICK_B(DT_MODULE_HAS_ ## fn, fn, fb)
+  #define OPTIONAL(return_type, function_name, ...) module->function_name = DT_MODULE_PICK(function_name, NULL)
+  #define REQUIRED(return_type, function_name, ...) module->function_name = function_name
+  #define DEFAULT(return_type, function_name, ...) module->function_name = DT_MODULE_PICK(function_name, NULL)
+  #undef INCLUDE_API_FROM_MODULE_STATIC
+#elif defined(INCLUDE_API_FROM_MODULE_STATIC_DEFAULTS)
+  /* Second half of the static bind, expanded where the default_<fn> fallbacks are in
+   * scope. Only DEFAULT entries have one; OPTIONAL legitimately stays NULL and REQUIRED
+   * was already bound. */
+  #define OPTIONAL(return_type, function_name, ...) (void)0
+  #define REQUIRED(return_type, function_name, ...) (void)0
+  #define DEFAULT(return_type, function_name, ...) \
+      if(IS_NULL_PTR(module->function_name)) module->function_name = default_ ## function_name
+  #undef INCLUDE_API_FROM_MODULE_STATIC_DEFAULTS
 #elif defined(INCLUDE_API_FROM_MODULE_LOAD_BY_SO)
   #define OPTIONAL(return_type, function_name, ...) module->function_name = so->function_name
   #define REQUIRED(return_type, function_name, ...) module->function_name = so->function_name
@@ -83,18 +116,51 @@ skip_error:
   #undef INCLUDE_API_FROM_MODULE_LOAD_BY_SO
 #else
   #define FULL_API_H
-  #define OPTIONAL(return_type, function_name, ...) return_type function_name(__VA_ARGS__)
-  #define REQUIRED(return_type, function_name, ...) return_type function_name(__VA_ARGS__)
-  #define DEFAULT(return_type, function_name, ...) return_type function_name(__VA_ARGS__)
+  /* Symbol namespacing for statically-linked modules.
+   *
+   * Every module defines the same ~30 entry points -- `process', `name', `commit_params'.
+   * That sameness IS the API: it is what makes a module read like an implementation of an
+   * abstract class, and it is not negotiable. It is also, once the modules stop being one
+   * shared object each and land in a single link, ~30 duplicate symbols per module.
+   *
+   * An asm label renames the emitted SYMBOL and leaves the identifier alone, so the module
+   * source keeps writing `int process(...)' and nothing substitutes tokens: struct members,
+   * locals and `->name' are untouched by construction, which a `#define process ...' could
+   * not promise. The label attaches here, on the first declaration, and the definition in
+   * the module source inherits it. Re-declaring it identically (iop_api.h is re-included by
+   * most modules, by design -- it has no guard) is accepted by GCC and Clang alike.
+   *
+   * DT_MODULE_SYMBOL_PREFIX is set per module by the build. Undefined -- for src/libs and
+   * src/views, still one shared object each and still dlopen'd -- this is a no-op and the
+   * symbols keep their plain names.
+   *
+   * Mach-O prefixes symbols with an underscore and an asm label is emitted VERBATIM, so the
+   * label has to carry it; ELF and PE/COFF x86-64 do not. */
+  #ifdef DT_MODULE_SYMBOL_PREFIX
+    #define DT_MODULE_SYM_STR_(x) #x
+    #define DT_MODULE_SYM_STR(x) DT_MODULE_SYM_STR_(x)
+    #define DT_MODULE_SYM_CAT_(a, b) a ## b
+    #define DT_MODULE_SYM_CAT(a, b) DT_MODULE_SYM_CAT_(a, b)
+    #ifdef __APPLE__
+      #define DT_MODULE_SYM(fn) __asm__("_" DT_MODULE_SYM_STR(DT_MODULE_SYM_CAT(DT_MODULE_SYMBOL_PREFIX, fn)))
+    #else
+      #define DT_MODULE_SYM(fn) __asm__(DT_MODULE_SYM_STR(DT_MODULE_SYM_CAT(DT_MODULE_SYMBOL_PREFIX, fn)))
+    #endif
+  #else
+    #define DT_MODULE_SYM(fn)
+  #endif
+  #define OPTIONAL(return_type, function_name, ...) return_type function_name(__VA_ARGS__) DT_MODULE_SYM(function_name)
+  #define REQUIRED(return_type, function_name, ...) return_type function_name(__VA_ARGS__) DT_MODULE_SYM(function_name)
+  #define DEFAULT(return_type, function_name, ...) return_type function_name(__VA_ARGS__) DT_MODULE_SYM(function_name)
   #ifdef __cplusplus
   extern "C" {
   #endif
   // these 2 functions are defined by DT_MODULE() macro.
   #pragma GCC visibility push(default)
   // returns the version of dt's module interface at the time this module was build
-  int dt_module_dt_version();
+  int dt_module_dt_version() DT_MODULE_SYM(dt_module_dt_version);
   // returns the version of this module
-  int dt_module_mod_version();
+  int dt_module_mod_version() DT_MODULE_SYM(dt_module_mod_version);
   #pragma GCC visibility pop
   #ifdef __cplusplus
   }

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -432,12 +432,34 @@ int default_iop_focus(dt_gui_module_t *m, gboolean toggle)
   return 1;
 }
 
-int dt_iop_load_module_so(void *m, const char *libname, const char *module_name)
+/**
+ * @brief Bind one statically-linked IOP module into its @ref dt_iop_module_so_t.
+ *
+ * @details IOP modules are compiled into lib_ansel, not dlopen'd: the set of them is fixed
+ * at build time, and both develop/iop_order.c's order tables and develop/geometry's roster
+ * are written against that same fixed set, so a module discovered on disk could never be
+ * anything but a disagreement with them -- which is exactly what
+ * dt_ioppr_check_so_iop_order() used to abort startup over. See doc/static-iop.md.
+ *
+ * This replaces the g_module_symbol() sweep. Two halves, and they cannot be merged:
+ * @p entry->fill_so() runs in the MODULE's translation unit, where the plain API names
+ * resolve to that module's own asm-labelled symbols, and stores NULL for every entry point
+ * it does not define; the DEFAULT fallbacks are applied here instead, because default_<fn>
+ * is static to this file.
+ *
+ * @param module Zeroed module descriptor to fill.
+ * @param entry Registry entry naming the module and its generated binder.
+ * @return 0 on success, 1 if the module must not be used.
+ */
+static int _iop_load_module_static(dt_iop_module_so_t *module,
+                                   const dt_iop_module_static_entry_t *const entry)
 {
-  dt_iop_module_so_t *module = (dt_iop_module_so_t *)m;
+  const char *const module_name = entry->op;
   g_strlcpy(module->op, module_name, sizeof(module->op));
 
-#define INCLUDE_API_FROM_MODULE_LOAD "iop_load_module"
+  entry->fill_so(module);
+
+#define INCLUDE_API_FROM_MODULE_STATIC_DEFAULTS
 #include "iop/iop_api.h"
 
   if(IS_NULL_PTR(module->init)) module->init = dt_iop_default_init;
@@ -467,7 +489,12 @@ int dt_iop_load_module_so(void *m, const char *libname, const char *module_name)
          module->get_f == default_get_f ||
          module->get_introspection_linear == default_get_introspection_linear ||
          module->get_introspection == default_get_introspection)
-        goto api_h_error;
+      {
+        fprintf(stderr,
+                "[iop_load_module] `%s' claims introspection but did not replace the default"
+                " accessors\n", module_name);
+        return 1;
+      }
     }
     else
       fprintf(stderr, "[iop_load_module] failed to initialize introspection for operation `%s'\n", module_name);
@@ -511,8 +538,6 @@ int dt_iop_load_module_by_so(dt_iop_module_t *module, dt_iop_module_so_t *so, dt
   module->raster_mask.sink.source = NULL;
   module->raster_mask.sink.id = 0;
 
-  // only reference cached results of dlopen:
-  module->module = so->module;
   module->so = so;
 
 #define INCLUDE_API_FROM_MODULE_LOAD_BY_SO
@@ -920,8 +945,28 @@ void dt_iop_load_modules_so(void)
 {
   // Batch presets initialization in a single transaction to avoid per-module BEGIN/COMMIT overhead.
   dt_database_begin_transaction_batch();
-  darktable.iop = dt_module_load_modules("/plugins", sizeof(dt_iop_module_so_t), dt_iop_load_module_so,
-                                         _init_module_so, NULL);
+
+  GList *modules = NULL;
+  for(int k = 0; k < dt_iop_static_modules_count; k++)
+  {
+    const dt_iop_module_static_entry_t *const entry = &dt_iop_static_modules[k];
+    dt_iop_module_so_t *module = (dt_iop_module_so_t *)calloc(1, sizeof(dt_iop_module_so_t));
+
+    if(_iop_load_module_static(module, entry))
+    {
+      dt_free(module);
+      continue;
+    }
+
+    modules = g_list_prepend(modules, module);
+    _init_module_so(module);
+  }
+
+  // The registry is emitted in a stable (alphabetical) order; keep it, rather than the
+  // arbitrary readdir() order the directory scan used to produce. Pipe order comes from
+  // iop_order and does not depend on this list's order at all.
+  darktable.iop = g_list_reverse(modules);
+
   dt_database_end_transaction_batch();
 }
 
@@ -992,7 +1037,6 @@ void dt_iop_unload_modules_so()
   {
     dt_iop_module_so_t *module = (dt_iop_module_so_t *)darktable.iop->data;
     if(module->cleanup_global) module->cleanup_global(module);
-    if(module->module) g_module_close(module->module);
     dt_free(darktable.iop->data);
     darktable.iop = g_list_delete_link(darktable.iop, darktable.iop);
   }

--- a/src/develop/imageop.h
+++ b/src/develop/imageop.h
@@ -220,7 +220,9 @@ typedef enum dt_dev_request_colorpick_flags_t
  * space, which is a layer-2 concept, and colorprofiles/iop_profile.h needs it. */
 
 
-/** part of the module which only contains the cached dlopen stuff. */
+/** The per-operation half of a module: everything that exists once, whatever the image.
+ *  Modules are linked into lib_ansel and bound at startup by dt_iop_load_modules_so();
+ *  there is no dlopen handle to cache any more. See doc/static-iop.md. */
 typedef struct dt_iop_module_so_t
 {
   // Needs to stay on top for casting
@@ -229,8 +231,6 @@ typedef struct dt_iop_module_so_t
 #define INCLUDE_API_FROM_MODULE_H
 #include "iop/iop_api.h"
 
-  /** opened module. */
-  GModule *module;
   /** string identifying this operation. */
   dt_dev_operation_t op;
   /** other stuff that may be needed by the module, not only in gui mode. inited only once, has to be
@@ -255,8 +255,6 @@ typedef struct dt_iop_module_t
 #define INCLUDE_API_FROM_MODULE_H
 #include "iop/iop_api.h"
 
-  /** opened module. */
-  GModule *module;
   /** string identifying this operation. */
   dt_dev_operation_t op;
   /** used to identify this module in the history stack. */
@@ -378,9 +376,27 @@ typedef struct dt_iop_module_t
 
 } dt_iop_module_t;
 
-/** loads and inits the modules in the plugins/ directory. */
+/**
+ * @brief One IOP module built into this binary, and the generated function that binds it.
+ *
+ * @details IOP modules are linked in, not dlopen'd. The table below is generated from
+ * src/iop/CMakeLists.txt by tools/generate_iop_static.py -- the same list develop/iop_order.c
+ * and develop/geometry/geometry.c are written against, so the three cannot drift the way a
+ * directory scan could. @p fill_so lives in the module's own translation unit, which is the
+ * only place its entry points are reachable by their plain names.
+ */
+typedef struct dt_iop_module_static_entry_t
+{
+  const char *op;                                 /**< operation name, e.g. "exposure" */
+  void (*fill_so)(dt_iop_module_so_t *module);    /**< generated; binds this module's API */
+} dt_iop_module_static_entry_t;
+
+extern const dt_iop_module_static_entry_t dt_iop_static_modules[];
+extern const int dt_iop_static_modules_count;
+
+/** loads and inits every module in dt_iop_static_modules. */
 void dt_iop_load_modules_so(void);
-/** cleans up the dlopen refs. */
+/** tears down the module descriptors built by dt_iop_load_modules_so(). */
 void dt_iop_unload_modules_so(void);
 /** load a module for a given .so */
 int dt_iop_load_module_by_so(dt_iop_module_t *module, dt_iop_module_so_t *so, struct dt_develop_t *dev);

--- a/src/iop/CMakeLists.txt
+++ b/src/iop/CMakeLists.txt
@@ -41,20 +41,69 @@ macro(add_iop _lib _src)
   list(REMOVE_ITEM OPT_SRC "DEFAULT_VISIBLE")
 
   set_source_files_properties(${_input} PROPERTIES LANGUAGE "")
-  # yes, input is added as part of the library. since we just set it's LANGUAGE
-  # to "", no compilation will happen. this is needed for proper IDE support.
-  add_library(${_lib} MODULE ${_output} ${OPT_SRC} ${_input})
-  target_link_libraries(${_lib} lib_ansel)
 
-  if(WIN32)
-    # _detach_debuginfo(${_lib} ${CMAKE_INSTALL_LIBDIR}/ansel/plugins)
-  else()
-    set_target_properties(${_lib}
-                          PROPERTIES
-                          INSTALL_RPATH ${RPATH_ORIGIN}/../..)
-  endif(WIN32)
+  # IOP modules are compiled into lib_ansel, not dlopen'd from a plugins directory. See
+  # tools/generate_iop_static.py for why, and doc/static-iop.md for the whole decision.
+  #
+  # Two files are generated per module. ${_lib}_present.h answers, per entry point, the
+  # question g_module_symbol() used to answer at load time -- does this module define it?
+  # -- by running this compiler's preprocessor over these sources with these flags.
+  # ${_lib}_static.c is the resulting dt_iop_module_so_t filler.
+  set(_present ${CMAKE_CURRENT_BINARY_DIR}/${_lib}_present.h)
+  set(_fill ${CMAKE_CURRENT_BINARY_DIR}/${_lib}_static.c)
 
-  install(TARGETS ${_lib} DESTINATION ${CMAKE_INSTALL_LIBDIR}/ansel/plugins COMPONENT DTApplication)
+  # Scan the generated introspection wrapper -- which #includes the module source, and adds
+  # introspection_init()/get_p()/get_f()/get_introspection*() itself -- plus every secondary
+  # source, since an entry point may live in one (iop/highlights/, iop/drawlayer/) and one
+  # the generator missed would be a silently NULL function pointer, not a link error.
+  set(_scan_sources ${_output})
+  foreach(_extra IN LISTS OPT_SRC)
+    list(APPEND _scan_sources ${CMAKE_CURRENT_SOURCE_DIR}/${_extra})
+  endforeach()
+
+  add_library(${_lib} OBJECT ${_output} ${_fill} ${OPT_SRC} ${_input})
+  # NOT lib_ansel: these objects are compiled INTO it, and naming it here would be a
+  # dependency cycle. Everything the modules actually took from lib_ansel was its PUBLIC
+  # usage requirements -- ansel_deps and OpenMP -- so take those directly. Its symbols
+  # need no linking now that the objects live inside it.
+  target_link_libraries(${_lib} PRIVATE ansel_deps)
+  if(OpenMP_C_FOUND)
+    target_link_libraries(${_lib} PRIVATE OpenMP::OpenMP_C)
+  endif()
+  if(OpenMP_CXX_FOUND)
+    target_link_libraries(${_lib} PRIVATE OpenMP::OpenMP_CXX)
+  endif()
+
+  # This is what makes every module's `process' a distinct symbol while every module's
+  # source still writes plain `int process(...)'. See common/module_api.h.
+  target_compile_definitions(${_lib} PRIVATE DT_MODULE_SYMBOL_PREFIX=dt_iop_${_lib}__)
+  target_include_directories(${_lib} PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
+
+  add_custom_command(
+    OUTPUT ${_present} ${_fill}
+    COMMAND ${Python3_EXECUTABLE} ${CMAKE_SOURCE_DIR}/tools/generate_iop_static.py module
+            --module ${_lib}
+            --module-dir ${CMAKE_CURRENT_SOURCE_DIR}
+            --api ${CMAKE_CURRENT_SOURCE_DIR}/iop_api.h
+            --present ${_present}
+            --fill ${_fill}
+            --cc ${CMAKE_C_COMPILER}
+            --sources ${_scan_sources}
+            --
+              "-I$<JOIN:$<TARGET_PROPERTY:${_lib},INCLUDE_DIRECTORIES>,;-I>"
+              "$<$<BOOL:$<TARGET_PROPERTY:${_lib},COMPILE_DEFINITIONS>>:-D$<JOIN:$<TARGET_PROPERTY:${_lib},COMPILE_DEFINITIONS>,;-D>>"
+              "$<TARGET_PROPERTY:${_lib},COMPILE_OPTIONS>"
+    DEPENDS ${_scan_sources} ${_input} ${CMAKE_SOURCE_DIR}/tools/generate_iop_static.py
+            ${CMAKE_CURRENT_SOURCE_DIR}/iop_api.h ${CMAKE_CURRENT_SOURCE_DIR}/../common/module_api.h
+    COMMAND_EXPAND_LISTS
+    VERBATIM
+    COMMENT "Scanning iop/${_lib} for its API surface"
+  )
+
+  # Referencing the objects from lib_ansel is what links them in. lib_ansel is a shared
+  # library: on Windows it cannot leave symbols for the executable to resolve, so the
+  # modules have to live inside it rather than beside it.
+  target_sources(lib_ansel PRIVATE $<TARGET_OBJECTS:${_lib}>)
 
   list(APPEND _iop_list ${_lib})
 
@@ -186,6 +235,33 @@ add_iop(lens "lens.cc" DEFAULT_VISIBLE)
 if(APPLE)
   set_target_properties(demosaic PROPERTIES LINKER_LANGUAGE C)
 endif(APPLE)
+
+# Shared implementation used by more than one module. It used to be #include'd textually
+# into each consumer, because two shared objects could not each carry a copy of its globals.
+# With one link there is one copy, so it is a translation unit again.
+add_library(iop_shared_channelmixer OBJECT channelmixerrgb_shared.c)
+target_link_libraries(iop_shared_channelmixer PRIVATE ansel_deps)
+if(OpenMP_C_FOUND)
+  target_link_libraries(iop_shared_channelmixer PRIVATE OpenMP::OpenMP_C)
+endif()
+target_sources(lib_ansel PRIVATE $<TARGET_OBJECTS:iop_shared_channelmixer>)
+
+# The registry of every module built into this binary, generated at CONFIGURE time: the
+# module list is a CMake variable, so there is nothing to discover later, and this keeps
+# lib_ansel's source list free of a cross-directory build-time dependency.
+set(_iop_registry ${CMAKE_CURRENT_BINARY_DIR}/iop_registry.c)
+execute_process(
+  COMMAND ${Python3_EXECUTABLE} ${CMAKE_SOURCE_DIR}/tools/generate_iop_static.py registry
+          --out ${_iop_registry} --modules ${_iop_list}
+  RESULT_VARIABLE _iop_registry_result
+)
+if(NOT _iop_registry_result EQUAL 0)
+  message(FATAL_ERROR "Failed to generate the IOP registry (${_iop_registry_result})")
+endif()
+target_sources(lib_ansel PRIVATE ${_iop_registry})
+
+list(LENGTH _iop_list _iop_count)
+message(STATUS "IOP modules linked into lib_ansel: ${_iop_count}")
 
 set_property(GLOBAL PROPERTY DT_PLUGIN_IOPS ${_iop_list})
 set_property(GLOBAL PROPERTY DT_PLUGIN_IOPS_VISIBLE_BY_DEFAULT ${_iop_default_visible_list})

--- a/src/iop/channelmixerrgb.c
+++ b/src/iop/channelmixerrgb.c
@@ -74,9 +74,10 @@
 #include "iop/channelmixerrgb_shared.h"
 #include "iop/iop_api.h"
 
-// Keep the shared implementation in this translation unit to avoid
-// duplicate globals from a separate compiled object.
-#include "channelmixerrgb_shared.c"
+// The shared implementation is its own translation unit, compiled once and linked
+// into the single IOP object set. It used to be textually included here, once per
+// consuming module, because two shared objects could not each carry a copy of its
+// globals; with the modules linked statically there is exactly one link and one copy.
 
 #include <assert.h>
 #include <float.h>

--- a/src/iop/finalscale.c
+++ b/src/iop/finalscale.c
@@ -216,7 +216,6 @@ void cleanup(dt_iop_module_t *self)
 typedef struct dt_iop_finalscale_gui_data_t
 { } dt_iop_finalscale_gui_data_t;
 
-static dt_iop_finalscale_gui_data_t dummy;
 
 void gui_init(dt_iop_module_t *self)
 {

--- a/src/iop/finalscale.c
+++ b/src/iop/finalscale.c
@@ -216,7 +216,7 @@ void cleanup(dt_iop_module_t *self)
 typedef struct dt_iop_finalscale_gui_data_t
 { } dt_iop_finalscale_gui_data_t;
 
-dt_iop_finalscale_gui_data_t dummy;
+static dt_iop_finalscale_gui_data_t dummy;
 
 void gui_init(dt_iop_module_t *self)
 {

--- a/src/iop/initialscale.c
+++ b/src/iop/initialscale.c
@@ -161,7 +161,7 @@ void cleanup(dt_iop_module_t *self)
 typedef struct dt_iop_initialscale_gui_data_t
 { } dt_iop_initialscale_gui_data_t;
 
-dt_iop_initialscale_gui_data_t dummy;
+static dt_iop_initialscale_gui_data_t dummy;
 
 void gui_init(dt_iop_module_t *self)
 {

--- a/src/iop/initialscale.c
+++ b/src/iop/initialscale.c
@@ -161,7 +161,6 @@ void cleanup(dt_iop_module_t *self)
 typedef struct dt_iop_initialscale_gui_data_t
 { } dt_iop_initialscale_gui_data_t;
 
-static dt_iop_initialscale_gui_data_t dummy;
 
 void gui_init(dt_iop_module_t *self)
 {

--- a/src/iop/lens.cc
+++ b/src/iop/lens.cc
@@ -175,12 +175,124 @@ typedef struct dt_iop_lensfun_gui_data_t
 
 typedef struct dt_iop_lensfun_global_data_t
 {
+  /** The lensfun database. NULL until something actually asks for a lens: read it through
+   *  _lensfun_db(), never directly. */
   lfDatabase *db;
+  gboolean db_tried;
   int kernel_lens_distort_bilinear;
   int kernel_lens_distort_bicubic;
   int kernel_lens_distort_mitchell;
   int kernel_lens_vignette;
 } dt_iop_lensfun_global_data_t;
+
+/* Building the lensfun database means parsing ~8 MB of XML into 1051 cameras and 1562
+ * lenses: measured 89-102 ms and +4 MB RSS on a stock Fedora database plus the user's
+ * updates. init_global() did it at startup, in EVERY session -- including every
+ * lighttable-only session that never corrects a lens. Nothing can need it that early:
+ * this module is switched on per image by reload_defaults() (workflow_enabled), so the
+ * first possible consumer is an image being loaded, and by then the cost is amortised
+ * against a pipeline run rather than added to the splash screen.
+ *
+ * _lensfun_db_lock covers the construction only, and is never held while the plugin mutex
+ * is taken, so the two cannot deadlock against each other. db_tried makes a failed load
+ * final: retrying it per lookup would turn a broken installation into a slow one. */
+static GMutex _lensfun_db_lock;
+
+/* Resolved (maker, model) -> lfCamera and (camera, lens name) -> lfLens.
+ *
+ * FindCamerasExt() is a fuzzy scan over every camera in the database and costs 0.35-0.42 ms;
+ * FindLenses() costs 0.06 ms when it hits and 0.84 ms when it misses, because a miss scans
+ * the lot. commit_params() resolves both on every pipe resync, for every pipe, and it asks
+ * the same question every time -- the camera and lens of an image do not change while it is
+ * open. The answers are pointers INTO the database, which is built once and never reloaded,
+ * so they stay valid for the process's life.
+ *
+ * Guarded by the plugin mutex, which the lookups already took. */
+static GHashTable *_lensfun_camera_memo = NULL;
+static GHashTable *_lensfun_lens_memo = NULL;
+
+/** @brief Build the database. Call once, under _lensfun_db_lock. */
+static lfDatabase *_lensfun_db_create(void);
+
+/**
+ * @brief The lensfun database, built on first use.
+ * @return The database, or NULL if it could not be loaded (already reported).
+ */
+static lfDatabase *_lensfun_db(dt_iop_lensfun_global_data_t *gd)
+{
+  if(IS_NULL_PTR(gd)) return NULL;
+
+  g_mutex_lock(&_lensfun_db_lock);
+  if(!gd->db_tried)
+  {
+    gd->db_tried = TRUE;
+    gd->db = _lensfun_db_create();
+  }
+  lfDatabase *db = gd->db;
+  g_mutex_unlock(&_lensfun_db_lock);
+
+  return db;
+}
+
+/**
+ * @brief Memoised lfDatabase::FindCamerasExt().
+ * @details Caller must hold the plugin mutex. The returned camera belongs to the database.
+ */
+static const lfCamera *_lensfun_find_camera(lfDatabase *db, const char *maker, const char *model)
+{
+  if(IS_NULL_PTR(db) || IS_NULL_PTR(model) || !model[0]) return NULL;
+
+  gchar *key = g_strdup_printf("%s\x1f%s", maker ? maker : "", model);
+
+  if(IS_NULL_PTR(_lensfun_camera_memo))
+    _lensfun_camera_memo = g_hash_table_new_full(g_str_hash, g_str_equal, dt_free_gpointer, NULL);
+
+  gpointer found = NULL;
+  if(g_hash_table_lookup_extended(_lensfun_camera_memo, key, NULL, &found))
+  {
+    dt_free(key);
+    return (const lfCamera *)found;
+  }
+
+  const lfCamera **cameras = db->FindCamerasExt(maker, model, 0);
+  const lfCamera *camera = (!IS_NULL_PTR(cameras)) ? cameras[0] : NULL;
+  if(!IS_NULL_PTR(cameras)) lf_free(cameras);
+
+  // A miss is cached too: it costs a full scan to establish, and it will not change.
+  g_hash_table_insert(_lensfun_camera_memo, key, (gpointer)camera);
+
+  return camera;
+}
+
+/**
+ * @brief Memoised lfDatabase::FindLenses().
+ * @details Caller must hold the plugin mutex. The returned lens belongs to the database.
+ */
+static const lfLens *_lensfun_find_lens(lfDatabase *db, const lfCamera *camera, const char *lens_name)
+{
+  if(IS_NULL_PTR(db) || IS_NULL_PTR(lens_name) || !lens_name[0]) return NULL;
+
+  gchar *key = g_strdup_printf("%s\x1f%s", (!IS_NULL_PTR(camera) && camera->Model) ? camera->Model : "",
+                               lens_name);
+
+  if(IS_NULL_PTR(_lensfun_lens_memo))
+    _lensfun_lens_memo = g_hash_table_new_full(g_str_hash, g_str_equal, dt_free_gpointer, NULL);
+
+  gpointer found = NULL;
+  if(g_hash_table_lookup_extended(_lensfun_lens_memo, key, NULL, &found))
+  {
+    dt_free(key);
+    return (const lfLens *)found;
+  }
+
+  const lfLens **lenses = db->FindLenses(camera, NULL, lens_name, 0);
+  const lfLens *lens = (!IS_NULL_PTR(lenses)) ? lenses[0] : NULL;
+  if(!IS_NULL_PTR(lenses)) lf_free(lenses);
+
+  g_hash_table_insert(_lensfun_lens_memo, key, (gpointer)lens);
+
+  return lens;
+}
 
 typedef struct dt_iop_lensfun_data_t
 {
@@ -1213,9 +1325,8 @@ static void _lens_build_data(dt_iop_module_t *self, const dt_iop_lensfun_params_
                              dt_iop_lensfun_data_t *d)
 {
   dt_iop_lensfun_global_data_t *gd = (dt_iop_lensfun_global_data_t *)self->global_data;
-  lfDatabase *dt_iop_lensfun_db = (lfDatabase *)gd->db;
+  lfDatabase *dt_iop_lensfun_db = _lensfun_db(gd);
   const lfCamera *camera = NULL;
-  const lfCamera **cam = NULL;
   if(d->lens)
   {
     delete d->lens;
@@ -1223,26 +1334,21 @@ static void _lens_build_data(dt_iop_module_t *self, const dt_iop_lensfun_params_
   }
   d->lens = new lfLens;
 
-  if(p->camera[0])
+  if(p->camera[0] && !IS_NULL_PTR(dt_iop_lensfun_db))
   {
     dt_pthread_mutex_lock(dt_plugin_threadsafe_mutex());
-    cam = dt_iop_lensfun_db->FindCamerasExt(NULL, p->camera, 0);
-    if(cam)
-    {
-      camera = cam[0];
-      d->crop = cam[0]->CropFactor;
-    }
+    camera = _lensfun_find_camera(dt_iop_lensfun_db, NULL, p->camera);
     dt_pthread_mutex_unlock(dt_plugin_threadsafe_mutex());
+    if(!IS_NULL_PTR(camera)) d->crop = camera->CropFactor;
   }
-  if(p->lens[0])
+  if(p->lens[0] && !IS_NULL_PTR(dt_iop_lensfun_db))
   {
     dt_pthread_mutex_lock(dt_plugin_threadsafe_mutex());
-    const lfLens **lens
-        = dt_iop_lensfun_db->FindLenses(camera, NULL, p->lens, 0);
+    const lfLens *lens = _lensfun_find_lens(dt_iop_lensfun_db, camera, p->lens);
     dt_pthread_mutex_unlock(dt_plugin_threadsafe_mutex());
-    if(lens)
+    if(!IS_NULL_PTR(lens))
     {
-      *d->lens = *lens[0];
+      *d->lens = *lens;
       if(p->tca_override)
       {
 #ifdef LF_0395
@@ -1272,10 +1378,8 @@ static void _lens_build_data(dt_iop_module_t *self, const dt_iop_lensfun_params_
         d->lens->AddCalibTCA(&tca);
 #endif
       }
-      lf_free(lens);
     }
   }
-  lf_free(cam);
   d->modify_flags = p->modify_flags;
   if(dt_image_is_monochrome(&self->dev->image_storage)) d->modify_flags &= ~LF_MODIFY_TCA;
   d->inverse = p->inverse;
@@ -1445,8 +1549,12 @@ void init_global(dt_iop_module_so_t *module)
   gd->kernel_lens_distort_mitchell = dt_opencl_create_kernel(program, "lens_distort_mitchell");
   gd->kernel_lens_vignette = dt_opencl_create_kernel(program, "lens_vignette");
 
+  // The database is NOT built here -- see _lensfun_db(). calloc() already left it NULL.
+}
+
+static lfDatabase *_lensfun_db_create(void)
+{
   lfDatabase *dt_iop_lensfun_db = new lfDatabase;
-  gd->db = (lfDatabase *)dt_iop_lensfun_db;
 
 #if defined(__MACH__) || defined(__APPLE__)
 #else
@@ -1497,6 +1605,8 @@ void init_global(dt_iop_module_so_t *module)
 #endif
     dt_free(path);
   }
+
+  return dt_iop_lensfun_db;
 }
 
 static float get_autoscale(dt_iop_module_t *self, dt_iop_lensfun_params_t *p, const lfCamera *camera);
@@ -1538,15 +1648,16 @@ void reload_defaults(dt_iop_module_t *module)
     dt_iop_lensfun_global_data_t *gd = (dt_iop_lensfun_global_data_t *)module->global_data;
 
     // just to be sure
-    if(IS_NULL_PTR(gd) || IS_NULL_PTR(gd->db)) return;
+    lfDatabase *db = _lensfun_db(gd);
+    if(IS_NULL_PTR(db)) return;
 
     dt_pthread_mutex_lock(dt_plugin_threadsafe_mutex());
-    const lfCamera **cam = gd->db->FindCamerasExt(img->exif_maker, img->exif_model, 0);
+    const lfCamera **cam = db->FindCamerasExt(img->exif_maker, img->exif_model, 0);
     dt_pthread_mutex_unlock(dt_plugin_threadsafe_mutex());
     if(cam)
     {
       dt_pthread_mutex_lock(dt_plugin_threadsafe_mutex());
-      const lfLens **lens = gd->db->FindLenses(cam[0], NULL, d->lens, 0);
+      const lfLens **lens = db->FindLenses(cam[0], NULL, d->lens, 0);
       dt_pthread_mutex_unlock(dt_plugin_threadsafe_mutex());
 
       if(!lens && islower(cam[0]->Mount[0]))
@@ -1561,7 +1672,7 @@ void reload_defaults(dt_iop_module_t *module)
         g_strlcpy(d->lens, "", sizeof(d->lens));
 
         dt_pthread_mutex_lock(dt_plugin_threadsafe_mutex());
-        lens = gd->db->FindLenses(cam[0], NULL, d->lens, 0);
+        lens = db->FindLenses(cam[0], NULL, d->lens, 0);
         dt_pthread_mutex_unlock(dt_plugin_threadsafe_mutex());
       }
 
@@ -1612,8 +1723,23 @@ void reload_defaults(dt_iop_module_t *module)
 void cleanup_global(dt_iop_module_so_t *module)
 {
   dt_iop_lensfun_global_data_t *gd = (dt_iop_lensfun_global_data_t *)module->data;
+
+  /* The memos hold pointers INTO the database, so they go first. Both may be NULL: a session
+   * that never opened an image never built any of this. */
+  if(!IS_NULL_PTR(_lensfun_camera_memo))
+  {
+    g_hash_table_destroy(_lensfun_camera_memo);
+    _lensfun_camera_memo = NULL;
+  }
+  if(!IS_NULL_PTR(_lensfun_lens_memo))
+  {
+    g_hash_table_destroy(_lensfun_lens_memo);
+    _lensfun_lens_memo = NULL;
+  }
+
   lfDatabase *dt_iop_lensfun_db = (lfDatabase *)gd->db;
-  delete dt_iop_lensfun_db;
+  if(!IS_NULL_PTR(dt_iop_lensfun_db)) delete dt_iop_lensfun_db;
+  gd->db = NULL;
 
   dt_opencl_free_kernel(gd->kernel_lens_distort_bilinear);
   dt_opencl_free_kernel(gd->kernel_lens_distort_bicubic);
@@ -1858,7 +1984,7 @@ static void camera_menusearch_clicked(GtkWidget *button, gpointer user_data)
 {
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
   dt_iop_lensfun_global_data_t *gd = (dt_iop_lensfun_global_data_t *)self->global_data;
-  lfDatabase *dt_iop_lensfun_db = (lfDatabase *)gd->db;
+  lfDatabase *dt_iop_lensfun_db = _lensfun_db(gd);
   dt_iop_lensfun_gui_data_t *g = (dt_iop_lensfun_gui_data_t *)dt_iop_gui_data(self);
 
   (void)button;
@@ -1877,7 +2003,7 @@ static void camera_autosearch_clicked(GtkWidget *button, gpointer user_data)
 {
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
   dt_iop_lensfun_global_data_t *gd = (dt_iop_lensfun_global_data_t *)self->global_data;
-  lfDatabase *dt_iop_lensfun_db = (lfDatabase *)gd->db;
+  lfDatabase *dt_iop_lensfun_db = _lensfun_db(gd);
   dt_iop_lensfun_gui_data_t *g = (dt_iop_lensfun_gui_data_t *)dt_iop_gui_data(self);
   char make[200], model[200];
   const gchar *txt = (const gchar *)((dt_iop_lensfun_params_t *)self->default_params)->camera;
@@ -2204,7 +2330,7 @@ static void lens_menusearch_clicked(GtkWidget *button, gpointer user_data)
 {
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
   dt_iop_lensfun_global_data_t *gd = (dt_iop_lensfun_global_data_t *)self->global_data;
-  lfDatabase *dt_iop_lensfun_db = (lfDatabase *)gd->db;
+  lfDatabase *dt_iop_lensfun_db = _lensfun_db(gd);
   dt_iop_lensfun_gui_data_t *g = (dt_iop_lensfun_gui_data_t *)dt_iop_gui_data(self);
   const lfLens **lenslist;
 
@@ -2224,7 +2350,7 @@ static void lens_autosearch_clicked(GtkWidget *button, gpointer user_data)
 {
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
   dt_iop_lensfun_global_data_t *gd = (dt_iop_lensfun_global_data_t *)self->global_data;
-  lfDatabase *dt_iop_lensfun_db = (lfDatabase *)gd->db;
+  lfDatabase *dt_iop_lensfun_db = _lensfun_db(gd);
   dt_iop_lensfun_gui_data_t *g = (dt_iop_lensfun_gui_data_t *)dt_iop_gui_data(self);
   const lfLens **lenslist;
   char model[200];
@@ -2302,7 +2428,7 @@ void gui_changed(dt_iop_module_t *self, GtkWidget *w, void *previous)
 static float get_autoscale(dt_iop_module_t *self, dt_iop_lensfun_params_t *p, const lfCamera *camera)
 {
   dt_iop_lensfun_global_data_t *gd = (dt_iop_lensfun_global_data_t *)self->global_data;
-  lfDatabase *dt_iop_lensfun_db = (lfDatabase *)gd->db;
+  lfDatabase *dt_iop_lensfun_db = _lensfun_db(gd);
   float scale = 1.0;
   if(p->lens[0] != '\0')
   {
@@ -2602,7 +2728,7 @@ void gui_update(struct dt_iop_module_t *self)
   }
 
   dt_iop_lensfun_global_data_t *gd = (dt_iop_lensfun_global_data_t *)self->global_data;
-  lfDatabase *dt_iop_lensfun_db = (lfDatabase *)gd->db;
+  lfDatabase *dt_iop_lensfun_db = _lensfun_db(gd);
   // these are the wrong (untranslated) strings in general but that's ok, they will be overwritten further
   // down
   gtk_label_set_text(GTK_LABEL(gtk_bin_get_child(GTK_BIN(g->camera_model))), p->camera);

--- a/src/iop/lens.cc
+++ b/src/iop/lens.cc
@@ -179,6 +179,8 @@ typedef struct dt_iop_lensfun_global_data_t
    *  _lensfun_db(), never directly. */
   lfDatabase *db;
   gboolean db_tried;
+  /** Pre-warm thread, see _lensfun_db_warm(). Joined by cleanup_global(). */
+  GThread *db_warm;
   int kernel_lens_distort_bilinear;
   int kernel_lens_distort_bicubic;
   int kernel_lens_distort_mitchell;
@@ -192,6 +194,11 @@ typedef struct dt_iop_lensfun_global_data_t
  * this module is switched on per image by reload_defaults() (workflow_enabled), so the
  * first possible consumer is an image being loaded, and by then the cost is amortised
  * against a pipeline run rather than added to the splash screen.
+ *
+ * It is not left to chance either: init_global() starts _lensfun_db_warm() to build it on a
+ * background thread, so the work overlaps the rest of startup and is normally finished before
+ * any image asks. Whoever gets there first builds it and the other waits -- there is one lock
+ * and one construction either way.
  *
  * _lensfun_db_lock covers the construction only, and is never held while the plugin mutex
  * is taken, so the two cannot deadlock against each other. db_tried makes a failed load
@@ -213,6 +220,22 @@ static GHashTable *_lensfun_lens_memo = NULL;
 
 /** @brief Build the database. Call once, under _lensfun_db_lock. */
 static lfDatabase *_lensfun_db_create(void);
+static lfDatabase *_lensfun_db(dt_iop_lensfun_global_data_t *gd);
+
+/**
+ * @brief Build the database off the startup path.
+ *
+ * @details Pure pre-warm: it takes the same accessor everything else does, so if an image
+ * gets there first this simply waits on the lock and returns. It touches nothing but the
+ * database, so there is nothing here for the GUI thread to race against -- but it must not
+ * still be running when cleanup_global() frees the database, which is why the thread is
+ * joined there rather than detached.
+ */
+static gpointer _lensfun_db_warm(gpointer data)
+{
+  (void)_lensfun_db((dt_iop_lensfun_global_data_t *)data);
+  return NULL;
+}
 
 /**
  * @brief The lensfun database, built on first use.
@@ -1549,7 +1572,8 @@ void init_global(dt_iop_module_so_t *module)
   gd->kernel_lens_distort_mitchell = dt_opencl_create_kernel(program, "lens_distort_mitchell");
   gd->kernel_lens_vignette = dt_opencl_create_kernel(program, "lens_vignette");
 
-  // The database is NOT built here -- see _lensfun_db(). calloc() already left it NULL.
+  // The database is NOT built on this thread -- see _lensfun_db() and _lensfun_db_warm().
+  gd->db_warm = g_thread_new("lensfun-db", _lensfun_db_warm, gd);
 }
 
 static lfDatabase *_lensfun_db_create(void)
@@ -1723,6 +1747,13 @@ void reload_defaults(dt_iop_module_t *module)
 void cleanup_global(dt_iop_module_so_t *module)
 {
   dt_iop_lensfun_global_data_t *gd = (dt_iop_lensfun_global_data_t *)module->data;
+
+  /* Before anything is freed: the pre-warm thread may still be building the database. */
+  if(!IS_NULL_PTR(gd->db_warm))
+  {
+    g_thread_join(gd->db_warm);
+    gd->db_warm = NULL;
+  }
 
   /* The memos hold pointers INTO the database, so they go first. Both may be NULL: a session
    * that never opened an image never built any of this. */

--- a/src/iop/rotatepixels.c
+++ b/src/iop/rotatepixels.c
@@ -65,7 +65,6 @@ typedef struct dt_iop_rotatepixels_data_t
   float m[4];      // rotation matrix
 } dt_iop_rotatepixels_data_t;
 
-static dt_iop_rotatepixels_gui_data_t dummy;
 
 // helper to count corners in for loops:
 static void get_corner(const float *aabb, const int i, float *p)

--- a/src/iop/rotatepixels.c
+++ b/src/iop/rotatepixels.c
@@ -65,7 +65,7 @@ typedef struct dt_iop_rotatepixels_data_t
   float m[4];      // rotation matrix
 } dt_iop_rotatepixels_data_t;
 
-dt_iop_rotatepixels_gui_data_t dummy;
+static dt_iop_rotatepixels_gui_data_t dummy;
 
 // helper to count corners in for loops:
 static void get_corner(const float *aabb, const int i, float *p)

--- a/src/iop/splittoningrgb.c
+++ b/src/iop/splittoningrgb.c
@@ -43,9 +43,10 @@
 #include "iop/channelmixerrgb_shared.h"
 #include "iop/iop_api.h"
 
-// Keep the shared implementation in this translation unit to avoid
-// duplicate globals from a separate compiled object.
-#include "channelmixerrgb_shared.c"
+// The shared implementation is its own translation unit, compiled once and linked
+// into the single IOP object set. It used to be textually included here, once per
+// consuming module, because two shared objects could not each carry a copy of its
+// globals; with the modules linked statically there is exactly one link and one copy.
 
 #include <gtk/gtk.h>
 #include <math.h>

--- a/src/pixel/chromatic_adaptation.h
+++ b/src/pixel/chromatic_adaptation.h
@@ -43,11 +43,11 @@ typedef enum dt_adaptation_t
 // but coeffs are wrong in the above, so they come from :
 // http://www2.cmp.uea.ac.uk/Research/compvis/Papers/FinSuss_COL00.pdf
 // At any time, ensure XYZ_to_LMS is the exact matrice inverse of LMS_to_XYZ
-const dt_colormatrix_t XYZ_to_Bradford_LMS = { {  0.8951f,  0.2664f, -0.1614f, 0.f },
+static const dt_colormatrix_t XYZ_to_Bradford_LMS = { {  0.8951f,  0.2664f, -0.1614f, 0.f },
                                                { -0.7502f,  1.7135f,  0.0367f, 0.f },
                                                {  0.0389f, -0.0685f,  1.0296f, 0.f } };
 
-const dt_colormatrix_t Bradford_LMS_to_XYZ = { {  0.9870f, -0.1471f,  0.1600f, 0.f },
+static const dt_colormatrix_t Bradford_LMS_to_XYZ = { {  0.9870f, -0.1471f,  0.1600f, 0.f },
                                                {  0.4323f,  0.5184f,  0.0493f, 0.f },
                                                { -0.0085f,  0.0400f,  0.9685f, 0.f } };
 
@@ -83,11 +83,11 @@ convert_bradford_LMS_to_XYZ(const dt_aligned_pixel_simd_t LMS)
 // modified LMS cone response for CAT16, from CIECAM16
 // reference : https://ntnuopen.ntnu.no/ntnu-xmlui/bitstream/handle/11250/2626317/CCIW-23.pdf?sequence=1
 // At any time, ensure XYZ_to_LMS is the exact matrice inverse of LMS_to_XYZ
-const dt_colormatrix_t XYZ_to_CAT16_LMS = { {  0.401288f, 0.650173f, -0.051461f, 0.f },
+static const dt_colormatrix_t XYZ_to_CAT16_LMS = { {  0.401288f, 0.650173f, -0.051461f, 0.f },
                                             { -0.250268f, 1.204414f,  0.045854f, 0.f },
                                             { -0.002079f, 0.048952f,  0.953127f, 0.f } };
 
-const dt_colormatrix_t CAT16_LMS_to_XYZ = { {  1.862068f, -1.011255f,  0.149187f, 0.f },
+static const dt_colormatrix_t CAT16_LMS_to_XYZ = { {  1.862068f, -1.011255f,  0.149187f, 0.f },
                                             {  0.38752f ,  0.621447f, -0.008974f, 0.f },
                                             { -0.015841f, -0.034123f,  1.049964f, 0.f } };
 
@@ -245,22 +245,22 @@ XYZ_adapt_D50(const dt_aligned_pixel_simd_t lms_in,
 
 /* Pre-solved matrices to adjust white point for triplets in CIE XYZ 1931 2° observer */
 
-const dt_colormatrix_t XYZ_D50_to_D65_CAT16
+static const dt_colormatrix_t XYZ_D50_to_D65_CAT16
     = { { 9.89466254e-01f, -4.00304626e-02f, 4.40530317e-02f, 0.f },
         { -5.40518733e-03f, 1.00666069e+00f, -1.75551955e-03f, 0.f },
         { -4.03920992e-04f, 1.50768030e-02f, 1.30210211e+00f, 0.f } };
 
-const dt_colormatrix_t XYZ_D50_to_D65_Bradford
+static const dt_colormatrix_t XYZ_D50_to_D65_Bradford
     = { { 0.95547342f, -0.02309845f, 0.06325924f, 0.f },
         { -0.02836971f, 1.00999540f, 0.02104144f, 0.f },
         { 0.01231401f, -0.02050765f, 1.33036593f, 0.f } };
 
-const dt_colormatrix_t XYZ_D65_to_D50_CAT16
+static const dt_colormatrix_t XYZ_D65_to_D50_CAT16
     = { { 1.01085433e+00f, 4.07086103e-02f, -3.41445825e-02f, 0.f },
         { 5.42814201e-03f, 9.93581926e-01f, 1.15592039e-03f, 0.f },
         { 2.50722468e-04f, -1.14918759e-02f, 7.67964947e-01f, 0.f } };
 
-const dt_colormatrix_t XYZ_D65_to_D50_Bradford
+static const dt_colormatrix_t XYZ_D65_to_D50_Bradford
     = { { 1.04792979f, 0.02294687f, -0.05019227f, 0.f },
         { 0.02962781f, 0.99043443f, -0.0170738f, 0.f },
         { -0.00924304f, 0.01505519f, 0.75187428f, 0.f } };

--- a/src/pixel/illuminants.h
+++ b/src/pixel/illuminants.h
@@ -527,7 +527,7 @@ typedef struct pair
   float temperature;
 } pair;
 
-struct pair pair_min(struct pair r, struct pair n)
+static inline struct pair pair_min(struct pair r, struct pair n)
 {
   // r is the current min value, n in the value to compare against it
   if(n.radius < r.radius) return n;

--- a/src/pixel/locallaplacian.h
+++ b/src/pixel/locallaplacian.h
@@ -68,7 +68,7 @@ int local_laplacian_internal(
     // the following is just needed for clipped roi with boundary conditions from coarse buffer (can be 0)
     local_laplacian_boundary_t *b);
 
-int local_laplacian(
+static inline int local_laplacian(
     const float *const input,   // input buffer in some Labx or yuvx format
     float *const out,           // output buffer with colour
     const int wd,               // width and

--- a/tools/generate_iop_static.py
+++ b/tools/generate_iop_static.py
@@ -1,0 +1,288 @@
+#!/usr/bin/env python3
+#
+#   This file is part of Ansel,
+#   Copyright (C) 2026 Aurélien PIERRE.
+#
+#   Ansel is free software: you can redistribute it and/or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation, either version 3 of the License, or
+#   (at your option) any later version.
+#
+#   Ansel is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with Ansel.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Generate the glue that binds statically-linked IOP modules into the application.
+
+IOP modules used to be one shared object each, discovered by scanning a directory and
+bound with g_module_symbol(). That indirection bought nothing -- the module set is fixed
+at build time, and src/develop/iop_order.c and src/develop/geometry/geometry.c both carry
+a hardcoded census of module names that a module on disk cannot join -- while costing a
+dlopen per module at every startup and turning a stale .so left over from an experimental
+branch into a refusal to start (see dt_ioppr_check_so_iop_order).
+
+Two things have to be generated to replace it:
+
+  * <module>_present.h -- DT_MODULE_HAS_<fn>, 0 or 1, for EVERY name in the API. This is
+    the question g_module_symbol() used to answer at runtime: does this module define this
+    entry point at all? It is answered here by running the real compiler's preprocessor
+    over the module's real sources with the module's real flags. That is not
+    over-engineering: a regex over the raw source gets 90 of 91 modules right and then
+    trips over iop/censorize.c, which hides four functions behind `#if FALSE', and writes
+    name() with its return type on the previous line. Only the preprocessor knows what
+    HAVE_OPENCL and `#if FALSE' resolve to, and it costs one -E pass per source.
+
+  * <module>_static.c -- the function that fills this module's dt_iop_module_so_t, expanded
+    from the same X-macro list in iop/iop_api.h that used to drive the g_module_symbol()
+    calls, inside the module's own translation unit so the plain API names resolve to THIS
+    module's asm-labelled symbols.
+
+plus one registry naming every module, compiled into lib_ansel.
+"""
+
+import argparse
+import os
+import re
+import subprocess
+import sys
+
+# Emitted into every module's translation unit by DT_MODULE(), not declared through the
+# X-macro list, but colliding across modules exactly like the API does.
+VERSION_FUNCTIONS = ("dt_module_dt_version", "dt_module_mod_version")
+
+
+def _usable_flags(flags):
+    """Drop what the preprocessor cannot use, keep the rest verbatim.
+
+    CMake's COMPILE_DEFINITIONS carries at least one entry that already includes its own
+    `-D' (LIBSOUP_VERSION_MAJOR), which reaches us as `-D-DLIBSOUP_VERSION_MAJOR=2' -- not a
+    macro name. Imported targets also leak into INCLUDE_DIRECTORIES as `-I<dir>/LCMS2::LCMS2'.
+    Neither changes which functions a module defines, so neither is worth failing over.
+    """
+    usable = []
+    for flag in flags:
+        if not flag:
+            continue
+        if flag.startswith("-D"):
+            name = flag[2:].split("=", 1)[0]
+            if not name or not (name[0].isalpha() or name[0] == "_"):
+                continue
+        usable.append(flag)
+    return usable
+
+
+def parse_api(path):
+    """Return [(kind, name)] for every entry point declared in an X-macro API header."""
+    entries = []
+    seen = set()
+    pattern = re.compile(r"^\s*(OPTIONAL|REQUIRED|DEFAULT)\(\s*[^,]+,\s*([A-Za-z_]\w*)")
+    with open(path, encoding="utf-8") as handle:
+        for line in handle:
+            match = pattern.match(line)
+            if match is None:
+                continue
+            kind, name = match.group(1), match.group(2)
+            if name in seen:
+                continue
+            seen.add(name)
+            entries.append((kind, name))
+    if not entries:
+        sys.exit(f"generate_iop_static: no API entries found in {path}")
+    return entries
+
+
+def preprocess(compiler, flags, source):
+    """Run the compiler's preprocessor over one source, keeping its line markers."""
+    command = [compiler, "-E"] + flags + [source]
+    result = subprocess.run(command, capture_output=True, text=True, errors="replace")
+    if result.returncode != 0:
+        sys.stderr.write(result.stderr[-4000:])
+        sys.exit(f"generate_iop_static: preprocessing failed for {source}")
+    return result.stdout
+
+
+def own_code(preprocessed, module_dir):
+    """Keep only the regions the line markers attribute to the module's own files.
+
+    Without this, a definition in an included header counts as the module's own: two C++
+    modules (iop/bilateral.cc, iop/tonemap.cc) pick up an unrelated `init(...)' from a
+    header and would claim an init() they do not have.
+    """
+    kept = []
+    keeping = False
+    marker = re.compile(r'^#\s+\d+\s+"([^"]*)"')
+    module_dir = os.path.realpath(module_dir)
+    for line in preprocessed.splitlines():
+        match = marker.match(line)
+        if match is not None:
+            name = match.group(1)
+            path = os.path.realpath(name) if os.path.isabs(name) else None
+            keeping = (path is not None and path.startswith(module_dir + os.sep)) \
+                or os.path.basename(name).startswith("introspection_")
+            continue
+        if keeping:
+            kept.append(line)
+    return "\n".join(kept)
+
+
+def defined_entry_points(body, names):
+    """Names among `names' that `body' defines at file scope with external linkage."""
+    if not names:
+        return set()
+    definition = re.compile(
+        r"(?<![\w.>])(%s)\s*\([^;{]*\)\s*\{" % "|".join(sorted(names, key=len, reverse=True))
+    )
+    found = {match.group(1) for match in definition.finditer(body)}
+    # A static definition is the module's own business and never crosses the link.
+    return {
+        name for name in found
+        if re.search(r"\bstatic\b[^;{}]*\b%s\s*\(" % re.escape(name), body) is None
+    }
+
+
+def generate_present(args, api_names):
+    flags = [flag for flag in args.flags if flag]
+    found = set()
+    for source in args.sources:
+        body = own_code(preprocess(args.cc, flags, source), args.module_dir)
+        found |= defined_entry_points(body, api_names)
+
+    missing_required = [name for kind, name in args.api if kind == "REQUIRED" and name not in found]
+    if missing_required:
+        sys.exit(
+            f"generate_iop_static: module '{args.module}' defines no "
+            f"{', '.join(missing_required)} -- every module must."
+        )
+
+    lines = [
+        "/* Auto-generated by tools/generate_iop_static.py -- do not edit.",
+        " *",
+        f" * Which entry points iop/{args.module} actually defines, as the compiler's own",
+        " * preprocessor sees them. Consumed by DT_MODULE_PICK() in common/module_api.h;",
+        " * every name in the API appears here, so a name the generator did not consider",
+        " * is a compile error rather than a silently NULL function pointer. */",
+        "",
+        f"#ifndef DT_IOP_{args.module.upper()}_PRESENT_H",
+        f"#define DT_IOP_{args.module.upper()}_PRESENT_H",
+        "",
+    ]
+    for _kind, name in args.api:
+        lines.append(f"#define DT_MODULE_HAS_{name} {1 if name in found else 0}")
+    lines += ["", f"#endif // DT_IOP_{args.module.upper()}_PRESENT_H", ""]
+    write_if_changed(args.present, "\n".join(lines))
+
+
+def generate_fill(args):
+    prefix = f"dt_iop_{args.module}__"
+    content = f"""/* Auto-generated by tools/generate_iop_static.py -- do not edit.
+ *
+ * Binds iop/{args.module}'s entry points into its dt_iop_module_so_t. This is compiled
+ * as part of the {args.module} object library, so DT_MODULE_SYMBOL_PREFIX is set and the
+ * plain API names below carry this module's asm label: `module->process = process'
+ * stores the address of {prefix}process and nothing else.
+ *
+ * The DEFAULT fallbacks are NOT applied here -- default_<fn> is static to
+ * develop/imageop.c, which applies them right after calling this. */
+
+#include "develop/imageop.h"
+#include "{args.module}_present.h"
+
+void {prefix}fill_so(dt_iop_module_so_t *module)
+{{
+#define INCLUDE_API_FROM_MODULE_STATIC
+#include "iop/iop_api.h"
+
+  /* Not an X-macro entry: DT_MODULE() defines this in every module unconditionally. */
+  module->version = dt_module_mod_version;
+}}
+"""
+    write_if_changed(args.fill, content)
+
+
+def generate_registry(args):
+    modules = sorted(args.modules)
+    lines = [
+        "/* Auto-generated by tools/generate_iop_static.py -- do not edit.",
+        " *",
+        " * Every IOP module built into this binary. This replaces the directory scan in",
+        " * dt_module_load_modules(): the set of modules is decided by src/iop/CMakeLists.txt",
+        " * at build time, which is also what develop/iop_order.c's order tables and",
+        " * develop/geometry/geometry.c's roster are written against, so discovering it again",
+        " * at runtime could only ever disagree with them.",
+        " *",
+        " * Referencing every fill function from lib_ansel's own sources is also what pulls",
+        " * each module's objects into the link. */",
+        "",
+        '#include "develop/imageop.h"',
+        "",
+    ]
+    for module in modules:
+        lines.append(f"extern void dt_iop_{module}__fill_so(dt_iop_module_so_t *module);")
+    lines += ["", "const dt_iop_module_static_entry_t dt_iop_static_modules[] = {"]
+    for module in modules:
+        lines.append(f'  {{ "{module}", dt_iop_{module}__fill_so }},')
+    lines += [
+        "};",
+        "",
+        "const int dt_iop_static_modules_count "
+        "= (int)(sizeof(dt_iop_static_modules) / sizeof(dt_iop_static_modules[0]));",
+        "",
+    ]
+    write_if_changed(args.out, "\n".join(lines))
+
+
+def write_if_changed(path, content):
+    """Avoid touching an unchanged output, so ninja does not rebuild the world."""
+    if os.path.exists(path):
+        with open(path, encoding="utf-8") as handle:
+            if handle.read() == content:
+                return
+    os.makedirs(os.path.dirname(os.path.abspath(path)), exist_ok=True)
+    with open(path, "w", encoding="utf-8") as handle:
+        handle.write(content)
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    module_parser = sub.add_parser("module", help="presence header + so-fill source")
+    module_parser.add_argument("--module", required=True)
+    module_parser.add_argument("--module-dir", required=True)
+    module_parser.add_argument("--api", required=True)
+    module_parser.add_argument("--present", required=True)
+    module_parser.add_argument("--fill", required=True)
+    module_parser.add_argument("--cc", required=True)
+    module_parser.add_argument("--sources", nargs="+", required=True)
+
+    registry_parser = sub.add_parser("registry", help="the table of every built module")
+    registry_parser.add_argument("--out", required=True)
+    registry_parser.add_argument("--modules", nargs="+", required=True)
+
+    # Compiler flags come after a `--' sentinel: they are full of tokens starting with a
+    # dash, which argparse would read as options of its own.
+    argv = sys.argv[1:]
+    flags = []
+    if "--" in argv:
+        cut = argv.index("--")
+        argv, flags = argv[:cut], argv[cut + 1:]
+
+    args = parser.parse_args(argv)
+    args.flags = _usable_flags(flags)
+
+    if args.command == "registry":
+        generate_registry(args)
+        return
+
+    args.api = parse_api(args.api)
+    api_names = {name for _kind, name in args.api} | set(VERSION_FUNCTIONS)
+    generate_present(args, api_names)
+    generate_fill(args)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
`src/iop` was loaded like `src/libs` and `src/views`: one shared object per module, discovered by scanning a directory, bound with `g_module_symbol()`. For IOPs that boundary was fiction, and it cost real time and one hard failure mode.

**It could not discover anything.** All 90 `add_iop()` calls are unconditional, and `iop_order.c`'s five order tables, its `insert_missing_modules()` and `geometry.c`'s `_roster[]` all carry a hardcoded census of module names a module on disk cannot join. The scan could only ever find a *disagreement* — and `dt_ioppr_check_so_iop_order()` turns that into `ERROR: iop order looks bad, aborting`, GUI included, for one stale `.so` left by an experimental branch. Reproduced, and now impossible. The quiet variant is worse: a stale module whose op name *does* have an order loads fine and reads a struct whose layout has moved.

## The API does not change

Every module still writes plain `int process(...)` — no module source is edited. The ~30 duplicate symbols per module are resolved by an **asm label** attached to the declaration in `module_api.h`'s `FULL_API_H` branch, which renames the symbol and leaves the identifier alone; a `#define process ...` could not promise that for struct members, locals and `->name`. Verified on GCC and Clang, ±LTO, through an archive.

It is a compiler feature, not a linker one — which is what makes it work on the Windows nightly, where clang drives **lld in COFF mode**: no `-r` partial link, and no symbol visibility to localize, so the `objcopy --localize-hidden` route available on ELF is not.

What `g_module_symbol()` answered at runtime is answered at build time by `tools/generate_iop_static.py`, running the real compiler's preprocessor over the module's real sources. It has to be the preprocessor: a regex gets 90 of 91 right, then meets `censorize.c`, which parks four functions behind `#if FALSE` and writes `name()` with its return type on the previous line. The generated header defines a macro for *every* API name, so one the generator missed is a compile error, not a silently NULL pointer.

## Measured

| | master | this branch |
|---|---|---|
| headless startup | 0.345–0.356 s | **0.109–0.115 s** |
| export vs master, 16-bit | — | max delta **1 / 65535** |
| stale `.so` in `plugins/` | aborts startup | ignored |
| dead `plugins/*/enable` conf keys | 88 of 155 anselrc lines | 0 |
| **rebuild after touching one module** | **1.7 s** | **75 s** |

The pixel delta is LTO now reaching across the module boundary under `-ffast-math -ffp-contract=fast` — last-place rounding, not behaviour.

**It does not make pixel processing faster.** Whole pipeline: +0.6%, p = 0.44 (n = 13 interleaved). The hot paths were already inlined through headers (`colorspaces_inline_conversions.h`, `math/*.h`, `pixel/*.h`), so crossing the boundary gives LTO mostly cold glue. Take this for startup and the failure mode, not for throughput.

## lensfun, which kept coming up

Measured against `liblensfun` directly: `Load()` parses 8.4 MB into 1051 cameras and 1562 lenses in **89–102 ms** for 4 MB RSS, and `init_global()` did it at *every* startup, including lighttable-only sessions that never correct a lens. `FindCamerasExt()` is a 0.35–0.42 ms fuzzy scan that `commit_params()` re-ran on every pipe resync, for every pipe, under the global plugin mutex.

- The database is built on first use behind `_lensfun_db()`, and pre-warmed on a background thread so the parse overlaps startup. Joined in `cleanup_global()`, not detached.
- `_lensfun_find_camera()` / `_lensfun_find_lens()` memoise the resolved pointers, misses included.

Not fixed, and not a profile problem: the module's ~0.9 s in a full-res export is `ApplySubpixelGeometryDistortion` building the coordinate map (278 ms/frame of lensfun's own maths) plus resampling.

## The one open item

`Lens correction` reads +10.7% (p = 0.003) under static linking. Chased to the end: LTO off for `lens` alone does not help; the cost is in `dt_interpolation_compute_sample`, which is in `lib_ansel` in **both** builds and whose **disassembly is identical** — 883 instructions, same 15 `ymm`, same 50 FMA, byte for byte, only relocated from a 32-byte-aligned address in a 32 MB library to a 16-byte-aligned one in a 42 MB library. Process counters agree: 4% fewer instructions retired at lower IPC, 9.3% fewer µops from the DSB, 11.8% more i-cache tag stalls. Code placement, not code quality; total pipeline cycles moved +0.8%.

## Reviewer notes

- **75 s per IOP edit** is the real cost (52–72 s of it is the one `lib_ansel` LTO link). If that is unacceptable, the modules can go in their own shared library instead — the registry gets handed to `dt_init()` by the executable rather than looked up, ~30 lines plus ~6 call sites. That keeps the whole startup win and restores the LTO boundary.
- **Untested platforms.** macOS: asm labels emit verbatim and Mach-O wants a leading underscore, so `DT_MODULE_SYM` adds one under `__APPLE__` — no Darwin box here. Windows: the design avoids every COFF/lld limitation found, but the nightly is the proof.
- The link surfaced **30 duplicate definitions**, nearly all headers that define rather than declare — `common/colorchecker.h` alone had 24. Each got internal linkage, the lifetime it already had. `common/colorchecker.h`'s should properly move into `common/colorchecker.c`; deliberately left as a separate cleanup.

`doc/static-iop.md` and `doc/lensfun-cost.md` carry the full write-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)