### PR TITLE
Add ansel-lens-db-update: merge this machine's lens profiles into the shipped database

### DIFF
--- a/data/CMakeLists.txt
+++ b/data/CMakeLists.txt
@@ -326,6 +326,27 @@ if(TARGET import_lensfun_xml)
   add_custom_target(lenses_db ALL DEPENDS "${LENSES_DB}")
   install(FILES "${LENSES_DB}" DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/ansel
           COMPONENT DTApplication OPTIONAL)
+  # ansel-lens-db-update rebuilds this file on the user's machine and needs the schema to
+  # do it, so the schema is part of the installation rather than a build-tree artefact.
+  # Renamed on the way in: "schema.sql" says nothing in a directory shared with every other
+  # data file Ansel ships.
+  install(FILES "${LENSES_SCHEMA}" DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/ansel
+          RENAME lenses-schema.sql COMPONENT DTApplication)
+
+  # The calibrations themselves, as XML, beside the database built from them.
+  #
+  # ansel-lens-db-update loads these FIRST and then lets the machine's own lensfun profiles
+  # override them, which is what makes an update ADDITIVE: a user who calibrated one lens
+  # ends up with that lens on top of the fifteen hundred we ship, rather than a database
+  # containing only theirs. Doing the merge here, in lensfun's own loader, is why nothing
+  # has to upsert SQL rows or rebuild the corpus-wide token statistics by hand.
+  #
+  # About 5 MB. Only installed when the fetch succeeded -- with no baseline the tool still
+  # runs, it simply cannot be additive, and it says so.
+  if(LENS_XML_SOURCE)
+    install(DIRECTORY "${LENS_XML_SOURCE}/" DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/ansel/lensfun-xml
+            COMPONENT DTApplication FILES_MATCHING PATTERN "*.xml")
+  endif()
 else()
   message(WARNING "liblensfun not found: lenses.db will not be built, and the lens "
                   "correction module will report no calibration data")

--- a/packaging/macosx/ansel.bundle
+++ b/packaging/macosx/ansel.bundle
@@ -12,6 +12,10 @@
   <binary dest="${bundle}/Contents/MacOS/">${prefix:dt}/bin/ansel-cli</binary>
   <binary dest="${bundle}/Contents/MacOS/">${prefix:dt}/bin/ansel-cltest</binary>
   <binary dest="${bundle}/Contents/MacOS/">${prefix:dt}/bin/ansel-generate-cache</binary>
+  <!-- Rebuilds lenses.db from the profiles installed on the user's own machine. It is the
+       one binary here that links liblensfun, so listing it is also what pulls that dylib
+       into the bundle; the application itself does not link it and does not need it. -->
+  <binary dest="${bundle}/Contents/MacOS/">${prefix:dt}/bin/ansel-lens-db-update</binary>
   <binary dest="${bundle}/Contents/MacOS/">${prefix:dt}/bin/ansel-rs-identify</binary>
   <binary dest="${bundle}/Contents/MacOS/">${prefix:dt}/libexec/ansel/tools/ansel-curve-tool</binary>
   <binary dest="${bundle}/Contents/MacOS/">${prefix:dt}/libexec/ansel/tools/ansel-noiseprofile</binary>

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -909,6 +909,13 @@ add_subdirectory(apps/ansel-cli)
 # have a command line utility to generate all the thumbnails
 add_subdirectory(apps/ansel-generate-cache)
 
+# have a command line utility to rebuild lenses.db from THIS machine's lensfun profiles --
+# the ones a package build could not have seen, because they only exist on the user's own
+# machine. Needs liblensfun, so it exists only where LensSerious found it.
+if(TARGET lensserious_import)
+  add_subdirectory(apps/ansel-lens-db-update)
+endif()
+
 # have a small test program that verifies your color management setup
 if(BUILD_CMSTEST)
   add_subdirectory(apps/ansel-cmstest)

--- a/src/apps/ansel-lens-db-update/CMakeLists.txt
+++ b/src/apps/ansel-lens-db-update/CMakeLists.txt
@@ -1,0 +1,22 @@
+include_directories(${CMAKE_CURRENT_BINARY_DIR}/../..)
+
+add_executable(ansel-lens-db-update main.c)
+set_target_properties(ansel-lens-db-update PROPERTIES LINKER_LANGUAGE C)
+
+# lib_ansel for dt_loc_*, so this resolves the data and configuration directories through
+# exactly the code the application uses -- a hand-rolled lookup here is how the two would
+# drift the first time a packager moves something.
+#
+# lensserious_import is the ONLY target in the tree that links liblensfun, and it stops
+# here: it is not in lib_ansel and nothing that renders a pixel reaches it.
+target_link_libraries(ansel-lens-db-update lib_ansel whereami lensserious_import)
+
+if(WIN32)
+  # _detach_debuginfo(ansel-lens-db-update bin)
+else()
+  set_target_properties(ansel-lens-db-update
+                        PROPERTIES
+                        INSTALL_RPATH ${RPATH_ORIGIN}/${REL_BIN_TO_LIBDIR})
+endif(WIN32)
+
+install(TARGETS ansel-lens-db-update DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT DTApplication)

--- a/src/apps/ansel-lens-db-update/main.c
+++ b/src/apps/ansel-lens-db-update/main.c
@@ -1,0 +1,256 @@
+/*
+    This file is part of Ansel,
+    Copyright (C) 2026 Aurélien PIERRE.
+
+    Ansel is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Ansel is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Ansel.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+/** @file ansel-lens-db-update/main.c
+ *
+ * @brief Rebuild the lens-correction database from this machine's lensfun installation.
+ *
+ * @details Ansel ships a `lenses.db` built at package time from upstream's published
+ * calibrations. That is the right default and it is all most people ever need. What it
+ * cannot contain is a profile that did not exist when the package was built: a calibration
+ * upstream published since, or -- the case this tool exists for -- one the user measured
+ * themselves and wrote into `~/.local/share/lensfun`.
+ *
+ * Those profiles are only ever present at RUNTIME, on the machine that has them. A build
+ * runner has none, so no amount of care at package time can pick them up. Hence a separate
+ * command, run by the person who has the profiles.
+ *
+ * It deliberately makes no attempt to be clever about aggregation. lensfun already defines
+ * where profiles live and which wins when two disagree -- the system database, the system
+ * updates directory, the user's updates directory, and the user's own hand-written
+ * profiles, with the last always overriding -- and `ls_import_run(..., NULL)` calls
+ * lensfun's own `lf_db_load()` to apply exactly those rules. Re-deriving them here would be
+ * an approximation of a moving target.
+ *
+ * Nor does it fetch anything. Downloading upstream's newest calibrations is what lensfun's
+ * own `lensfun-update-data` is for, and it writes them into one of the directories above.
+ * Run that first if that is what you want; this converts whatever lensfun can currently see.
+ *
+ * @note Close Ansel first. The result is written to a temporary and renamed into place, so a
+ * running Ansel can never read a half-written file -- but each of its threads holds its
+ * database handle open for the life of the process, so it would go on using the old one
+ * until restarted. Nothing breaks; the update simply would not appear.
+ */
+
+#include "common/file_location.h"
+#include "whereami.h"
+#include "lensserious_import.h"
+
+#include <glib.h>
+#include <glib/gstdio.h>
+#include <limits.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#ifdef __APPLE__
+#include "osx/osx.h"   // conditional-ok: dt_osx_prepare_environment() is called only
+                       // from the matching __APPLE__ block in main()
+#endif
+
+static void usage(const char *progname)
+{
+  fprintf(stderr,
+          "usage: %s [options]\n"
+          "\n"
+          "Rebuilds Ansel's lens-correction database from the lensfun profiles installed\n"
+          "on THIS machine, including any you wrote yourself. The result is written to\n"
+          "your configuration directory, where Ansel looks before the one it shipped with.\n"
+          "\n"
+          "Close Ansel before running this: a running instance keeps its database open and\n"
+          "would not see the new file until restarted.\n"
+          "\n"
+          "options:\n"
+          "  --xml-dir <dir>    read exactly this directory of lensfun XML, instead of\n"
+          "                     letting lensfun search its four standard locations.\n"
+          "                     Skips your own profiles unless they are in <dir>.\n"
+          "  --output <path>    write here instead of <configdir>/lenses.db\n"
+          "  --schema <path>    the SQL schema; defaults to the installed one\n"
+          "  --configdir <dir>  use this configuration directory\n"
+          "  --datadir <dir>    use this data directory\n"
+          "  --no-baseline      do not start from the calibrations Ansel shipped with, so\n"
+          "                     the result holds only what lensfun finds on this machine\n"
+          "  -h, --help         this text\n"
+          "\n"
+          "To pull upstream's newest calibrations first, use lensfun's own updater:\n"
+          "  lensfun-update-data\n"
+          "then run this to convert what it fetched.\n",
+          progname);
+}
+
+int main(int argc, char *argv[])
+{
+#ifdef __APPLE__
+  dt_osx_prepare_environment();
+#endif
+
+  const char *xml_dir = NULL;
+  const char *out_override = NULL;
+  const char *schema_override = NULL;
+  const char *configdir = NULL;
+  const char *datadir = NULL;
+  int no_baseline = 0;
+
+  for(int k = 1; k < argc; k++)
+  {
+    if(!strcmp(argv[k], "-h") || !strcmp(argv[k], "--help"))
+    {
+      usage(argv[0]);
+      return 0;
+    }
+
+    if(!strcmp(argv[k], "--no-baseline"))
+    {
+      no_baseline = 1;
+      continue;
+    }
+
+    /* Every option below takes a value, so a missing one is an error rather than a
+     * silently ignored flag -- the difference between "read your own profiles" and "read
+     * one directory" is exactly the kind of thing that must not be decided by a typo. */
+    const char *const opts[] = { "--xml-dir", "--output", "--schema", "--configdir", "--datadir" };
+    const char **const dests[] = { &xml_dir, &out_override, &schema_override, &configdir, &datadir };
+    int matched = 0;
+    for(size_t o = 0; o < sizeof(opts) / sizeof(*opts); o++)
+    {
+      if(strcmp(argv[k], opts[o])) continue;
+      if(k + 1 >= argc)
+      {
+        fprintf(stderr, "%s: %s needs a value\n", argv[0], opts[o]);
+        return 2;
+      }
+      *dests[o] = argv[++k];
+      matched = 1;
+      break;
+    }
+    if(matched) continue;
+
+    fprintf(stderr, "%s: unknown argument `%s'\n", argv[0], argv[k]);
+    usage(argv[0]);
+    return 2;
+  }
+
+  /* Resolves the same paths the application resolves, from the same code, so this writes
+   * where Ansel will actually look. Doing the lookup by hand here is how the two would
+   * drift the first time a packager moves something.
+   *
+   * Only the two directories this tool actually reads, though, rather than dt_loc_init()'s
+   * eight. Each initialiser ends in dt_check_opendir(), which exit()s the process when a
+   * directory is missing and could not be created -- and dt_loc_init_generic() creates with
+   * mode 0700, which a normal user cannot do under a system prefix. Asking for the module,
+   * locale, kernel, cache, share and temporary directories would make this tool die over
+   * any of the six it never opens. */
+  char *application_directory = NULL;
+  int dirname_length = 0;
+  const int length = wai_getExecutablePath(NULL, 0, &dirname_length);
+  if(length > 0)
+  {
+    application_directory = (char *)malloc(length + 1);
+    if(application_directory)
+    {
+      wai_getExecutablePath(application_directory, length, &dirname_length);
+      application_directory[dirname_length] = '\0';
+    }
+  }
+  dt_loc_init_datadir(application_directory, datadir);
+  dt_loc_init_user_config_dir(configdir);
+  free(application_directory);
+
+  char schema_path[PATH_MAX] = { 0 };
+  if(schema_override)
+    g_strlcpy(schema_path, schema_override, sizeof(schema_path));
+  else
+    snprintf(schema_path, sizeof(schema_path), "%s/lenses-schema.sql", dt_loc_datadir());
+
+  if(!g_file_test(schema_path, G_FILE_TEST_IS_REGULAR))
+  {
+    fprintf(stderr,
+            "%s: no schema at `%s'.\n"
+            "This file is installed with Ansel; if it is missing, the installation is\n"
+            "incomplete. Pass --schema to point at one explicitly.\n",
+            argv[0], schema_path);
+    return 1;
+  }
+
+  char out_path[PATH_MAX] = { 0 };
+  if(out_override)
+    g_strlcpy(out_path, out_override, sizeof(out_path));
+  else
+    snprintf(out_path, sizeof(out_path), "%s/lenses.db", dt_loc_configdir());
+
+  /* The calibrations Ansel shipped, loaded first so everything below merely overrides
+   * them. This is what makes the update additive rather than a replacement -- see
+   * ls_import_run(). */
+  char base_dir[PATH_MAX] = { 0 };
+  const char *base = NULL;
+  if(!no_baseline)
+  {
+    snprintf(base_dir, sizeof(base_dir), "%s/lensfun-xml", dt_loc_datadir());
+    if(g_file_test(base_dir, G_FILE_TEST_IS_DIR))
+      base = base_dir;
+    else
+      fprintf(stderr,
+              "warning: no shipped calibrations at `%s'.\n"
+              "The result will hold ONLY what lensfun finds on this machine, which may be\n"
+              "far less than Ansel came with.\n",
+              base_dir);
+  }
+
+  if(xml_dir)
+    printf("Reading lensfun XML from `%s'.\n", xml_dir);
+  else
+    printf("Reading every lensfun profile this machine has: the system database, the\n"
+           "system and user update directories, and your own profiles in\n"
+           "~/.local/share/lensfun (which override the rest).\n");
+
+  /* Written aside and only then moved into place, because the result has to be JUDGED
+   * before it is allowed to shadow anything.
+   *
+   * lf_db_load() reads lensfun's own directories and knows nothing about the database
+   * Ansel ships. On a machine with no system-wide lensfun -- the normal case on Windows
+   * and macOS -- it can therefore come back with nothing but the handful of profiles the
+   * user wrote themselves. That file is not wrong, but installing it WOULD be: iop/lens.c
+   * prefers the configuration directory and never falls back once it opens something, so
+   * a three-lens database would silently replace the fifteen hundred that shipped. */
+  char staged_path[PATH_MAX] = { 0 };
+  snprintf(staged_path, sizeof(staged_path), "%s.incoming", out_path);
+
+  const int rc = ls_import_run(schema_path, staged_path, base, xml_dir);
+  if(rc)
+  {
+    g_unlink(staged_path);
+    fprintf(stderr, "%s: the database was NOT updated; the previous one is untouched.\n",
+            argv[0]);
+    return rc;
+  }
+
+  if(g_rename(staged_path, out_path) != 0)
+  {
+    fprintf(stderr, "%s: cannot move `%s' to `%s'; nothing was changed.\n",
+            argv[0], staged_path, out_path);
+    g_unlink(staged_path);
+    return 1;
+  }
+
+  printf("\nWrote `%s'.\n"
+         "Ansel reads this in preference to the database it shipped with, so the new\n"
+         "profiles are available next time you start it. Delete this file to go back to\n"
+         "the shipped one.\n",
+         out_path);
+  return 0;
+}

--- a/src/apps/ansel-lens-db-update/main.c
+++ b/src/apps/ansel-lens-db-update/main.c
@@ -63,6 +63,14 @@
                        // from the matching __APPLE__ block in main()
 #endif
 
+#ifdef _WIN32
+// This header DEFINES wmain(), which -municode makes the entry point on Windows, and which
+// forwards to main() with the arguments converted to UTF-8. Without it the linker finds no
+// entry it recognises, falls back to the GUI-subsystem C runtime, and fails on an undefined
+// wWinMain. Every other app in src/apps includes it the same way.
+#include "win/main_wrapper.h"   // conditional-ok: it defines the Windows entry point itself
+#endif
+
 static void usage(const char *progname)
 {
   fprintf(stderr,


### PR DESCRIPTION
Adds `ansel-lens-db-update`, a command-line tool that merges the lens profiles installed
on the user's own machine into the database Ansel ships.

Branched off `master`, not off #1243 — so the submodule bump here carries #1243's
LensSerious commits as well as this one's. Whichever merges second wins and the result is
correct either way; the Ansel-side files do not overlap except for a comment in
`data/CMakeLists.txt`.

## Why a tool at all

The `lenses.db` we ship is built at package time from upstream's published calibrations.
That is the right default and all most people ever need. What it structurally cannot
contain is a profile that did not exist when the package was built — and in particular one
the user measured themselves and wrote into `~/.local/share/lensfun`. Those exist only at
runtime, on the machine that has them; a build runner has none, so no amount of care at
package time picks them up.

**No GUI entry point, on purpose.** It is a power-user operation, it is not interactive, and
it wants Ansel closed — three reasons a menu item would be the wrong shape.

## The update is additive, and that is the whole design

The calibrations are now installed as XML beside the database built from them. The tool
loads those **first**, then lets whatever lensfun finds on this machine override them.
lensfun's own rule is that a later definition wins, so a lens only the user has is added,
a lens they redefine is replaced, and the other fifteen hundred survive untouched.

Measured, with one hand-written profile:

| | lenses | cameras | mounts |
|---|---|---|---|
| shipped | 1562 | 1051 | 52 |
| + one hand-written profile | **1563** | 1051 | 52 |
| same input, `--no-baseline` | **1** | **0** | **0** |

That last row is not a curiosity, it is the hazard this design removes. `lf_db_load()`
knows nothing about the database we ship, so without a baseline a machine with no
system-wide lensfun — the normal case on Windows and macOS — produces a database holding
only the user's own few profiles. `iop/lens.c` prefers the configuration directory and
never falls back once it opens something, so installing that would silently replace
everything. An earlier draft caught this by refusing to install a database smaller than the
shipped one; making the result a superset by construction is better than detecting that it
is not.

## Why not upsert SQL rows

That is the obvious reading of "merge onto the shipped database", and it is worse for three
reasons, none visible from outside the schema:

- **Row identity would have to be invented.** The schema keys lenses by an id the importer
  assigns, not by anything intrinsic.
- **New ids would have to avoid colliding** with the ones already there.
- **`token_df` holds document frequencies computed across the whole corpus** for the fuzzy
  matcher. Every insert silently invalidates it — matching would degrade with nothing
  failing.

Merging at the source instead leaves the conversion a single pass over a complete database,
exactly as before, and none of those problems exists.

## Aggregation is lensfun's, not ours

lensfun already defines where profiles live and which wins: system database, system updates,
user updates, and the user's own directory overriding all. `ls_import_run(..., NULL)` calls
`lf_db_load()` and gets exactly those rules rather than this tree maintaining an
approximation of a moving target. It fetches nothing either — that is what lensfun's own
`lensfun-update-data` does, into one of those same directories, so the two compose without
either knowing about the other.

## Verification

The check has teeth because it **fails** on the naive version. Run the tool, then
`parity_db` against its output: 1562 lenses compared field by field against liblensfun,
1051 cameras, every lens range and mount list — **pass**. Importing
`/usr/share/lensfun/version_1` alone on the same machine gives **8581 field mismatches**,
because that user's update directory overrides same-named profiles. Same lens *count*
either way, different content — so counting rows would have shown nothing.

## Incidental

- `src/schema.sql` is now installed (as `lenses-schema.sql`, since "schema.sql" says
  nothing in a shared data directory) because the conversion needs it at runtime.
- The macOS bundle gains the binary, which is also what pulls `liblensfun` into the bundle:
  this executable is the only thing that links it, it is not in `lib_ansel`, and nothing
  rendering a pixel reaches it.
- Paths come from `dt_loc_*` through `lib_ansel`, so the tool writes where the application
  looks rather than where a second hand-rolled lookup guesses.

## On the LensSerious side

`ls_import_run()` becomes a library function in its own target (`lensserious_import`) —
the only target in the tree that links liblensfun — so both the offline tool and this one
call one implementation. It gains the baseline parameter described above.

`version_2` is dropped from the roadmap, with the reasoning recorded in the README rather
than left to be rediscovered. Measured 2026-08: upstream publishes a `version_2` tarball
whose content is the same calibrations as `version_1` — 56 files either way, identical
model census, **zero** entries using the ACM forms the format exists to allow. The only
real difference is `<real-focal-length>` becoming a `real-focal` attribute. Meanwhile
`LF_MAX_DATABASE_VERSION` is still **1** in the liblensfun every distribution ships, so
handing it a version-2 file makes it reject every one of them. Nothing to gain, a build to
lose. Worth revisiting only if upstream ships ACM calibrations — noting that ACM distortion
is *not radial*, so it would not fit the one assumption every model in the library shares.

Documentation: aurelienpierreeng/ansel-doc#21.
