### PR TITLE
CI: probe OpenCL on the macOS Release build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -385,3 +385,48 @@ jobs:
                  --conf worker_threads=4 -t 4 \
                  --conf plugins/lighttable/export/force_lcms2=FALSE \
                  --conf plugins/lighttable/export/iccintent=0
+      - name: Probe OpenCL
+        # Nothing else in CI ever initialises OpenCL: every ansel-cli invocation in this file
+        # passes --disable-opencl, so device enumeration and kernel building are untested on
+        # every platform. ansel-cltest exists precisely for this -- it forces `-d opencl`, runs
+        # dt_init(), and that enumerates devices and builds every .cl program.
+        #
+        # This is NOT the same check as TESTBUILD_OPENCL_PROGRAMS. That one compiles the kernel
+        # sources with clang's OpenCL frontend, which proves the source is valid OpenCL C. It
+        # cannot see a driver refusing an already-valid program -- which is exactly the reported
+        # macOS failure, where Apple's OpenCL-over-Metal shim answers
+        # "createKernel: newComputePipelineState failed" and Ansel then disables OpenCL entirely.
+        #
+        # Informational on purpose, for now. Whether a GitHub macOS runner exposes a usable
+        # OpenCL device at all is unknown -- these are VMs -- and a gate that fails on "no device"
+        # would simply be red forever. Once a few runs show what the hardware reports, the
+        # classification below becomes the gate.
+        #
+        # Two details this has to get right to mean anything:
+        #  - a COLD cache. With a warm --cachedir, dt_opencl_load_program() loads cached binaries
+        #    and compiles nothing, so the probe would pass while testing nothing at all.
+        #  - parse the output, not the exit status. ansel-cltest exits 0 whether OpenCL worked or
+        #    not: dt_init() succeeds regardless, and a failed OpenCL init merely disables OpenCL.
+        if: ${{ matrix.btype == 'Release' }}
+        continue-on-error: true
+        run: |
+          probe="$(mktemp -d)"
+          "${INSTALL_PREFIX}/bin/ansel-cltest" \
+                 --configdir "${probe}/config" --cachedir "${probe}/cache" \
+                 > "${probe}/cltest.log" 2>&1 || true
+          echo "----- ansel-cltest output -----"
+          cat "${probe}/cltest.log"
+          echo "-------------------------------"
+
+          if grep -q "failed to compile program" "${probe}/cltest.log"; then
+            grep -o "failed to compile program '[^']*'" "${probe}/cltest.log" | sort -u
+            echo "::warning title=OpenCL kernels failed to build::A driver refused one or more kernels; see the list above."
+            exit 1
+          elif grep -q "newComputePipelineState failed" "${probe}/cltest.log"; then
+            echo "::warning title=Apple OpenCL shim rejected a kernel::newComputePipelineState failed -- the Metal translation layer could not build a kernel."
+            exit 1
+          elif grep -q "opencl is AVAILABLE" "${probe}/cltest.log"; then
+            echo "::notice title=OpenCL usable on this runner::Every kernel built. This runner can gate OpenCL regressions."
+          else
+            echo "::notice title=No OpenCL device on this runner::Nothing was compiled, so this run proves nothing about the kernels."
+          fi


### PR DESCRIPTION
Adds an OpenCL probe to the macOS **Release** job in CI. Follow-up to discussion #1218.

### Why nothing catches this today

**No CI job has ever initialised OpenCL.** Every `ansel-cli` invocation in `ci.yml` and in the nightlies passes `--disable-opencl` (lines 154, 313, 384, and mac-nightly 120). Device enumeration and kernel building are untested on every platform, so a driver that refuses one of our kernels reaches users unremarked.

That is precisely what #1218 reports: Apple's OpenCL-over-Metal shim answers `createKernel: newComputePipelineState failed`, Ansel disables OpenCL entirely, and the GPU sits idle with nothing but one line in the log to say so.

**`TESTBUILD_OPENCL_PROGRAMS` does not cover this, and structurally cannot.** It compiles the `.cl` sources with clang's OpenCL frontend, which proves they are valid OpenCL C. It never asks a *driver* to build them, so it is blind to a driver rejecting a program that is perfectly well-formed — which is the entire failure mode here.

### Why this needs almost no new machinery

`ansel-cltest` already does the work: it forces `-d opencl`, calls `dt_init()`, and that enumerates devices and builds every kernel. It is already built and installed on macOS (`install(TARGETS ansel-cltest ...)`), and the macOS builds already compile OpenCL in — `.ci/ci-script-mac.sh` never disables it and `USE_OPENCL` defaults ON. All that was missing was something to run it.

### Informational on purpose

Whether a GitHub macOS runner exposes a usable OpenCL device **is unknown** — they are VMs, and I can't verify from outside. A gate that failed on "no device" would be red forever while proving nothing, so the step classifies what it finds and annotates the run:

| Finding | Result |
|---|---|
| `failed to compile program 'X'` | lists the programs, warning annotation, soft-fail |
| `newComputePipelineState failed` | warning annotation, soft-fail — the Apple shim marker |
| `opencl is AVAILABLE` | notice: this runner can gate OpenCL regressions |
| neither | notice: nothing was compiled, this run proves nothing |

Once a few runs show what the hardware actually reports, that classification becomes the gate.

### Two details that would otherwise make it pass vacuously

1. **A cold cache.** With a warm `--cachedir`, `dt_opencl_load_program()` loads cached binaries and compiles nothing — the probe would pass while testing nothing at all. It runs against a throwaway config and cache directory from `mktemp -d`.
2. **Parse the output, not the exit status.** `ansel-cltest` exits 0 whether OpenCL worked or not: `dt_init()` succeeds regardless, and a failed OpenCL init merely disables OpenCL.

### Verification

`ci.yml` parses; the step is confirmed to sit in the `macOS` job under `if: matrix.btype == 'Release'` with `continue-on-error: true`, and the extracted `run:` script passes `bash -n`. The real test is the first run on this PR — which is rather the point.
