### PR TITLE
colorprofiles: conversions authenticate themselves; commits publish once (#1212)

### DIFF
--- a/src/colorprofiles/conversion.c
+++ b/src/colorprofiles/conversion.c
@@ -47,8 +47,18 @@
  * are stored, because that is what dt_ioppr_eval_trc() and the OpenCL kernels read. The
  * difference is that they are now read here and by the kernels, not by module logic.
  */
+/* First field, deliberately. Issues #1212/#1216: two field crashes handed accessors a
+ * conversion pointer whose FIRST bytes were readable but which was not (or no longer) a
+ * conversion -- the fault only fired on a deeper member. A tag at offset zero is checkable
+ * on exactly the memory those pointers could read, so the accessors can refuse and name the
+ * pointer instead of dereferencing into the unmapped part. */
+#define DT_CONVERSION_MAGIC_LIVE 0xC0117E51u
+#define DT_CONVERSION_MAGIC_DEAD 0xDEADC017u
+
 struct dt_colorspaces_conversion_t
 {
+  uint32_t magic;
+
   dt_colorspaces_color_profile_type_t from_type;
   dt_colorspaces_color_profile_type_t to_type;
 
@@ -214,6 +224,7 @@ dt_colorspaces_conversion_t *dt_colorspaces_prepare_conversion(const dt_colorspa
 
   dt_colorspaces_conversion_t *conversion = calloc(1, sizeof(dt_colorspaces_conversion_t));
   if(IS_NULL_PTR(conversion)) return NULL;
+  conversion->magic = DT_CONVERSION_MAGIC_LIVE;
 
   /* Read before any profile entry lock is taken, so this never nests the settings lock inside
    * one. It is folded into the identity below: it is the only thing that distinguishes two
@@ -461,15 +472,47 @@ give_up:
   return NULL;
 }
 
+/**
+ * @brief Is this pointer a live conversion?
+ *
+ * @details NULL is an ordinary, quiet "no conversion" -- every accessor already treated it
+ * that way. A dead tag is a use-after-free caught while the page is still mapped; anything
+ * else is a pointer that never was a conversion (issues #1212/#1216 observed the module's
+ * conversion field clobbered with a foreign pointer mid-commit). Both are reported by
+ * address so the next field report carries the value instead of a signal name.
+ */
+static gboolean _conversion_valid(const dt_colorspaces_conversion_t *const conversion, const char *caller)
+{
+  if(IS_NULL_PTR(conversion)) return FALSE;
+  if(conversion->magic == DT_CONVERSION_MAGIC_LIVE) return TRUE;
+
+  if(conversion->magic == DT_CONVERSION_MAGIC_DEAD)
+    dt_print(DT_DEBUG_ALWAYS, "[colorprofiles] %s was handed a FREED conversion %p -- refusing\n",
+             caller, (void *)conversion);
+  else
+    dt_print(DT_DEBUG_ALWAYS, "[colorprofiles] %s was handed %p which is NOT a conversion"
+             " (tag 0x%08x) -- refusing\n", caller, (void *)conversion, conversion->magic);
+  return FALSE;
+}
+
 uint64_t dt_colorspaces_conversion_identity(const dt_colorspaces_conversion_t *const conversion)
 {
-  return IS_NULL_PTR(conversion) ? 0 : conversion->identity;
+  return _conversion_valid(conversion, "conversion_identity") ? conversion->identity : 0;
 }
 
 void dt_colorspaces_free_conversion(dt_colorspaces_conversion_t **conversion)
 {
   if(IS_NULL_PTR(conversion) || IS_NULL_PTR(*conversion)) return;
   dt_colorspaces_conversion_t *c = *conversion;
+
+  if(!_conversion_valid(c, "free_conversion"))
+  {
+    /* Freeing a pointer that is not a live conversion CORRUPTS THE HEAP -- it is how a
+     * clobbered field turns into a crash three modules away. Drop the reference instead. */
+    *conversion = NULL;
+    return;
+  }
+  c->magic = DT_CONVERSION_MAGIC_DEAD;
 
   _free_curves(c->lut_source);
   _free_curves(c->lut_target);
@@ -697,7 +740,13 @@ void dt_colorspaces_apply_conversion_hooked(const dt_colorspaces_conversion_t *c
                                             const float *const in, float *const out, const size_t width,
                                             const size_t height, const dt_colorspaces_conversion_hook_t hook)
 {
-  if(IS_NULL_PTR(conversion) || IS_NULL_PTR(in) || IS_NULL_PTR(out)) return;
+  if(IS_NULL_PTR(in) || IS_NULL_PTR(out)) return;
+  if(!_conversion_valid(conversion, "apply_conversion"))
+  {
+    /* Passthrough, not garbage: the caller owns a destination buffer that WILL be consumed. */
+    if(in != out) memcpy(out, in, width * height * 4 * sizeof(float));
+    return;
+  }
 
   if(conversion->is_matrix)
     _apply_matrix(conversion, in, out, width * height, hook);
@@ -715,18 +764,18 @@ void dt_colorspaces_apply_conversion(const dt_colorspaces_conversion_t *const co
 
 gboolean dt_colorspaces_conversion_is_matrix(const dt_colorspaces_conversion_t *const conversion)
 {
-  return !IS_NULL_PTR(conversion) && conversion->is_matrix;
+  return _conversion_valid(conversion, "conversion_is_matrix") && conversion->is_matrix;
 }
 
 gboolean dt_colorspaces_conversion_has_clipping(const dt_colorspaces_conversion_t *const conversion)
 {
-  return !IS_NULL_PTR(conversion) && conversion->has_clipping;
+  return _conversion_valid(conversion, "conversion_has_clipping") && conversion->has_clipping;
 }
 
 gboolean dt_colorspaces_conversion_matrix(const dt_colorspaces_conversion_t *const conversion,
                                           dt_colormatrix_t matrix)
 {
-  if(IS_NULL_PTR(conversion) || !conversion->is_matrix) return FALSE;
+  if(!_conversion_valid(conversion, "conversion_matrix") || !conversion->is_matrix) return FALSE;
   memcpy(matrix, conversion->matrix, sizeof(dt_colormatrix_t));
   return TRUE;
 }
@@ -734,7 +783,7 @@ gboolean dt_colorspaces_conversion_matrix(const dt_colorspaces_conversion_t *con
 gboolean dt_colorspaces_conversion_source_matrix(const dt_colorspaces_conversion_t *const conversion,
                                                  dt_colormatrix_t matrix)
 {
-  if(IS_NULL_PTR(conversion) || !conversion->have_source_matrix) return FALSE;
+  if(!_conversion_valid(conversion, "conversion_source_matrix") || !conversion->have_source_matrix) return FALSE;
   memcpy(matrix, conversion->source_matrix, sizeof(dt_colormatrix_t));
   return TRUE;
 }
@@ -742,7 +791,7 @@ gboolean dt_colorspaces_conversion_source_matrix(const dt_colorspaces_conversion
 gboolean dt_colorspaces_conversion_clip_matrix(const dt_colorspaces_conversion_t *const conversion,
                                                dt_colormatrix_t matrix)
 {
-  if(IS_NULL_PTR(conversion) || !conversion->is_matrix || !conversion->has_clipping) return FALSE;
+  if(!_conversion_valid(conversion, "conversion_clip_matrix") || !conversion->is_matrix || !conversion->has_clipping) return FALSE;
   memcpy(matrix, conversion->clip_matrix, sizeof(dt_colormatrix_t));
   return TRUE;
 }
@@ -750,26 +799,26 @@ gboolean dt_colorspaces_conversion_clip_matrix(const dt_colorspaces_conversion_t
 const float *dt_colorspaces_conversion_source_curve(const dt_colorspaces_conversion_t *const conversion,
                                                     const int channel)
 {
-  if(IS_NULL_PTR(conversion) || channel < 0 || channel > 2) return NULL;
+  if(!_conversion_valid(conversion, "conversion_source_curve") || channel < 0 || channel > 2) return NULL;
   return conversion->lut_source[channel];
 }
 
 const float *dt_colorspaces_conversion_target_curve(const dt_colorspaces_conversion_t *const conversion,
                                                     const int channel)
 {
-  if(IS_NULL_PTR(conversion) || channel < 0 || channel > 2) return NULL;
+  if(!_conversion_valid(conversion, "conversion_target_curve") || channel < 0 || channel > 2) return NULL;
   return conversion->lut_target[channel];
 }
 
 const float *dt_colorspaces_conversion_source_coeffs(const dt_colorspaces_conversion_t *const conversion)
 {
-  if(IS_NULL_PTR(conversion) || IS_NULL_PTR(conversion->lut_source[0])) return NULL;
+  if(!_conversion_valid(conversion, "conversion_source_coeffs") || IS_NULL_PTR(conversion->lut_source[0])) return NULL;
   return &conversion->coeffs_source[0][0];
 }
 
 const float *dt_colorspaces_conversion_target_coeffs(const dt_colorspaces_conversion_t *const conversion)
 {
-  if(IS_NULL_PTR(conversion) || IS_NULL_PTR(conversion->lut_target[0])) return NULL;
+  if(!_conversion_valid(conversion, "conversion_target_coeffs") || IS_NULL_PTR(conversion->lut_target[0])) return NULL;
   return &conversion->coeffs_target[0][0];
 }
 

--- a/src/iop/colorin.c
+++ b/src/iop/colorin.c
@@ -775,7 +775,14 @@ void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pix
   g_strlcpy(d->filename_work, p->filename_work, sizeof(d->filename_work));
   d->blue_mapping = p->blue_mapping;
 
-  dt_colorspaces_free_conversion(&d->conversion);
+  /* Detach before freeing, and never re-read the published field below: both crashes in
+   * issues #1212/#1216 caught this function using a d->conversion that no longer held what
+   * this same call had stored moments earlier. Build through a local, publish once at the
+   * end -- the commit is then immune to a mid-commit clobber of the field, and the final
+   * store overwrites whatever landed there. */
+  dt_colorspaces_conversion_t *stale_conversion = d->conversion;
+  d->conversion = NULL;
+  dt_colorspaces_free_conversion(&stale_conversion);
   piece->process_cl_ready = 1;
 
   // commit and resolve working profile first, it is the target output profile of this module
@@ -837,11 +844,12 @@ void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pix
    * stage for the output side, so a non-linear working profile goes through lcms2. */
   const dt_colorspaces_conversion_flags_t flags = DT_CONVERSION_SOURCE_CURVES;
 
-  d->conversion = dt_colorspaces_prepare_conversion(&source, &target,
-                                                    clip_type == DT_COLORSPACE_NONE ? NULL : &clip,
-                                                    NULL, p->intent, flags);
+  dt_colorspaces_conversion_t *conversion
+      = dt_colorspaces_prepare_conversion(&source, &target,
+                                          clip_type == DT_COLORSPACE_NONE ? NULL : &clip,
+                                          NULL, p->intent, flags);
 
-  if(IS_NULL_PTR(d->conversion))
+  if(IS_NULL_PTR(conversion))
   {
     /* Whatever the user asked for cannot be rendered. Linear Rec709 is the fallback that has
      * always been here; the clipping detour goes with the profile that needed it. */
@@ -857,7 +865,7 @@ void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pix
     source.type = type;
     source.filename = "";
     source.resolved = NULL;
-    d->conversion = dt_colorspaces_prepare_conversion(&source, &target, NULL, NULL, p->intent, flags);
+    conversion = dt_colorspaces_prepare_conversion(&source, &target, NULL, NULL, p->intent, flags);
   }
 
   _set_input_profile_metadata(d, p, type);
@@ -867,7 +875,7 @@ void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pix
                  dt_image_is_matrix_correction_supported(&pipe->dev->image_storage),
                  requested_type, type, d->blue_mapping);
 
-  if(IS_NULL_PTR(d->conversion))
+  if(IS_NULL_PTR(conversion))
   {
     dt_print(DT_DEBUG_COLORPROFILE, "[colorin] input profile could not be generated!\n");
     dt_control_log(_("input profile could not be generated!"));
@@ -877,12 +885,12 @@ void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pix
   }
 
   // Only the vectorised branch has a kernel; the lcms2 one is host-only.
-  if(!dt_colorspaces_conversion_is_matrix(d->conversion)) piece->process_cl_ready = 0;
+  if(!dt_colorspaces_conversion_is_matrix(conversion)) piece->process_cl_ready = 0;
 
   /* The pipe records what space it is being handed, which is the input profile's own
    * RGB -> XYZ, uncomposed -- not the conversion this module runs. */
   dt_colormatrix_t input_matrix_for_pipe = { { NAN } };
-  dt_colorspaces_conversion_source_matrix(d->conversion, input_matrix_for_pipe);
+  dt_colorspaces_conversion_source_matrix(conversion, input_matrix_for_pipe);
 
   dt_ioppr_set_pipe_input_profile_info(self->dev, pipe, d->type, d->filename, p->intent,
                                        input_matrix_for_pipe);
@@ -891,6 +899,8 @@ void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pix
    * copied out everything it needed, so the container's job ended when the conversion was
    * built. */
   dt_colorspaces_free_image_profile(image_profile);
+
+  d->conversion = conversion; // single publication, after the conversion is complete
 }
 
 void init_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)

--- a/src/iop/colorout.c
+++ b/src/iop/colorout.c
@@ -421,7 +421,11 @@ void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pix
   // we need to bypass the cache entirely in these modes.
   dt_iop_set_cache_bypass(self, (d->mode != DT_PROFILE_NORMAL));
 
-  dt_colorspaces_free_conversion(&d->conversion);
+  /* Detach-then-free, and build through a local below: same discipline as colorin, for the
+   * same reason (issues #1212/#1216 -- a mid-commit clobber of the published field). */
+  dt_colorspaces_conversion_t *stale_conversion = d->conversion;
+  d->conversion = NULL;
+  dt_colorspaces_free_conversion(&stale_conversion);
   /* Cleared here rather than beside each prepare below, so that every path which returns
    * without building a conversion -- a Lab output -- leaves a hashed prefix that says so. */
   d->conversion_id = 0;
@@ -558,10 +562,11 @@ void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pix
   if(force_lcms2) flags |= DT_CONVERSION_FORCE_LCMS2;
   if(d->mode == DT_PROFILE_GAMUTCHECK) flags |= DT_CONVERSION_GAMUTCHECK;
 
-  d->conversion = dt_colorspaces_prepare_conversion(&source, &target, NULL,
-                                                    softproofing ? &proof : NULL, out_intent, flags);
+  dt_colorspaces_conversion_t *conversion
+      = dt_colorspaces_prepare_conversion(&source, &target, NULL,
+                                          softproofing ? &proof : NULL, out_intent, flags);
 
-  if(IS_NULL_PTR(d->conversion))
+  if(IS_NULL_PTR(conversion))
   {
     /* Whatever the user asked for, we cannot render it. sRGB is the fallback that has always
      * been here; saying so out loud is the point, since the exported file will not be in the
@@ -573,20 +578,22 @@ void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pix
     target.filename = "";
     target.resolved = NULL;
     if(work_type == DT_COLORSPACE_NONE) source = target;
-    d->conversion = dt_colorspaces_prepare_conversion(&source, &target, NULL,
-                                                      softproofing ? &proof : NULL, out_intent, flags);
+    conversion = dt_colorspaces_prepare_conversion(&source, &target, NULL,
+                                                   softproofing ? &proof : NULL, out_intent, flags);
   }
 
   /* After BOTH prepare attempts: what the sRGB fallback built is what will render. */
-  d->conversion_id = dt_colorspaces_conversion_identity(d->conversion);
+  d->conversion_id = dt_colorspaces_conversion_identity(conversion);
 
   dt_colorspaces_free_image_profile(image_output);
 
   /* Only the vectorised branch has a kernel. The lcms2 one is host-only, and saying so here
    * is the whole of what `process_cl_ready` needs to know. */
-  if(!dt_colorspaces_conversion_is_matrix(d->conversion)) piece->process_cl_ready = 0;
+  if(!dt_colorspaces_conversion_is_matrix(conversion)) piece->process_cl_ready = 0;
 
   dt_ioppr_set_pipe_output_profile_info(self->dev, pipe, d->type, out_filename, p->intent);
+
+  d->conversion = conversion; // single publication, after the conversion is complete
 }
 
 gboolean runtime_data_hash(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe,


### PR DESCRIPTION
Follow-up to #1219, which was merged before this landed — I pushed this commit onto the already-merged branch by mistake, so it never reached master. Content is identical to what passed the full dispatched CI run there (all 22 checks, including a fresh `Win64.UCRT64.LLVM.skiptest.Release` runtime pass).

## What the second backtrace on #1216 proved

With symbols and locals, both field crashes show the same two properties:

1. **`d->conversion` is clobbered mid-commit.** `commit_params` assigned it from `prepare_conversion()`, NULL-checked it, and a few instructions later `source_matrix()` received a value that was neither NULL nor what was stored — `0x2dfeffd0` / `0x282dcfd0`, the same page offset in two different sessions. Systematic writer, invisible to #1219's node-level guard (which passed: piece, module and data were all valid).
2. **The bogus pointers have readable heads** — `is_matrix()` dereferenced them without faulting; only the deeper `source_matrix` read hit unmapped memory.

## Two fixes that hold regardless of who the writer is

**Publish once** — colorin and colorout commits build through a *local* pointer, read only the local, and store `d->conversion` exactly once at the end. Five re-read windows existed; now zero, and the final store self-heals a clobbered field. Stale values are detached-and-NULLed before freeing.

**Self-authenticating conversions** — `dt_colorspaces_conversion_t` carries a magic tag as its **first** field (checkable on exactly the bytes the observed pointers could read), stamped at creation, poisoned at free. All accessors refuse anything that is not a live conversion, logging pointer + tag + caller; `apply` falls back to a passthrough copy rather than leaving the destination unwritten; `free_conversion()` refuses to free a clobbered pointer — freeing garbage is how one bad field becomes heap corruption three modules away — and drops the reference instead.

If the clobber recurs, the crash becomes a **named log line carrying the bogus value** — the next report fingerprints the writer instead of `Magick: abort due to signal 11`. If it does not recur, the class is closed at the consumer boundary.

Verified inert under ASAN (the CI runtime test's own export on the repo's `ansel.png`, plus one RAW export through colorin's image-derived-profile path and colorout): zero sanitizer findings, zero refusals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)