### PR TITLE
highlights: unbreak the Debug, macOS and Windows builds

### DIFF
--- a/data/kernels/highlights_harmonic.cl
+++ b/data/kernels/highlights_harmonic.cl
@@ -24,6 +24,29 @@
 
 #include "common.h"
 
+// Double precision: where it is available, and what happens where it is not.
+//
+// Four stage-2 reduction finalizers below accumulate their partials in double, to match the
+// host arithmetic they replaced bit for bit. cl_khr_fp64 is an OPTIONAL OpenCL extension and
+// Apple's implementation does not have it, so naming `double` unguarded does not merely make
+// those four kernels unavailable -- it fails the build of THIS ENTIRE PROGRAM, taking the
+// sixty-odd single-precision kernels in it down as well. That is what the file header above
+// means by "must not require the fp64 extension on every device", and it is what silently
+// happened when these finalizers arrived.
+//
+// So they are compiled only where the extension exists. Where it does not, dt_opencl_create_kernel()
+// returns -1 for each of them and the host stages that use them bail out to their CPU twins --
+// the same arrangement highlights_sparse.cl and the PDE/aniso solvers already use. See
+// _region_guided_filter_cl(), _selfdome_stage_cl(), _chromaticity_gradient_stage_cl() and
+// _aniso_pyramid_cl().
+#if defined(cl_khr_fp64)
+#pragma OPENCL EXTENSION cl_khr_fp64 : enable
+#define HL_HARMONIC_FP64 1
+#elif defined(cl_amd_fp64)
+#pragma OPENCL EXTENSION cl_amd_fp64 : enable
+#define HL_HARMONIC_FP64 1
+#endif
+
 // ===== harmonic-fill kernels (highlights harmonic transposition) ============================
 // "Harmonic fill" = repeatedly replace every hole pixel by the average of its four neighbours
 // (Jacobi relaxation) until the surface is smooth -- like letting heat diffuse from the
@@ -1122,6 +1145,7 @@ hl_region_benefit(global const float *estimate, global const float *valid, globa
     for(int k = 0; k < 6; k++) partial[get_group_id(0) * 6 + k] = scratch[k];
 }
 
+#ifdef HL_HARMONIC_FP64
 // Stage 2: one thread folds the partials into region_worth. Mirrors the CPU _hl_region_worth
 // (highlights/common.h) -- the LO/HI thresholds arrive as arguments so the two cannot drift.
 kernel void
@@ -1141,6 +1165,7 @@ hl_region_worth_finalize(global const float *partial, global float *worth, const
   const float t = clamp((benefit - lo) / (hi - lo), 0.f, 1.f);
   worth[0] = t * t * (3.f - 2.f * t);
 }
+#endif // HL_HARMONIC_FP64
 
 static float hl_floor_worth(const float chroma_gain, const float joint_tau)
 {
@@ -1917,6 +1942,7 @@ hl_vote_reduce(read_only image2d_t gate_src, read_only image2d_t gate_msk, globa
   }
 }
 
+#ifdef HL_HARMONIC_FP64
 // Stage-2 for the chromaticity mean: fold hl_cmean_reduce's float4 partials into the region's
 // mean chromaticity, published as {cmean.r, cmean.g, cmean.b, count} in device memory. Mirrors the
 // host arithmetic it replaces exactly (sum/count in double, zero when the count is zero).
@@ -1998,6 +2024,7 @@ hl_reduce_finalize(global const float *partial, global float *result, const int 
               : (mode == 2) ? fmax((float)(scale * a), 1e-9f)
                             : ((b > 0.0) ? (float)(scale * a / b) : 0.f);
 }
+#endif // HL_HARMONIC_FP64
 
 // Reduction: per-workgroup partial sums of {luminance, count} over any-clip pixels; the stage-2
 // finalizer below turns them into the plateau luminance that gates the anchors, on the device.

--- a/src/iop/highlights/chroma.c
+++ b/src/iop/highlights/chroma.c
@@ -745,12 +745,18 @@ static cl_int _aniso_pyramid_cl(const int devid, void *gd_void, cl_mem ratios, c
                                 const int box_x_lo, const int box_y_lo, const int box_x_hi, const int box_y_hi,
                                 const dt_dev_pixelpipe_t *pipe)
 {
+  dt_iop_highlights_global_data_t *global_data = (dt_iop_highlights_global_data_t *)gd_void;
+  cl_int cl_err = CL_SUCCESS;
+
+  // The stage-2 reduction finalizers this needs are compiled only where the fp64 extension
+  // is (data/kernels/highlights_harmonic.cl). Without them the caller falls back to the CPU
+  // twin, the same way the sparse solver and the PDE/aniso stages already do.
+  if(global_data->kernel_hl_reduce_finalize < 0) return DT_OPENCL_DEFAULT_ERROR; // no fp64 device
+
   cl_mem gnorm_dev = dt_opencl_alloc_device_buffer(devid, sizeof(float)); // gradient-mean normaliser, device-resident
   // the pyramid levels run reaction-free; the "inpaint a flat color" pull is applied by the
   // direct solve and the full-resolution polish only, like the CPU twin
   const float no_react = 0.f;
-  dt_iop_highlights_global_data_t *global_data = (dt_iop_highlights_global_data_t *)gd_void;
-  cl_int cl_err = CL_SUCCESS;
 
   int n_levels = 1;
   while(((int)radius >> (n_levels - 1)) > 8 && n_levels < 7) n_levels++;

--- a/src/iop/highlights/chroma.c
+++ b/src/iop/highlights/chroma.c
@@ -1173,7 +1173,6 @@ cl_int _aniso_stage_cl(const int devid, void *gd_void, cl_mem estimate, cl_mem v
     cl_err = dt_opencl_enqueue_kernel_2d_with_local(devid, kernel, sizes, local);
     if(cl_err != CL_SUCCESS) goto out;
 
-    float psum[256];
     {
       const int gfin = global_data->kernel_hl_reduce_finalize;
       const int gstride = 1, gmode = 2;
@@ -1429,7 +1428,6 @@ reassemble:;
       cl_err = dt_opencl_enqueue_kernel_2d_with_local(devid, kernel, sizes, local);
       if(cl_err == CL_SUCCESS)
       {
-        float partial_sums[256];
         {
           const int gfin = global_data->kernel_hl_reduce_finalize;
           const int gstride = 1, gmode = 2, gn = 256;

--- a/src/iop/highlights/coefficient_field.c
+++ b/src/iop/highlights/coefficient_field.c
@@ -1431,9 +1431,13 @@ void _cf_reconstruct(_hl_region_ctx_t *const ctx)
                           + fabsf(sj2 / tj - sp2 / tp);
     region_worth = _hl_region_worth(benefit);
     ctx->region_worth = region_worth; // every floor site in this region reuses the same decision
+    // %llu and a cast below, not %zu: dt_print() carries __attribute__((format(printf))),
+    // which MinGW maps to ms_printf, and that does not implement the C99 length modifier.
+    // Plain fprintf() gets gnu_printf via __USE_MINGW_ANSI_STDIO and does accept %zu, which
+    // is why the ones in selftests.c are fine. Same reasoning as develop/pixelpipe_hb.c.
     if(getenv("HL_REGION_W"))
-      dt_print(DT_DEBUG_ALWAYS, "[hl regionw] px=%zu benefit=%.6f region_worth=%.4f\n", region_pixels,
-               benefit, region_worth);
+      dt_print(DT_DEBUG_ALWAYS, "[hl regionw] px=%llu benefit=%.6f region_worth=%.4f\n",
+               (unsigned long long)region_pixels, benefit, region_worth);
   }
 
   HL_PFOR()

--- a/src/iop/highlights/core.c
+++ b/src/iop/highlights/core.c
@@ -886,7 +886,6 @@ cl_int _selfdome_stage_cl(const int devid, void *gd_void, cl_mem estimate, cl_me
     }
     size_t sizes[3] = { (size_t)n_groups * local_size, 1, 1 };
     size_t local[3] = { local_size, 1, 1 };
-    float partial_host[8 * 256];
 
     // blown-zone plateau -> bright-valid gate for the refinements' surround mean: the
     // whole-window mean is contaminated by dark, unrelated content (the cgrad anchors learned

--- a/src/iop/highlights/core.c
+++ b/src/iop/highlights/core.c
@@ -818,6 +818,13 @@ cl_int _selfdome_stage_cl(const int devid, void *gd_void, cl_mem estimate, cl_me
   size_t size[3] = { ROUNDUPDWD(region_w, devid), ROUNDUPDHT(region_h, devid), 1 };
   const float epsilon = 1e-6f;
 
+  // The stage-2 reduction finalizers this needs are compiled only where the fp64 extension
+  // is (data/kernels/highlights_harmonic.cl). Without them the caller falls back to the CPU
+  // twin, the same way the sparse solver and the PDE/aniso stages already do.
+  if(global_data->kernel_hl_reduce_finalize < 0 || global_data->kernel_hl_cmean_finalize < 0
+     || global_data->kernel_hl_ring_vote_finalize < 0)
+    return cl_err; // no fp64 device
+
   cl_mem luminance = dt_opencl_alloc_device_buffer(devid, sizeof(float) * region_pixels);
   cl_mem hole = dt_opencl_alloc_device_buffer(devid, region_pixels);
   cl_mem dome_lum = dt_opencl_alloc_device_buffer(devid, sizeof(float) * region_pixels);
@@ -1534,6 +1541,13 @@ cl_int _chromaticity_gradient_stage_cl(const int devid, void *gd_void, cl_mem es
   cl_int cl_err = DT_OPENCL_DEFAULT_ERROR;
   size_t size[3] = { ROUNDUPDWD(region_w, devid), ROUNDUPDHT(region_h, devid), 1 };
   const float epsilon = 1e-6f;
+
+  // The stage-2 reduction finalizers this needs are compiled only where the fp64 extension
+  // is (data/kernels/highlights_harmonic.cl). Without them the caller falls back to the CPU
+  // twin, the same way the sparse solver and the PDE/aniso stages already do.
+  if(global_data->kernel_hl_reduce_finalize < 0 || global_data->kernel_hl_cmean_finalize < 0
+     || global_data->kernel_hl_ring_vote_finalize < 0)
+    return cl_err; // no fp64 device
 
   cl_mem guard_src = dt_opencl_alloc_device(devid, region_w, region_h, sizeof(float));  // image (gaussian)
   cl_mem guard_blur = dt_opencl_alloc_device(devid, region_w, region_h, sizeof(float)); // image (gaussian)

--- a/src/iop/highlights/pde.c
+++ b/src/iop/highlights/pde.c
@@ -493,7 +493,6 @@ cl_int _region_pde_cg_cl(const int devid, void *gd_void, cl_mem solution, cl_mem
   // CG scalar state (rr, rr_new, rr_init, alpha, beta, active) -- device-resident for the
   // whole solve: the iteration reads and writes it without ever touching the host
   cl_mem cg_state = dt_opencl_alloc_device_buffer(devid, sizeof(float) * 6);
-  double partial_sums[256];
   if(!temp1 || !temp2 || !residual || !search_dir || !matvec || !partials) goto out;
 
 #define CG_EMBED(src_, keep_)                                                                                     \
@@ -563,7 +562,6 @@ cl_int _region_pde_cg_cl(const int devid, void *gd_void, cl_mem solution, cl_mem
   for(int iteration = 0; iteration < maxiter; iteration++)
   {
     CG_EMBED(search_dir, 1);
-    double p_dot_matvec;
     {
       const int kernel = global_data->kernel_hl_cg_ap;
       dt_opencl_set_kernel_arg(devid, kernel, 0, sizeof(cl_mem), &matvec);

--- a/src/iop/highlights/region.c
+++ b/src/iop/highlights/region.c
@@ -424,6 +424,11 @@ cl_int _region_guided_filter_cl(const int devid, void *gd_void, cl_mem interp, c
   size_t work_size[3] = { ROUNDUPDWD(region_w, devid), ROUNDUPDHT(region_h, devid), 1 };
   dt_gaussian_cl_t *cf_gaussian = NULL;
 
+  // The stage-2 reduction finalizers this needs are compiled only where the fp64 extension
+  // is (data/kernels/highlights_harmonic.cl). Without them the caller falls back to the CPU
+  // twin, the same way the sparse solver and the PDE/aniso stages already do.
+  if(global_data->kernel_hl_region_worth_finalize < 0) return cl_err; // no fp64 device
+
   cl_mem estimate = dt_opencl_alloc_device_buffer(devid, sizeof(float) * region_pixels * 4);
   cl_mem valid = dt_opencl_alloc_device_buffer(devid, sizeof(float) * region_pixels * 4);
   cl_mem clip0 = dt_opencl_alloc_device_buffer(devid, sizeof(float) * region_pixels * 4);


### PR DESCRIPTION
Master does not currently build in any Debug configuration with OpenCL enabled, and does not build at all on macOS. Both come from the `highlights/opencl` series; master itself has had no CI run since 2026-08-03, so nothing caught either. Surfaced on an unrelated PR's matrix ([#1258](https://github.com/aurelienpierreeng/ansel/pull/1258)).

Two independent problems, one commit each.

## 1. Dead host staging buffers → `-Werror=unused-variable`

Five locals declared and then never written and never read — leftovers from moving the reductions onto the device:

| file | variable | what took over |
|---|---|---|
| `highlights/chroma.c` | `float psum[256]` | the gnorm reduction writes `gnorm_dev` |
| `highlights/chroma.c` | `float partial_sums[256]` | same, in the second reduce site |
| `highlights/pde.c` | `double partial_sums[256]` | the CG solve keeps its scalars in `cg_state` |
| `highlights/pde.c` | `double p_dot_matvec` | consumed on-device, never read back |
| `highlights/core.c` | `float partial_host[8 * 256]` | the plateau reduce writes `partial_sums` (a `cl_mem`) |

Each occurs **exactly once** in its file — the declaration. Dead weight, not a missing readback. Worth saying since the name repeats: `core.c` has two *other* `partial_host` arrays that **are** read back with `dt_opencl_read_buffer_from_device()` and stay; only the one at line 889 goes.

`-Wunused-variable` is in `-Wall` and Debug adds `-Werror`; Release does not, which is why local Release builds only warned.

## 2. `double` without `cl_khr_fp64` → macOS cannot build the kernels

`data/kernels/highlights_harmonic.cl` names `double` in four stage-2 reduction finalizers with no extension guard. `cl_khr_fp64` is **optional** in OpenCL and Apple does not have it — so this does not merely make those four kernels unavailable there, it fails the build of the **whole program**, taking the sixty-odd single-precision kernels in the same file down with it. The file's own header already said the doubles belong in `highlights_sparse.cl` because this one "must not require the fp64 extension on every device".

```
hl_region_worth_finalize   hl_cmean_finalize   hl_ring_vote_finalize   hl_reduce_finalize
```

They are now compiled only behind `HL_HARMONIC_FP64`, exactly as [`highlights_sparse.cl`](../blob/master/data/kernels/highlights_sparse.cl#L47-L55) already does it. Where the extension is missing, `dt_opencl_create_kernel()` returns -1 for each and the four host stages that call them fall back to their CPU twins, the same way the sparse solver and the PDE/aniso stages already do:

| stage | file | needs |
|---|---|---|
| `_region_guided_filter_cl()` | `region.c` | `hl_region_worth_finalize` |
| `_selfdome_stage_cl()` | `core.c` | reduce / cmean / ring_vote |
| `_chromaticity_gradient_stage_cl()` | `core.c` | reduce / cmean / ring_vote |
| `_aniso_pyramid_cl()` | `chroma.c` | reduce |

`_aniso_stage_cl()` and `_joint_core_stage_cl()` were already covered — they guard on kernels that live in the fp64-gated `highlights_sparse.cl`. These four were not.

`_aniso_pyramid_cl()` allocated `gnorm_dev` before it had a `global_data` to test, so those two declarations move above the allocation; it also starts from `CL_SUCCESS` rather than `DT_OPENCL_DEFAULT_ERROR`, so its guard returns the error explicitly.

## Verified

Against the exact command `data/kernels/CMakeLists.txt` runs, with `-cl-ext=-cl_khr_fp64,-cl_amd_fp64` standing in for Apple:

| | result |
|---|---|
| before, fp64 **off** | `highlights_harmonic.cl:1132: use of type 'double' requires cl_khr_fp64 support` — the macOS error, same line |
| after, fp64 **off** | clean |
| after, fp64 **on** | clean |

Plus the `highlights` module built with Clang, Debug, `-Werror`, `USE_OPENCL=ON` — the configuration that was failing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)