### PR TITLE
Revert the lensfun background pre-warm: it races setlocale()

### DIFF
--- a/doc/lensfun-cost.md
+++ b/doc/lensfun-cost.md
@@ -37,15 +37,44 @@ modules in (see `static-iop.md`), which is the other half of the number:
 |---|---|---|---|
 | startup | 0.293–0.340 s | 0.206–0.211 s | **0.097–0.112 s** |
 
-The 90-odd ms does not disappear, but it is not left on the critical path either:
-`init_global()` starts `_lensfun_db_warm()` on a background thread, so the parse overlaps the
-rest of startup and is normally done before any image asks. Whoever arrives first builds it
-and the other waits on the same lock — there is one construction either way, and the accessor
-was already thread-safe. The thread is **joined** in `cleanup_global()`, not detached: it must
-not still be parsing when the database it is writing gets freed.
+The 90-odd ms does not disappear, it moves to the first image that needs a lens — where a raw
+decode already dwarfs it.
 
-Measured with the pre-warm in place, 5 interleaved runs: startup 0.109–0.115 s against
-master's 0.345–0.356 s — i.e. the background parse costs the startup path nothing.
+### Do not pre-warm it on a background thread
+
+That was tried, shipped, and reverted. `init_global()` started a thread that built the database
+so the parse would overlap the rest of startup. It looked safe — the accessor is mutex-guarded,
+the thread was joined in `cleanup_global()`, and it passed CI once — and it is not:
+
+**`liblensfun` calls `setlocale()`.** `lfDatabase::Load()` switches `LC_NUMERIC` to `"C"` so it
+can parse decimal points, then puts it back. `setlocale()` is process-global and not thread-safe.
+Running it on a background thread while the main thread is still initialising GTK, imageio and
+GraphicsMagick is a data race on the process locale, and it is invisible on glibc:
+
+```
+[empty history stack]
+0.238865 [rawdenoiseai] loaded ...denoise-quarter-multi-v1.anselnn
+Magick: abort due to signal 11 (SIGSEGV) "Segmentation Fault"...
+```
+
+That is the Windows Release CI job, on master, roughly 0.24 s in — inside the window where the
+pre-warm thread was parsing. The same job had passed on the pull request, which is what a race
+looks like.
+
+It also bought nothing measurable. Startup was 0.097–0.112 s with the lazy load alone and
+0.109–0.115 s with the pre-warm on top: thread creation and CPU contention cost slightly more
+than the overlap saved, and the end-to-end export time was a wash. So this is not a trade to
+re-litigate with better synchronisation — there is nothing on the other side of it.
+
+A caveat on "safe", so nobody reads too much into the revert: `dt_control_jobs_init()` runs at
+`darktable.c:1567`, before `dt_iop_load_modules_so()` at 1724, so the worker pool has always been
+alive when `Load()` ran — the `setlocale()` exposure predates all of this and is a property of
+lensfun, not of when we call it. What the pre-warm changed was the overlap: from "idle workers
+waiting on a job queue" to "the main thread actively initialising locale-sensitive libraries".
+That is the difference between a hazard nobody has hit and a crash.
+
+If the first-image hitch ever does matter, the only safe shape is to build the database on the
+**main** thread at a point where nothing else is running, not to move it onto another one.
 
 ## 2. The same lookup was repeated on every pipe resync
 

--- a/src/iop/lens.cc
+++ b/src/iop/lens.cc
@@ -179,8 +179,6 @@ typedef struct dt_iop_lensfun_global_data_t
    *  _lensfun_db(), never directly. */
   lfDatabase *db;
   gboolean db_tried;
-  /** Pre-warm thread, see _lensfun_db_warm(). Joined by cleanup_global(). */
-  GThread *db_warm;
   int kernel_lens_distort_bilinear;
   int kernel_lens_distort_bicubic;
   int kernel_lens_distort_mitchell;
@@ -194,11 +192,6 @@ typedef struct dt_iop_lensfun_global_data_t
  * this module is switched on per image by reload_defaults() (workflow_enabled), so the
  * first possible consumer is an image being loaded, and by then the cost is amortised
  * against a pipeline run rather than added to the splash screen.
- *
- * It is not left to chance either: init_global() starts _lensfun_db_warm() to build it on a
- * background thread, so the work overlaps the rest of startup and is normally finished before
- * any image asks. Whoever gets there first builds it and the other waits -- there is one lock
- * and one construction either way.
  *
  * _lensfun_db_lock covers the construction only, and is never held while the plugin mutex
  * is taken, so the two cannot deadlock against each other. db_tried makes a failed load
@@ -220,22 +213,6 @@ static GHashTable *_lensfun_lens_memo = NULL;
 
 /** @brief Build the database. Call once, under _lensfun_db_lock. */
 static lfDatabase *_lensfun_db_create(void);
-static lfDatabase *_lensfun_db(dt_iop_lensfun_global_data_t *gd);
-
-/**
- * @brief Build the database off the startup path.
- *
- * @details Pure pre-warm: it takes the same accessor everything else does, so if an image
- * gets there first this simply waits on the lock and returns. It touches nothing but the
- * database, so there is nothing here for the GUI thread to race against -- but it must not
- * still be running when cleanup_global() frees the database, which is why the thread is
- * joined there rather than detached.
- */
-static gpointer _lensfun_db_warm(gpointer data)
-{
-  (void)_lensfun_db((dt_iop_lensfun_global_data_t *)data);
-  return NULL;
-}
 
 /**
  * @brief The lensfun database, built on first use.
@@ -1572,8 +1549,7 @@ void init_global(dt_iop_module_so_t *module)
   gd->kernel_lens_distort_mitchell = dt_opencl_create_kernel(program, "lens_distort_mitchell");
   gd->kernel_lens_vignette = dt_opencl_create_kernel(program, "lens_vignette");
 
-  // The database is NOT built on this thread -- see _lensfun_db() and _lensfun_db_warm().
-  gd->db_warm = g_thread_new("lensfun-db", _lensfun_db_warm, gd);
+  // The database is NOT built here -- see _lensfun_db(). calloc() already left it NULL.
 }
 
 static lfDatabase *_lensfun_db_create(void)
@@ -1747,13 +1723,6 @@ void reload_defaults(dt_iop_module_t *module)
 void cleanup_global(dt_iop_module_so_t *module)
 {
   dt_iop_lensfun_global_data_t *gd = (dt_iop_lensfun_global_data_t *)module->data;
-
-  /* Before anything is freed: the pre-warm thread may still be building the database. */
-  if(!IS_NULL_PTR(gd->db_warm))
-  {
-    g_thread_join(gd->db_warm);
-    gd->db_warm = NULL;
-  }
 
   /* The memos hold pointers INTO the database, so they go first. Both may be NULL: a session
    * that never opened an image never built any of this. */


### PR DESCRIPTION
Reverts 724d180a2d, which crashed the Windows Release CI job on master:

```
[empty history stack]
0.238865 [rawdenoiseai] loaded ...denoise-quarter-multi-v1.anselnn
Magick: abort due to signal 11 (SIGSEGV) "Segmentation Fault"...
Process completed with exit code 127.
```

## Cause

**`liblensfun` calls `setlocale()`** — confirmed in its symbol table, and it is what `lfDatabase::Load()` does to parse decimal points: switch `LC_NUMERIC` to `"C"`, parse, put it back. `setlocale()` is process-global and not thread-safe.

The pre-warm ran that on a background thread started from `init_global()`, i.e. while the main thread was still bringing up GTK, imageio and GraphicsMagick — all locale-sensitive. That is a data race on the process locale. glibc tolerates it; UCRT did not.

It is also exactly what a race looks like from CI: the same job, on the same code, **passed on the pull request and failed on master**.

## Why revert rather than fix the synchronisation

There is nothing on the other side of the trade. From the original measurements:

| | startup |
|---|---|
| lazy load alone | 0.097–0.112 s |
| lazy load + pre-warm | 0.109–0.115 s |

Thread creation and CPU contention cost marginally more than the overlap saved, and end-to-end export was a wash. The pre-warm was an optimisation that did not optimise anything measurable, and it cannot be made safe by locking on our side — the unsafe call is inside lensfun.

## Scope

The parts that actually paid are untouched: the **lazy database build** and the **lookup memo**, which took startup from 0.345–0.356 s to ~0.11 s. Only the thread is gone.

## A caveat, so the revert is not over-read

The `setlocale()` exposure is older than this branch. `dt_control_jobs_init()` runs at `darktable.c:1567`, before `dt_iop_load_modules_so()` at 1724, so the worker pool has always been alive when `Load()` ran. What the pre-warm changed was what it overlapped with — idle workers on a job queue, versus the main thread actively initialising locale-sensitive libraries. That is the difference between a hazard nobody had hit and a crash. This revert restores the prior risk profile; it does not eliminate the underlying lensfun behaviour.

If the first-image hitch ever does matter, the only safe shape is to build the database on the **main** thread at a point where nothing else is running — not to move it onto another one. `doc/lensfun-cost.md` records this so it is not tried again.

## Verified

Release/LTO build clean; startup 0.115 s; the exact export command the failing CI step runs completes normally. The Windows Release job on this PR is the real test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)