### PR TITLE
channelmixer: a white-preserving primaries mixer mode, in color calibration and split-toning

### DIFF
--- a/src/iop/channelmixerrgb.c
+++ b/src/iop/channelmixerrgb.c
@@ -4400,7 +4400,11 @@ static void _channelmixerrgb_white_preserving_slider_callback(GtkWidget *slider,
   dt_iop_channelmixer_shared_white_preserving_from_sliders(widgets, &white_preserving);
   if(!dt_iop_channelmixer_shared_white_preserving_to_matrix(basis, &white_preserving, M))
   {
+    // Three primaries collapsed onto the white have no transform to describe. Snap the sliders
+    // back to the last representable state rather than leaving the page showing a setting the
+    // params do not hold -- the render would otherwise stop following the controls.
     dt_control_log(_("white-preserving mixer mode requires non-degenerate primaries."));
+    _channelmixerrgb_sync_white_preserving_from_params(self, NULL);
     return;
   }
 

--- a/src/iop/channelmixerrgb.c
+++ b/src/iop/channelmixerrgb.c
@@ -5426,9 +5426,11 @@ void gui_init(struct dt_iop_module_t *self)
   g_signal_connect(G_OBJECT(g->white_preserving_##var##_rotation), "value-changed",                           \
                    G_CALLBACK(_channelmixerrgb_white_preserving_slider_callback), self);                      \
   g->white_preserving_##var##_inset = dt_bauhaus_slider_new_with_range(                                       \
-      dt_bauhaus_get_global(), DT_GUI_MODULE(self), -0.9f, 0.9f, 0, 0, 1);                                    \
+      dt_bauhaus_get_global(), DT_GUI_MODULE(self), -0.9f, 0.9f, 0, 0, 3);                                    \
   dt_bauhaus_widget_set_label(g->white_preserving_##var##_inset, inset_label);                                \
-  dt_bauhaus_slider_set_factor(g->white_preserving_##var##_inset, 100.f);                                     \
+  /* On a range under 10, a "%" format makes bauhaus scale by 100 and take two digits off by     */           \
+  /* itself. Do not also set a factor, and leave it enough digits to take : it subtracts them    */           \
+  /* unconditionally, and a negative digit count used to hang the whole GUI in ipow().           */           \
   dt_bauhaus_slider_set_format(g->white_preserving_##var##_inset, "%");                                       \
   gtk_widget_set_tooltip_text(g->white_preserving_##var##_inset, inset_tooltip);                              \
   gtk_box_pack_start(GTK_BOX(mixer_white_preserving), GTK_WIDGET(g->white_preserving_##var##_inset), FALSE,   \

--- a/src/iop/channelmixerrgb.c
+++ b/src/iop/channelmixerrgb.c
@@ -170,12 +170,14 @@ typedef enum dt_iop_channelmixer_rgb_mixer_mode_t
   DT_CHANNELMIXERRGB_MIXER_COMPLETE = 0,
   DT_CHANNELMIXERRGB_MIXER_SIMPLE = 1,
   DT_CHANNELMIXERRGB_MIXER_PRIMARIES = 2,
+  DT_CHANNELMIXERRGB_MIXER_WHITE_PRESERVING = 3,
 } dt_iop_channelmixer_rgb_mixer_mode_t;
 
 typedef dt_iop_channelmixer_shared_simple_probe_t dt_iop_channelmixer_rgb_simple_probe_t;
 typedef dt_iop_channelmixer_shared_primaries_basis_t dt_iop_channelmixer_rgb_primaries_basis_t;
 typedef dt_iop_channelmixer_shared_simple_params_t dt_iop_channelmixer_rgb_simple_params_t;
 typedef dt_iop_channelmixer_shared_primaries_params_t dt_iop_channelmixer_rgb_primaries_params_t;
+typedef dt_iop_channelmixer_shared_white_preserving_params_t dt_iop_channelmixer_rgb_white_preserving_params_t;
 
 #define DT_CHANNELMIXERRGB_SIMPLE_PROBE_ROTATION DT_IOP_CHANNELMIXER_SHARED_SIMPLE_PROBE_ROTATION
 #define DT_CHANNELMIXERRGB_SIMPLE_PROBE_AXIS_1 DT_IOP_CHANNELMIXER_SHARED_SIMPLE_PROBE_AXIS_1
@@ -192,6 +194,9 @@ typedef struct dt_iop_channelmixer_rgb_gui_data_t
   GtkWidget *simple_theta, *simple_psi, *simple_stretch_1, *simple_stretch_2, *simple_coupling_1, *simple_coupling_2;
   GtkWidget *primaries_achromatic_hue, *primaries_achromatic_purity, *primaries_red_hue, *primaries_red_purity;
   GtkWidget *primaries_green_hue, *primaries_green_purity, *primaries_blue_hue, *primaries_blue_purity, *primaries_gain;
+  GtkWidget *white_preserving_red_rotation, *white_preserving_red_inset;
+  GtkWidget *white_preserving_green_rotation, *white_preserving_green_inset;
+  GtkWidget *white_preserving_blue_rotation, *white_preserving_blue_inset;
   GtkWidget *illuminant, *temperature, *adaptation, *gamut, *clip;
   GtkWidget *illum_fluo, *illum_led, *illum_x, *illum_y, *approx_cct, *illum_color;
   GtkWidget *scale_red_R, *scale_red_G, *scale_red_B;
@@ -3360,6 +3365,85 @@ static void _channelmixerrgb_update_primaries_colors(dt_iop_module_t *self)
                                                      widgets);
 }
 
+/**
+ * @brief Collect the six white-preserving mode widgets.
+ *
+ * @param[in] g Current module GUI data.
+ * @param[out] widgets Rotation/inset pairs, in red, green, blue order.
+ * @return FALSE while the widgets have not been created yet, which happens during gui_init().
+ */
+static gboolean _channelmixerrgb_white_preserving_widgets(const dt_iop_channelmixer_rgb_gui_data_t *const g,
+                                                          GtkWidget *widgets[6])
+{
+  widgets[0] = g->white_preserving_red_rotation;
+  widgets[1] = g->white_preserving_red_inset;
+  widgets[2] = g->white_preserving_green_rotation;
+  widgets[3] = g->white_preserving_green_inset;
+  widgets[4] = g->white_preserving_blue_rotation;
+  widgets[5] = g->white_preserving_blue_inset;
+
+  for(int widget = 0; widget < 6; widget++)
+    if(IS_NULL_PTR(widgets[widget])) return FALSE;
+
+  return TRUE;
+}
+
+/**
+ * @brief Synchronize the white-preserving mode GUI from the effective mixer matrix.
+ *
+ * @param[in] self Current module instance.
+ * @param[out] error Largest coefficient error after a full roundtrip, relative to the matrix.
+ * @return TRUE when the effective matrix is representable by the white-preserving mode, which
+ *         additionally requires it to actually leave the basis white unchanged.
+ */
+static gboolean _channelmixerrgb_sync_white_preserving_from_params(dt_iop_module_t *self, float *error)
+{
+  dt_iop_channelmixer_rgb_gui_data_t *g = (dt_iop_channelmixer_rgb_gui_data_t *)dt_iop_gui_data(self);
+  const dt_iop_channelmixer_rgb_params_t *const p = (dt_iop_channelmixer_rgb_params_t *)self->params;
+  GtkWidget *widgets[6] = { NULL };
+  dt_iop_channelmixer_rgb_white_preserving_params_t white_preserving;
+  const dt_iop_channelmixer_rgb_primaries_basis_t basis
+      = dt_iop_channelmixer_shared_primaries_basis_from_adaptation(p->adaptation);
+  const float rows[3][3] = { { p->red[0], p->red[1], p->red[2] },
+                             { p->green[0], p->green[1], p->green[2] },
+                             { p->blue[0], p->blue[1], p->blue[2] } };
+  const gboolean normalize[3] = { p->normalize_R, p->normalize_G, p->normalize_B };
+  float M[3][3] = { { 0.f } };
+  float roundtrip[3][3] = { { 0.f } };
+
+  if(!_channelmixerrgb_white_preserving_widgets(g, widgets)) return FALSE;
+  if(!dt_iop_channelmixer_shared_get_matrix(rows, normalize, FALSE, M)) return FALSE;
+  if(!dt_iop_channelmixer_shared_white_preserving_from_matrix(basis, M, &white_preserving)) return FALSE;
+  if(!dt_iop_channelmixer_shared_white_preserving_to_matrix(basis, &white_preserving, roundtrip)) return FALSE;
+
+  const float roundtrip_error = dt_iop_channelmixer_shared_roundtrip_error_relative(M, roundtrip);
+  if(!IS_NULL_PTR(error)) *error = roundtrip_error;
+
+  dt_gui_freeze_begin();
+  dt_iop_channelmixer_shared_white_preserving_to_sliders(&white_preserving, widgets);
+  dt_gui_freeze_end();
+  return isfinite(roundtrip_error) && roundtrip_error <= DT_CHANNELMIXERRGB_SIMPLE_EPS;
+}
+
+static void _channelmixerrgb_update_white_preserving_colors(dt_iop_module_t *self)
+{
+  dt_iop_channelmixer_rgb_gui_data_t *g = (dt_iop_channelmixer_rgb_gui_data_t *)dt_iop_gui_data(self);
+  dt_iop_channelmixer_rgb_params_t *p = (dt_iop_channelmixer_rgb_params_t *)self->params;
+  const dt_iop_order_iccprofile_info_t *const work_profile = dt_ioppr_get_pipe_work_profile_info(self->dev->pipe);
+  const dt_iop_order_iccprofile_info_t *const display_profile
+      = dt_ioppr_get_pipe_output_profile_info(self->dev->pipe);
+  GtkWidget *widgets[6] = { NULL };
+  dt_iop_channelmixer_rgb_white_preserving_params_t white_preserving;
+  const dt_iop_channelmixer_rgb_primaries_basis_t basis
+      = dt_iop_channelmixer_shared_primaries_basis_from_adaptation(p->adaptation);
+
+  if(!_channelmixerrgb_white_preserving_widgets(g, widgets)) return;
+
+  dt_iop_channelmixer_shared_white_preserving_from_sliders(widgets, &white_preserving);
+  dt_iop_channelmixer_shared_paint_white_preserving_sliders(p->adaptation, work_profile, display_profile, basis,
+                                                            &white_preserving, widgets);
+}
+
 static void _convert_GUI_colors(dt_iop_channelmixer_rgb_params_t *p,
                                 const struct dt_iop_order_iccprofile_info_t *const work_profile,
                                 const struct dt_iop_order_iccprofile_info_t *const display_profile,
@@ -3732,6 +3816,7 @@ void gui_update(struct dt_iop_module_t *self)
   dt_iop_channelmixer_rgb_params_t *p = (dt_iop_channelmixer_rgb_params_t *)module->params;
   float simple_error = INFINITY;
   float primaries_error = INFINITY;
+  float white_preserving_error = INFINITY;
 
   dt_iop_color_picker_reset(self, TRUE);
 
@@ -3776,6 +3861,8 @@ void gui_update(struct dt_iop_module_t *self)
 
   const gboolean simple_ok = _channelmixerrgb_sync_simple_from_params(self, &simple_error);
   const gboolean primaries_ok = _channelmixerrgb_sync_primaries_from_params(self, &primaries_error);
+  const gboolean white_preserving_ok
+      = _channelmixerrgb_sync_white_preserving_from_params(self, &white_preserving_error);
   const dt_iop_channelmixer_rgb_mixer_mode_t requested_mode
       = dt_conf_key_exists(DT_CHANNELMIXERRGB_SIMPLE_MODE_CONF)
             ? dt_conf_get_int(DT_CHANNELMIXERRGB_SIMPLE_MODE_CONF)
@@ -3785,7 +3872,9 @@ void gui_update(struct dt_iop_module_t *self)
             ? DT_CHANNELMIXERRGB_MIXER_SIMPLE
             : requested_mode == DT_CHANNELMIXERRGB_MIXER_PRIMARIES && primaries_ok
                   ? DT_CHANNELMIXERRGB_MIXER_PRIMARIES
-                  : DT_CHANNELMIXERRGB_MIXER_COMPLETE;
+                  : requested_mode == DT_CHANNELMIXERRGB_MIXER_WHITE_PRESERVING && white_preserving_ok
+                        ? DT_CHANNELMIXERRGB_MIXER_WHITE_PRESERVING
+                        : DT_CHANNELMIXERRGB_MIXER_COMPLETE;
   dt_bauhaus_combobox_set(g->mixer_mode, mixer_mode);
   _channelmixerrgb_set_mixer_mode(g, mixer_mode);
 
@@ -4001,7 +4090,72 @@ static void _channelmixerrgb_set_mixer_mode(dt_iop_channelmixer_rgb_gui_data_t *
   gtk_stack_set_visible_child_name(GTK_STACK(g->mixer_stack),
                                    mode == DT_CHANNELMIXERRGB_MIXER_SIMPLE ? "simple"
                                    : mode == DT_CHANNELMIXERRGB_MIXER_PRIMARIES ? "primaries"
+                                   : mode == DT_CHANNELMIXERRGB_MIXER_WHITE_PRESERVING ? "white-preserving"
                                    : "complete");
+}
+
+/**
+ * @brief Write a mixer matrix into the module params and mirror it on the complete-mode sliders.
+ *
+ * The reduced mixer models describe the EFFECTIVE matrix, which the row normalization toggles
+ * would otherwise rescale a second time, so those toggles are cleared here.
+ *
+ * @param[in] self Current module instance.
+ * @param[in] M Mixer matrix to commit.
+ * @return TRUE when anything actually changed, so the caller can skip a useless history commit.
+ */
+static gboolean _channelmixerrgb_push_matrix_to_params(dt_iop_module_t *self, const float M[3][3])
+{
+  dt_iop_channelmixer_rgb_gui_data_t *g = (dt_iop_channelmixer_rgb_gui_data_t *)dt_iop_gui_data(self);
+  dt_iop_channelmixer_rgb_params_t *p = (dt_iop_channelmixer_rgb_params_t *)self->params;
+  gboolean changed = p->normalize_R || p->normalize_G || p->normalize_B;
+
+  for(int col = 0; col < 3; col++)
+  {
+    changed = changed || p->red[col] != M[0][col] || p->green[col] != M[1][col] || p->blue[col] != M[2][col];
+    p->red[col] = M[0][col];
+    p->green[col] = M[1][col];
+    p->blue[col] = M[2][col];
+  }
+
+  p->normalize_R = FALSE;
+  p->normalize_G = FALSE;
+  p->normalize_B = FALSE;
+
+  dt_gui_freeze_begin();
+  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->normalize_R), FALSE);
+  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->normalize_G), FALSE);
+  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->normalize_B), FALSE);
+  dt_bauhaus_slider_set(g->scale_red_R, p->red[0]);
+  dt_bauhaus_slider_set(g->scale_red_G, p->red[1]);
+  dt_bauhaus_slider_set(g->scale_red_B, p->red[2]);
+  dt_bauhaus_slider_set(g->scale_green_R, p->green[0]);
+  dt_bauhaus_slider_set(g->scale_green_G, p->green[1]);
+  dt_bauhaus_slider_set(g->scale_green_B, p->green[2]);
+  dt_bauhaus_slider_set(g->scale_blue_R, p->blue[0]);
+  dt_bauhaus_slider_set(g->scale_blue_G, p->blue[1]);
+  dt_bauhaus_slider_set(g->scale_blue_B, p->blue[2]);
+  dt_gui_freeze_end();
+
+  return changed;
+}
+
+/**
+ * @brief Leave a reduced mixer mode that cannot represent the current matrix.
+ *
+ * @param[in] self Current module instance.
+ * @param[in] message User-facing reason, already translated.
+ */
+static void _channelmixerrgb_reject_mixer_mode(dt_iop_module_t *self, const char *message)
+{
+  dt_iop_channelmixer_rgb_gui_data_t *g = (dt_iop_channelmixer_rgb_gui_data_t *)dt_iop_gui_data(self);
+
+  dt_control_log("%s", message);
+  dt_gui_freeze_begin();
+  dt_bauhaus_combobox_set(g->mixer_mode, DT_CHANNELMIXERRGB_MIXER_COMPLETE);
+  dt_gui_freeze_end();
+  _channelmixerrgb_set_mixer_mode(g, DT_CHANNELMIXERRGB_MIXER_COMPLETE);
+  dt_conf_set_int(DT_CHANNELMIXERRGB_SIMPLE_MODE_CONF, DT_CHANNELMIXERRGB_MIXER_COMPLETE);
 }
 
 static void _channelmixerrgb_mixer_mode_callback(GtkWidget *combo, gpointer user_data)
@@ -4094,6 +4248,34 @@ static void _channelmixerrgb_mixer_mode_callback(GtkWidget *combo, gpointer user
     if(changed)
     {
       dt_print(DT_DEBUG_DEV, "[channelmixerrgb] history commit source=mixer_mode_primaries\n");
+      dt_dev_add_history_item(self->dev, self, TRUE, TRUE);
+    }
+  }
+
+  if(mode == DT_CHANNELMIXERRGB_MIXER_WHITE_PRESERVING)
+  {
+    const float rows[3][3] = { { p->red[0], p->red[1], p->red[2] },
+                               { p->green[0], p->green[1], p->green[2] },
+                               { p->blue[0], p->blue[1], p->blue[2] } };
+    const gboolean normalize[3] = { p->normalize_R, p->normalize_G, p->normalize_B };
+    float M[3][3] = { { 0.f } };
+    float error = INFINITY;
+    if(!dt_iop_channelmixer_shared_get_matrix(rows, normalize, FALSE, M)
+       || !_channelmixerrgb_sync_white_preserving_from_params(self, &error))
+    {
+      _channelmixerrgb_reject_mixer_mode(
+          self, _("white-preserving mixer mode requires a matrix that leaves the basis white unchanged."));
+      return;
+    }
+
+    const gboolean changed = _channelmixerrgb_push_matrix_to_params(self, M);
+
+    _channelmixerrgb_set_mixer_mode(g, mode);
+    gui_changed(self, NULL, NULL);
+
+    if(changed)
+    {
+      dt_print(DT_DEBUG_DEV, "[channelmixerrgb] history commit source=mixer_mode_white_preserving\n");
       dt_dev_add_history_item(self->dev, self, TRUE, TRUE);
     }
   }
@@ -4200,6 +4382,38 @@ static void _channelmixerrgb_primaries_slider_callback(GtkWidget *slider, gpoint
 }
 
 
+static void _channelmixerrgb_white_preserving_slider_callback(GtkWidget *slider, gpointer user_data)
+{
+  if(dt_gui_widgets_suppressed()) return;
+
+  dt_iop_module_t *self = (dt_iop_module_t *)user_data;
+  dt_iop_channelmixer_rgb_gui_data_t *g = (dt_iop_channelmixer_rgb_gui_data_t *)dt_iop_gui_data(self);
+  dt_iop_channelmixer_rgb_params_t *p = (dt_iop_channelmixer_rgb_params_t *)self->params;
+  GtkWidget *widgets[6] = { NULL };
+  dt_iop_channelmixer_rgb_white_preserving_params_t white_preserving;
+  const dt_iop_channelmixer_rgb_primaries_basis_t basis
+      = dt_iop_channelmixer_shared_primaries_basis_from_adaptation(p->adaptation);
+  float M[3][3] = { { 0.f } };
+
+  if(!_channelmixerrgb_white_preserving_widgets(g, widgets)) return;
+
+  dt_iop_channelmixer_shared_white_preserving_from_sliders(widgets, &white_preserving);
+  if(!dt_iop_channelmixer_shared_white_preserving_to_matrix(basis, &white_preserving, M))
+  {
+    dt_control_log(_("white-preserving mixer mode requires non-degenerate primaries."));
+    return;
+  }
+
+  _channelmixerrgb_push_matrix_to_params(self, M);
+
+  gui_changed(self, slider, NULL);
+
+  dt_print(DT_DEBUG_DEV, "[channelmixerrgb] history commit source=white_preserving_slider slider=%p\n",
+           (void *)slider);
+  dt_dev_add_history_item(self->dev, self, TRUE, TRUE);
+}
+
+
 void gui_changed(dt_iop_module_t *self, GtkWidget *w, void *previous)
 {
   dt_iop_channelmixer_rgb_params_t *p = (dt_iop_channelmixer_rgb_params_t *)self->params;
@@ -4211,6 +4425,13 @@ void gui_changed(dt_iop_module_t *self, GtkWidget *w, void *previous)
       = w == g->primaries_achromatic_hue || w == g->primaries_achromatic_purity || w == g->primaries_red_hue
         || w == g->primaries_red_purity || w == g->primaries_green_hue || w == g->primaries_green_purity
         || w == g->primaries_blue_hue || w == g->primaries_blue_purity || w == g->primaries_gain;
+  const gboolean white_preserving_widget
+      = w == g->white_preserving_red_rotation || w == g->white_preserving_red_inset
+        || w == g->white_preserving_green_rotation || w == g->white_preserving_green_inset
+        || w == g->white_preserving_blue_rotation || w == g->white_preserving_blue_inset;
+  GtkWidget *white_preserving_widgets[6] = { NULL };
+  // Bauhaus setters emit gui_changed() from gui_init(), before this page has been built.
+  const gboolean white_preserving_ready = _channelmixerrgb_white_preserving_widgets(g, white_preserving_widgets);
   const gboolean normalize[3] = { p->normalize_R, p->normalize_G, p->normalize_B };
   const gboolean rows_are_normalized = dt_iop_channelmixer_shared_rows_are_normalized(normalize);
   const gboolean complete_widget
@@ -4313,11 +4534,11 @@ void gui_changed(dt_iop_module_t *self, GtkWidget *w, void *previous)
   if(w == g->adaptation)
     update_illuminants(self);
 
-  if(IS_NULL_PTR(w) || w == g->adaptation || primaries_widget || w == g->scale_red_R   || w == g->scale_red_G   || w == g->scale_red_B   || w == g->normalize_R)
+  if(IS_NULL_PTR(w) || w == g->adaptation || primaries_widget || white_preserving_widget || w == g->scale_red_R   || w == g->scale_red_G   || w == g->scale_red_B   || w == g->normalize_R)
     _update_RGB_colors(self, 1, 0, 0, p->normalize_R, p->red, g->scale_red_R, g->scale_red_G, g->scale_red_B);
-  if(IS_NULL_PTR(w) || w == g->adaptation || primaries_widget || w == g->scale_green_R || w == g->scale_green_G || w == g->scale_green_B || w == g->normalize_G)
+  if(IS_NULL_PTR(w) || w == g->adaptation || primaries_widget || white_preserving_widget || w == g->scale_green_R || w == g->scale_green_G || w == g->scale_green_B || w == g->normalize_G)
     _update_RGB_colors(self, 0, 1, 0, p->normalize_G, p->green, g->scale_green_R, g->scale_green_G, g->scale_green_B);
-  if(IS_NULL_PTR(w) || w == g->adaptation || primaries_widget || w == g->scale_blue_R  || w == g->scale_blue_G  || w == g->scale_blue_B  || w == g->normalize_B)
+  if(IS_NULL_PTR(w) || w == g->adaptation || primaries_widget || white_preserving_widget || w == g->scale_blue_R  || w == g->scale_blue_G  || w == g->scale_blue_B  || w == g->normalize_B)
     _update_RGB_colors(self, 0, 0, 1, p->normalize_B, p->blue, g->scale_blue_R, g->scale_blue_G, g->scale_blue_B);
 
   if(rows_are_normalized && !simple_widget && (IS_NULL_PTR(w) || complete_widget))
@@ -4354,11 +4575,33 @@ void gui_changed(dt_iop_module_t *self, GtkWidget *w, void *previous)
     }
   }
 
-  if(IS_NULL_PTR(w) || w == g->adaptation || complete_widget || simple_widget || primaries_widget)
+  if(white_preserving_ready && !white_preserving_widget
+     && (IS_NULL_PTR(w) || complete_widget || simple_widget || primaries_widget || w == g->adaptation))
+  {
+    float error = INFINITY;
+    if(!_channelmixerrgb_sync_white_preserving_from_params(self, &error))
+    {
+      if(dt_bauhaus_combobox_get(g->mixer_mode) == DT_CHANNELMIXERRGB_MIXER_WHITE_PRESERVING)
+      {
+        dt_print(DT_DEBUG_DEV, "[channelmixerrgb] white-preserving mixer roundtrip error=%g\n", error);
+        dt_conf_set_int(DT_CHANNELMIXERRGB_SIMPLE_MODE_CONF, DT_CHANNELMIXERRGB_MIXER_COMPLETE);
+        dt_bauhaus_combobox_set(g->mixer_mode, DT_CHANNELMIXERRGB_MIXER_COMPLETE);
+        _channelmixerrgb_set_mixer_mode(g, DT_CHANNELMIXERRGB_MIXER_COMPLETE);
+      }
+    }
+  }
+
+  if(IS_NULL_PTR(w) || w == g->adaptation || complete_widget || simple_widget || primaries_widget
+     || white_preserving_widget)
     _channelmixerrgb_update_simple_colors(self);
 
-  if(IS_NULL_PTR(w) || w == g->adaptation || complete_widget || simple_widget || primaries_widget)
+  if(IS_NULL_PTR(w) || w == g->adaptation || complete_widget || simple_widget || primaries_widget
+     || white_preserving_widget)
     _channelmixerrgb_update_primaries_colors(self);
+
+  if(IS_NULL_PTR(w) || w == g->adaptation || complete_widget || simple_widget || primaries_widget
+     || white_preserving_widget)
+    _channelmixerrgb_update_white_preserving_colors(self);
 
   // if grey channel is used and norm = 0 and normalization = ON, we are going to have a division by zero
   // in commit_param, we avoid dividing by zero automatically, but user needs a notification
@@ -4985,11 +5228,14 @@ void gui_init(struct dt_iop_module_t *self)
   dt_bauhaus_combobox_add(g->mixer_mode, _("Complete"));
   dt_bauhaus_combobox_add(g->mixer_mode, _("Simple"));
   dt_bauhaus_combobox_add(g->mixer_mode, _("Primaries"));
+  dt_bauhaus_combobox_add(g->mixer_mode, _("White-preserving"));
   gtk_widget_set_tooltip_text(g->mixer_mode,
                               _("complete exposes the original nine mixer coefficients.\n"
                                 "simple rebuilds the normalized mixer as an exact chroma-plane rotation,\n"
                                 "two signed stretches and two neutral couplings.\n"
-                                "primaries rebuilds the mixer as a generalized primaries, white tint and gain model."));
+                                "primaries rebuilds the mixer as a generalized primaries, white tint and gain model.\n"
+                                "white-preserving rotates and contracts each primary around the white,\n"
+                                "which stays exactly where it is."));
   gtk_box_pack_start(GTK_BOX(mixer_page), GTK_WIDGET(g->mixer_mode), FALSE, FALSE, 0);
   g_signal_connect(G_OBJECT(g->mixer_mode), "value-changed", G_CALLBACK(_channelmixerrgb_mixer_mode_callback), self);
 
@@ -5163,6 +5409,53 @@ void gui_init(struct dt_iop_module_t *self)
   gtk_box_pack_start(GTK_BOX(mixer_primaries), GTK_WIDGET(g->primaries_gain), FALSE, FALSE, 0);
   g_signal_connect(G_OBJECT(g->primaries_gain), "value-changed",
                    G_CALLBACK(_channelmixerrgb_primaries_slider_callback), self);
+
+  GtkWidget *mixer_white_preserving = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_GUI_BOX_SPACING);
+  gtk_stack_add_named(GTK_STACK(g->mixer_stack), mixer_white_preserving, "white-preserving");
+
+#define WHITE_PRESERVING_PRIMARY(var, section, rotation_label, rotation_tooltip, inset_label, inset_tooltip)   \
+  gtk_box_pack_start(GTK_BOX(mixer_white_preserving), dt_ui_section_label_new(section), FALSE, FALSE, 0);      \
+  g->white_preserving_##var##_rotation                                                                        \
+      = dt_bauhaus_slider_new_with_range(dt_bauhaus_get_global(), DT_GUI_MODULE(self), -1.f, 1.f, 0, 0, 3);    \
+  dt_bauhaus_widget_set_label(g->white_preserving_##var##_rotation, rotation_label);                          \
+  dt_bauhaus_slider_set_factor(g->white_preserving_##var##_rotation, 90.f);                                   \
+  dt_bauhaus_slider_set_format(g->white_preserving_##var##_rotation, "\302\260");                             \
+  gtk_widget_set_tooltip_text(g->white_preserving_##var##_rotation, rotation_tooltip);                        \
+  gtk_box_pack_start(GTK_BOX(mixer_white_preserving), GTK_WIDGET(g->white_preserving_##var##_rotation), FALSE,\
+                     FALSE, 0);                                                                               \
+  g_signal_connect(G_OBJECT(g->white_preserving_##var##_rotation), "value-changed",                           \
+                   G_CALLBACK(_channelmixerrgb_white_preserving_slider_callback), self);                      \
+  g->white_preserving_##var##_inset = dt_bauhaus_slider_new_with_range(                                       \
+      dt_bauhaus_get_global(), DT_GUI_MODULE(self), -0.9f, 0.9f, 0, 0, 1);                                    \
+  dt_bauhaus_widget_set_label(g->white_preserving_##var##_inset, inset_label);                                \
+  dt_bauhaus_slider_set_factor(g->white_preserving_##var##_inset, 100.f);                                     \
+  dt_bauhaus_slider_set_format(g->white_preserving_##var##_inset, "%");                                       \
+  gtk_widget_set_tooltip_text(g->white_preserving_##var##_inset, inset_tooltip);                              \
+  gtk_box_pack_start(GTK_BOX(mixer_white_preserving), GTK_WIDGET(g->white_preserving_##var##_inset), FALSE,   \
+                     FALSE, 0);                                                                               \
+  g_signal_connect(G_OBJECT(g->white_preserving_##var##_inset), "value-changed",                              \
+                   G_CALLBACK(_channelmixerrgb_white_preserving_slider_callback), self);
+
+  WHITE_PRESERVING_PRIMARY(red, _("red primary"), N_("red rotation"),
+                           _("rotate the red primary around the white of the current mixer basis.\n"
+                             "the white itself is left exactly where it is."),
+                           N_("red inset"),
+                           _("contract the red primary toward the white of the current mixer basis.\n"
+                             "negative values push it away instead."))
+  WHITE_PRESERVING_PRIMARY(green, _("green primary"), N_("green rotation"),
+                           _("rotate the green primary around the white of the current mixer basis.\n"
+                             "the white itself is left exactly where it is."),
+                           N_("green inset"),
+                           _("contract the green primary toward the white of the current mixer basis.\n"
+                             "negative values push it away instead."))
+  WHITE_PRESERVING_PRIMARY(blue, _("blue primary"), N_("blue rotation"),
+                           _("rotate the blue primary around the white of the current mixer basis.\n"
+                             "the white itself is left exactly where it is."),
+                           N_("blue inset"),
+                           _("contract the blue primary toward the white of the current mixer basis.\n"
+                             "negative values push it away instead."))
+
+#undef WHITE_PRESERVING_PRIMARY
 
   GtkWidget *outputs_page = dt_ui_notebook_page(g->notebook, N_("Outputs"),
                                                 _("output colorfulness, brightness and B&W mixing"));

--- a/src/iop/channelmixerrgb.c
+++ b/src/iop/channelmixerrgb.c
@@ -194,9 +194,9 @@ typedef struct dt_iop_channelmixer_rgb_gui_data_t
   GtkWidget *simple_theta, *simple_psi, *simple_stretch_1, *simple_stretch_2, *simple_coupling_1, *simple_coupling_2;
   GtkWidget *primaries_achromatic_hue, *primaries_achromatic_purity, *primaries_red_hue, *primaries_red_purity;
   GtkWidget *primaries_green_hue, *primaries_green_purity, *primaries_blue_hue, *primaries_blue_purity, *primaries_gain;
-  GtkWidget *white_preserving_red_rotation, *white_preserving_red_inset;
-  GtkWidget *white_preserving_green_rotation, *white_preserving_green_inset;
-  GtkWidget *white_preserving_blue_rotation, *white_preserving_blue_inset;
+  GtkWidget *white_preserving_red_rotation, *white_preserving_red_saturation;
+  GtkWidget *white_preserving_green_rotation, *white_preserving_green_saturation;
+  GtkWidget *white_preserving_blue_rotation, *white_preserving_blue_saturation;
   GtkWidget *illuminant, *temperature, *adaptation, *gamut, *clip;
   GtkWidget *illum_fluo, *illum_led, *illum_x, *illum_y, *approx_cct, *illum_color;
   GtkWidget *scale_red_R, *scale_red_G, *scale_red_B;
@@ -3369,18 +3369,18 @@ static void _channelmixerrgb_update_primaries_colors(dt_iop_module_t *self)
  * @brief Collect the six white-preserving mode widgets.
  *
  * @param[in] g Current module GUI data.
- * @param[out] widgets Rotation/inset pairs, in red, green, blue order.
+ * @param[out] widgets Rotation/saturation pairs, in red, green, blue order.
  * @return FALSE while the widgets have not been created yet, which happens during gui_init().
  */
 static gboolean _channelmixerrgb_white_preserving_widgets(const dt_iop_channelmixer_rgb_gui_data_t *const g,
                                                           GtkWidget *widgets[6])
 {
   widgets[0] = g->white_preserving_red_rotation;
-  widgets[1] = g->white_preserving_red_inset;
+  widgets[1] = g->white_preserving_red_saturation;
   widgets[2] = g->white_preserving_green_rotation;
-  widgets[3] = g->white_preserving_green_inset;
+  widgets[3] = g->white_preserving_green_saturation;
   widgets[4] = g->white_preserving_blue_rotation;
-  widgets[5] = g->white_preserving_blue_inset;
+  widgets[5] = g->white_preserving_blue_saturation;
 
   for(int widget = 0; widget < 6; widget++)
     if(IS_NULL_PTR(widgets[widget])) return FALSE;
@@ -4426,9 +4426,9 @@ void gui_changed(dt_iop_module_t *self, GtkWidget *w, void *previous)
         || w == g->primaries_red_purity || w == g->primaries_green_hue || w == g->primaries_green_purity
         || w == g->primaries_blue_hue || w == g->primaries_blue_purity || w == g->primaries_gain;
   const gboolean white_preserving_widget
-      = w == g->white_preserving_red_rotation || w == g->white_preserving_red_inset
-        || w == g->white_preserving_green_rotation || w == g->white_preserving_green_inset
-        || w == g->white_preserving_blue_rotation || w == g->white_preserving_blue_inset;
+      = w == g->white_preserving_red_rotation || w == g->white_preserving_red_saturation
+        || w == g->white_preserving_green_rotation || w == g->white_preserving_green_saturation
+        || w == g->white_preserving_blue_rotation || w == g->white_preserving_blue_saturation;
   GtkWidget *white_preserving_widgets[6] = { NULL };
   // Bauhaus setters emit gui_changed() from gui_init(), before this page has been built.
   const gboolean white_preserving_ready = _channelmixerrgb_white_preserving_widgets(g, white_preserving_widgets);
@@ -5234,7 +5234,7 @@ void gui_init(struct dt_iop_module_t *self)
                                 "simple rebuilds the normalized mixer as an exact chroma-plane rotation,\n"
                                 "two signed stretches and two neutral couplings.\n"
                                 "primaries rebuilds the mixer as a generalized primaries, white tint and gain model.\n"
-                                "white-preserving rotates and contracts each primary around the white,\n"
+                                "white-preserving rotates and saturates each primary around the white,\n"
                                 "which stays exactly where it is."));
   gtk_box_pack_start(GTK_BOX(mixer_page), GTK_WIDGET(g->mixer_mode), FALSE, FALSE, 0);
   g_signal_connect(G_OBJECT(g->mixer_mode), "value-changed", G_CALLBACK(_channelmixerrgb_mixer_mode_callback), self);
@@ -5413,7 +5413,8 @@ void gui_init(struct dt_iop_module_t *self)
   GtkWidget *mixer_white_preserving = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_GUI_BOX_SPACING);
   gtk_stack_add_named(GTK_STACK(g->mixer_stack), mixer_white_preserving, "white-preserving");
 
-#define WHITE_PRESERVING_PRIMARY(var, section, rotation_label, rotation_tooltip, inset_label, inset_tooltip)   \
+#define WHITE_PRESERVING_PRIMARY(var, section, rotation_label, rotation_tooltip, saturation_label,             \
+                                 saturation_tooltip)                                                          \
   gtk_box_pack_start(GTK_BOX(mixer_white_preserving), dt_ui_section_label_new(section), FALSE, FALSE, 0);      \
   g->white_preserving_##var##_rotation                                                                        \
       = dt_bauhaus_slider_new_with_range(dt_bauhaus_get_global(), DT_GUI_MODULE(self), -1.f, 1.f, 0, 0, 3);    \
@@ -5425,37 +5426,41 @@ void gui_init(struct dt_iop_module_t *self)
                      FALSE, 0);                                                                               \
   g_signal_connect(G_OBJECT(g->white_preserving_##var##_rotation), "value-changed",                           \
                    G_CALLBACK(_channelmixerrgb_white_preserving_slider_callback), self);                      \
-  g->white_preserving_##var##_inset = dt_bauhaus_slider_new_with_range(                                       \
-      dt_bauhaus_get_global(), DT_GUI_MODULE(self), -0.9f, 0.9f, 0, 0, 3);                                    \
-  dt_bauhaus_widget_set_label(g->white_preserving_##var##_inset, inset_label);                                \
+  /* -100%/+100% is the travel this control is meant to be used over, but a matrix hand-built  */           \
+  /* in complete mode can legitimately push a primary further out. Keep the hard range wider so */           \
+  /* the page reports such a matrix instead of clamping and quietly lying about it.             */           \
+  g->white_preserving_##var##_saturation                                                                      \
+      = dt_bauhaus_slider_new_with_range(dt_bauhaus_get_global(), DT_GUI_MODULE(self), -4.f, 4.f, 0, 0, 3);    \
+  dt_bauhaus_slider_set_soft_range(g->white_preserving_##var##_saturation, -1.f, 1.f);                        \
+  dt_bauhaus_widget_set_label(g->white_preserving_##var##_saturation, saturation_label);                      \
   /* On a range under 10, a "%" format makes bauhaus scale by 100 and take two digits off by     */           \
   /* itself. Do not also set a factor, and leave it enough digits to take : it subtracts them    */           \
   /* unconditionally, and a negative digit count used to hang the whole GUI in ipow().           */           \
-  dt_bauhaus_slider_set_format(g->white_preserving_##var##_inset, "%");                                       \
-  gtk_widget_set_tooltip_text(g->white_preserving_##var##_inset, inset_tooltip);                              \
-  gtk_box_pack_start(GTK_BOX(mixer_white_preserving), GTK_WIDGET(g->white_preserving_##var##_inset), FALSE,   \
-                     FALSE, 0);                                                                               \
-  g_signal_connect(G_OBJECT(g->white_preserving_##var##_inset), "value-changed",                              \
+  dt_bauhaus_slider_set_format(g->white_preserving_##var##_saturation, "%");                                  \
+  gtk_widget_set_tooltip_text(g->white_preserving_##var##_saturation, saturation_tooltip);                    \
+  gtk_box_pack_start(GTK_BOX(mixer_white_preserving), GTK_WIDGET(g->white_preserving_##var##_saturation),      \
+                     FALSE, FALSE, 0);                                                                        \
+  g_signal_connect(G_OBJECT(g->white_preserving_##var##_saturation), "value-changed",                         \
                    G_CALLBACK(_channelmixerrgb_white_preserving_slider_callback), self);
 
   WHITE_PRESERVING_PRIMARY(red, _("red primary"), N_("red rotation"),
                            _("rotate the red primary around the white of the current mixer basis.\n"
                              "the white itself is left exactly where it is."),
-                           N_("red inset"),
-                           _("contract the red primary toward the white of the current mixer basis.\n"
-                             "negative values push it away instead."))
+                           N_("red saturation"),
+                           _("scale the red primary's distance to the white of the current mixer basis.\n"
+                             "-100% collapses it onto the white, +100% doubles it."))
   WHITE_PRESERVING_PRIMARY(green, _("green primary"), N_("green rotation"),
                            _("rotate the green primary around the white of the current mixer basis.\n"
                              "the white itself is left exactly where it is."),
-                           N_("green inset"),
-                           _("contract the green primary toward the white of the current mixer basis.\n"
-                             "negative values push it away instead."))
+                           N_("green saturation"),
+                           _("scale the green primary's distance to the white of the current mixer basis.\n"
+                             "-100% collapses it onto the white, +100% doubles it."))
   WHITE_PRESERVING_PRIMARY(blue, _("blue primary"), N_("blue rotation"),
                            _("rotate the blue primary around the white of the current mixer basis.\n"
                              "the white itself is left exactly where it is."),
-                           N_("blue inset"),
-                           _("contract the blue primary toward the white of the current mixer basis.\n"
-                             "negative values push it away instead."))
+                           N_("blue saturation"),
+                           _("scale the blue primary's distance to the white of the current mixer basis.\n"
+                             "-100% collapses it onto the white, +100% doubles it."))
 
 #undef WHITE_PRESERVING_PRIMARY
 

--- a/src/iop/channelmixerrgb_shared.c
+++ b/src/iop/channelmixerrgb_shared.c
@@ -125,11 +125,11 @@ void dt_iop_channelmixer_shared_white_preserving_from_sliders(
     GtkWidget *const widgets[6], dt_iop_channelmixer_shared_white_preserving_params_t *white_preserving)
 {
   white_preserving->red_rotation = dt_bauhaus_slider_get(widgets[0]) * (float)M_PI_2;
-  white_preserving->red_inset = dt_bauhaus_slider_get(widgets[1]);
+  white_preserving->red_saturation = dt_bauhaus_slider_get(widgets[1]);
   white_preserving->green_rotation = dt_bauhaus_slider_get(widgets[2]) * (float)M_PI_2;
-  white_preserving->green_inset = dt_bauhaus_slider_get(widgets[3]);
+  white_preserving->green_saturation = dt_bauhaus_slider_get(widgets[3]);
   white_preserving->blue_rotation = dt_bauhaus_slider_get(widgets[4]) * (float)M_PI_2;
-  white_preserving->blue_inset = dt_bauhaus_slider_get(widgets[5]);
+  white_preserving->blue_saturation = dt_bauhaus_slider_get(widgets[5]);
 }
 
 void dt_iop_channelmixer_shared_white_preserving_to_sliders(
@@ -137,11 +137,11 @@ void dt_iop_channelmixer_shared_white_preserving_to_sliders(
     GtkWidget *const widgets[6])
 {
   dt_bauhaus_slider_set(widgets[0], CLAMP(white_preserving->red_rotation / (float)M_PI_2, -1.f, 1.f));
-  dt_bauhaus_slider_set(widgets[1], white_preserving->red_inset);
+  dt_bauhaus_slider_set(widgets[1], white_preserving->red_saturation);
   dt_bauhaus_slider_set(widgets[2], CLAMP(white_preserving->green_rotation / (float)M_PI_2, -1.f, 1.f));
-  dt_bauhaus_slider_set(widgets[3], white_preserving->green_inset);
+  dt_bauhaus_slider_set(widgets[3], white_preserving->green_saturation);
   dt_bauhaus_slider_set(widgets[4], CLAMP(white_preserving->blue_rotation / (float)M_PI_2, -1.f, 1.f));
-  dt_bauhaus_slider_set(widgets[5], white_preserving->blue_inset);
+  dt_bauhaus_slider_set(widgets[5], white_preserving->blue_saturation);
 }
 
 gboolean dt_iop_channelmixer_shared_rows_are_normalized(const gboolean normalize[3])
@@ -490,30 +490,30 @@ static gboolean _affine_polar_from_point(const float white_normalized[3], const 
 }
 
 /**
- * @brief Place one white-preserving primary from its rotation and inset.
+ * @brief Place one white-preserving primary from its rotation and saturation.
  *
  * Unlike the generalized primaries model, the radius is measured against the REFERENCE primary
- * itself rather than against the gamut footprint edge, so `inset` reads as darktable's does :
- * 0 keeps the basis primary, positive contracts it toward the white, negative expands it away.
+ * itself rather than against the gamut footprint edge, so the control reads as a saturation :
+ * 0 keeps the basis primary, -1 collapses it onto the white, +1 doubles its distance to it.
  *
  * @param[in] white_normalized Basis white, normalized in the affine plane.
  * @param[in] reference_primaries Affine coordinates of the three basis primaries.
  * @param[in] reference_index Which primary is being placed.
  * @param[in] rotation Rotation around the white, in radians.
- * @param[in] inset Radial contraction toward the white, 0 being the untouched primary.
+ * @param[in] saturation Radial scaling of the distance to the white, by 1 + saturation.
  * @param[out] point_normalized Resulting chromaticity, normalized in the affine plane.
  * @return FALSE when the reference primary is degenerate.
  */
 static gboolean _white_preserving_point_from_polar(const float white_normalized[3],
                                                    const float reference_primaries[3][2],
                                                    const int reference_index, const float rotation,
-                                                   const float inset, float point_normalized[3])
+                                                   const float saturation, float point_normalized[3])
 {
   const float *const reference = reference_primaries[reference_index];
   const float reference_radius = hypotf(reference[0], reference[1]);
   if(reference_radius < DT_IOP_CHANNELMIXER_SHARED_SIMPLE_EPS) return FALSE;
 
-  const float scale = 1.f - inset;
+  const float scale = 1.f + saturation;
   float rotated[2] = { 0.f };
   float difference[3] = { 0.f };
 
@@ -527,21 +527,21 @@ static gboolean _white_preserving_point_from_polar(const float white_normalized[
 }
 
 /**
- * @brief Read back the rotation and inset of one white-preserving primary.
+ * @brief Read back the rotation and saturation of one white-preserving primary.
  *
  * @param[in] white_normalized Basis white, normalized in the affine plane.
  * @param[in] reference_primaries Affine coordinates of the three basis primaries.
  * @param[in] reference_index Which primary is being read.
  * @param[in] point_normalized Chromaticity of the mixer column, normalized in the affine plane.
  * @param[out] rotation Rotation around the white, in radians.
- * @param[out] inset Radial contraction toward the white.
+ * @param[out] saturation Radial scaling of the distance to the white, minus one.
  * @return FALSE when the reference primary is degenerate.
  */
 static gboolean _white_preserving_polar_from_point(const float white_normalized[3],
                                                    const float reference_primaries[3][2],
                                                    const int reference_index,
                                                    const float point_normalized[3], float *rotation,
-                                                   float *inset)
+                                                   float *saturation)
 {
   const float *const reference = reference_primaries[reference_index];
   const float reference_radius = hypotf(reference[0], reference[1]);
@@ -560,12 +560,12 @@ static gboolean _white_preserving_polar_from_point(const float white_normalized[
   {
     // The column collapsed onto the white : the rotation carries no information any more.
     *rotation = 0.f;
-    *inset = 1.f;
+    *saturation = -1.f;
     return TRUE;
   }
 
   *rotation = dt_iop_channelmixer_shared_wrap_pi(atan2f(uv[1], uv[0]) - reference_angle);
-  *inset = 1.f - radius / reference_radius;
+  *saturation = radius / reference_radius - 1.f;
   return TRUE;
 }
 
@@ -694,13 +694,13 @@ static float _affine_triangle_area(const float vertices[3][2])
 /**
  * @brief Build the mixer matrix of a white-preserving primaries state.
  *
- * The three rotated/inset chromaticities give the DIRECTION of each mixer column. Their
+ * The three rotated and rescaled chromaticities give the DIRECTION of each mixer column. Their
  * magnitudes are then solved from the single constraint that the basis white maps to itself :
  * with `t = P^-1 . w` (P holding the chromaticities in columns), column c of the matrix is
  * `t_c / w_c` times chromaticity c, and `M . w == w` holds by construction.
  *
  * @param[in] basis Affine basis the mixer operates in, from the module's adaptation.
- * @param[in] white_preserving Per-primary rotations and insets.
+ * @param[in] white_preserving Per-primary rotations and saturations.
  * @param[out] M Resulting mixer matrix.
  * @return FALSE when the displaced primaries are degenerate or the basis white has a null channel.
  */
@@ -710,8 +710,8 @@ gboolean dt_iop_channelmixer_shared_white_preserving_to_matrix(
 {
   const float rotations[3] = { white_preserving->red_rotation, white_preserving->green_rotation,
                                white_preserving->blue_rotation };
-  const float insets[3] = { white_preserving->red_inset, white_preserving->green_inset,
-                            white_preserving->blue_inset };
+  const float saturations[3] = { white_preserving->red_saturation, white_preserving->green_saturation,
+                                 white_preserving->blue_saturation };
   float white_reference[3] = { 0.f };
   float white_reference_normalized[3] = { 0.f };
   float reference_primaries[3][2] = { { 0.f } };
@@ -727,7 +727,7 @@ gboolean dt_iop_channelmixer_shared_white_preserving_to_matrix(
   for(int primary = 0; primary < 3; primary++)
   {
     if(!_white_preserving_point_from_polar(white_reference_normalized, reference_primaries, primary,
-                                           rotations[primary], insets[primary], custom_primaries[primary]))
+                                           rotations[primary], saturations[primary], custom_primaries[primary]))
       return FALSE;
 
     const float difference[3] = { custom_primaries[primary][0] - white_reference_normalized[0],
@@ -778,7 +778,7 @@ gboolean dt_iop_channelmixer_shared_white_preserving_to_matrix(
  *
  * @param[in] basis Affine basis the mixer operates in, from the module's adaptation.
  * @param[in] M Mixer matrix.
- * @param[out] white_preserving Per-primary rotations and insets.
+ * @param[out] white_preserving Per-primary rotations and saturations.
  * @return FALSE when a column has a null affine sum or the basis is degenerate.
  */
 gboolean dt_iop_channelmixer_shared_white_preserving_from_matrix(
@@ -799,12 +799,12 @@ gboolean dt_iop_channelmixer_shared_white_preserving_from_matrix(
     float *rotation = primary == 0 ? &white_preserving->red_rotation
                                    : primary == 1 ? &white_preserving->green_rotation
                                                   : &white_preserving->blue_rotation;
-    float *inset = primary == 0 ? &white_preserving->red_inset
-                                : primary == 1 ? &white_preserving->green_inset
-                                               : &white_preserving->blue_inset;
+    float *saturation = primary == 0 ? &white_preserving->red_saturation
+                                     : primary == 1 ? &white_preserving->green_saturation
+                                                    : &white_preserving->blue_saturation;
 
     if(!_white_preserving_polar_from_point(white_reference_normalized, reference_primaries, primary,
-                                           custom_primary_normalized, rotation, inset))
+                                           custom_primary_normalized, rotation, saturation))
       return FALSE;
   }
 
@@ -1216,19 +1216,19 @@ void dt_iop_channelmixer_shared_paint_white_preserving_sliders(
           probe.red_rotation = value * (float)M_PI_2;
           break;
         case 1:
-          probe.red_inset = value;
+          probe.red_saturation = value;
           break;
         case 2:
           probe.green_rotation = value * (float)M_PI_2;
           break;
         case 3:
-          probe.green_inset = value;
+          probe.green_saturation = value;
           break;
         case 4:
           probe.blue_rotation = value * (float)M_PI_2;
           break;
         case 5:
-          probe.blue_inset = value;
+          probe.blue_saturation = value;
           break;
         default:
           break;

--- a/src/iop/channelmixerrgb_shared.c
+++ b/src/iop/channelmixerrgb_shared.c
@@ -121,6 +121,29 @@ void dt_iop_channelmixer_shared_primaries_to_sliders(const dt_iop_channelmixer_s
   dt_bauhaus_slider_set(widgets[8], primaries->gain);
 }
 
+void dt_iop_channelmixer_shared_white_preserving_from_sliders(
+    GtkWidget *const widgets[6], dt_iop_channelmixer_shared_white_preserving_params_t *white_preserving)
+{
+  white_preserving->red_rotation = dt_bauhaus_slider_get(widgets[0]) * (float)M_PI_2;
+  white_preserving->red_inset = dt_bauhaus_slider_get(widgets[1]);
+  white_preserving->green_rotation = dt_bauhaus_slider_get(widgets[2]) * (float)M_PI_2;
+  white_preserving->green_inset = dt_bauhaus_slider_get(widgets[3]);
+  white_preserving->blue_rotation = dt_bauhaus_slider_get(widgets[4]) * (float)M_PI_2;
+  white_preserving->blue_inset = dt_bauhaus_slider_get(widgets[5]);
+}
+
+void dt_iop_channelmixer_shared_white_preserving_to_sliders(
+    const dt_iop_channelmixer_shared_white_preserving_params_t *const white_preserving,
+    GtkWidget *const widgets[6])
+{
+  dt_bauhaus_slider_set(widgets[0], CLAMP(white_preserving->red_rotation / (float)M_PI_2, -1.f, 1.f));
+  dt_bauhaus_slider_set(widgets[1], white_preserving->red_inset);
+  dt_bauhaus_slider_set(widgets[2], CLAMP(white_preserving->green_rotation / (float)M_PI_2, -1.f, 1.f));
+  dt_bauhaus_slider_set(widgets[3], white_preserving->green_inset);
+  dt_bauhaus_slider_set(widgets[4], CLAMP(white_preserving->blue_rotation / (float)M_PI_2, -1.f, 1.f));
+  dt_bauhaus_slider_set(widgets[5], white_preserving->blue_inset);
+}
+
 gboolean dt_iop_channelmixer_shared_rows_are_normalized(const gboolean normalize[3])
 {
   return normalize[0] && normalize[1] && normalize[2];
@@ -256,6 +279,31 @@ float dt_iop_channelmixer_shared_roundtrip_error(const float M[3][3], const floa
       max_error = fmaxf(max_error, fabsf(M[row][col] - roundtrip[row][col]));
 
   return max_error;
+}
+
+/**
+ * @brief Roundtrip error, measured against the magnitude of the matrix itself.
+ *
+ * A reduced mixer model is a reparametrization, so the question its gate asks is whether the
+ * rebuilt matrix is the SAME matrix, which is a relative question. Comparing an absolute
+ * coefficient difference against a fixed tolerance silently demands more and more precision as
+ * the coefficients grow, and the white-preserving model can legitimately produce large ones : two
+ * primaries rotated onto the same ray make the chromaticity basis near-singular, which inflates
+ * the column scales that the white constraint solves for. The denominator is floored at 1 so
+ * ordinary, near-identity matrices keep the plain absolute behaviour.
+ *
+ * @param[in] M Original mixer matrix.
+ * @param[in] roundtrip Matrix rebuilt from the parameters read back from M.
+ * @return Largest coefficient error, relative to the largest coefficient magnitude.
+ */
+float dt_iop_channelmixer_shared_roundtrip_error_relative(const float M[3][3], const float roundtrip[3][3])
+{
+  float max_magnitude = 1.f;
+  for(int row = 0; row < 3; row++)
+    for(int col = 0; col < 3; col++)
+      max_magnitude = fmaxf(max_magnitude, fabsf(M[row][col]));
+
+  return dt_iop_channelmixer_shared_roundtrip_error(M, roundtrip) / max_magnitude;
 }
 
 dt_iop_channelmixer_shared_primaries_basis_t
@@ -441,6 +489,86 @@ static gboolean _affine_polar_from_point(const float white_normalized[3], const 
   return TRUE;
 }
 
+/**
+ * @brief Place one white-preserving primary from its rotation and inset.
+ *
+ * Unlike the generalized primaries model, the radius is measured against the REFERENCE primary
+ * itself rather than against the gamut footprint edge, so `inset` reads as darktable's does :
+ * 0 keeps the basis primary, positive contracts it toward the white, negative expands it away.
+ *
+ * @param[in] white_normalized Basis white, normalized in the affine plane.
+ * @param[in] reference_primaries Affine coordinates of the three basis primaries.
+ * @param[in] reference_index Which primary is being placed.
+ * @param[in] rotation Rotation around the white, in radians.
+ * @param[in] inset Radial contraction toward the white, 0 being the untouched primary.
+ * @param[out] point_normalized Resulting chromaticity, normalized in the affine plane.
+ * @return FALSE when the reference primary is degenerate.
+ */
+static gboolean _white_preserving_point_from_polar(const float white_normalized[3],
+                                                   const float reference_primaries[3][2],
+                                                   const int reference_index, const float rotation,
+                                                   const float inset, float point_normalized[3])
+{
+  const float *const reference = reference_primaries[reference_index];
+  const float reference_radius = hypotf(reference[0], reference[1]);
+  if(reference_radius < DT_IOP_CHANNELMIXER_SHARED_SIMPLE_EPS) return FALSE;
+
+  const float scale = 1.f - inset;
+  float rotated[2] = { 0.f };
+  float difference[3] = { 0.f };
+
+  _rotate_2d(reference, rotation, rotated);
+
+  const float uv[2] = { scale * rotated[0], scale * rotated[1] };
+  _affine_unproject_difference(uv, difference);
+
+  for(int c = 0; c < 3; c++) point_normalized[c] = white_normalized[c] + difference[c];
+  return TRUE;
+}
+
+/**
+ * @brief Read back the rotation and inset of one white-preserving primary.
+ *
+ * @param[in] white_normalized Basis white, normalized in the affine plane.
+ * @param[in] reference_primaries Affine coordinates of the three basis primaries.
+ * @param[in] reference_index Which primary is being read.
+ * @param[in] point_normalized Chromaticity of the mixer column, normalized in the affine plane.
+ * @param[out] rotation Rotation around the white, in radians.
+ * @param[out] inset Radial contraction toward the white.
+ * @return FALSE when the reference primary is degenerate.
+ */
+static gboolean _white_preserving_polar_from_point(const float white_normalized[3],
+                                                   const float reference_primaries[3][2],
+                                                   const int reference_index,
+                                                   const float point_normalized[3], float *rotation,
+                                                   float *inset)
+{
+  const float *const reference = reference_primaries[reference_index];
+  const float reference_radius = hypotf(reference[0], reference[1]);
+  if(reference_radius < DT_IOP_CHANNELMIXER_SHARED_SIMPLE_EPS) return FALSE;
+
+  const float reference_angle = atan2f(reference[1], reference[0]);
+  const float difference[3] = { point_normalized[0] - white_normalized[0],
+                                point_normalized[1] - white_normalized[1],
+                                point_normalized[2] - white_normalized[2] };
+  float uv[2] = { 0.f };
+
+  _affine_project_difference(difference, uv);
+
+  const float radius = hypotf(uv[0], uv[1]);
+  if(radius < DT_IOP_CHANNELMIXER_SHARED_SIMPLE_EPS)
+  {
+    // The column collapsed onto the white : the rotation carries no information any more.
+    *rotation = 0.f;
+    *inset = 1.f;
+    return TRUE;
+  }
+
+  *rotation = dt_iop_channelmixer_shared_wrap_pi(atan2f(uv[1], uv[0]) - reference_angle);
+  *inset = 1.f - radius / reference_radius;
+  return TRUE;
+}
+
 gboolean dt_iop_channelmixer_shared_primaries_to_matrix(const dt_iop_channelmixer_shared_primaries_basis_t basis,
                                                         const dt_iop_channelmixer_shared_primaries_params_t *primaries,
                                                         float M[3][3])
@@ -485,7 +613,12 @@ gboolean dt_iop_channelmixer_shared_primaries_to_matrix(const dt_iop_channelmixe
                                             white_gain * custom_white_normalized[2],
                                             0.f };
   dt_aligned_pixel_t column_scales = { 0.f };
-  dt_apply_transposed_color_matrix(custom_white, normalized_inverse, column_scales);
+
+  // The column scales solve normalized_primaries . scales = custom_white, so this is a plain
+  // matrix-vector product with the inverse. dt_apply_transposed_color_matrix() expects a matrix
+  // that is ALREADY stored transposed (see xyz_to_srgb_matrix_transposed) and would therefore
+  // compute the transpose of the inverse here, which is not the solution of that system.
+  dot_product(custom_white, normalized_inverse, column_scales);
 
   for(int col = 0; col < 3; col++)
     for(int row = 0; row < 3; row++)
@@ -538,6 +671,140 @@ gboolean dt_iop_channelmixer_shared_primaries_from_matrix(const dt_iop_channelmi
 
     if(!_affine_polar_from_point(white_reference_normalized, reference_primaries, primary,
                                  custom_primary_normalized, hue, purity))
+      return FALSE;
+  }
+
+  return TRUE;
+}
+
+/**
+ * @brief Twice the signed area of a triangle given in affine plane coordinates.
+ *
+ * @param[in] vertices The three vertices, projected on the affine plane.
+ * @return Twice the signed area, whose magnitude vanishes as the three points become collinear.
+ */
+static float _affine_triangle_area(const float vertices[3][2])
+{
+  const float first[2] = { vertices[1][0] - vertices[0][0], vertices[1][1] - vertices[0][1] };
+  const float second[2] = { vertices[2][0] - vertices[0][0], vertices[2][1] - vertices[0][1] };
+
+  return first[0] * second[1] - first[1] * second[0];
+}
+
+/**
+ * @brief Build the mixer matrix of a white-preserving primaries state.
+ *
+ * The three rotated/inset chromaticities give the DIRECTION of each mixer column. Their
+ * magnitudes are then solved from the single constraint that the basis white maps to itself :
+ * with `t = P^-1 . w` (P holding the chromaticities in columns), column c of the matrix is
+ * `t_c / w_c` times chromaticity c, and `M . w == w` holds by construction.
+ *
+ * @param[in] basis Affine basis the mixer operates in, from the module's adaptation.
+ * @param[in] white_preserving Per-primary rotations and insets.
+ * @param[out] M Resulting mixer matrix.
+ * @return FALSE when the displaced primaries are degenerate or the basis white has a null channel.
+ */
+gboolean dt_iop_channelmixer_shared_white_preserving_to_matrix(
+    const dt_iop_channelmixer_shared_primaries_basis_t basis,
+    const dt_iop_channelmixer_shared_white_preserving_params_t *const white_preserving, float M[3][3])
+{
+  const float rotations[3] = { white_preserving->red_rotation, white_preserving->green_rotation,
+                               white_preserving->blue_rotation };
+  const float insets[3] = { white_preserving->red_inset, white_preserving->green_inset,
+                            white_preserving->blue_inset };
+  float white_reference[3] = { 0.f };
+  float white_reference_normalized[3] = { 0.f };
+  float reference_primaries[3][2] = { { 0.f } };
+  float custom_primaries[3][3] = { { 0.f } };
+  dt_colormatrix_t normalized_primaries = { { 0.f } };
+  dt_colormatrix_t normalized_inverse = { { 0.f } };
+
+  _primaries_reference_white(basis, white_reference);
+  if(!_build_affine_simplex(basis, white_reference_normalized, reference_primaries)) return FALSE;
+
+  float custom_footprint[3][2] = { { 0.f } };
+
+  for(int primary = 0; primary < 3; primary++)
+  {
+    if(!_white_preserving_point_from_polar(white_reference_normalized, reference_primaries, primary,
+                                           rotations[primary], insets[primary], custom_primaries[primary]))
+      return FALSE;
+
+    const float difference[3] = { custom_primaries[primary][0] - white_reference_normalized[0],
+                                  custom_primaries[primary][1] - white_reference_normalized[1],
+                                  custom_primaries[primary][2] - white_reference_normalized[2] };
+    _affine_project_difference(difference, custom_footprint[primary]);
+  }
+
+  // Two primaries rotated onto the same ray flatten the chromaticity triangle. The matrix is then
+  // still invertible on paper, but the column scales the white constraint solves for explode and
+  // the model stops being numerically reversible, so refuse it here rather than hand back a
+  // matrix no roundtrip can recognize. The bound is a fraction of the untouched basis triangle,
+  // which keeps it scale-free across bases.
+  if(fabsf(_affine_triangle_area(custom_footprint))
+     < DT_IOP_CHANNELMIXER_SHARED_MIN_FOOTPRINT * fabsf(_affine_triangle_area(reference_primaries)))
+    return FALSE;
+
+  for(int row = 0; row < 3; row++)
+    for(int col = 0; col < 3; col++)
+      normalized_primaries[row][col] = custom_primaries[col][row];
+
+  if(mat3SSEinv(normalized_inverse, normalized_primaries)) return FALSE;
+
+  const dt_aligned_pixel_t padded_white
+      = { white_reference[0], white_reference[1], white_reference[2], 0.f };
+  dt_aligned_pixel_t white_weights = { 0.f };
+  dot_product(padded_white, normalized_inverse, white_weights);
+
+  for(int col = 0; col < 3; col++)
+  {
+    if(fabsf(white_reference[col]) < DT_IOP_CHANNELMIXER_SHARED_SIMPLE_EPS) return FALSE;
+
+    const float column_scale = white_weights[col] / white_reference[col];
+    for(int row = 0; row < 3; row++) M[row][col] = column_scale * custom_primaries[col][row];
+  }
+
+  return TRUE;
+}
+
+/**
+ * @brief Read a white-preserving primaries state back from a mixer matrix.
+ *
+ * Only the column DIRECTIONS are read here, so this succeeds for any matrix whose columns have a
+ * non-zero affine sum, white-preserving or not. Callers must gate on the roundtrip error against
+ * dt_iop_channelmixer_shared_white_preserving_to_matrix() to know whether the matrix actually sits
+ * on the white-preserving submanifold : a matrix that moves the white reconstructs to a different
+ * one, exactly like the other reduced mixer models.
+ *
+ * @param[in] basis Affine basis the mixer operates in, from the module's adaptation.
+ * @param[in] M Mixer matrix.
+ * @param[out] white_preserving Per-primary rotations and insets.
+ * @return FALSE when a column has a null affine sum or the basis is degenerate.
+ */
+gboolean dt_iop_channelmixer_shared_white_preserving_from_matrix(
+    const dt_iop_channelmixer_shared_primaries_basis_t basis, const float M[3][3],
+    dt_iop_channelmixer_shared_white_preserving_params_t *white_preserving)
+{
+  float white_reference_normalized[3] = { 0.f };
+  float reference_primaries[3][2] = { { 0.f } };
+  float custom_primary_normalized[3] = { 0.f };
+
+  if(!_build_affine_simplex(basis, white_reference_normalized, reference_primaries)) return FALSE;
+
+  for(int primary = 0; primary < 3; primary++)
+  {
+    const float column[3] = { M[0][primary], M[1][primary], M[2][primary] };
+    if(!_affine_normalize(column, custom_primary_normalized)) return FALSE;
+
+    float *rotation = primary == 0 ? &white_preserving->red_rotation
+                                   : primary == 1 ? &white_preserving->green_rotation
+                                                  : &white_preserving->blue_rotation;
+    float *inset = primary == 0 ? &white_preserving->red_inset
+                                : primary == 1 ? &white_preserving->green_inset
+                                               : &white_preserving->blue_inset;
+
+    if(!_white_preserving_polar_from_point(white_reference_normalized, reference_primaries, primary,
+                                           custom_primary_normalized, rotation, inset))
       return FALSE;
   }
 
@@ -918,4 +1185,66 @@ void dt_iop_channelmixer_shared_paint_primaries_sliders(
   }
 
   for(int widget = 0; widget < 9; widget++) gtk_widget_queue_draw(widgets[widget]);
+}
+
+void dt_iop_channelmixer_shared_paint_white_preserving_sliders(
+    const dt_adaptation_t adaptation, const dt_iop_order_iccprofile_info_t *const work_profile,
+    const dt_iop_order_iccprofile_info_t *const display_profile,
+    const dt_iop_channelmixer_shared_primaries_basis_t basis,
+    const dt_iop_channelmixer_shared_white_preserving_params_t *const white_preserving,
+    GtkWidget *const widgets[6])
+{
+  for(int widget = 0; widget < 6; widget++) dt_bauhaus_slider_clear_stops(widgets[widget]);
+
+  for(int i = 0; i < DT_BAUHAUS_SLIDER_MAX_STOPS; i++)
+  {
+    const float stop = (float)i / (float)(DT_BAUHAUS_SLIDER_MAX_STOPS - 1);
+
+    for(int widget = 0; widget < 6; widget++)
+    {
+      dt_iop_channelmixer_shared_white_preserving_params_t probe = *white_preserving;
+      float M[3][3] = { { 0.f } };
+      float module_color[3] = { 0.f };
+      float display_rgb[3] = { 0.f };
+      const float hard_min = dt_bauhaus_slider_get_hard_min(widgets[widget]);
+      const float hard_max = dt_bauhaus_slider_get_hard_max(widgets[widget]);
+      const float value = hard_min + stop * (hard_max - hard_min);
+
+      switch(widget)
+      {
+        case 0:
+          probe.red_rotation = value * (float)M_PI_2;
+          break;
+        case 1:
+          probe.red_inset = value;
+          break;
+        case 2:
+          probe.green_rotation = value * (float)M_PI_2;
+          break;
+        case 3:
+          probe.green_inset = value;
+          break;
+        case 4:
+          probe.blue_rotation = value * (float)M_PI_2;
+          break;
+        case 5:
+          probe.blue_inset = value;
+          break;
+        default:
+          break;
+      }
+
+      if(!dt_iop_channelmixer_shared_white_preserving_to_matrix(basis, &probe, M)) continue;
+
+      // Each pair of sliders drives one mixer column : show that column's own color.
+      const int column = widget / 2;
+      for(int row = 0; row < 3; row++) module_color[row] = M[row][column];
+
+      dt_iop_channelmixer_shared_module_color_to_display(module_color, adaptation, work_profile, display_profile,
+                                                         display_rgb);
+      dt_bauhaus_slider_set_stop(widgets[widget], stop, display_rgb[0], display_rgb[1], display_rgb[2]);
+    }
+  }
+
+  for(int widget = 0; widget < 6; widget++) gtk_widget_queue_draw(widgets[widget]);
 }

--- a/src/iop/channelmixerrgb_shared.h
+++ b/src/iop/channelmixerrgb_shared.h
@@ -58,24 +58,25 @@ typedef struct dt_iop_channelmixer_shared_primaries_params_t
 } dt_iop_channelmixer_shared_primaries_params_t;
 
 /**
- * @brief White-preserving primaries model : per-primary rotation and inset, no white freedom.
+ * @brief White-preserving primaries model : per-primary rotation and saturation, no white freedom.
  *
  * Each primary is the chromaticity of one column of the mixer matrix, expressed in the affine
- * plane of the current mixer basis. `rotation` turns it around the basis white, `inset` contracts
- * it toward that white (negative values expand it away). The three column magnitudes are then
- * SOLVED, not chosen, so that the basis white maps to itself : that constraint is what removes the
- * three remaining degrees of freedom of a 3x3 matrix, and is why six parameters describe the whole
+ * plane of the current mixer basis. `rotation` turns it around the basis white, and `saturation`
+ * scales its distance to that white by `1 + saturation` : -1 collapses the primary onto the white,
+ * 0 leaves it untouched, +1 doubles its distance. The three column magnitudes are then SOLVED, not
+ * chosen, so that the basis white maps to itself : that constraint is what removes the three
+ * remaining degrees of freedom of a 3x3 matrix, and is why six parameters describe the whole
  * white-preserving submanifold exactly. All-zero parameters are the identity matrix, and a uniform
- * inset is the classic desaturation matrix toward the basis white.
+ * saturation is the classic saturation matrix around the basis white.
  */
 typedef struct dt_iop_channelmixer_shared_white_preserving_params_t
 {
   float red_rotation;
-  float red_inset;
+  float red_saturation;
   float green_rotation;
-  float green_inset;
+  float green_saturation;
   float blue_rotation;
-  float blue_inset;
+  float blue_saturation;
 } dt_iop_channelmixer_shared_white_preserving_params_t;
 
 float dt_iop_channelmixer_shared_wrap_pi(float angle);

--- a/src/iop/channelmixerrgb_shared.h
+++ b/src/iop/channelmixerrgb_shared.h
@@ -15,6 +15,9 @@ typedef struct _GtkWidget GtkWidget;
 #define DT_IOP_CHANNELMIXER_SHARED_SIMPLE_TAN_SCALE 1.55f
 #define DT_IOP_CHANNELMIXER_SHARED_SIMPLE_EPS 5e-5f
 #define DT_IOP_CHANNELMIXER_SHARED_SIMPLE_CHROMA_PROBE 0.5f
+// Smallest chromaticity triangle, as a fraction of the untouched basis triangle, that the
+// white-preserving model accepts before calling the primaries degenerate.
+#define DT_IOP_CHANNELMIXER_SHARED_MIN_FOOTPRINT 0.02f
 
 typedef enum dt_iop_channelmixer_shared_primaries_basis_t
 {
@@ -54,6 +57,27 @@ typedef struct dt_iop_channelmixer_shared_primaries_params_t
   float gain;
 } dt_iop_channelmixer_shared_primaries_params_t;
 
+/**
+ * @brief White-preserving primaries model : per-primary rotation and inset, no white freedom.
+ *
+ * Each primary is the chromaticity of one column of the mixer matrix, expressed in the affine
+ * plane of the current mixer basis. `rotation` turns it around the basis white, `inset` contracts
+ * it toward that white (negative values expand it away). The three column magnitudes are then
+ * SOLVED, not chosen, so that the basis white maps to itself : that constraint is what removes the
+ * three remaining degrees of freedom of a 3x3 matrix, and is why six parameters describe the whole
+ * white-preserving submanifold exactly. All-zero parameters are the identity matrix, and a uniform
+ * inset is the classic desaturation matrix toward the basis white.
+ */
+typedef struct dt_iop_channelmixer_shared_white_preserving_params_t
+{
+  float red_rotation;
+  float red_inset;
+  float green_rotation;
+  float green_inset;
+  float blue_rotation;
+  float blue_inset;
+} dt_iop_channelmixer_shared_white_preserving_params_t;
+
 float dt_iop_channelmixer_shared_wrap_pi(float angle);
 float dt_iop_channelmixer_shared_wrap_half_pi(float angle);
 float dt_iop_channelmixer_shared_encode_simple_stretch(float stretch);
@@ -68,6 +92,10 @@ void dt_iop_channelmixer_shared_primaries_from_sliders(GtkWidget *const widgets[
                                                        dt_iop_channelmixer_shared_primaries_params_t *primaries);
 void dt_iop_channelmixer_shared_primaries_to_sliders(const dt_iop_channelmixer_shared_primaries_params_t *primaries,
                                                      GtkWidget *const widgets[9]);
+void dt_iop_channelmixer_shared_white_preserving_from_sliders(
+    GtkWidget *const widgets[6], dt_iop_channelmixer_shared_white_preserving_params_t *white_preserving);
+void dt_iop_channelmixer_shared_white_preserving_to_sliders(
+    const dt_iop_channelmixer_shared_white_preserving_params_t *white_preserving, GtkWidget *const widgets[6]);
 
 gboolean dt_iop_channelmixer_shared_rows_are_normalized(const gboolean normalize[3]);
 gboolean dt_iop_channelmixer_shared_get_matrix(const float rows[3][3], const gboolean normalize[3],
@@ -80,6 +108,7 @@ void dt_iop_channelmixer_shared_simple_from_matrix(const float M[3][3],
 void dt_iop_channelmixer_shared_simple_to_matrix(const dt_iop_channelmixer_shared_simple_params_t *simple,
                                                  float M[3][3]);
 float dt_iop_channelmixer_shared_roundtrip_error(const float M[3][3], const float roundtrip[3][3]);
+float dt_iop_channelmixer_shared_roundtrip_error_relative(const float M[3][3], const float roundtrip[3][3]);
 
 dt_iop_channelmixer_shared_primaries_basis_t
 dt_iop_channelmixer_shared_primaries_basis_from_adaptation(dt_adaptation_t adaptation);
@@ -89,6 +118,12 @@ gboolean dt_iop_channelmixer_shared_primaries_to_matrix(dt_iop_channelmixer_shar
 gboolean dt_iop_channelmixer_shared_primaries_from_matrix(dt_iop_channelmixer_shared_primaries_basis_t basis,
                                                           const float M[3][3],
                                                           dt_iop_channelmixer_shared_primaries_params_t *primaries);
+gboolean dt_iop_channelmixer_shared_white_preserving_to_matrix(
+    dt_iop_channelmixer_shared_primaries_basis_t basis,
+    const dt_iop_channelmixer_shared_white_preserving_params_t *white_preserving, float M[3][3]);
+gboolean dt_iop_channelmixer_shared_white_preserving_from_matrix(
+    dt_iop_channelmixer_shared_primaries_basis_t basis, const float M[3][3],
+    dt_iop_channelmixer_shared_white_preserving_params_t *white_preserving);
 
 void dt_iop_channelmixer_shared_simple_probe_source(dt_iop_channelmixer_shared_simple_probe_t probe, float source[3]);
 void dt_iop_channelmixer_shared_work_rgb_to_display(const dt_aligned_pixel_t work_rgb,
@@ -116,6 +151,11 @@ void dt_iop_channelmixer_shared_paint_primaries_sliders(
     const dt_iop_order_iccprofile_info_t *display_profile,
     dt_iop_channelmixer_shared_primaries_basis_t basis,
     const dt_iop_channelmixer_shared_primaries_params_t *primaries, GtkWidget *const widgets[9]);
+void dt_iop_channelmixer_shared_paint_white_preserving_sliders(
+    dt_adaptation_t adaptation, const dt_iop_order_iccprofile_info_t *work_profile,
+    const dt_iop_order_iccprofile_info_t *display_profile,
+    dt_iop_channelmixer_shared_primaries_basis_t basis,
+    const dt_iop_channelmixer_shared_white_preserving_params_t *white_preserving, GtkWidget *const widgets[6]);
 
 #ifdef __cplusplus
 }

--- a/src/iop/splittoningrgb.c
+++ b/src/iop/splittoningrgb.c
@@ -991,7 +991,11 @@ static void _white_preserving_slider_callback(GtkWidget *widget, gpointer user_d
   if(!dt_iop_channelmixer_shared_white_preserving_to_matrix(DT_IOP_CHANNELMIXER_SHARED_PRIMARIES_BASIS_RGB,
                                                             &white_preserving, M))
   {
+    // Three primaries collapsed onto the neutral have no transform to describe. Snap the sliders
+    // back to the last representable state rather than leaving the page showing a setting the
+    // params do not hold.
     dt_control_log(_("white-preserving mixer mode requires non-degenerate primaries."));
+    _sync_white_preserving_from_params(self, point, NULL);
     return;
   }
 

--- a/src/iop/splittoningrgb.c
+++ b/src/iop/splittoningrgb.c
@@ -74,6 +74,7 @@ typedef enum dt_iop_splittoning_rgb_mixer_mode_t
   DT_SPLITTONING_RGB_MIXER_COMPLETE = 0,
   DT_SPLITTONING_RGB_MIXER_SIMPLE = 1,
   DT_SPLITTONING_RGB_MIXER_PRIMARIES = 2,
+  DT_SPLITTONING_RGB_MIXER_WHITE_PRESERVING = 3,
 } dt_iop_splittoning_rgb_mixer_mode_t;
 
 typedef struct dt_iop_splittoning_rgb_params_t
@@ -125,6 +126,12 @@ typedef struct dt_iop_splittoning_rgb_point_gui_t
   GtkWidget *primaries_blue_hue;
   GtkWidget *primaries_blue_purity;
   GtkWidget *primaries_gain;
+  GtkWidget *white_preserving_red_rotation;
+  GtkWidget *white_preserving_red_saturation;
+  GtkWidget *white_preserving_green_rotation;
+  GtkWidget *white_preserving_green_saturation;
+  GtkWidget *white_preserving_blue_rotation;
+  GtkWidget *white_preserving_blue_saturation;
 } dt_iop_splittoning_rgb_point_gui_t;
 
 typedef struct dt_iop_splittoning_rgb_gui_data_t
@@ -249,6 +256,7 @@ static void _set_point_mixer_mode(dt_iop_splittoning_rgb_gui_data_t *g, const in
   gtk_stack_set_visible_child_name(GTK_STACK(g->point[point].mixer_stack),
                                    mode == DT_SPLITTONING_RGB_MIXER_SIMPLE ? "simple"
                                    : mode == DT_SPLITTONING_RGB_MIXER_PRIMARIES ? "primaries"
+                                   : mode == DT_SPLITTONING_RGB_MIXER_WHITE_PRESERVING ? "white-preserving"
                                    : "complete");
   gtk_widget_queue_resize(g->point[point].mixer_stack);
   gtk_widget_queue_resize(g->point[point].page);
@@ -449,6 +457,72 @@ static gboolean _sync_primaries_from_params(dt_iop_module_t *self, const int poi
   return isfinite(roundtrip_error) && roundtrip_error <= DT_IOP_CHANNELMIXER_SHARED_SIMPLE_EPS;
 }
 
+/**
+ * @brief Collect the six white-preserving widgets of one keyframe.
+ *
+ * @param[in] g Current module GUI data.
+ * @param[in] point Shadow or highlight keyframe.
+ * @param[out] widgets Rotation/saturation pairs, in red, green, blue order.
+ * @return FALSE while the widgets have not been created yet, which happens during gui_init().
+ */
+static gboolean _white_preserving_widgets(const dt_iop_splittoning_rgb_gui_data_t *const g, const int point,
+                                          GtkWidget *widgets[6])
+{
+  widgets[0] = g->point[point].white_preserving_red_rotation;
+  widgets[1] = g->point[point].white_preserving_red_saturation;
+  widgets[2] = g->point[point].white_preserving_green_rotation;
+  widgets[3] = g->point[point].white_preserving_green_saturation;
+  widgets[4] = g->point[point].white_preserving_blue_rotation;
+  widgets[5] = g->point[point].white_preserving_blue_saturation;
+
+  for(int widget = 0; widget < 6; widget++)
+    if(IS_NULL_PTR(widgets[widget])) return FALSE;
+
+  return TRUE;
+}
+
+/**
+ * @brief Synchronize the white-preserving GUI of one keyframe from its effective mixer matrix.
+ *
+ * @param[in] self Current module instance.
+ * @param[in] point Shadow or highlight keyframe.
+ * @param[out] error Largest coefficient error after a full roundtrip, relative to the matrix.
+ * @return TRUE when the effective matrix leaves white unchanged and is representable.
+ */
+static gboolean _sync_white_preserving_from_params(dt_iop_module_t *self, const int point, float *error)
+{
+  dt_iop_splittoning_rgb_gui_data_t *g = (dt_iop_splittoning_rgb_gui_data_t *)dt_iop_gui_data(self);
+  dt_iop_splittoning_rgb_params_t *p = (dt_iop_splittoning_rgb_params_t *)self->params;
+  GtkWidget *widgets[6] = { NULL };
+  float rows[3][3] = { { 0.f } };
+  gboolean normalize[3] = { FALSE, FALSE, FALSE };
+  float M[3][3] = { { 0.f } };
+  float roundtrip[3][3] = { { 0.f } };
+  dt_iop_channelmixer_shared_white_preserving_params_t white_preserving;
+
+  if(!IS_NULL_PTR(error)) *error = INFINITY;
+
+  if(!_white_preserving_widgets(g, point, widgets)) return FALSE;
+
+  _get_point_rows(p, point, rows, normalize);
+  if(!dt_iop_channelmixer_shared_get_matrix(rows, normalize, FALSE, M)) return FALSE;
+  if(!dt_iop_channelmixer_shared_white_preserving_from_matrix(DT_IOP_CHANNELMIXER_SHARED_PRIMARIES_BASIS_RGB, M,
+                                                              &white_preserving))
+    return FALSE;
+  if(!dt_iop_channelmixer_shared_white_preserving_to_matrix(DT_IOP_CHANNELMIXER_SHARED_PRIMARIES_BASIS_RGB,
+                                                            &white_preserving, roundtrip))
+    return FALSE;
+
+  const float roundtrip_error = dt_iop_channelmixer_shared_roundtrip_error_relative(M, roundtrip);
+  if(!IS_NULL_PTR(error)) *error = roundtrip_error;
+
+  dt_gui_freeze_begin();
+  dt_iop_channelmixer_shared_white_preserving_to_sliders(&white_preserving, widgets);
+  dt_gui_freeze_end();
+
+  return isfinite(roundtrip_error) && roundtrip_error <= DT_IOP_CHANNELMIXER_SHARED_SIMPLE_EPS;
+}
+
 static void _queue_preview_redraw(dt_iop_module_t *self)
 {
   dt_iop_splittoning_rgb_gui_data_t *g = (dt_iop_splittoning_rgb_gui_data_t *)dt_iop_gui_data(self);
@@ -539,6 +613,17 @@ static void _update_point_slider_colors(dt_iop_module_t *self, const int point)
   dt_iop_channelmixer_shared_paint_primaries_sliders(DT_ADAPTATION_RGB, work_profile, display_profile,
                                                      DT_IOP_CHANNELMIXER_SHARED_PRIMARIES_BASIS_RGB, &primaries,
                                                      primaries_widgets);
+
+  GtkWidget *white_preserving_widgets[6] = { NULL };
+  if(_white_preserving_widgets(g, point, white_preserving_widgets))
+  {
+    dt_iop_channelmixer_shared_white_preserving_params_t white_preserving;
+
+    dt_iop_channelmixer_shared_white_preserving_from_sliders(white_preserving_widgets, &white_preserving);
+    dt_iop_channelmixer_shared_paint_white_preserving_sliders(DT_ADAPTATION_RGB, work_profile, display_profile,
+                                                              DT_IOP_CHANNELMIXER_SHARED_PRIMARIES_BASIS_RGB,
+                                                              &white_preserving, white_preserving_widgets);
+  }
 }
 
 static void _update_point_gui(dt_iop_module_t *self, const int point, GtkWidget *changed)
@@ -559,8 +644,14 @@ static void _update_point_gui(dt_iop_module_t *self, const int point, GtkWidget 
   {
     float simple_error = INFINITY;
     float primaries_error = INFINITY;
+    float white_preserving_error = INFINITY;
     const gboolean simple_ok = _sync_simple_from_params(self, point, &simple_error);
     const gboolean primaries_ok = _sync_primaries_from_params(self, point, &primaries_error);
+    GtkWidget *white_preserving_widgets[6] = { NULL };
+    // Guard the kick-out below : a sync that only failed because gui_init() has not built this
+    // page yet must not push the user out of a mode they legitimately saved.
+    const gboolean white_preserving_ready = _white_preserving_widgets(g, point, white_preserving_widgets);
+    const gboolean white_preserving_ok = _sync_white_preserving_from_params(self, point, &white_preserving_error);
 
     if(active_mode == DT_SPLITTONING_RGB_MIXER_SIMPLE && !simple_ok)
     {
@@ -579,6 +670,16 @@ static void _update_point_gui(dt_iop_module_t *self, const int point, GtkWidget 
       _set_point_mixer_mode(g, point, DT_SPLITTONING_RGB_MIXER_COMPLETE);
       dt_conf_set_int(_mode_conf[point], DT_SPLITTONING_RGB_MIXER_COMPLETE);
       dt_control_log(_("primaries mixer mode requires a non-singular 3x3 matrix with non-zero affine sums."));
+    }
+    else if(active_mode == DT_SPLITTONING_RGB_MIXER_WHITE_PRESERVING && white_preserving_ready
+            && !white_preserving_ok)
+    {
+      dt_gui_freeze_begin();
+      dt_bauhaus_combobox_set(g->point[point].mixer_mode, DT_SPLITTONING_RGB_MIXER_COMPLETE);
+      dt_gui_freeze_end();
+      _set_point_mixer_mode(g, point, DT_SPLITTONING_RGB_MIXER_COMPLETE);
+      dt_conf_set_int(_mode_conf[point], DT_SPLITTONING_RGB_MIXER_COMPLETE);
+      dt_control_log(_("white-preserving mixer mode requires a matrix that leaves white unchanged."));
     }
   }
 
@@ -782,6 +883,20 @@ static void _mixer_mode_callback(GtkWidget *widget, gpointer user_data)
       return;
     }
   }
+  else if(mode == DT_SPLITTONING_RGB_MIXER_WHITE_PRESERVING)
+  {
+    float error = INFINITY;
+    if(!_sync_white_preserving_from_params(self, point, &error))
+    {
+      dt_control_log(_("white-preserving mixer mode requires a matrix that leaves white unchanged."));
+      dt_gui_freeze_begin();
+      dt_bauhaus_combobox_set(widget, DT_SPLITTONING_RGB_MIXER_COMPLETE);
+      dt_gui_freeze_end();
+      _set_point_mixer_mode(g, point, DT_SPLITTONING_RGB_MIXER_COMPLETE);
+      dt_conf_set_int(_mode_conf[point], DT_SPLITTONING_RGB_MIXER_COMPLETE);
+      return;
+    }
+  }
 
   if(mode == DT_SPLITTONING_RGB_MIXER_SIMPLE)
     for(int row = 0; row < 3; row++) p->normalize[point][row] = TRUE;
@@ -817,6 +932,7 @@ static void _simple_slider_callback(GtkWidget *widget, gpointer user_data)
   dt_gui_freeze_begin();
   _set_point_complete_widgets(g, p, point);
   _sync_primaries_from_params(self, point, NULL);
+  _sync_white_preserving_from_params(self, point, NULL);
   dt_gui_freeze_end();
 
   _commit_gui_change(self, widget);
@@ -851,6 +967,40 @@ static void _primaries_slider_callback(GtkWidget *widget, gpointer user_data)
 
   dt_gui_freeze_begin();
   _set_point_complete_widgets(g, p, point);
+  _sync_white_preserving_from_params(self, point, NULL);
+  dt_gui_freeze_end();
+
+  _commit_gui_change(self, widget);
+}
+
+static void _white_preserving_slider_callback(GtkWidget *widget, gpointer user_data)
+{
+  if(dt_gui_widgets_suppressed()) return;
+
+  dt_iop_module_t *self = (dt_iop_module_t *)user_data;
+  dt_iop_splittoning_rgb_gui_data_t *g = (dt_iop_splittoning_rgb_gui_data_t *)dt_iop_gui_data(self);
+  dt_iop_splittoning_rgb_params_t *p = (dt_iop_splittoning_rgb_params_t *)self->params;
+  const int point = GPOINTER_TO_INT(g_object_get_data(G_OBJECT(widget), "split-point"));
+  GtkWidget *widgets[6] = { NULL };
+  dt_iop_channelmixer_shared_white_preserving_params_t white_preserving;
+  float M[3][3] = { { 0.f } };
+
+  if(!_white_preserving_widgets(g, point, widgets)) return;
+
+  dt_iop_channelmixer_shared_white_preserving_from_sliders(widgets, &white_preserving);
+  if(!dt_iop_channelmixer_shared_white_preserving_to_matrix(DT_IOP_CHANNELMIXER_SHARED_PRIMARIES_BASIS_RGB,
+                                                            &white_preserving, M))
+  {
+    dt_control_log(_("white-preserving mixer mode requires non-degenerate primaries."));
+    return;
+  }
+
+  _set_point_rows(p, point, M);
+  for(int row = 0; row < 3; row++) p->normalize[point][row] = FALSE;
+
+  dt_gui_freeze_begin();
+  _set_point_complete_widgets(g, p, point);
+  _sync_primaries_from_params(self, point, NULL);
   dt_gui_freeze_end();
 
   _commit_gui_change(self, widget);
@@ -1077,8 +1227,10 @@ void gui_update(struct dt_iop_module_t *self)
 
     float simple_error = INFINITY;
     float primaries_error = INFINITY;
+    float white_preserving_error = INFINITY;
     const gboolean simple_ok = _sync_simple_from_params(self, point, &simple_error);
     const gboolean primaries_ok = _sync_primaries_from_params(self, point, &primaries_error);
+    const gboolean white_preserving_ok = _sync_white_preserving_from_params(self, point, &white_preserving_error);
     const dt_iop_splittoning_rgb_mixer_mode_t requested_mode = dt_conf_key_exists(_mode_conf[point])
                                                                    ? dt_conf_get_int(_mode_conf[point])
                                                                    : DT_SPLITTONING_RGB_MIXER_SIMPLE;
@@ -1087,7 +1239,9 @@ void gui_update(struct dt_iop_module_t *self)
               ? DT_SPLITTONING_RGB_MIXER_SIMPLE
               : requested_mode == DT_SPLITTONING_RGB_MIXER_PRIMARIES && primaries_ok
                     ? DT_SPLITTONING_RGB_MIXER_PRIMARIES
-                    : DT_SPLITTONING_RGB_MIXER_COMPLETE;
+                    : requested_mode == DT_SPLITTONING_RGB_MIXER_WHITE_PRESERVING && white_preserving_ok
+                          ? DT_SPLITTONING_RGB_MIXER_WHITE_PRESERVING
+                          : DT_SPLITTONING_RGB_MIXER_COMPLETE;
 
     dt_bauhaus_combobox_set(g->point[point].mixer_mode, mode);
     _set_point_mixer_mode(g, point, mode);
@@ -1269,6 +1423,53 @@ static void _build_primaries_ui(dt_iop_module_t *self, dt_iop_splittoning_rgb_gu
   }
 }
 
+static void _build_white_preserving_ui(dt_iop_module_t *self, dt_iop_splittoning_rgb_gui_data_t *g,
+                                      const int point, GtkWidget *container)
+{
+#define SPLITTONING_WHITE_PRESERVING_PRIMARY(var, rotation_label, saturation_label)                             \
+  g->point[point].white_preserving_##var##_rotation                                                             \
+      = dt_bauhaus_slider_new_with_range(dt_bauhaus_get_global(), DT_GUI_MODULE(self), -1.f, 1.f, 0, 0.f, 3);    \
+  dt_bauhaus_widget_set_label(g->point[point].white_preserving_##var##_rotation, rotation_label);               \
+  dt_bauhaus_slider_set_factor(g->point[point].white_preserving_##var##_rotation, 90.f);                        \
+  dt_bauhaus_slider_set_format(g->point[point].white_preserving_##var##_rotation, "\302\260");                  \
+  /* -100%/+100% is the intended travel ; the wider hard range lets the page report a matrix   */               \
+  /* hand-built in complete mode that pushes a primary further out, instead of clamping it.     */               \
+  g->point[point].white_preserving_##var##_saturation                                                           \
+      = dt_bauhaus_slider_new_with_range(dt_bauhaus_get_global(), DT_GUI_MODULE(self), -4.f, 4.f, 0, 0.f, 3);    \
+  dt_bauhaus_slider_set_soft_range(g->point[point].white_preserving_##var##_saturation, -1.f, 1.f);              \
+  dt_bauhaus_widget_set_label(g->point[point].white_preserving_##var##_saturation, saturation_label);           \
+  /* A "%" format on a range under 10 applies the 100x factor and takes two digits off by itself. */             \
+  dt_bauhaus_slider_set_format(g->point[point].white_preserving_##var##_saturation, "%");
+
+  SPLITTONING_WHITE_PRESERVING_PRIMARY(red, N_("red rotation"), N_("red saturation"))
+  SPLITTONING_WHITE_PRESERVING_PRIMARY(green, N_("green rotation"), N_("green saturation"))
+  SPLITTONING_WHITE_PRESERVING_PRIMARY(blue, N_("blue rotation"), N_("blue saturation"))
+
+#undef SPLITTONING_WHITE_PRESERVING_PRIMARY
+
+  GtkWidget *widgets[] = {
+    dt_ui_section_label_new(_("red primary")),
+    g->point[point].white_preserving_red_rotation,
+    g->point[point].white_preserving_red_saturation,
+    dt_ui_section_label_new(_("green primary")),
+    g->point[point].white_preserving_green_rotation,
+    g->point[point].white_preserving_green_saturation,
+    dt_ui_section_label_new(_("blue primary")),
+    g->point[point].white_preserving_blue_rotation,
+    g->point[point].white_preserving_blue_saturation,
+  };
+
+  for(size_t i = 0; i < G_N_ELEMENTS(widgets); i++)
+  {
+    if(i % 3 != 0)
+    {
+      _tag_widget(widgets[i], point);
+      g_signal_connect(G_OBJECT(widgets[i]), "value-changed", G_CALLBACK(_white_preserving_slider_callback), self);
+    }
+    gtk_box_pack_start(GTK_BOX(container), widgets[i], FALSE, FALSE, 0);
+  }
+}
+
 void gui_init(struct dt_iop_module_t *self)
 {
   dt_iop_splittoning_rgb_gui_data_t *g = IOP_GUI_ALLOC(splittoning_rgb);
@@ -1316,6 +1517,7 @@ void gui_init(struct dt_iop_module_t *self)
     dt_bauhaus_combobox_add(g->point[point].mixer_mode, _("Complete"));
     dt_bauhaus_combobox_add(g->point[point].mixer_mode, _("Simple"));
     dt_bauhaus_combobox_add(g->point[point].mixer_mode, _("Primaries"));
+    dt_bauhaus_combobox_add(g->point[point].mixer_mode, _("White-preserving"));
     _tag_widget(g->point[point].mixer_mode, point);
     g_signal_connect(G_OBJECT(g->point[point].mixer_mode), "value-changed", G_CALLBACK(_mixer_mode_callback), self);
     gtk_box_pack_start(GTK_BOX(page), g->point[point].mixer_mode, FALSE, FALSE, 0);
@@ -1329,13 +1531,16 @@ void gui_init(struct dt_iop_module_t *self)
     GtkWidget *complete = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_GUI_BOX_SPACING);
     GtkWidget *simple = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_GUI_BOX_SPACING);
     GtkWidget *primaries = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_GUI_BOX_SPACING);
+    GtkWidget *white_preserving = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_GUI_BOX_SPACING);
     gtk_stack_add_named(GTK_STACK(g->point[point].mixer_stack), complete, "complete");
     gtk_stack_add_named(GTK_STACK(g->point[point].mixer_stack), simple, "simple");
     gtk_stack_add_named(GTK_STACK(g->point[point].mixer_stack), primaries, "primaries");
+    gtk_stack_add_named(GTK_STACK(g->point[point].mixer_stack), white_preserving, "white-preserving");
 
     _build_complete_ui(self, g, point, complete);
     _build_simple_ui(self, g, point, simple);
     _build_primaries_ui(self, g, point, primaries);
+    _build_white_preserving_ui(self, g, point, white_preserving);
   }
 
   DT_DEBUG_CONTROL_SIGNAL_CONNECT(dt_control_signal_get_global(), DT_SIGNAL_DEVELOP_UI_PIPE_FINISHED,

--- a/src/math/math.h
+++ b/src/math/math.h
@@ -414,6 +414,11 @@ static inline __m128 sinf_fast_sse(__m128 t)
  */
 static inline int ipow(int base, int exp)
 {
+  // Shifting a negative exponent right never reaches zero, so the loop below would spin
+  // forever. There is no integer answer for one anyway; callers use this for decimal
+  // precision, where "fewer than zero digits" is just "no fractional part".
+  if(exp <= 0) return 1;
+
   int result = 1;
   for(;;)
   {

--- a/src/widgets/bauhaus.c
+++ b/src/widgets/bauhaus.c
@@ -3408,7 +3408,10 @@ void dt_bauhaus_slider_set_format(GtkWidget *widget, const char *format)
   if(strstr(format,"%") && fabsf(d->hard_max) <= 10)
   {
     if(d->factor == 1.0f) d->factor = 100;
-    d->digits -= 2;
+    // Scaling by 100 costs two decimals, but a slider declared with fewer than two must not end
+    // up with a negative digit count : it is a decimal exponent, fed to ipow() on every value
+    // change and every redraw, and there is no such thing as fewer than zero decimals.
+    d->digits = MAX(d->digits - 2, 0);
   }
 }
 


### PR DESCRIPTION
Adds a fourth mixer GUI mode — **White-preserving** — to _color calibration_ and _split-toning_: one rotation and one saturation per primary, with the white nailed down. It is a reparametrization, not a new algorithm; the pipeline still applies the same 3×3 matrix.

## Why six controls describe exactly this

Mixer matrices that leave the basis white unchanged form a **6-dimensional manifold** — `M · w = w` is three linear constraints on nine coefficients. The per-primary model has exactly six knobs, so the two match dimension for dimension and the map between them inverts in closed form rather than needing a fit.

Reading a column of the mixer as the tristimulus of unit light in that channel splits it into a chromaticity (the column normalized by its own affine sum) and a magnitude (that sum). Rotation and saturation act on the chromaticity alone; the three magnitudes are then **solved** from the white constraint, which is what consumes the remaining three degrees of freedom. The inverse just reads each column's chromaticity back off, so both directions are exact.

`saturation` scales the primary's distance to the white by `1 + s`: `-100%` collapses it onto the white, `0` is the identity, `+100%` doubles it.

Anchoring the geometry on the basis white — D50 expressed in the adaptation's LMS, which is what a neutral pixel actually carries where the mixer runs — makes the identity matrix the zero of the model in every basis, and a uniform saturation the classic saturation matrix around that white.

## Verification

A scratch program linked against the compiled `channelmixerrgb_shared.c.o`, 20 k random parameter draws per basis:

| basis | identity from zeros | white preserved | param roundtrip | matrix roundtrip | uniform = saturation matrix |
|---|---|---|---|---|---|
| RGB | 3.0e‑08 | 2.3e‑05 | 1.0e‑06 | 1.6e‑05 | 1.5e‑08 |
| Bradford | 1.2e‑07 | 2.6e‑05 | 1.1e‑06 | 2.2e‑05 | 6.0e‑08 |
| CAT16 | 1.2e‑07 | 1.4e‑05 | 1.4e‑06 | 6.1e‑05 | 1.2e‑07 |
| XYZ | 6.0e‑08 | 1.8e‑05 | 1.2e‑06 | 3.2e‑05 | 6.0e‑08 |

Two numerical points the measurements forced:

- **Degeneracy guard.** Two primaries rotated onto the same ray flatten the chromaticity triangle; the matrix stays invertible but the solved column scales explode, and 3 % of a uniform parameter box failed its own roundtrip. `to_matrix()` now refuses a triangle below 2 % of the untouched basis triangle → 0/193 k. Consequence, measured: one primary desaturates to `-100%`, all three together stop at `-85.8%`.
- **The roundtrip gate is relative** to the matrix magnitude (`dt_iop_channelmixer_shared_roundtrip_error_relative`, denominator floored at 1). A reparametrization gate asks "is this the same matrix", which is a relative question. The existing modes keep the absolute form unchanged.

## Two bugs fixed along the way

**The existing _Primaries_ mode was silently unusable.** `primaries_to_matrix()` solved for its column scales with `dt_apply_transposed_color_matrix()`, which expects a matrix *already stored transposed* (see `xyz_to_srgb_matrix_transposed`) and therefore applied the transpose of the inverse. Measured on the pre-fix object, the roundtrip error gating the mode was **2.71** against a 5e-5 tolerance for any non-identity state — the mode only worked at defaults, where `P = I` is its own transpose. Now 2.4e-6. Rendering is unaffected; that function is GUI-side only.

**A `"%"` slider format could hang the whole GUI.** `dt_bauhaus_slider_set_format(w, "%")` also does `digits -= 2` for `|hard_max| <= 10`, unconditionally; `ipow()` shifts its exponent right until zero, which a negative int never reaches. A slider declared with fewer than two decimals therefore froze the app on the first `dt_bauhaus_slider_set()`, reachable from an ordinary darkroom entry. Guarded at both ends (floor in `set_format`, `exp <= 0 -> 1` in `ipow`). Audited the tree: no other slider had that shape.

## Not covered

**The GUI has not been clicked.** The maths is verified against the shipped binary and the plumbing mirrors the working _Primaries_ mode, but there is no display on the machine this was written on — mode switching, slider drag and darkroom re-entry are verified by construction only. The _split-toning_ page in particular is new UI that has only been read.

No `po/` strings updated. Docs are in aurelienpierreeng/ansel-doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)