### PR TITLE
Allocate over-aligned structs with the aligned allocator — root cause of #1212/#1216

### DIFF
--- a/src/apps/ansel-chart/colorchart.c
+++ b/src/apps/ansel-chart/colorchart.c
@@ -137,6 +137,13 @@ void checker_set_color(box_t *box, dt_colorspaces_color_profile_type_t color_spa
   }
 }
 
+/* box_t embeds 64-aligned members and is allocated with dt_calloc_align; on Windows that
+ * memory must go back through _aligned_free, which dt_free_gpointer (plain g_free) is not. */
+static void _free_box_gpointer(gpointer ptr)
+{
+  dt_free_align_ptr(ptr);
+}
+
 static void free_labels_list(gpointer data)
 {
   g_list_free_full((GList *)data, dt_free_gpointer);
@@ -175,7 +182,7 @@ chart_t *parse_cht(const char *filename)
   // data gathered from the CHT file
   unsigned int n_boxes;
   result->d_table = g_hash_table_new_full(g_str_hash, g_str_equal, dt_free_gpointer, dt_free_gpointer);
-  result->box_table = g_hash_table_new_full(g_str_hash, g_str_equal, dt_free_gpointer, dt_free_gpointer);
+  result->box_table = g_hash_table_new_full(g_str_hash, g_str_equal, dt_free_gpointer, _free_box_gpointer);
   result->patch_sets = g_hash_table_new_full(g_str_hash, g_str_equal, dt_free_gpointer, free_labels_list);
 
   float x_min = FLT_MAX, x_max = FLT_MIN, y_min = FLT_MAX, y_max = FLT_MIN;
@@ -345,7 +352,7 @@ chart_t *parse_cht(const char *filename)
               last_label = label;
 
               // store it
-              box_t *box = calloc(1, sizeof(box_t));
+              box_t *box = dt_calloc_align(sizeof(box_t)); // box_t is 64-aligned, see #1212
               box->p.x = x;
               box->p.y = y;
               box->w = w;

--- a/src/apps/ansel-chart/main.c
+++ b/src/apps/ansel-chart/main.c
@@ -1515,7 +1515,7 @@ static box_t *find_patch(GHashTable *table, gpointer key)
   if(IS_NULL_PTR(patch))
   {
     // the patch won't be found in the first pass
-    patch = (box_t *)calloc(1, sizeof(box_t));
+    patch = (box_t *)dt_calloc_align(sizeof(box_t)); // goes into box_table, freed via _free_box_gpointer
     g_hash_table_insert(table, g_strdup(key), patch);
   }
   return patch;

--- a/src/caches/image_cache.c
+++ b/src/caches/image_cache.c
@@ -231,7 +231,8 @@ void dt_image_cache_allocate(void *data, dt_cache_entry_t *entry)
 {
   entry->cost = sizeof(dt_image_t);
 
-  dt_image_t *img = (dt_image_t *)g_malloc(sizeof(dt_image_t));
+  // dt_alloc_align: dt_image_t embeds dt_aligned_pixel_t members (alignof 64); see #1212.
+  dt_image_t *img = (dt_image_t *)dt_alloc_align(sizeof(dt_image_t));
   entry->data = img;
   dt_image_init(img);
   _image_cache_reload_from_db(img, entry->key, DT_SV_CREATE); // emits the create event
@@ -250,7 +251,7 @@ void dt_image_cache_deallocate(void *data, dt_cache_entry_t *entry)
   img->embedded_profile = NULL;
   g_list_free_full(img->dng_gain_maps, dt_free_gpointer);
   img->dng_gain_maps = NULL;
-  dt_free(img);
+  dt_free_align(img);
 }
 
 void dt_image_cache_init(const gboolean verbose)

--- a/src/colorprofiles/conversion.c
+++ b/src/colorprofiles/conversion.c
@@ -222,7 +222,12 @@ dt_colorspaces_conversion_t *dt_colorspaces_prepare_conversion(const dt_colorspa
 {
   if(IS_NULL_PTR(from) || IS_NULL_PTR(to)) return NULL;
 
-  dt_colorspaces_conversion_t *conversion = calloc(1, sizeof(dt_colorspaces_conversion_t));
+  /* dt_calloc_align, NOT calloc: this struct embeds dt_colormatrix_t members, whose declared
+   * 64-byte alignment the compiler is entitled to rely on with aligned vector loads. A plain
+   * calloc returns 16-aligned storage, and on any block that lands 16-mod-32 the first wide
+   * access to a matrix member faults -- issues #1212/#1216: all three field backtraces show a
+   * VALID conversion at an address = 16 (mod 32), crashing in conversion_source_matrix(). */
+  dt_colorspaces_conversion_t *conversion = dt_calloc_align(sizeof(dt_colorspaces_conversion_t));
   if(IS_NULL_PTR(conversion)) return NULL;
   conversion->magic = DT_CONVERSION_MAGIC_LIVE;
 
@@ -522,7 +527,7 @@ void dt_colorspaces_free_conversion(dt_colorspaces_conversion_t **conversion)
 
   for(int k = 0; k < c->n_owned; k++) dt_colorspaces_cleanup_profile(c->owned[k]);
 
-  free(c);
+  dt_free_align(c); // paired with dt_calloc_align: on Windows this memory is _aligned_malloc'd
   *conversion = NULL;
 }
 

--- a/src/common/colorchecker.c
+++ b/src/common/colorchecker.c
@@ -28,6 +28,7 @@
  * labeled as Dmin or GS0, and Dmax or GS23.
  */
 
+#include "system/mem_alloc.h"
 #include "colorchecker.h"
 #include "common/colorspaces_inline_conversions.h"
 #include "file_location.h"
@@ -236,7 +237,9 @@ static void _dt_colorchecker_chart_spec_cleanup(dt_colorchecker_chart_spec_t *ch
 
 static dt_color_checker_patch *_dt_colorchecker_patch_init()
 {
-  dt_color_checker_patch *patch = (dt_color_checker_patch *)malloc(sizeof(dt_color_checker_patch));
+  // dt_alloc_align: dt_color_checker_patch is 64-aligned (its array sibling above already
+  // allocates aligned); dt_colorchecker_patch_cleanup_list() frees with dt_free_align.
+  dt_color_checker_patch *patch = (dt_color_checker_patch *)dt_alloc_align(sizeof(dt_color_checker_patch));
   if(IS_NULL_PTR(patch)) return NULL;
 
   patch->name = NULL;

--- a/src/common/colorchecker.h
+++ b/src/common/colorchecker.h
@@ -496,7 +496,7 @@ static inline void dt_colorchecker_patch_cleanup_list(void *_patch)
   // Free the name if it was allocated
   dt_free(patch->name);
 
-  dt_free(patch);
+  dt_free_align(patch); // paired with the dt_alloc_align in _dt_colorchecker_patch_init()
 }
 
 static inline dt_color_checker_t *dt_colorchecker_init()

--- a/src/common/folder_survey.c
+++ b/src/common/folder_survey.c
@@ -13,6 +13,7 @@
     GNU General Public License for more details.
 */
 
+#include "system/mem_alloc.h"
 #include "common/folder_survey.h"
 #include "control/settings.h"
 #include <glib/gstdio.h>
@@ -624,7 +625,7 @@ char *dt_folder_survey_destination_preview()
     }
 
     char datetime_check[DT_DATETIME_LENGTH] = { 0 };
-    dt_image_t *img = malloc(sizeof(dt_image_t));
+    dt_image_t *img = dt_alloc_align(sizeof(dt_image_t)); // dt_image_t is 64-aligned, see #1212
     if(dt_datetime_entry_to_exif(datetime_check, sizeof(datetime_check), date) && !IS_NULL_PTR(img))
     {
       dt_image_init(img);
@@ -678,7 +679,7 @@ char *dt_folder_survey_destination_preview()
       dt_free(example);
       dt_control_import_data_free(&data);
     }
-    dt_free(img);
+    dt_free_align(img);
   }
 
   dt_free(folder);

--- a/src/common/noiseprofiles.c
+++ b/src/common/noiseprofiles.c
@@ -349,7 +349,8 @@ GList *dt_noiseprofile_get_matching(const dt_image_t *cimg)
             json_reader_end_element(reader);
 
             // everything worked out, add tmp_profile to result
-            dt_noiseprofile_t *new_profile = (dt_noiseprofile_t *)malloc(sizeof(dt_noiseprofile_t));
+            // dt_alloc_align: dt_noiseprofile_t is 64-aligned; dt_noiseprofile_free() pairs with it.
+  dt_noiseprofile_t *new_profile = (dt_noiseprofile_t *)dt_alloc_align(sizeof(dt_noiseprofile_t));
             *new_profile = tmp_profile;
             result = g_list_prepend(result, new_profile);
 
@@ -383,7 +384,7 @@ void dt_noiseprofile_free(gpointer data)
   dt_free(profile->name);
   dt_free(profile->maker);
   dt_free(profile->model);
-  dt_free(profile);
+  dt_free_align(profile);
 }
 
 void dt_noiseprofile_interpolate(

--- a/src/control/jobs/import_jobs.c
+++ b/src/control/jobs/import_jobs.c
@@ -15,6 +15,7 @@
     You should have received a copy of the GNU General Public License
     along with Ansel.  If not, see <http://www.gnu.org/licenses/>.
 */
+#include "system/mem_alloc.h"
 #include "common/conf.h"
 #include "import_jobs.h"
 #include "common/collection.h"
@@ -256,7 +257,7 @@ int _import_copy_txt(const char *const filename, const char *dest_file_path)
  */
 int _import_copy_file(const char *const filename, const int index, dt_control_import_t *data, gchar *img_path_to_db, size_t pathname_len, GList **discarded)
 {
-  dt_image_t *img = malloc(sizeof(dt_image_t));
+  dt_image_t *img = dt_alloc_align(sizeof(dt_image_t)); // dt_image_t is 64-aligned, see #1212
   dt_image_init(img);
 
   // Generate file I/O only if the pattern is using EXIF variables.
@@ -271,7 +272,7 @@ int _import_copy_file(const char *const filename, const int index, dt_control_im
 
   gchar *dest_file_path = dt_build_filename_from_pattern(filename, index, img, data);
   dt_print(DT_DEBUG_IMPORT, "[Import] Image %s will be copied into %s\n", filename, dest_file_path);
-  dt_free(img);
+  dt_free_align(img);
 
   int process = TRUE;
   int copied = 0;

--- a/src/gui/import.c
+++ b/src/gui/import.c
@@ -20,6 +20,7 @@
     along with Ansel.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#include "system/mem_alloc.h"
 #include "common/film.h"
 #include "caches/pixelpipe_cache_alloc.h"
 #include "common/file_location.h"
@@ -701,7 +702,7 @@ static void update_preview_cb(GtkFileChooser *file_chooser, gpointer userdata)
     dt_free(d->path_file);
     d->path_file = g_strdup(filename);
 
-    img = malloc(sizeof(dt_image_t));
+    img = dt_alloc_align(sizeof(dt_image_t)); // dt_image_t is 64-aligned, see #1212
     dt_image_init(img);
     if(!(file_type & DT_IMAGE_HDR))
       valid_exif = dt_exif_read(img, filename);
@@ -788,7 +789,7 @@ static void update_preview_cb(GtkFileChooser *file_chooser, gpointer userdata)
 
   dt_free(filename);
   dt_free(uri);
-  dt_free(img);
+  dt_free_align(img);
 }
 
 static void _update_directory(GtkWidget *file_chooser, dt_lib_import_t *d)
@@ -855,7 +856,7 @@ static void _set_test_path(dt_lib_import_t *d, dt_image_t *img)
     gboolean free_after = FALSE;
     if(IS_NULL_PTR(img))
     {
-      img = malloc(sizeof(dt_image_t));
+      img = dt_alloc_align(sizeof(dt_image_t)); // dt_image_t is 64-aligned, see #1212
       dt_image_init(img);
 
       // Generate file I/O only if the pattern is using EXIF variables.
@@ -874,7 +875,7 @@ static void _set_test_path(dt_lib_import_t *d, dt_image_t *img)
 
     if(free_after)
     {
-      dt_free(img);
+      dt_free_align(img);
     }
 
     if(fake_path && fake_path[0] != 0)


### PR DESCRIPTION
Fixes #1212, fixes #1216 — the actual root cause, proven by the third backtrace.

## Diagnosis

sahlirc's third trace ran a build **with** #1222's validity tag and single-publication commit. The locals show the bad pointer in the **local** variable, fresh from `dt_colorspaces_prepare_conversion()`, with the magic check **passed** — a fully valid, live conversion — and the ~550-byte struct fits in one page, so the faulting memcpy cannot have touched unmapped memory. Then the three crash addresses across three independent sessions:

| trace | address | mod 32 |
|---|---|---|
| #1216 first | `0x2dfeffd0` | **16** |
| #1216 second | `0x282dcfd0` | **16** |
| #1216 third | `0x30098a30` | **16** |

`dt_colormatrix_t` is `DT_ALIGNED_ARRAY` → **alignof 64**. Any struct embedding one by value inherits that alignment, and the compiler is entitled to emit **aligned vector moves** for its matrix members. `prepare_conversion()` allocated with plain `calloc`, which guarantees **16**. Every block that lands 16-mod-32 faults with #GP (reported as SIGSEGV) on the first wide access; every block that lands 0-mod-32 works.

That single fact explains the entire three-day hunt: intermittent (heap-phase coin flip), rate moving between ~12% and ~75% with unrelated commits (allocation history reshuffles the phase), Windows-heavy (that toolchain emitted aligned moves at this site; the Linux builds happened not to), unbisectable (the good/bad signal is the coin flip, not the code), invisible to ASAN (alignment is UBSan's department), and immune to both prior hardening layers (the pointer was *valid* — its address was illegal).

## Fix: the class, not the instance

Every plain allocation of a type that embeds `dt_colormatrix_t` or `dt_aligned_pixel_t` **by value**, found by walking struct definitions transitively — ten sites, each switched together with its **paired free** (on Windows `dt_alloc_align` memory is `_aligned_malloc`'d and must go back through `dt_free_align`):

- `colorprofiles/conversion.c` — the crashing one
- `caches/image_cache.c`, `common/folder_survey.c`, `control/jobs/import_jobs.c`, `gui/import.c` (×2) — `dt_image_t`
- `common/colorchecker.c`/`.h` — `dt_color_checker_patch` (its array sibling already allocated aligned — someone met this class before)
- `common/noiseprofiles.c` — `dt_noiseprofile_t`
- `apps/ansel-chart` (×2) — `box_t`, plus its hash-table destructor

## Verified

`-fsanitize=alignment` in trap mode (no libubsan needed): the CI runtime export and a RAW export both complete with **zero traps** — any remaining misaligned access on those paths would have SIGILL'd instantly.

## On the create-vs-cache design question

Conversions were never long-lived — they are rebuilt on every `commit_params` and freed on the next. Lifetime was never the trade at stake; the object's **address** was illegal. The long-lived caches (profile list, LUT memo) appear in none of the three traces. No architectural change needed — and per-use recreation of the prepared transforms would cost 2.2–38 ms per rebuild ×tiles (the measured numbers that motivated the memo), for a bug that was never theirs.

sahlirc has been asked to confirm on the machine that reproduces best.

🤖 Generated with [Claude Code](https://claude.com/claude-code)