### PR TITLE
CI: stop the known Windows Release crash from gating every PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -293,6 +293,13 @@ jobs:
           cmake -E make_directory "${INSTALL_PREFIX}"
           $(cygpath ${SRC_DIR})/.ci/ci-script.sh
       - name: Check if it runs
+        # TODO(#1212): the Windows Release/LTO binary segfaults intermittently in
+        # colorin's commit_params during export -- a latent memory bug whose rate moves
+        # with code layout (~12% to ~75% across neighbouring commits), not something this
+        # job introduced. The BUILD half of this job is the only CI coverage of Windows
+        # LTO and must keep gating; the runtime half cannot gate every PR until #1212 is
+        # fixed. Drop this line then.
+        continue-on-error: ${{ matrix.btype == 'Release' }}
         run: |
           $(cygpath ${INSTALL_PREFIX})/bin/ansel.exe --version || true
           $(cygpath ${INSTALL_PREFIX})/bin/ansel-cli.exe --version || true


### PR DESCRIPTION
Master's `Win64.UCRT64.LLVM.skiptest.Release.Ninja` is red on most runs because of #1212 — an intermittent SIGSEGV in `colorin::commit_params` during export, on Windows clang+LTO only.

It is **not** caused by anything in CI or by #1208: it reproduces on `597eb1bbc2`, which predates the static-IOP merge, and the failure rate swings from ~12% to ~75% across neighbouring unrelated commits — a latent memory bug that code layout moves, not one a bisect can attribute.

This makes **only the runtime step, and only for Release**, `continue-on-error`:

- The **build and link** half keeps gating. That is the point of the job and the only CI coverage of Windows clang + lld + LTO — it caught real problems on day one.
- **Debug's runtime coverage is untouched**, so Windows still has a gating runtime test.
- The crash stays **visible in the job log**; it is not silenced, just not blocking.

Revert the moment #1212 is fixed — the TODO in the workflow says so and names the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)