### PR TITLE
Fix -t N (clobbered by GraphicsMagick), filmic's deprecation test and tiling plan, and guided_filter's vRAM fallback

### DIFF
--- a/src/darktable.c
+++ b/src/darktable.c
@@ -1612,6 +1612,18 @@ int dt_init(int argc, char *argv[], const gboolean init_gui, const gboolean load
 
 #endif
 
+#if(defined(HAVE_GRAPHICSMAGICK) || defined(HAVE_IMAGEMAGICK)) && defined(_OPENMP)
+  // *SIGH*, part two. GraphicsMagick's InitializeMagick() sizes its own thread pool from
+  // omp_get_num_procs() and publishes that by calling omp_set_num_threads() -- a PROCESS-wide
+  // side effect on a library-local decision. It runs after our own omp_set_num_threads() above,
+  // so it silently overrode `-t N` and the "CPU cores" preference for every parallel region
+  // entered from this thread afterwards. That is invisible in the GUI, where pixel work runs on
+  // control worker threads that set their own count in dt_control_work(), and total in ansel-cli,
+  // where the export pipeline runs on this very thread: `-t 1` still ran a full-width team.
+  // Re-assert ours last. Keep this call after EVERY library init that may do the same.
+  omp_set_num_threads(darktable.num_openmp_threads);
+#endif
+
   darktable.noiseprofile_parser = dt_noiseprofile_init(noiseprofiles_from_command);
 
   // The GUI must be initialized before the views, because the init()

--- a/src/iop/filmicrgb.c
+++ b/src/iop/filmicrgb.c
@@ -379,6 +379,11 @@ typedef struct dt_iop_filmicrgb_data_t
   int version;
   int spline_version;
   int high_quality_reconstruction;
+  // Whether this edit sits at the deprecation sentinel, decided from the RAW user parameter
+  // (see FILMIC_RECONSTRUCT_DEPRECATED). It cannot be re-derived from reconstruct_threshold
+  // above, which commit_params() has already mapped through the exposure scaling into scene
+  // units -- a legacy edit at the old +3 EV default lands well above the sentinel there.
+  gboolean hl_deprecated;
   float agx_beta_hue; // AgX: hue recovery mix [0, 1] — 0 at -100% (full AgX drift),
                       // 1 at +100% (original hue). Chroma is NOT user-controlled : it
                       // follows the bracket's own outset recovery + clamp only, because
@@ -2663,19 +2668,38 @@ static const dt_iop_order_iccprofile_info_t *_filmic_get_output_profile(const dt
 void tiling_callback(struct dt_iop_module_t *self, const struct dt_dev_pixelpipe_t *pipe, const struct dt_dev_pixelpipe_iop_t *piece, struct dt_develop_tiling_t *tiling)
 {
   const dt_iop_roi_t *const roi_in = &piece->roi_in;
+  const dt_iop_filmicrgb_data_t *const data = (const dt_iop_filmicrgb_data_t *)piece->data;
+
+  tiling->maxbuf = 1.0f;
+  tiling->maxbuf_cl = 1.0f;
+  tiling->overhead = 0;
+  tiling->xalign = 1;
+  tiling->yalign = 1;
+
+  // Once the deprecated highlights reconstruction is off -- which is the case for every new edit,
+  // the sentinel being the default -- process()/process_cl() allocate nothing beyond the input and
+  // the output: no mask, no inpainted copy, no reconstructed copy, and above all no wavelet
+  // decomposition. The tone mapping that remains is strictly pointwise, so there is no filter
+  // footprint to overlap tiles by either. Declaring the reconstruction's 9 buffers and its
+  // 2^scales overlap regardless is not a harmless over-estimate: on a 24 Mpx export it asks for
+  // ~3.3 GB of vRAM that will never be touched, which on a mid-range card exceeds what is free and
+  // demotes the whole module to the CPU -- measured 1.03 s CPU against 0.22 s on GPU for the very
+  // same pixels.
+  if(IS_NULL_PTR(data) || data->hl_deprecated)
+  {
+    tiling->factor = 2.0f; // in + out
+    tiling->factor_cl = 2.0f;
+    tiling->overlap = 0;
+    return;
+  }
+
   const int scales = get_scales(pipe, roi_in, piece);
   const int max_filter_radius = (1 << scales);
 
   // in + out + 2 * tmp + 2 * LF + 2 * temp + ratios
   tiling->factor = 9.0f;
   tiling->factor_cl = 9.0f;
-
-  tiling->maxbuf = 1.0f;
-  tiling->maxbuf_cl = 1.0f;
-  tiling->overhead = 0;
   tiling->overlap = max_filter_radius;
-  tiling->xalign = 1;
-  tiling->yalign = 1;
   return;
 }
 
@@ -2706,7 +2730,7 @@ int process(dt_iop_module_t *self, const dt_dev_pixelpipe_t *pipe, const dt_dev_
 
   // Deprecated highlights path (issue #1084): bypassed entirely and unconditionally -- not even the
   // mask buffer is allocated, let alone the full-frame mask pass. See FILMIC_RECONSTRUCT_DEPRECATED.
-  const gboolean hl_deprecated = (data->reconstruct_threshold >= FILMIC_RECONSTRUCT_DEPRECATED);
+  const gboolean hl_deprecated = data->hl_deprecated;
 
   float *const restrict mask
       = hl_deprecated ? NULL
@@ -3184,7 +3208,7 @@ int process_cl(struct dt_iop_module_t *self, const dt_dev_pixelpipe_t *pipe, con
 
   // Deprecated highlights path (issue #1084): bypassed entirely and unconditionally -- no flag
   // buffer, no mask image, no mask kernel, no readback. See FILMIC_RECONSTRUCT_DEPRECATED.
-  const gboolean hl_deprecated = (d->reconstruct_threshold >= FILMIC_RECONSTRUCT_DEPRECATED);
+  const gboolean hl_deprecated = d->hl_deprecated;
 
   uint32_t is_clipped = 0;
   if(!hl_deprecated)
@@ -4077,6 +4101,7 @@ void commit_params(dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pixelpipe_
   d->sigma_toe = powf(d->spline.latitude_min / 3.0f, 2.0f);
   d->sigma_shoulder = powf((1.0f - d->spline.latitude_max) / 3.0f, 2.0f);
 
+  d->hl_deprecated = (p->reconstruct_threshold >= FILMIC_RECONSTRUCT_DEPRECATED);
   d->reconstruct_threshold = powf(2.0f, white_source + p->reconstruct_threshold) * grey_source;
   d->reconstruct_feather = exp2f(12.f / p->reconstruct_feather);
 

--- a/src/pixel/guided_filter.c
+++ b/src/pixel/guided_filter.c
@@ -43,6 +43,7 @@
 #include "system/mem_alloc.h"
 #include "system/simd.h"
 #include "common/logging.h"
+#include "caches/pixelpipe_cache.h"
 #include "caches/pixelpipe_cache_alloc.h"
 #include "pixel/box_filters.h"
 #include "pixel/guided_filter.h"
@@ -768,7 +769,18 @@ int guided_filter_cl(int devid, cl_mem guide, cl_mem in, cl_mem out, const int w
   assert(ch >= 3);
   assert(w >= 1);
 
-  const gboolean fits = dt_opencl_image_fits_device(devid, width, height, sizeof(float), 18.0f, 0);
+  gboolean fits = dt_opencl_image_fits_device(devid, width, height, sizeof(float), 18.0f, 0);
+  if(!fits)
+  {
+    // What the device reports free is not what it can be made to have free: most of the
+    // "used" vRAM is the pixelpipe cache holding device copies nobody is reading right now.
+    // Reclaim the idle ones and ask again before writing off the GPU for this call -- the
+    // same flush-then-retry the pipeline itself does around its own per-module fit check.
+    // We are called from inside process_cl(), so the pipe already holds the device lock and
+    // this is the variant that expects the caller to hold it.
+    dt_dev_pixelpipe_cache_flush_clmem(devid);
+    fits = dt_opencl_image_fits_device(devid, width, height, sizeof(float), 18.0f, 0);
+  }
   if(!fits)
     dt_print(DT_DEBUG_OPENCL, "[guided filter] fall back to cpu implementation due to insufficient gpu memory\n");
 


### PR DESCRIPTION
Three independent fixes found while investigating the benchmark measurements in discussion #1218.

### 1. `-t N` and the "CPU cores" preference did nothing

`dt_init()` calls `omp_set_num_threads()` with our value, then calls `InitializeMagick()`, which sizes GraphicsMagick's own pool from `omp_get_num_procs()` and publishes that with a second `omp_set_num_threads()` — a process-wide side effect on a library-local decision. Traced with an `LD_PRELOAD` shim: `(2)`, then `(8)`, `(8)`, all on the main thread, the last two from `InitializeMagickResources()`.

Invisible in the GUI, where pixel work runs on control worker threads that set their own count in `dt_control_work()`. Total in `ansel-cli`, where the export pipeline runs on the main thread itself: `-t 1` reported "using 1 threads" and then ran an 8-wide team at 567 % CPU.

Fixed by re-asserting our count after the Magick init. Measured after, on a 4c/8t box — matching what `OMP_NUM_THREADS` already produced, which was the only working lever:

| `-t` | pipeline | total | %cpu |
|---|---|---|---|
| 1 | 24.26 s | 26.51 s | 100 % |
| 2 | 13.18 s | 15.12 s | 184 % |
| 4 | 8.08 s | 9.95 s | 321 % |
| 8 | 6.34 s | 8.07 s | 535 % |

Note `omp_set_num_threads()` only ever writes the *calling thread's* ICV, so this has to be re-asserted after any library init that does the same, not fixed once at the top.

### 2. filmic decided its deprecation from the wrong quantity, and over-reserved tiling buffers

The "is the highlights reconstruction deprecated?" test read `d->reconstruct_threshold`, which `commit_params()` has already mapped out of EV into scene units as `2^(white_point_source + p) * grey_source`. `FILMIC_RECONSTRUCT_DEPRECATED` is a value of the **raw** parameter. The two agree only by accident.

- **Wrong for legacy edits.** With a typical white point of 3.15 EV and 18.45 % grey, the scene-referred value crosses 16 at a stored threshold of about +3.3 EV, so an existing edit above that had its reconstruction silently skipped — while `gui_changed()`, which reads `p->reconstruct_threshold` correctly, kept showing the tab and its sliders. The crossing point moves with the white relative exposure slider, so dragging an unrelated control toggled the reconstruction on and off.
- **`tiling_callback()` never knew about the deprecation at all**, and declared 9 buffers plus a `2^scales` overlap unconditionally — though `process()`/`process_cl()` allocate nothing beyond input and output on that path, and the remaining tone mapping is pointwise. On a 45 Mpx export that was a 2949 MiB vRAM request for buffers no kernel touches; 921 MiB after, the one buffer actually needed. Not a harmless over-estimate: it fails the pre-check, and when the cache flush behind it cannot free enough, the module is demoted to the CPU — 1.03 s against 0.22 s for the same pixels.

Fixed by recording the decision in `commit_params()` as `dt_iop_filmicrgb_data_t.hl_deprecated`, straight from `p->reconstruct_threshold`, and reading that in all three places.

### 3. guided_filter wrote off the GPU without trying to reclaim

`guided_filter_cl()` asked for room for 18 buffers and fell back to the CPU on a no. Most of the "in use" vRAM is the pixelpipe cache holding device copies nobody is reading. `pixelpipe_gpu.c` already does flush-then-retry around its own per-module pre-check; this mirrors it. `pixel/` is layer 2 and `caches/` layer 1, so the new include is a downward edge.

### Verification

- Full build and `build-nofeatures` (the CI-mirrored configuration) both clean; 9/9 unit tests pass.
- `tools/check_layering.sh`: 0 cycles, 184 violations = baseline.
- Pixel-verified with `ansel-cli --disable-opencl`: an image whose stored threshold leaves filmic's reconstruction active exports **bit-identical** (0 of 72.7 M subpixels differ). A fresh edit differs only within this pipeline's pre-existing run-to-run noise — two runs of the *unmodified* binary on that file already differ by max 1 LSB on 5.9 M subpixels.

Fix 1 is a symptom of #1224 (GraphicsMagick hijacking process-global state); it becomes dead code if that dependency is removed.
