### PR TITLE
pipe: refuse to dispatch module code on an untrustworthy node (#1212)

### DIFF
--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -593,11 +593,38 @@ int dt_iop_load_module_by_so(dt_iop_module_t *module, dt_iop_module_so_t *so, dt
   return 0;
 }
 
+/**
+ * @brief Build one pixelpipe node's module-owned storage.
+ *
+ * @details Establishes what _iop_piece_is_committable() later relies on. init_pipe is OPTIONAL
+ * in the module API, so a module that allocates nothing is legitimate and leaves data NULL with
+ * data_size 0; what is never legitimate is claiming a size without the storage, which is how a
+ * failed allocation would otherwise reach 61 modules that dereference piece->data unchecked.
+ */
 void dt_iop_init_pipe(struct dt_iop_module_t *module, struct dt_dev_pixelpipe_t *pipe,
                       struct dt_dev_pixelpipe_iop_t *piece)
 {
-  module->init_pipe(module, pipe, piece);
+  if(IS_NULL_PTR(module) || IS_NULL_PTR(piece)) return;
+
+  if(!IS_NULL_PTR(module->init_pipe)) module->init_pipe(module, pipe, piece);
+
+  if(piece->data_size > 0 && IS_NULL_PTR(piece->data))
+  {
+    dt_print(DT_DEBUG_ALWAYS,
+             "[dt_iop_init_pipe] `%s' could not allocate its %zu bytes of node storage;"
+             " the node stays disabled\n", module->op, piece->data_size);
+    piece->data_size = 0;
+    piece->enabled = 0;
+  }
+
   piece->blendop_data = dt_calloc_align(sizeof(dt_develop_blend_params_t));
+  if(IS_NULL_PTR(piece->blendop_data))
+  {
+    dt_print(DT_DEBUG_ALWAYS,
+             "[dt_iop_init_pipe] `%s' could not allocate blend storage; the node stays disabled\n",
+             module->op);
+    piece->enabled = 0;
+  }
 }
 
 /**
@@ -1354,10 +1381,103 @@ void dt_iop_compute_module_hash(dt_iop_module_t *module, GList *masks)
   module->hash = hash;
 }
 
+/**
+ * @brief Is this pipeline node safe to dispatch module code on?
+ *
+ * @details The mirror of the validation dt_iop_cleanup_pipe() already performs, and for the
+ * same reason it gives: a pipe can be walked while holding a node whose backing storage is no
+ * longer trustworthy, and "calling the descriptor callback with that same instance would only
+ * move the use-after-free into the module cleanup code". Commit is the other door into module
+ * code, and it was unguarded -- it memcpy'd into piece->blendop_data before reading anything,
+ * so a stale node corrupted memory before any callback could object.
+ *
+ * Every check here is an invariant the pipeline establishes itself, never a guess:
+ *
+ *  - dt_dev_pixelpipe_create_nodes() calloc's the node, sets piece->module, and calls
+ *    dt_iop_init_pipe(), which allocates piece->blendop_data. A node reaching commit without
+ *    those did not come from there.
+ *  - piece->module is the module the node was built for. Committing module A's params through
+ *    node B reinterprets B's private data_size bytes as A's parameter struct.
+ *  - All 89 modules that define init_pipe() set piece->data_size when they allocate
+ *    piece->data, so `data_size > 0 && data == NULL' is never a legitimate state -- it is
+ *    either a failed allocation or storage that has already been torn down. 61 modules
+ *    dereference piece->data in commit_params() without checking it, which is fine as long as
+ *    this holds, and a guaranteed SIGSEGV the moment it does not.
+ *
+ * @return TRUE when the node may be dispatched on. Reports and refuses otherwise.
+ */
+static gboolean _iop_piece_is_committable(dt_iop_module_t *module, dt_dev_pixelpipe_t *pipe,
+                                          dt_dev_pixelpipe_iop_t *piece)
+{
+  if(IS_NULL_PTR(piece)) return FALSE;
+
+  if(IS_NULL_PTR(module))
+  {
+    dt_print(DT_DEBUG_ALWAYS, "[dt_iop_commit_params] missing module, skipping commit\n");
+    return FALSE;
+  }
+
+  if(IS_NULL_PTR(pipe))
+  {
+    dt_print(DT_DEBUG_ALWAYS, "[dt_iop_commit_params] missing pipe for `%s', skipping commit\n",
+             module->op);
+    return FALSE;
+  }
+
+  if(piece->module != module)
+  {
+    dt_print(DT_DEBUG_ALWAYS,
+             "[dt_iop_commit_params] node belongs to `%s' but `%s' is committing, skipping\n",
+             IS_NULL_PTR(piece->module) ? "(none)" : piece->module->op, module->op);
+    return FALSE;
+  }
+
+  if(IS_NULL_PTR(piece->blendop_data))
+  {
+    dt_print(DT_DEBUG_ALWAYS,
+             "[dt_iop_commit_params] `%s' node has no blend storage, skipping commit\n", module->op);
+    return FALSE;
+  }
+
+  if(piece->data_size > 0 && IS_NULL_PTR(piece->data))
+  {
+    dt_print(DT_DEBUG_ALWAYS,
+             "[dt_iop_commit_params] `%s' node claims %zu bytes of private data but has none,"
+             " skipping commit\n", module->op, piece->data_size);
+    return FALSE;
+  }
+
+  if(IS_NULL_PTR(module->commit_params))
+  {
+    dt_print(DT_DEBUG_ALWAYS, "[dt_iop_commit_params] `%s' has no commit_params, skipping\n",
+             module->op);
+    return FALSE;
+  }
+
+  return TRUE;
+}
+
 void dt_iop_commit_params(dt_iop_module_t *module, dt_iop_params_t *params,
                           dt_develop_blend_params_t *blendop_params, dt_dev_pixelpipe_t *pipe,
                           dt_dev_pixelpipe_iop_t *piece)
 {
+  /* Before the memcpy below, not after: an untrustworthy node has already been written through
+   * by the time a callback could reject it. A refused node stays disabled rather than running
+   * with parameters that were never committed. */
+  if(!_iop_piece_is_committable(module, pipe, piece))
+  {
+    if(!IS_NULL_PTR(piece)) piece->enabled = 0;
+    return;
+  }
+
+  if(IS_NULL_PTR(params) || IS_NULL_PTR(blendop_params))
+  {
+    dt_print(DT_DEBUG_ALWAYS, "[dt_iop_commit_params] `%s' committed with no parameters,"
+             " skipping\n", module->op);
+    piece->enabled = 0;
+    return;
+  }
+
   // We need to commit also modules that are disabled because some of them
   // may self-enabled at commit time, depending on image input.
   // 1. commit params

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -611,8 +611,8 @@ void dt_iop_init_pipe(struct dt_iop_module_t *module, struct dt_dev_pixelpipe_t 
   if(piece->data_size > 0 && IS_NULL_PTR(piece->data))
   {
     dt_print(DT_DEBUG_ALWAYS,
-             "[dt_iop_init_pipe] `%s' could not allocate its %zu bytes of node storage;"
-             " the node stays disabled\n", module->op, piece->data_size);
+             "[dt_iop_init_pipe] `%s' could not allocate its %" G_GSIZE_FORMAT
+             " bytes of node storage; the node stays disabled\n", module->op, piece->data_size);
     piece->data_size = 0;
     piece->enabled = 0;
   }
@@ -1442,8 +1442,8 @@ static gboolean _iop_piece_is_committable(dt_iop_module_t *module, dt_dev_pixelp
   if(piece->data_size > 0 && IS_NULL_PTR(piece->data))
   {
     dt_print(DT_DEBUG_ALWAYS,
-             "[dt_iop_commit_params] `%s' node claims %zu bytes of private data but has none,"
-             " skipping commit\n", module->op, piece->data_size);
+             "[dt_iop_commit_params] `%s' node claims %" G_GSIZE_FORMAT
+             " bytes of private data but has none, skipping commit\n", module->op, piece->data_size);
     return FALSE;
   }
 

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -654,6 +654,20 @@ void dt_dev_pixelpipe_cleanup_nodes(dt_dev_pixelpipe_t *pipe)
                          piece->module->op, piece->module->multi_priority, piece->module->iop_order,
                          pipe->type, pipe->imgid);
     if(piece->module) dt_iop_cleanup_pipe(piece->module, pipe, piece);
+
+    /* Clear the node before releasing it. A freed node whose fields still read as a live one is
+     * exactly what makes this class of bug land far from its cause: a walker that outlives the
+     * teardown finds a plausible module pointer and a plausible private-data pointer, and the
+     * crash surfaces inside whichever module's commit_params() dereferences them. Zeroed, the
+     * same node is rejected by _iop_piece_is_committable() and reported by name.
+     * This does not make use-after-free safe -- the allocator may hand the bytes out again --
+     * it removes the window where the node is stale but still self-consistent. */
+    piece->module = NULL;
+    piece->data = NULL;
+    piece->data_size = 0;
+    piece->blendop_data = NULL;
+    piece->enabled = 0;
+
     dt_free(piece);
   }
   g_list_free(pipe->nodes);

--- a/src/iop/colorequal.c
+++ b/src/iop/colorequal.c
@@ -820,6 +820,8 @@ void init_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pi
 
 void cleanup_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
 {
+  /* init_pipe() may have failed to allocate, and cleanup runs regardless. */
+  if(IS_NULL_PTR(piece->data)) return;
   dt_iop_colorequal_data_t *d = (dt_iop_colorequal_data_t *)piece->data;
   dt_free_align(d->clut);
   d->clut = NULL;

--- a/src/iop/colorin.c
+++ b/src/iop/colorin.c
@@ -901,6 +901,8 @@ void init_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pi
 
 void cleanup_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
 {
+  /* init_pipe() may have failed to allocate, and cleanup runs regardless. */
+  if(IS_NULL_PTR(piece->data)) return;
   dt_iop_colorin_data_t *d = (dt_iop_colorin_data_t *)piece->data;
   dt_colorspaces_free_conversion(&d->conversion);
 

--- a/src/iop/colorout.c
+++ b/src/iop/colorout.c
@@ -607,6 +607,8 @@ void init_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pi
 
 void cleanup_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
 {
+  /* init_pipe() may have failed to allocate, and cleanup runs regardless. */
+  if(IS_NULL_PTR(piece->data)) return;
   dt_iop_colorout_data_t *d = (dt_iop_colorout_data_t *)piece->data;
   dt_colorspaces_free_conversion(&d->conversion);
 

--- a/src/iop/colorprimaries.c
+++ b/src/iop/colorprimaries.c
@@ -843,6 +843,8 @@ void init_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pi
 
 void cleanup_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
 {
+  /* init_pipe() may have failed to allocate, and cleanup runs regardless. */
+  if(IS_NULL_PTR(piece->data)) return;
   dt_iop_colorprimaries_data_t *d = (dt_iop_colorprimaries_data_t *)piece->data;
   dt_free_align(d->clut);
   d->clut = NULL;

--- a/src/iop/lens.cc
+++ b/src/iop/lens.cc
@@ -1550,6 +1550,8 @@ void init_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pi
 
 void cleanup_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
 {
+  /* init_pipe() may have failed to allocate, and cleanup runs regardless. */
+  if(IS_NULL_PTR(piece->data)) return;
   dt_iop_lensfun_data_t *d = (dt_iop_lensfun_data_t *)piece->data;
 
   if(d->lens)

--- a/src/iop/lut3d.c
+++ b/src/iop/lut3d.c
@@ -1159,6 +1159,8 @@ void init_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pi
 
 void cleanup_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
 {
+  /* init_pipe() may have failed to allocate, and cleanup runs regardless. */
+  if(IS_NULL_PTR(piece->data)) return;
   dt_iop_lut3d_data_t *d = (dt_iop_lut3d_data_t *)piece->data;;
     dt_pixelpipe_cache_free_align(d->clut);
   d->clut = NULL;


### PR DESCRIPTION
Fixes the class behind #1212 / #1216 at the boundary where it is decidable, rather than at the address where it crashes.

## What the crash is

```
#0  dt_colorspaces_conversion_source_matrix (conversion=0x2dfeffd0, ...) at colorprofiles/conversion.c:738
#1  dt_iop_colorin__commit_params (...) at iop/colorin.c:885
#2  dt_iop_commit_params → #3 _commit_piece_contract → #4 _sync_pipe_nodes_from_history
#8  _generate_blocking → #12 _get_image_buffer (thumbnail.c:513)
```

`conversion.c:738` is three lines: NULL-check, read a field, `memcpy`. It is handed a **non-NULL pointer that is no longer a conversion**.

Ruled out, each by inspection or measurement:

- `dt_colorspaces_prepare_conversion()` returns NULL or a fully-built object on **every** path.
- colorin's `cleanup_pipe()` both frees **and** NULLs `d->conversion` and `piece->data`.
- Not a cross-thread race on `pipe->nodes`: frame #4 shows `pipe=0x7afd240`, `dev=0x7afd570` — both **stack-local** to the thumbnail job.
- Not the lensfun pre-warm (#1209 fails identically), not #1208 (#1210 reproduces without it), and not bisectable — the rate moves with code layout (~12% → ~75%).

What remains is a node reaching module code in a state the pipeline never intended.

## The precedent this follows

`dt_iop_cleanup_pipe()` **already** validates the descriptor by address and the callback identity before dispatching, with the comment: *"calling the descriptor callback with that same instance would only move the use-after-free into the module cleanup code."*

Commit is the other door into module code and had **no** such check — and it `memcpy`d into `piece->blendop_data` *before* reading anything, so a bad node was written through before any callback could object. This makes the two doors symmetric.

## Three layers

**Creation** — `dt_iop_init_pipe()` stops assuming `init_pipe` exists (it is OPTIONAL in the module API) and reports a failed allocation instead of propagating it. All **89** modules defining `init_pipe` set `piece->data_size` when they allocate `piece->data`, so "data_size > 0 and data == NULL" is established as never legitimate.

**Dispatch** — `dt_iop_commit_params()` validates before the memcpy: node, module and pipe present; `piece->module` *is* the committing module; blend storage present; the data/data_size invariant; non-NULL `commit_params`. A refused node is named in the log and left disabled. This covers the **61** modules that dereference `piece->data` in `commit_params()` unchecked — correct while the invariant holds, a guaranteed SIGSEGV the moment it does not.

**Teardown** — `dt_dev_pixelpipe_cleanup_nodes()` clears module / data / data_size / blendop_data before freeing. This does not make use-after-free *safe*; it removes the window where a freed node still reads as a **live** one, which is what makes this class land far from its cause.

Plus the six modules dereferencing `piece->data` in `cleanup_pipe()` with no guard, where cleanup runs whether or not `init_pipe` allocated: colorequal, colorin, colorout, colorprimaries, lens, lut3d.

## Verified

Under ASAN, with the memory capped: the exact export the CI runtime step performs, on the repository's own `data/pixmaps/256x256/ansel.png`, plus one RAW export exercising colorin's image-derived-profile path. **Zero** sanitizer findings, **zero** guard rejections — the checks are inert on the healthy path.

The commit contains the 8 source files and nothing else — no test images, no databases, no logs. (This PR replaces #1217, which was closed because its push accidentally included local test artifacts.)

## Honest limit

This does not reproduce on Linux (ASAN clean single- and multi-threaded, 40 runs with `MALLOC_PERTURB_`), so **I cannot claim the crash is fixed** until the Windows Release job stops failing. What it guarantees is that the same corruption is *reported by module name* rather than dereferenced — which either fixes it, or tells us exactly which node is bad on the next report.

Pairs with #1215 (stop the known crash gating every PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
