### PR TITLE
Fix the macOS build: an enum is not an int in C++

### DIFF
--- a/src/widgets/widget_settings.h
+++ b/src/widgets/widget_settings.h
@@ -316,8 +316,11 @@ static inline gboolean dt_modifier_is(GdkModifierType state, const GdkModifierTy
   // widgets/accelerators.c for the same dedup on the accelerator-dispatch path). Mouse/scroll
   // events never carry GDK_META_MASK, so this is a no-op for the majority of this function's
   // callers; it only matters for the callers that read a real GdkEventKey.state directly.
+  /* Cast, not a compound assignment: this header is included from C++ translation units
+   * too (iop/lens.cc, iop/tonemap.cc, imageio/format/exr.cc, ...), and in C++ the operand
+   * `~GDK_META_MASK` is an int, which cannot be assigned back into an enum. */
   if((state & GDK_MOD2_MASK) && (state & GDK_META_MASK))
-    state &= ~GDK_META_MASK;
+    state = (GdkModifierType)(state & ~GDK_META_MASK);
 #endif
   return (state & modifiers) == dt_modifier_primary_mask(desired_modifier_mask);
 }
@@ -328,9 +331,9 @@ static inline gboolean dt_modifiers_include(GdkModifierType state, const GdkModi
   const GdkModifierType modifiers = gtk_accelerator_get_default_mod_mask();
   const GdkModifierType wanted = dt_modifier_primary_mask(desired_modifier_mask);
 #ifdef GDK_WINDOWING_QUARTZ
-  // See dt_modifier_is() just above.
+  // See dt_modifier_is() just above, cast included.
   if((state & GDK_MOD2_MASK) && (state & GDK_META_MASK))
-    state &= ~GDK_META_MASK;
+    state = (GdkModifierType)(state & ~GDK_META_MASK);
 #endif
   return (state & (modifiers & wanted)) == wanted;
 }


### PR DESCRIPTION
Master is red on all three macOS jobs, and is failing every open PR's macOS matrix with it.

`accels: make macOS Cmd act as the Primary shortcut key` (8d960e6a23) added `state &= ~GDK_META_MASK` to the two inline predicates in `widgets/widget_settings.h`. In C that is ordinary; in C++ `~GDK_META_MASK` is an `int` and cannot be assigned back into a `GdkModifierType`, so every C++ translation unit reaching this header through `widgets/bauhaus.h` fails to compile — `iop/lens.cc`, `iop/tonemap.cc`, `iop/bilateral.cc`, `imageio/format/exr.cc` and the rest.

Only macOS shows it: the statements sit inside `#ifdef GDK_WINDOWING_QUARTZ`, so no other platform compiles them at all.

Fixed by casting the result back instead of compound-assigning, which compiles as both C and C++.

**Verified** by extracting both functions with the quartz guard stripped and compiling them on Linux under `gcc` and `g++` with `-Werror` — the only way to exercise that branch without a Mac. The pre-fix form reproduces the exact CI error there; the post-fix form compiles clean in both languages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)