### PR TITLE
[diagnostic, do not merge] Windows Release runtime test on a pre-static-IOP tree

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,6 +90,19 @@ jobs:
           - nofeatures
         generator:
           - Ninja
+        # One Release build per OS. Release is the ONLY configuration that turns LTO on
+        # (CMakeLists.txt disables IPO for Debug), and LTO is what the nightlies ship, so a
+        # Debug-only matrix never exercises the configuration users actually run. It also
+        # cannot catch what LTO changes: with LTO the linker localises module-internal
+        # symbols, so a duplicate-definition clash shows up in Debug and NOT in Release --
+        # and cross-TU inlining, which moves pixels under -ffast-math, only exists here.
+        # See doc/static-iop.md.
+        include:
+          - os: { label: ubuntu-24.04, code: noble }
+            compiler: { compiler: GNU14, CC: gcc-14, CXX: g++-14, GCC_VER: "14", LLVM_VER: "" }
+            btype: Release
+            target: skiptest
+            generator: Ninja
     env:
       CC: ${{ matrix.compiler.CC }}
       CXX: ${{ matrix.compiler.CXX }}
@@ -213,13 +226,15 @@ jobs:
           ./run.sh --no-opencl --no-deltae --fast-fail
 
   Win64:
-    name: Win64.${{ matrix.msystem }}.${{ matrix.target }}.${{ matrix.btype }}.${{ matrix.generator }}
+    name: Win64.${{ matrix.msystem }}.${{ matrix.compiler.compiler }}.${{ matrix.target }}.${{ matrix.btype }}.${{ matrix.generator }}
     runs-on: windows-latest
     strategy:
       fail-fast: true
       matrix:
         btype:
           - Debug
+        compiler:
+          - { compiler: GNU, CC: gcc, CXX: g++ }
         eco: [-DUSE_XMLLINT=OFF]
         target:
           - skiptest
@@ -228,6 +243,23 @@ jobs:
           - Ninja
         msystem:
           - UCRT64
+        # One Release build per OS. Release is the ONLY configuration that turns LTO on
+        # (CMakeLists.txt disables IPO for Debug), and LTO is what the nightlies ship, so a
+        # Debug-only matrix never exercises the configuration users actually run. It also
+        # cannot catch what LTO changes: with LTO the linker localises module-internal
+        # symbols, so a duplicate-definition clash shows up in Debug and NOT in Release --
+        # and cross-TU inlining, which moves pixels under -ffast-math, only exists here.
+        # See doc/static-iop.md.
+        # On Windows LTO needs clang and lld: CMakeLists.txt disables IPO outright for
+        # WIN32 with the GNU toolchain, because GNU ld cannot do it. Both are already in
+        # packaging/install-deps-windows-msys2.sh, and this is what win-nightly.yml ships.
+        include:
+          - btype: Release
+            compiler: { compiler: LLVM, CC: clang, CXX: clang++ }
+            eco: -DUSE_XMLLINT=OFF
+            target: skiptest
+            generator: Ninja
+            msystem: UCRT64
     defaults:
       run:
         shell: msys2 {0}
@@ -235,6 +267,8 @@ jobs:
       SRC_DIR: ${{ github.workspace }}/src
       BUILD_DIR: ${{ github.workspace }}/build
       INSTALL_PREFIX: ${{ github.workspace }}/install
+      CC: ${{ matrix.compiler.CC }}
+      CXX: ${{ matrix.compiler.CXX }}
       ECO: ${{ matrix.eco }}
       CMAKE_BUILD_TYPE: ${{ matrix.btype }}
       TARGET: ${{ matrix.target }}
@@ -292,6 +326,20 @@ jobs:
         generator:
           - Ninja
         eco: [-DUSE_GRAPHICSMAGICK=ON -DUSE_IMAGEMAGICK=OFF]
+        # One Release build per OS. Release is the ONLY configuration that turns LTO on
+        # (CMakeLists.txt disables IPO for Debug), and LTO is what the nightlies ship, so a
+        # Debug-only matrix never exercises the configuration users actually run. It also
+        # cannot catch what LTO changes: with LTO the linker localises module-internal
+        # symbols, so a duplicate-definition clash shows up in Debug and NOT in Release --
+        # and cross-TU inlining, which moves pixels under -ffast-math, only exists here.
+        # See doc/static-iop.md.
+        include:
+          - build: { os: macos-15, xcode: 26.3, deployment: 15.0 }
+            compiler: { compiler: XCode, CC: cc, CXX: c++ }
+            btype: Release
+            target: skiptest
+            generator: Ninja
+            eco: -DUSE_GRAPHICSMAGICK=ON -DUSE_IMAGEMAGICK=OFF
     env:
       DEVELOPER_DIR: /Applications/Xcode_${{ matrix.build.xcode }}.app/Contents/Developer
       CC: ${{ matrix.compiler.CC }}


### PR DESCRIPTION
Draft, diagnostic only — **do not merge**.

The `Win64.UCRT64.LLVM.skiptest.Release.Ninja` runtime test crashes intermittently:

```
[empty history stack]
0.262253 [rawdenoiseai] loaded ...denoise-quarter-multi-v1.anselnn
Magick: abort due to signal 11 (SIGSEGV) "Segmentation Fault"...
```

Observed: **pass** on PR #1208, **fail** on master, **fail** on PR #1209 (the pre-warm revert). Identical output up to the last log line. That is nondeterministic, and it rules out the lensfun pre-warm as the cause.

That job did not exist before #1208 added it, so Windows Release has **never** been runtime-tested. This branch is `740c10683c^` — the commit immediately before the IOP modules were linked in — with **only** the ci.yml Release-jobs change applied.

- If it crashes here too, the bug is pre-existing and #1208 merely exposed it.
- If it passes repeatedly, the static-IOP change introduced it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)