### PR TITLE
lens: compile the module as C, and let a camera's own profile drive the same pixel code

### DIFF
--- a/data/CMakeLists.txt
+++ b/data/CMakeLists.txt
@@ -280,7 +280,7 @@ install(FILES ansel.bash DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/ansel COMPONEN
 # from "the system database" found nothing and failed the build.
 #
 # Falls back to the system database when the fetch is off or fails, and if neither can
-# produce a database the build still succeeds -- iop/lens.cc reports the database as
+# produce a database the build still succeeds -- iop/lens.c reports the database as
 # unavailable and the module disables itself, the same way rawdenoiseai does without its
 # model. Shipping no lens corrections is bad; failing a release build over a network hiccup
 # is worse.

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -46,7 +46,7 @@ build/src/iop/introspection_highlights.c
 build/src/iop/introspection_highpass.c
 build/src/iop/introspection_hotpixels.c
 build/src/iop/introspection_invert.c
-build/src/iop/introspection_lens.cc
+build/src/iop/introspection_lens.c
 build/src/iop/introspection_levels.c
 build/src/iop/introspection_liquify.c
 build/src/iop/introspection_lowlight.c
@@ -251,7 +251,7 @@ src/iop/highlights.c
 src/iop/highpass.c
 src/iop/hotpixels.c
 src/iop/invert.c
-src/iop/lens.cc
+src/iop/lens.c
 src/iop/levels.c
 src/iop/liquify.c
 src/iop/lowlight.c

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -817,7 +817,7 @@ target_link_libraries(lib_ansel PRIVATE lib_ansel_imageio_rawspeed)
 target_link_libraries(lib_ansel PRIVATE lib_ansel_imageio_libraw)
 target_link_libraries(lib_ansel PRIVATE whereami)
 target_link_libraries(lib_ansel PRIVATE lensserious)
-# ... and the calibration reader. iop/lens.cc resolves a lens through it, so the symbols
+# ... and the calibration reader. iop/lens.c resolves a lens through it, so the symbols
 # have to be in lib_ansel: the plugin links the headers only (src/iop/CMakeLists.txt).
 if(TARGET lensserious_db)
   target_link_libraries(lib_ansel PRIVATE lensserious_db)

--- a/src/iop/CMakeLists.txt
+++ b/src/iop/CMakeLists.txt
@@ -225,7 +225,7 @@ add_iop(diffuse "diffuse.c")
 add_iop(blurs "blurs.c")
 add_iop(initialscale "initialscale.c")
 add_iop(watermark "watermark.c")
-add_iop(lens "lens.cc" DEFAULT_VISIBLE)
+add_iop(lens "lens.c" DEFAULT_VISIBLE)
 target_link_libraries(lens PRIVATE lensserious) # headers; symbols come via lib_ansel
 if(TARGET lensserious_db)
   target_link_libraries(lens PRIVATE lensserious_db) # ditto, for the calibration reader

--- a/src/iop/lens.c
+++ b/src/iop/lens.c
@@ -107,7 +107,6 @@
 #include "lensserious.h"    // side-by-side latch against lensfun, see feat/lensserious
 #include "lensserious_db.h" // ... and its calibration database, latched the same way
 
-extern "C" {
 
 /* The correction axes and the projection numbering.
  *
@@ -142,7 +141,7 @@ typedef enum dt_lens_type_t
   DT_LENS_FISHEYE_THOBY = 8,
 } dt_lens_type_t;
 
-static_assert((int)DT_LENS_RECTILINEAR == (int)LS_LENS_RECTILINEAR
+_Static_assert((int)DT_LENS_RECTILINEAR == (int)LS_LENS_RECTILINEAR
                   && (int)DT_LENS_FISHEYE == (int)LS_LENS_FISHEYE
                   && (int)DT_LENS_PANORAMIC == (int)LS_LENS_PANORAMIC
                   && (int)DT_LENS_EQUIRECTANGULAR == (int)LS_LENS_EQUIRECTANGULAR
@@ -244,28 +243,49 @@ typedef struct dt_iop_lensfun_global_data_t
  * it is open. A per-thread cache of the last answer serves that exactly, with no lock and
  * no unbounded growth, where a shared table would need a mutex back.
  * ------------------------------------------------------------------------------------ */
-namespace
+typedef struct _ls_tls_t
 {
-struct _ls_tls_t
+  ls_db_t *db;
+  gboolean tried;
+
+  char cam_key[512];
+  ls_camera_t cam;
+  gboolean cam_found;
+  gboolean cam_cached;
+
+  char lens_key[512];
+  long long lens_id;
+  gboolean lens_cached;
+} _ls_tls_t;
+
+/* Closed when the thread that opened it exits, which is the whole reason this is a GPrivate
+ * and not a plain __thread pointer: the handle has to be RELEASED, and nothing else in C
+ * runs code at thread exit. iop/drawlayer.c holds its per-thread scratch buffers the same
+ * way, for the same reason. */
+static void _ls_tls_free(gpointer data)
 {
-  ls_db_t *db = nullptr;
-  bool tried = false;
+  _ls_tls_t *tls = (_ls_tls_t *)data;
+  if(IS_NULL_PTR(tls)) return;
+  if(!IS_NULL_PTR(tls->db)) ls_db_close(tls->db);
+  dt_free(tls);
+}
 
-  char cam_key[512] = { 0 };
-  ls_camera_t cam = {};
-  bool cam_found = false;
-  bool cam_cached = false;
+static GPrivate _ls_tls_key = G_PRIVATE_INIT(_ls_tls_free);
 
-  char lens_key[512] = { 0 };
-  long long lens_id = -1;
-  bool lens_cached = false;
+/** @brief This thread's cache block, allocated on first use. NULL only if that allocation
+ *  failed, in which case every caller below degrades to "no database" rather than crashing. */
+static _ls_tls_t *_ls_tls_get(void)
+{
+  _ls_tls_t *tls = (_ls_tls_t *)g_private_get(&_ls_tls_key);
+  if(!IS_NULL_PTR(tls)) return tls;
 
-  ~_ls_tls_t()
-  {
-    if(db) ls_db_close(db);
-  }
-};
-thread_local _ls_tls_t _ls_tls;
+  tls = (_ls_tls_t *)g_malloc0(sizeof(_ls_tls_t));
+  if(IS_NULL_PTR(tls)) return NULL;
+  /* The only field whose zeroed value is not the right one: -1 is "no lens", 0 is a
+   * perfectly good row id. */
+  tls->lens_id = -1;
+  g_private_set(&_ls_tls_key, tls);
+  return tls;
 }
 
 /**
@@ -278,57 +298,63 @@ thread_local _ls_tls_t _ls_tls;
  */
 static ls_db_t *_ls_db(void)
 {
-  if(_ls_tls.tried) return _ls_tls.db;
-  _ls_tls.tried = true;
+  _ls_tls_t *tls = _ls_tls_get();
+  if(IS_NULL_PTR(tls)) return NULL;
+
+  if(tls->tried) return tls->db;
+  tls->tried = TRUE;
 
   char dir[PATH_MAX] = { 0 };
   char path[PATH_MAX] = { 0 };
 
   dt_loc_get_user_config_dir(dir, sizeof(dir));
   snprintf(path, sizeof(path), "%s/lenses.db", dir);
-  _ls_tls.db = ls_db_open(path);
+  tls->db = ls_db_open(path);
 
-  if(IS_NULL_PTR(_ls_tls.db))
+  if(IS_NULL_PTR(tls->db))
   {
     dt_loc_get_datadir(dir, sizeof(dir));
     snprintf(path, sizeof(path), "%s/lenses.db", dir);
-    _ls_tls.db = ls_db_open(path);
+    tls->db = ls_db_open(path);
   }
 
-  if(IS_NULL_PTR(_ls_tls.db))
+  if(IS_NULL_PTR(tls->db))
     dt_print(DT_DEBUG_ALWAYS,
              "[lens] no calibration database: looked for lenses.db in the config directory"
              " and in `%s'\n", dir);
   else
     dt_print(DT_DEBUG_PIPE, "[lens] opened `%s' (schema v%d)\n", path,
-             ls_db_schema_version(_ls_tls.db));
+             ls_db_schema_version(tls->db));
 
-  return _ls_tls.db;
+  return tls->db;
 }
 
 /** @brief The camera an EXIF maker/model names. @return TRUE when found. */
 static gboolean _ls_find_camera(const char *maker, const char *model, ls_camera_t *out)
 {
   if(IS_NULL_PTR(model) || !model[0]) return FALSE;
+  /* _ls_db() has already established that this thread has a cache block; it cannot have
+   * returned a database without one. */
+  _ls_tls_t *tls = _ls_tls_get();
   ls_db_t *db = _ls_db();
-  if(IS_NULL_PTR(db)) return FALSE;
+  if(IS_NULL_PTR(db) || IS_NULL_PTR(tls)) return FALSE;
 
   char key[512];
   snprintf(key, sizeof(key), "%s\x1f%s", maker ? maker : "", model);
-  if(_ls_tls.cam_cached && !strcmp(key, _ls_tls.cam_key))
+  if(tls->cam_cached && !strcmp(key, tls->cam_key))
   {
-    if(_ls_tls.cam_found) *out = _ls_tls.cam;
-    return _ls_tls.cam_found ? TRUE : FALSE;
+    if(tls->cam_found) *out = tls->cam;
+    return tls->cam_found ? TRUE : FALSE;
   }
 
   ls_camera_t cam;
   /* A miss is cached too: it costs a lookup to establish and it will not change. */
   const gboolean found = (ls_db_find_camera(db, maker, model, &cam) == 1) ? TRUE : FALSE;
 
-  g_strlcpy(_ls_tls.cam_key, key, sizeof(_ls_tls.cam_key));
-  _ls_tls.cam = cam;
-  _ls_tls.cam_found = (found == TRUE);
-  _ls_tls.cam_cached = true;
+  g_strlcpy(tls->cam_key, key, sizeof(tls->cam_key));
+  tls->cam = cam;
+  tls->cam_found = found;
+  tls->cam_cached = TRUE;
 
   if(found) *out = cam;
   return found;
@@ -345,20 +371,21 @@ static gboolean _ls_find_camera(const char *maker, const char *model, ls_camera_
 static long long _ls_find_lens(long long mount_id, float crop, const char *lens_name)
 {
   if(IS_NULL_PTR(lens_name) || !lens_name[0]) return -1;
+  _ls_tls_t *tls = _ls_tls_get();
   ls_db_t *db = _ls_db();
-  if(IS_NULL_PTR(db)) return -1;
+  if(IS_NULL_PTR(db) || IS_NULL_PTR(tls)) return -1;
 
   char key[512];
   snprintf(key, sizeof(key), "%lld\x1f%.4f\x1f%s", mount_id, (double)crop, lens_name);
-  if(_ls_tls.lens_cached && !strcmp(key, _ls_tls.lens_key)) return _ls_tls.lens_id;
+  if(tls->lens_cached && !strcmp(key, tls->lens_key)) return tls->lens_id;
 
   ls_db_match_t m[1];
   const long long id
       = (ls_db_match_lens(db, NULL, lens_name, mount_id, crop, m, 1) > 0) ? m[0].lens_id : -1;
 
-  g_strlcpy(_ls_tls.lens_key, key, sizeof(_ls_tls.lens_key));
-  _ls_tls.lens_id = id;
-  _ls_tls.lens_cached = true;
+  g_strlcpy(tls->lens_key, key, sizeof(tls->lens_key));
+  tls->lens_id = id;
+  tls->lens_cached = TRUE;
   return id;
 }
 
@@ -785,7 +812,7 @@ int process(dt_iop_module_t *self, const dt_dev_pixelpipe_t *pipe, const dt_dev_
       /* Nothing moved, so there was no resampling loop to fold the falloff into. */
       if(have_vig)
       {
-        __OMP_PARALLEL_FOR_CPP__(firstprivate(modifier, ovoid, roi_out, ch))
+        __OMP_PARALLEL_FOR__(firstprivate(modifier, ovoid, roi_out, ch))
         for(int y = 0; y < roi_out->height; y++)
         {
           float *out = ((float *)ovoid) + (size_t)y * roi_out->width * ch;
@@ -878,7 +905,7 @@ int process(dt_iop_module_t *self, const dt_dev_pixelpipe_t *pipe, const dt_dev_
       /* Nothing moved, so there was no resampling loop to fold the falloff into. */
       if(have_vig)
       {
-        __OMP_PARALLEL_FOR_CPP__(firstprivate(modifier, ovoid, roi_in, ch))
+        __OMP_PARALLEL_FOR__(firstprivate(modifier, ovoid, roi_in, ch))
         for(int y = 0; y < roi_in->height; y++)
         {
           float *out = ((float *)ovoid) + (size_t)ch * roi_in->width * y;
@@ -1086,7 +1113,7 @@ int distort_transform(dt_iop_module_t *self, const dt_dev_pixelpipe_t *pipe, con
 
   if(modflags & (DT_LENS_MODIFY_TCA | DT_LENS_MODIFY_DISTORTION | DT_LENS_MODIFY_GEOMETRY | DT_LENS_MODIFY_SCALE))
   {
-    __OMP_PARALLEL_FOR_CPP__(firstprivate(points, points_count, modifier) if(points_count > 100))
+    __OMP_PARALLEL_FOR__(firstprivate(points, points_count, modifier) if(points_count > 100))
     for(size_t i = 0; i < points_count * 2; i += 2)
     {
       float DT_ALIGNED_ARRAY buf[6];
@@ -1119,7 +1146,7 @@ int distort_backtransform(dt_iop_module_t *self, const dt_dev_pixelpipe_t *pipe,
 
   if(modflags & (DT_LENS_MODIFY_TCA | DT_LENS_MODIFY_DISTORTION | DT_LENS_MODIFY_GEOMETRY | DT_LENS_MODIFY_SCALE))
   {
-    __OMP_PARALLEL_FOR_CPP__(firstprivate(points_count, modifier, points) if(points_count > 100))
+    __OMP_PARALLEL_FOR__(firstprivate(points_count, modifier, points) if(points_count > 100))
     for(size_t i = 0; i < points_count * 2; i += 2)
     {
       float DT_ALIGNED_ARRAY buf[6];
@@ -1173,7 +1200,7 @@ void distort_mask(struct dt_iop_module_t *self, const struct dt_dev_pixelpipe_t 
   size_t padded_bufsize;
   float *const buf = dt_pixelpipe_cache_alloc_perthread_float(bufsize, &padded_bufsize);
   if(IS_NULL_PTR(buf)) return;
-  __OMP_PARALLEL_FOR_CPP__(firstprivate(buf, padded_bufsize, d, modifier, in, out, interpolation, roi_in, roi_out))
+  __OMP_PARALLEL_FOR__(firstprivate(buf, padded_bufsize, d, modifier, in, out, interpolation, roi_in, roi_out))
   for(int y = 0; y < roi_out->height; y++)
   {
     float *bufptr = (float*)dt_get_perthread(buf, padded_bufsize);
@@ -2825,7 +2852,6 @@ void gui_cleanup(struct dt_iop_module_t *self)
   IOP_GUI_FREE;
 }
 
-}
 
 // clang-format off
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py

--- a/src/iop/lens.cc
+++ b/src/iop/lens.cc
@@ -965,7 +965,7 @@ int process_cl(struct dt_iop_module_t *self, const dt_dev_pixelpipe_t *pipe, con
 
   /* One kernel, in and out, in both directions.
    *
-   * The correction crosses as an ls_eval_t -- 112 bytes of coefficients passed by value --
+   * The correction crosses as an ls_eval_t -- 632 bytes of coefficients passed by value --
    * and each work-item evaluates its own source coordinates from it, so there is no
    * displacement map, no host buffer and no upload. Vignetting rides along inside the same
    * resampling pass rather than writing a whole intermediate image for the resampler to

--- a/tools/mingw_syntax_check.py
+++ b/tools/mingw_syntax_check.py
@@ -25,7 +25,7 @@ Setup (Fedora):
 Usage:
   python3 tools/mingw_syntax_check.py                    # every .c/.cc under src/
   python3 tools/mingw_syntax_check.py --changed master   # only what a branch touched
-  python3 tools/mingw_syntax_check.py src/iop/lens.cc    # specific files
+  python3 tools/mingw_syntax_check.py src/iop/lens.c    # specific files
   python3 tools/mingw_syntax_check.py --jobs 8
 """
 import concurrent.futures


### PR DESCRIPTION
Three commits on top of `master`, independent of each other. The middle one is the
headline; the last one fixes the currently-red Linux nightly.

## Fix the nightly (submodule bump)

The nightly stopped linking today:

```
import_lensfun_xml.c:282: undefined reference to `lf_db_load_directory'
```

`lf_db_load_directory()` arrived in **liblensfun 0.3.3**. The nightly runs on Ubuntu
22.04, which ships **0.3.2**. `lensfun.h` declares it either way, so it compiled fine and
died at the link with an error that names no version at all. This is not specific to that
runner — the importer is a build-time tool that produces `data/lenses.db`, so anyone
building on a distribution older than 0.3.3 hit the same wall.

LensSerious now **probes** for the symbol rather than reading a version string (a
distribution's version is not a reliable statement about which symbols it exports), and
falls back to walking the directory itself with `lf_db_load_file()`, which does exist in
0.3.2. Verified by building both branches and importing the same XML with each: the two
SQLite files come out **byte-identical**, and the full suite passes with the fallback
forced on. An untested fallback is how this class of bug repeats.

Note there are now three success conventions in that one function: `lf_db_load()` and
`lf_db_load_file()` return an `lfError` where 0 means success; `lf_db_load_directory()`
returns a `cbool` where non-zero does. The helper returns one convention for both branches.

**Vignetting no longer scales the fourth component.** A lens darkens light, not coverage,
so there is no falloff in it to remove, and scaling it corrupts whatever the caller keeps
there — routinely a mask, here. This was parity with lensfun, and it was parity with only
*half* of lensfun: the SSE2 `DeVignetting` multiplies all four components while its own
scalar path leaves the fourth alone. There was never a single upstream answer to be
faithful to, which is why the parity harness has always excluded alpha. The harness now
**asserts** it instead — the row goes in at 1.0 and must come back at exactly 1.0, across
all 8144 vignetting-compared configurations. Verified to have teeth by restoring the
multiply: it reports alpha scaled to 4.65 on the first lens it reaches.

That also settles an inconsistency on this side: `iop/lens.c` already restricts the
falloff to RGB everywhere it applies it itself — both fused resampling loops,
`_lens_devignette()` and the `lens_vignette` kernel all write `.xyz` — and only the
"vignetting alone, nothing moved" path reached the library function. So alpha survived
vignetting+distortion and was scaled by vignetting on its own.

## `lens.cc` becomes `lens.c`

The module was C++ for liblensfun's sake — a C++ library with a C wrapper nobody used
here. With lensfun gone the file was already valid C11 apart from about twenty-five lines.
It now compiles as `gcc -std=c11` instead of `g++ -std=c++17`.

What actually had to change:

- **The per-thread database cache.** It was a `thread_local` struct with a *destructor*,
  and the destructor is the load-bearing part: it closes this thread's SQLite handle when
  the thread exits. C has no thread-local destructor, so it becomes `GPrivate` with
  `G_PRIVATE_INIT(free_fn)` — which runs on thread exit on every platform we target,
  Windows included, where `pthread_key_create()` would not. `iop/drawlayer.c` holds its
  per-thread scratch buffers exactly this way already. The block can now be NULL where a
  C++ object could not, so all three users check and degrade to "no database".
- `extern "C"`, `nullptr`, `static_assert` — two lines and two tokens.
- The five OpenMP loops move to the generic `__OMP_PARALLEL_FOR__` the other C modules
  use. That swaps `default(none)` for `default(firstprivate)`, which sounds like a
  relaxation and is not one here: all five already list every variable explicitly, so the
  default clause had nothing left to decide. **Compiled both ways, the object files are
  byte-identical.**
- `po/POTFILES.in`, both entries. Easy to miss and the one that rots quietly: CI skips
  `po/`, so a stale path there stops extracting this module's strings without failing
  anything.

The build machinery needed one word — `add_iop` keeps the source extension deliberately,
the introspection generator handles either, and the static-IOP presence scan already ran
the **C** preprocessor over this file, so converting makes that honest rather than
incidental.

Verified beyond "it compiles": the set of top-level symbols is unchanged but for two new
statics, and all sixteen entry points in `lens_present.h` still resolve to a definition —
a missed one is a silently NULL function pointer, not a link error.

## Embedded maker profiles reach the same pixel code

Groundwork for #1056's vendor metadata. Cameras write their own lens profile into the raw
file, and Sony/Fujifilm/Olympus/DNG all express it the same way: a short list of radii and,
at each, the factor a coordinate is scaled by — per channel, so distortion and lateral CA
arrive measured together rather than as two stages.

Adding that as a second pixel path is the obvious move and the wrong one. Every model
LensSerious implements answers the same question — *at this radius, by what factor is the
coordinate scaled* — so a table is a distortion **model**, not a different kind of
correction. It takes the distortion slot in the coordinate chain and nothing else moves:
`ls_modifier_init_knots()` produces an ordinary modifier, the same evaluator and the same
kernels consume it, and `scale`/autoscale still compose around it because they measure the
chain rather than the model.

**`iop/lens.c` did not change at all for this** — that is the whole point of the exercise,
and the commit here is a submodule bump plus one comment (the by-value block's size, 112 →
632 bytes; the OpenCL 1.2 floor is 1024 for a kernel's whole argument list, and a
`static_assert` now fails the build rather than the device if the tables outgrow it).

The reverse direction costs nothing per pixel, unlike the polynomial models: a
piecewise-linear curve inverts by reading its own points the other way round, once at
resolve time. Exact at the knots, second-order between them — **measured at 0.13 px worst
case** over a 6000×4000 frame, against the 0.8 px by which liblensfun's own SSE row walk
differs from its own scalar answer.

`tests/knots.c` is property-based (liblensfun has no knot model, so there is no oracle) and
deliberately outside the `LENSFUN_FOUND` block so it runs where liblensfun is absent. The
vignetting direction *was* inverted on its first run — brightening nothing and darkening
corners by 0.6 EV — and the property test caught it immediately, where reading the branch
beside the polynomial's identically-shaped one had not.

## Known follow-up, not in this PR

`lenses.db` is built from one XML directory. It should aggregate the user's
`~/.local/share/lensfun/updates/version_1` as well as `/usr/share`, since some users write
their own profiles. Measured while diagnosing the link failure: on one machine those two
directories are different database versions, and building from `/usr/share` alone gives
8581 field mismatches against what `lf_db_load()` resolves. The hard part is not the merge
— user profiles exist at runtime on their machine, never at package-build time on a runner
— so it needs a decision rather than just code.
