### PR TITLE
image_test: say why the delta-E comparison failed, and refresh the baseline for LensSerious

### DIFF
--- a/tests/image_test.sh
+++ b/tests/image_test.sh
@@ -459,9 +459,15 @@ process_one() {
       printf '%s\n' "$deltae_out" > "$RESULTS_DIR/$rel.deltae.log"
       IFS=$'\t' read -r max_de avg_de pct_de <<< "$(extract_de_stats "$deltae_out")"
       if [ -z "$max_de" ]; then
-        # deltae crashed (e.g. size mismatch vs baseline) rather than computing a
-        # real dE -- never a silent PASS, --strict or not.
-        diffnote=" (delta-E comparison failed vs baseline, likely a size mismatch)"
+        # No numbers came back. Say WHY, from deltae's own exit code, instead of guessing:
+        # this used to claim "likely a size mismatch" for every failure, including the
+        # common one of colour-science not being installed, which sent the reader off to
+        # inspect export dimensions that were in fact identical. Never a silent PASS.
+        case "$deltae_rc" in
+          3) diffnote=" (delta-E comparator unavailable -- see $RESULTS_DIR/$rel.deltae.log)" ;;
+          4) diffnote=" ($(printf '%s\n' "$deltae_out" | sed -n 's/^deltae: \(size mismatch.*\)/\1/p' | head -1))" ;;
+          *) diffnote=" (delta-E comparison failed, exit $deltae_rc -- see $RESULTS_DIR/$rel.deltae.log)" ;;
+        esac
         verdict="DIFF"
       else
         # avg dE > 0.767 (2.3/3) is a population-wide problem -- never filtered
@@ -631,6 +637,20 @@ run_bank() {
   # sequential loop below warms the cache on its own first image for free.
   if [ "$OPENCL" = yes ] && [ "$COMMAND" != update-baseline ] && [ "$jobs" -gt 1 ]; then
     warm_opencl_cache "${raws[0]}"
+  fi
+
+  # Establish ONCE that the comparator can run, before exporting anything. A missing
+  # colour-science used to surface as every image reporting a delta-E failure, which reads
+  # as a fleet of regressions and hides the single line that says what is actually wrong --
+  # and costs a full export run to find out.
+  if [ -d "$BASELINE_DIR" ] && [ -x "$DELTAE_SCRIPT" ]; then
+    local check_out check_rc
+    check_out="$("$DELTAE_SCRIPT" --check 2>&1)"; check_rc=$?
+    if [ "$check_rc" -ne 0 ]; then
+      err "the delta-E comparator cannot run, so nothing would be checked against the baseline:"
+      printf '%s\n' "$check_out" >&2
+      return 1
+    fi
   fi
 
   log "Testing ${#raws[@]} raw file(s) from $BANK_DIR"

--- a/tests/image_test/deltae
+++ b/tests/image_test/deltae
@@ -38,19 +38,70 @@
 MAX_DELTA_E = 2.3
 MAX_AVG_DELTA_E = MAX_DELTA_E / 3.
 
-import colour
-import numpy
+# Exit codes, because the caller has to tell three different things apart and used to
+# guess:
+#   0  images match (max dE < 0.01)
+#   1  some drift, below both real thresholds
+#   2  a real difference (max dE > 2.3 or avg dE > 0.767)
+#   3  THIS COMPARATOR CANNOT RUN -- a missing dependency, not a verdict on the images
+#   4  the two images are different sizes, so there is nothing to compare pixel-wise
+#
+# 3 and 4 exist because the previous version had no way to say either. A missing
+# colour-science made every image report "likely a size mismatch" -- which was not true and
+# sent the reader looking at export dimensions -- and a colour-science too old to have
+# delta_E exited 0, reporting SUCCESS for a comparison that never happened.
+EXIT_UNAVAILABLE = 3
+EXIT_SIZE_MISMATCH = 4
+
 import sys
 
+try:
+    import colour
+    import numpy
+except ImportError as exc:
+    sys.stderr.write(
+        "deltae: cannot run -- %s\n"
+        "\n"
+        "This comparator needs colour-science (and numpy). Install it for the interpreter\n"
+        "that runs this script:\n"
+        "    pip3 install --user colour-science\n"
+        "or use your distribution's python3-colour-science package. If that would disturb\n"
+        "other packages, a throwaway virtualenv works and needs nothing system-wide:\n"
+        "    python3 -m venv /tmp/deltae-venv\n"
+        "    /tmp/deltae-venv/bin/pip install colour-science\n"
+        "    PATH=/tmp/deltae-venv/bin:$PATH tests/image_test.sh run\n"
+        % exc)
+    sys.exit(EXIT_UNAVAILABLE)
+
 if "delta_E" not in dir(colour):
-    print("  Unable to compute delta-E, please upgrade python3-colour-science")
-    exit(0)
+    # Used to exit(0): a comparator that cannot compare reported every image as passing.
+    sys.stderr.write("deltae: colour-science is too old to provide delta_E -- please upgrade\n")
+    sys.exit(EXIT_UNAVAILABLE)
+
+# Lets a caller establish ONCE, before testing anything, that the comparator works --
+# a setup problem reported per image reads as N regressions and buries its own cause.
+if len(sys.argv) > 1 and sys.argv[1] == "--check":
+    sys.exit(0)
+
+if len(sys.argv) < 3:
+    sys.stderr.write("usage: deltae <expected.png> <output.png>\n       deltae --check\n")
+    sys.exit(EXIT_UNAVAILABLE)
 
 expected = sys.argv[1]
 output = sys.argv[2]
 
 expected_rgb = colour.read_image(expected, method="Imageio")
 output_rgb = colour.read_image(output, method="Imageio")
+
+# Reported as its own thing, with the sizes, rather than left to a caller's guess.
+if expected_rgb.shape[:2] != output_rgb.shape[:2]:
+    sys.stderr.write(
+        "deltae: size mismatch -- expected %dx%d, got %dx%d.\n"
+        "Both sides must be exported at the same dimensions; the shared baseline is\n"
+        "always 1024x1024-capped (see image_test.sh BASELINE_WIDTH/HEIGHT).\n"
+        % (expected_rgb.shape[1], expected_rgb.shape[0],
+           output_rgb.shape[1], output_rgb.shape[0]))
+    sys.exit(EXIT_SIZE_MISMATCH)
 
 expected_lab = colour.XYZ_to_Lab(colour.sRGB_to_XYZ(expected_rgb,
                                                     chromatic_adaptation_transform="Bradford"))


### PR DESCRIPTION
Two things, from chasing a reported "LensSerious fails delta-E on CPU but holds on GPU".

## The report was a misreading, and the script invited it

There was no CPU/GPU divergence. The script prints two comparisons with **different
reference points** — `[CPU vs baseline]` is this run against the stored baseline,
`[opencl vs CPU]` is the GPU against this run's CPU. "Holds on GPU" only ever meant CPU and
GPU agree with each other. Making the comparison the script never makes:

| | vs baseline |
|---|---|
| CPU | 25.91% px over dE 2.3 |
| GPU | **25.92%** px over dE 2.3 |
| GPU vs CPU | 0.00%, max dE 2.26 |

## What the failure actually was

Only `Canon/EOS 40D/mire1.cr2` failed, 4/5 passed. Four measurements:

- the dE map is a **pure edge map** — edges mean dE 7.6 against 1.2 on flats, no colour cast
  (mean L\* 31.80 → 32.29);
- **no radial falloff** (so not vignetting), **no global shift**, **no scale change**
  (best-fit rescale improves RMSE by 0.0%);
- local sub-pixel displacement, **median 0.868 px**;
- that field is **radial** — 0.759 px radial against 0.197 px tangential, 3.9:1. Distortion,
  not resampling.

The baseline dated from 2026-07-21 and was rendered by **liblensfun's SSE row path**. Ansel
now corrects with LensSerious, which reproduces liblensfun's **scalar** answer — held to
0.007 px over 18292 configurations by that project's harness, which prints the counterpart
itself: *"upstream's own row walk deviates … from its own width-1 answer … that figure is
the approximation every lensfun-corrected render carries."*

So the new renders are **closer to lensfun's exact mathematics** than the images they were
being compared against. All five images carry the identical sub-pixel radial shift; the
Canon is simply the most detailed frame, so the same displacement crosses dE 2.3 on 26% of
its pixels while the others stay at 0.1–4%. Baseline refreshed for all five — leaving the
four that passed would leave them quietly stale until some unrelated edit tipped them over.

## The script fixes

**It guessed, and guessed wrong.** With `colour-science` missing, every image reported
`(delta-E comparison failed vs baseline, likely a size mismatch)`. The dimensions were
identical on all five, so that sent the reader to inspect export sizes that were never the
problem — and printing it per image made one missing dependency read as five regressions,
burying its own cause. Finding out cost a full export run.

`deltae` now distinguishes what it always could have, by exit code — `3` the comparator
cannot run, `4` the images are different sizes (reported *with* the sizes, compared rather
than inferred) — and `image_test.sh` reports whichever actually happened. It also
**preflights the comparator once**, before exporting anything, so a setup problem surfaces
in a second with an actionable message.

**One silent-pass bug fixed on the way.** A `colour-science` too old to provide `delta_E`
printed a note and **exited 0** — reporting success for a comparison that never ran. It
exits 3 now. A test that cannot check anything must not be able to report that everything
is fine; that is worse than no test, because it is believed.

Verified both directions: 5/5 pass against the refreshed baseline (CPU vs baseline
0.00000 dE, OpenCL vs CPU worst 0.05% of pixels), and with the comparator unavailable the
run stops immediately with the real reason and exit 1.
