### PR TITLE
Make the aligned-allocator mismatch unrepresentable, and gate the rest

### DIFF
--- a/src/caches/cache.c
+++ b/src/caches/cache.c
@@ -404,8 +404,7 @@ void dt_cache_release_with_caller(dt_cache_t *cache, dt_cache_entry_t *entry, co
   dt_pthread_rwlock_unlock(&entry->lock);
 }
 
-int dt_cache_seed(dt_cache_t *cache, const uint32_t key, const void *data, size_t data_size, size_t cost,
-                  gboolean aligned_alloc)
+int dt_cache_seed(dt_cache_t *cache, const uint32_t key, const void *data, size_t data_size, size_t cost)
 {
   if(IS_NULL_PTR(cache) || IS_NULL_PTR(data) || data_size == 0) return -1;
 
@@ -427,7 +426,9 @@ int dt_cache_seed(dt_cache_t *cache, const uint32_t key, const void *data, size_
   entry->key = key;
   entry->_lock_demoting = 0;
 
-  entry->data = aligned_alloc ? dt_alloc_align(entry->data_size) : g_malloc(entry->data_size);
+  /* dt_alloc_align, always: this file frees entry->data with dt_free_align() wherever a
+   * cache has no cleanup callback, so the two have to be the same family. See cache.h. */
+  entry->data = dt_alloc_align(entry->data_size);
   if(IS_NULL_PTR(entry->data))
   {
     g_slice_free1(sizeof(*entry), entry);

--- a/src/caches/cache.h
+++ b/src/caches/cache.h
@@ -112,9 +112,20 @@ void dt_cache_release_with_caller(dt_cache_t *cache, dt_cache_entry_t *entry, co
 int32_t dt_cache_contains(dt_cache_t *cache, const uint32_t key);
 // returns 0 on success, 1 if the key was not found.
 int32_t dt_cache_remove(dt_cache_t *cache, const uint32_t key);
-// seed a cache entry without running allocate callback. returns 0 on insert, 1 if already present, -1 on failure.
-int dt_cache_seed(dt_cache_t *cache, const uint32_t key, const void *data, size_t data_size, size_t cost,
-                  gboolean aligned_alloc);
+// Seed a cache entry without running the allocate callback. Returns 0 on insert, 1 if
+// already present, -1 on failure.
+//
+// The payload is always allocated with dt_alloc_align(), and that is not an implementation
+// detail a caller may vary: an entry whose cache has no cleanup callback is freed by this
+// file with dt_free_align(), in four places, whatever it was allocated with. On Windows
+// those are _aligned_malloc and _aligned_free, so a payload allocated any other way is a
+// corrupted heap on eviction -- and on Linux both sides end at free(), so nothing local
+// ever reproduces it.
+//
+// This used to take an `aligned_alloc` flag choosing between dt_alloc_align() and
+// g_malloc(). Passing FALSE was heap corruption on Windows and always had been; the one
+// caller that did was fixed, and the parameter is gone so the next one cannot.
+int dt_cache_seed(dt_cache_t *cache, const uint32_t key, const void *data, size_t data_size, size_t cost);
 // removes from the tip of the lru list, until the fill ratio of the hashtable
 // goes below the given parameter, in terms of the user defined cost measure.
 // will never lock and never fail, but sometimes not free memory (in case all

--- a/src/caches/image_cache.c
+++ b/src/caches/image_cache.c
@@ -421,10 +421,9 @@ int dt_image_cache_seed(const dt_image_t *img)
   seeded.dng_gain_maps = NULL;
   seeded.cache_entry = NULL;
 
-  // dt_image_cache_deallocate() always frees entry->data with dt_free_align(), regardless of
-  // how it was allocated -- seeded entries must therefore be allocated aligned too, or eviction
-  // frees a g_malloc()'d block with _aligned_free() on Windows, corrupting the heap.
-  return dt_cache_seed(&cache->cache, (uint32_t)seeded.id, &seeded, sizeof(dt_image_t), sizeof(dt_image_t), TRUE);
+  // dt_image_cache_deallocate() frees entry->data with dt_free_align(); dt_cache_seed()
+  // allocates with dt_alloc_align() and no longer offers any other option.
+  return dt_cache_seed(&cache->cache, (uint32_t)seeded.id, &seeded, sizeof(dt_image_t), sizeof(dt_image_t));
 }
 
 // This callback must run before any other DT_SIGNAL_IMAGE_INFO_CHANGED handler.

--- a/src/iop/drawlayer.c
+++ b/src/iop/drawlayer.c
@@ -2795,7 +2795,12 @@ void init(dt_iop_module_t *module)
 
 void init_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
 {
-  piece->data = calloc(1, sizeof(dt_iop_drawlayer_data_t));
+  /* The aligned family, like every other module: the DEFAULT cleanup_pipe frees
+   * piece->data with dt_free_align(), so a module that allocates any other way only stays
+   * correct for as long as it also overrides cleanup_pipe. That is a standing trap on
+   * Windows -- _aligned_malloc against g_free -- and invisible on Linux, where both end at
+   * free(). */
+  piece->data = dt_calloc_align(sizeof(dt_iop_drawlayer_data_t));
   if(IS_NULL_PTR(piece->data)) return;
   piece->data_size = sizeof(dt_iop_drawlayer_params_t);
   dt_iop_drawlayer_data_t *data = (dt_iop_drawlayer_data_t *)piece->data;
@@ -2816,7 +2821,7 @@ void cleanup_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev
   dt_iop_drawlayer_data_t *data = (dt_iop_drawlayer_data_t *)piece->data;
   dt_drawlayer_process_state_cleanup(&data->process);
   dt_drawlayer_runtime_manager_cleanup(&data->headless_manager);
-  dt_free(piece->data);
+  dt_free_align(piece->data);
   piece->data_size = 0;
 }
 

--- a/src/views/view.c
+++ b/src/views/view.c
@@ -1032,7 +1032,7 @@ void dt_cairo_sharpen_surface_rgb24(cairo_surface_t *surface)
       data[idx + 3] = copy[idx + 3];
     }
 
-  dt_free(copy);
+  dt_free_align(copy);   // paired with the dt_alloc_align above
   cairo_surface_mark_dirty(surface);
 }
 

--- a/tools/check_alloc_pairing.py
+++ b/tools/check_alloc_pairing.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""Allocator/deallocator pairing: dt_alloc_align* must be freed by dt_free_align, and
+nothing else may be.
+
+WHY THIS EXISTS, and why a build cannot replace it. dt_alloc_align() is _aligned_malloc()
+on Windows and posix_memalign() everywhere else; dt_free_align() is _aligned_free() on
+Windows and g_free() everywhere else. So on Linux and macOS BOTH families end at free(),
+every mismatch works perfectly, and no test, sanitizer or review on those platforms will
+ever see one. On Windows the same code corrupts the heap, and it crashes somewhere else
+entirely, later, in whatever unlucky code touches the heap next.
+
+That is a bug class you cannot find by running the program on the machine you develop on,
+which is what makes it worth a static check. Both directions are reported:
+
+  * something from malloc/calloc/g_malloc/g_new/strdup freed with dt_free_align()
+  * something from dt_alloc_align()/dt_calloc_align() freed with free()/g_free()/dt_free()
+
+Scope: matches allocations and frees of the SAME expression within the SAME file. That is
+deliberately narrow -- matching by name across files reports `data`, `buffer` and `img` in
+unrelated translation units and buries the real findings. It cannot see a struct field
+allocated in one file and freed in another; the generic-destructor case that produced the
+original bug report is prevented in the API instead (see dt_cache_seed in caches/cache.h),
+which is the better fix where it is available.
+
+Usage:  python3 tools/check_alloc_pairing.py [--quiet]
+Exits non-zero if any mismatch is found.
+"""
+import re, os, collections
+
+ALIGNED_ALLOC = re.compile(r'\b(dt_alloc_align\w*|dt_calloc_align\w*|dt_alloc_perthread\w*|dt_realloc_align\w*)\s*\(')
+PLAIN_ALLOC   = re.compile(r'(?<![_\w])(malloc|calloc|realloc|strdup|strndup|g_malloc\d*|g_try_malloc\d*|g_realloc|g_new\d*|g_strdup\w*|g_slice_new\w*)\s*\(')
+ALIGNED_FREE  = re.compile(r'\bdt_free_align(?:_ptr)?\s*\(\s*([^,;)]*)')
+PLAIN_FREE    = re.compile(r'(?<![_\w])(free|g_free|dt_free|dt_free_gpointer)\s*\(\s*([^,;)]*)')
+ASSIGN        = re.compile(r'([A-Za-z_][\w\.\->\[\]\s]*?)\s*=\s*(?:\([^)]*\)\s*)*$')
+
+def norm(expr):
+    e = expr.strip()
+    e = re.sub(r'^\(+\s*|\s*\)+$', '', e)
+    e = re.sub(r'\(\s*[\w\s]*\*+\s*\)', '', e)      # drop casts
+    e = e.strip().lstrip('&').strip()
+    e = re.sub(r'\[[^\]]*\]', '[]', e)              # normalise indices
+    e = re.sub(r'\s+', '', e)
+    return e
+
+files = []
+for root, dirs, fs in os.walk('src'):
+    if 'external' in root.split(os.sep): continue
+    for f in fs:
+        if f.endswith(('.c','.cc','.h')): files.append(os.path.join(root,f))
+
+findings = []
+for path in sorted(files):
+    if path.endswith('system/mem_alloc.h'): continue
+    try: lines = open(path, encoding='utf-8', errors='replace').read().split('\n')
+    except Exception: continue
+    A = collections.defaultdict(list); P = collections.defaultdict(list)
+    AF = collections.defaultdict(list); PF = collections.defaultdict(list)
+    for i, ln in enumerate(lines, 1):
+        code = re.sub(r'//.*$', '', ln)
+        st = code.strip()
+        if st.startswith('*') or st.startswith('/*') or st.startswith('#'): continue
+        for rx, b in ((ALIGNED_ALLOC, A), (PLAIN_ALLOC, P)):
+            m = rx.search(code)
+            if m:
+                a = ASSIGN.search(code[:m.start()])
+                if a:
+                    k = norm(a.group(1))
+                    if k and not k.endswith('='): b[k].append((i, ln.strip()[:120]))
+        m = ALIGNED_FREE.search(code)
+        if m:
+            k = norm(m.group(1))
+            if k: AF[k].append((i, ln.strip()[:120]))
+        for m in PLAIN_FREE.finditer(code):
+            k = norm(m.group(2))
+            if k: PF[k].append((i, ln.strip()[:120]))
+    for k in set(P) & set(AF):
+        findings.append(("PLAIN alloc -> dt_free_align", path, k, P[k], AF[k]))
+    for k in set(A) & set(PF):
+        findings.append(("ALIGNED alloc -> plain free", path, k, A[k], PF[k]))
+
+import sys
+quiet = "--quiet" in sys.argv
+
+if not findings:
+    if not quiet:
+        print("OK: every dt_alloc_align* is freed by dt_free_align, and nothing else is.")
+    sys.exit(0)
+
+print(f"Allocator/deallocator mismatches: {len(findings)}")
+print()
+for kind, path, k, al, fr in findings:
+    print(f"[{kind}]  {path}   `{k}`")
+    for i,t in al[:2]: print(f"    alloc :{i}  {t}")
+    for i,t in fr[:2]: print(f"    free  :{i}  {t}")
+    print()
+print("dt_alloc_align is _aligned_malloc on Windows and dt_free_align is _aligned_free;")
+print("everywhere else both end at free(). Each of these works on Linux and corrupts the")
+print("heap on Windows, crashing later in unrelated code.")
+sys.exit(1)


### PR DESCRIPTION
From the heap-corruption report on Windows when seeding the image cache. That specific
instance was already fixed in `80ffe3f8a1`; auditing the tree for the same class found **the
API that produced it**, **one more live bug**, and **one latent trap**.

## Why none of this is visible here

`dt_alloc_align()` is `_aligned_malloc()` on Windows and `posix_memalign()` elsewhere.
`dt_free_align()` is `_aligned_free()` on Windows and `g_free()` elsewhere. **Off Windows
both families end at `free()`**, so every mismatch below works perfectly on Linux and macOS,
passes every test and every sanitizer, and corrupts the heap only on Windows — crashing
later, somewhere unrelated, in whatever touches the heap next.

That is why this needed a static audit rather than a test run.

## What was found

**`dt_cache_seed()` let each caller pick the allocator.** It took an `aligned_alloc` flag
choosing between `dt_alloc_align()` and `g_malloc()`. The free side is not a choice:
`caches/cache.c` frees `entry->data` with `dt_free_align()` in **four** places whenever a
cache has no cleanup callback. So `FALSE` was heap corruption on Windows and always had
been. The one caller passing it was already fixed — but fixing the caller and leaving the
flag is fixing the symptom. The parameter is gone.

**`views/view.c` — live bug.** Allocates a surface copy with `dt_alloc_align()` at :988,
frees it with `dt_free()` (which is `g_free()`) at :1035. Every Windows render of that path.

**`iop/drawlayer.c` — latent trap.** Allocated `piece->data` with `calloc()` and freed with
`dt_free()`. Self-consistent, so not a bug today — but it was the only one of **89** modules
doing that, and the *default* `cleanup_pipe` frees `piece->data` with `dt_free_align()`.
Deleting its `cleanup_pipe` at any future point would silently become heap corruption. Now
uses the aligned family like the other 88.

## The gate

`tools/check_alloc_pairing.py` reports both directions for the same expression within one
file. Verified to have teeth by putting the `view.c` bug back, which it catches and names.

It is deliberately narrow. Matching by name *across* files reports `data`, `buffer` and
`img` in unrelated translation units and buries the real findings — I tried, and the first
pass produced 16 candidates of which every single one was a false positive. So it cannot see
a struct field allocated in one file and freed in another, which is exactly the shape the
original report had. The answer there is not a cleverer grep but an API that does not offer
the wrong option, which is what the `dt_cache_seed` change is.

## Audited and correct, so nobody redoes it

- all **89** modules defining `init_pipe`/`cleanup_pipe` pair correctly;
- every function returning `dt_alloc_align`'d memory has all callers freeing with
  `dt_free_align`;
- no `realloc()` on an aligned block (which would need `_aligned_realloc`);
- no memory from glib, sqlite or exiv2 freed with `dt_free_align`.

Two things look like mismatches to a name-based search and are not: `common/points.h` frees
the aligned states array and the plain pointer array with the matching call each (and
documents why), and the IOP `gui->gui_data` and imageio-format `gui_data` are different
fields with different owners.
