### PR TITLE
[bisect, do not merge] Windows Release runtime test on ee29751263

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -296,7 +296,22 @@ jobs:
         run: |
           $(cygpath ${INSTALL_PREFIX})/bin/ansel.exe --version || true
           $(cygpath ${INSTALL_PREFIX})/bin/ansel-cli.exe --version || true
-          echo "Testing RUN!"
+          echo "Testing RUN (8 attempts -- the crash is intermittent, ~2 in 3)!"
+          for i in 1 2 3 4 5 6 7 8; do
+            echo "--- attempt $i ---"
+            $(cygpath ${INSTALL_PREFIX})/bin/ansel-cli.exe \
+                 --verbose \
+                 --width 2048 --height 2048 \
+                 --apply-custom-presets false \
+                 $(cygpath ${SRC_DIR})/data/pixmaps/256x256/ansel.png \
+                 output_$i.png \
+                 --core --disable-opencl --conf host_memory_limit=8192 \
+                 --conf worker_threads=4 -t 4 \
+                 --conf plugins/lighttable/export/force_lcms2=FALSE \
+                 --conf plugins/lighttable/export/iccintent=0 \
+              || { echo "### FAILED ON ATTEMPT $i ###"; exit 1; }
+          done
+          echo "### 8/8 clean ###"
           $(cygpath ${INSTALL_PREFIX})/bin/ansel-cli.exe \
                  --verbose \
                  --width 2048 --height 2048 \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,6 +90,19 @@ jobs:
           - nofeatures
         generator:
           - Ninja
+        # One Release build per OS. Release is the ONLY configuration that turns LTO on
+        # (CMakeLists.txt disables IPO for Debug), and LTO is what the nightlies ship, so a
+        # Debug-only matrix never exercises the configuration users actually run. It also
+        # cannot catch what LTO changes: with LTO the linker localises module-internal
+        # symbols, so a duplicate-definition clash shows up in Debug and NOT in Release --
+        # and cross-TU inlining, which moves pixels under -ffast-math, only exists here.
+        # See doc/static-iop.md.
+        include:
+          - os: { label: ubuntu-24.04, code: noble }
+            compiler: { compiler: GNU14, CC: gcc-14, CXX: g++-14, GCC_VER: "14", LLVM_VER: "" }
+            btype: Release
+            target: skiptest
+            generator: Ninja
     env:
       CC: ${{ matrix.compiler.CC }}
       CXX: ${{ matrix.compiler.CXX }}
@@ -213,13 +226,15 @@ jobs:
           ./run.sh --no-opencl --no-deltae --fast-fail
 
   Win64:
-    name: Win64.${{ matrix.msystem }}.${{ matrix.target }}.${{ matrix.btype }}.${{ matrix.generator }}
+    name: Win64.${{ matrix.msystem }}.${{ matrix.compiler.compiler }}.${{ matrix.target }}.${{ matrix.btype }}.${{ matrix.generator }}
     runs-on: windows-latest
     strategy:
       fail-fast: true
       matrix:
         btype:
           - Debug
+        compiler:
+          - { compiler: GNU, CC: gcc, CXX: g++ }
         eco: [-DUSE_XMLLINT=OFF]
         target:
           - skiptest
@@ -228,6 +243,23 @@ jobs:
           - Ninja
         msystem:
           - UCRT64
+        # One Release build per OS. Release is the ONLY configuration that turns LTO on
+        # (CMakeLists.txt disables IPO for Debug), and LTO is what the nightlies ship, so a
+        # Debug-only matrix never exercises the configuration users actually run. It also
+        # cannot catch what LTO changes: with LTO the linker localises module-internal
+        # symbols, so a duplicate-definition clash shows up in Debug and NOT in Release --
+        # and cross-TU inlining, which moves pixels under -ffast-math, only exists here.
+        # See doc/static-iop.md.
+        # On Windows LTO needs clang and lld: CMakeLists.txt disables IPO outright for
+        # WIN32 with the GNU toolchain, because GNU ld cannot do it. Both are already in
+        # packaging/install-deps-windows-msys2.sh, and this is what win-nightly.yml ships.
+        include:
+          - btype: Release
+            compiler: { compiler: LLVM, CC: clang, CXX: clang++ }
+            eco: -DUSE_XMLLINT=OFF
+            target: skiptest
+            generator: Ninja
+            msystem: UCRT64
     defaults:
       run:
         shell: msys2 {0}
@@ -235,6 +267,8 @@ jobs:
       SRC_DIR: ${{ github.workspace }}/src
       BUILD_DIR: ${{ github.workspace }}/build
       INSTALL_PREFIX: ${{ github.workspace }}/install
+      CC: ${{ matrix.compiler.CC }}
+      CXX: ${{ matrix.compiler.CXX }}
       ECO: ${{ matrix.eco }}
       CMAKE_BUILD_TYPE: ${{ matrix.btype }}
       TARGET: ${{ matrix.target }}
@@ -292,6 +326,20 @@ jobs:
         generator:
           - Ninja
         eco: [-DUSE_GRAPHICSMAGICK=ON -DUSE_IMAGEMAGICK=OFF]
+        # One Release build per OS. Release is the ONLY configuration that turns LTO on
+        # (CMakeLists.txt disables IPO for Debug), and LTO is what the nightlies ship, so a
+        # Debug-only matrix never exercises the configuration users actually run. It also
+        # cannot catch what LTO changes: with LTO the linker localises module-internal
+        # symbols, so a duplicate-definition clash shows up in Debug and NOT in Release --
+        # and cross-TU inlining, which moves pixels under -ffast-math, only exists here.
+        # See doc/static-iop.md.
+        include:
+          - build: { os: macos-15, xcode: 26.3, deployment: 15.0 }
+            compiler: { compiler: XCode, CC: cc, CXX: c++ }
+            btype: Release
+            target: skiptest
+            generator: Ninja
+            eco: -DUSE_GRAPHICSMAGICK=ON -DUSE_IMAGEMAGICK=OFF
     env:
       DEVELOPER_DIR: /Applications/Xcode_${{ matrix.build.xcode }}.app/Contents/Developer
       CC: ${{ matrix.compiler.CC }}


### PR DESCRIPTION
Draft, diagnostic only — **do not merge**. Bisect step for #1212.

Last known-good Windows LTO run: the 2026-08-20 05:18 nightly, which built `1e369f2513`. The crash reproduces on `597eb1bbc2`. Exactly two commits separate them:

- `ee29751263` Highlights: the value-continuation pass is a collar, not a plateau ← **this branch**
- `597eb1bbc2` masks: fix session-cache heap corruption, clipped shapes, and a stray creation-mode line

Only the ci.yml Release-jobs change is applied on top.

- Passes repeatedly → `597eb1bbc2` is the culprit.
- Fails → `ee29751263` is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)