### PR TITLE
macOS packaging: crop the icons with sips, not GraphicsMagick's CLI

### DIFF
--- a/packaging/macosx/3_make_hb_ansel_package.sh
+++ b/packaging/macosx/3_make_hb_ansel_package.sh
@@ -25,8 +25,7 @@
 #               $ export CODECERT="developer@apple.id"
 #               The mail address is the email/id of your developer certificate.
 
-#   
- Exit in case of error
+# Exit in case of error
 set -e -o pipefail
 trap 'echo "${BASH_SOURCE[0]}{${FUNCNAME[0]}}:${LINENO}: Error: command \`${BASH_COMMAND}\` failed with exit code $?"' ERR
 
@@ -335,23 +334,29 @@ cp fonts/*  "$dtResourcesDir"/fonts/
 sed -i -e '/ansel-macos-strip/d' "$dtResourcesDir"/share/ansel/themes/ansel.css
 
 # Create Icon file
+#
+# The icon is rendered larger than the target and then cropped to the centre, which trims the
+# padding the SVG carries: every offset below is exactly (rendered - target)/2. That used to be
+# `gm mogrify -crop WxH+X+Y`, from GraphicsMagick, which is no longer a dependency of Ansel and so
+# is no longer installed on the build host. `sips` ships with macOS and its -c crops centred, so
+# it is an exact replacement rather than an approximation -- and it adds no dependency back.
 if [ -d "$buildDir"/Icons.iconset ]; then
     rm -R "$buildDir/Icons.iconset"
 fi
 mkdir "$buildDir"/Icons.iconset
 rsvg-convert -h 644 ../../data/pixmaps/scalable/ansel.svg > "$buildDir/Icons.iconset/icon_512x512.png"
-gm mogrify -crop 512x512+66+66 "$buildDir/Icons.iconset/icon_512x512.png"
+sips -c 512 512 "$buildDir/Icons.iconset/icon_512x512.png"
 cp  "$buildDir/Icons.iconset/icon_512x512.png" "$buildDir/Icons.iconset/icon_256x256@2.png"
 rsvg-convert -h 322 ../../data/pixmaps/scalable/ansel.svg > "$buildDir/Icons.iconset/icon_256x256.png"
-gm mogrify -crop 256x256+33+33 "$buildDir/Icons.iconset/icon_256x256.png"
+sips -c 256 256 "$buildDir/Icons.iconset/icon_256x256.png"
 cp  "$buildDir/Icons.iconset/icon_256x256.png" "$buildDir/Icons.iconset/icon_128x128@2.png"
 rsvg-convert -h 162 ../../data/pixmaps/scalable/ansel.svg > "$buildDir/Icons.iconset/icon_128x128.png"
-gm mogrify -crop 128x128+17+17 "$buildDir/Icons.iconset/icon_128x128.png"
+sips -c 128 128 "$buildDir/Icons.iconset/icon_128x128.png"
 rsvg-convert -h 40 ../../data/pixmaps/scalable/ansel.svg > "$buildDir/Icons.iconset/icon_32x32.png"
-gm mogrify -crop 32x32+4+4 "$buildDir/Icons.iconset/icon_32x32.png"
+sips -c 32 32 "$buildDir/Icons.iconset/icon_32x32.png"
 cp  "$buildDir/Icons.iconset/icon_32x32.png" "$buildDir/Icons.iconset/icon_16x168@2.png"
 rsvg-convert -h 20 ../../data/pixmaps/scalable/ansel.svg > "$buildDir/Icons.iconset/icon_16x16.png"
-gm mogrify -crop 16x16+2+2 "$buildDir/Icons.iconset/icon_16x16.png"
+sips -c 16 16 "$buildDir/Icons.iconset/icon_16x16.png"
 if [ -f "$buildDir/Icons.icns" ]; then
     rm "$buildDir/Icons.icns"
 fi


### PR DESCRIPTION
Fixes the macOS nightly, broken since #1229:

```
./src/packaging/macosx/3_make_hb_ansel_package.sh: line 343: gm: command not found
```

### What I missed

Removing GraphicsMagick took the `graphicsmagick` formula off the macOS build host, and `3_make_hb_ansel_package.sh` still shelled out to **`gm mogrify`** five times to crop the app icons.

I audited that removal for *linkage* — `nm -D`, `ldd`, `find_package` — and never checked for **shell-outs to the CLI**. No CI job builds the macOS package, only the nightly does, so nothing caught it before merge. Linux and Windows nightlies are green; this is macOS-only.

### The fix

Every one of those crops is a **centre crop**. The icon is rendered larger than the target so the padding carried in the SVG can be trimmed, and each offset is exactly `(rendered - target) / 2`:

| rendered | crop | offset | (rendered−target)/2 |
|---|---|---|---|
| `-h 644` | 512×512 | +66+66 | 66 |
| `-h 322` | 256×256 | +33+33 | 33 |
| `-h 162` | 128×128 | +17+17 | 17 |
| `-h 40` | 32×32 | +4+4 | 4 |
| `-h 20` | 16×16 | +2+2 | 2 |

(The SVG is square — `width="40" height="40"`, square viewBox — so a centred crop is well defined.)

`sips` ships with macOS and its `-c` crops centred, so **`sips -c H W` is an exact replacement here**, not an approximation. It also brings no dependency back. Re-adding `graphicsmagick` to the build host would have worked too, but only by reinstating the thing that was just removed — for five icon crops the OS can do itself.

### Also

A pre-existing typo two lines up: a stray newline had separated `#` from `Exit in case of error`, so every macOS build logged `Exit: command not found`. Harmless — it runs before `set -e` takes effect — but it is noise in the one log anybody reads when the build breaks. Confirmed it predates all of this (identical at `c326ab4a06`) and comes from `b694efb288 "Revert 30393398db"`.

### Verification

`bash -n` passes. **Cannot be verified locally** — `sips` is macOS-only — so the nightly is the test. I also swept `packaging/`, `.ci/`, `.github/` and `tools/` for other shell-outs to removed tools: the only remaining ones are `hdiutil convert` (a macOS built-in, unrelated) and `tools/basecurve/ansel-curve-tool-helper` + `tools/noise/subr.sh`, which use ImageMagick's `convert` but are standalone contributor scripts, not built by any packaging job (`BUILD_CURVE_TOOLS=OFF`, and the noise tools' CMake has no magick dependency — the Linux AppImage builds them fine, as its green nightly shows).
