### PR TITLE
doc: the screenshot panel stops reaching up into develop/ and libs/

### DIFF
--- a/src/darktable.c
+++ b/src/darktable.c
@@ -163,7 +163,9 @@
 #include "control/jobs/film_jobs.h"
 #include "control/signal.h"
 #include "develop/dev_pixelpipe.h"
+#include "develop/develop.h"      // dt_dev_get_global(), dev->iop
 #include "develop/imageop.h"
+#include "develop/imageop_gui.h"  // module->gui->expander
 #include "develop/supervisor.h"
 
 #include "gui/application.h"
@@ -859,6 +861,47 @@ static void _preferences_changed(gpointer instance, gpointer user_data)
 /* Same "read at startup, re-read on change, never anywhere else" lifecycle as the mipmap cache
  * settings above, for the "write_sidecar_files" preference: dt_image_get_xmp_mode() is on the
  * per-image hot path and reads a cache instead of conf directly. */
+/* Module inventories for the documentation capture panel (gui/actions/doc_screenshot.h).
+ *
+ * They live HERE, and that is deliberate. The panel lists tool modules and darkroom modules,
+ * which are dt_lib_module_t and dt_iop_module_t -- two and three layers above gui/, where the
+ * panel is. Reading them from there inverted the include graph four times over. The
+ * orchestrator is the one place that sits above every module by construction, so it is the
+ * only place that may legally see both lists; the panel asks for (widget, name) pairs and
+ * these hand them over.
+ *
+ * Called on every refresh of the panel, so they read the live lists rather than a snapshot.
+ */
+static void _doc_screenshot_lib_modules(void *inventory)
+{
+  // Tool modules of every view: the ones belonging to the view we are not in are unmapped,
+  // so they show up greyed out instead of disappearing from the inventory.
+  for(GList *item = dt_lib_get_global()->plugins; item; item = g_list_next(item))
+  {
+    dt_lib_module_t *module = (dt_lib_module_t *)item->data;
+    GtkWidget *target = IS_NULL_PTR(module->expander) ? module->widget : module->expander;
+    dt_gui_doc_screenshot_add_target(inventory, target, module->common_fields.name);
+  }
+}
+
+static void _doc_screenshot_iop_modules(void *inventory)
+{
+  // This list is only populated while an image is open in darkroom.
+  for(GList *item = dt_dev_get_global()->iop; item; item = g_list_next(item))
+  {
+    dt_iop_module_t *module = (dt_iop_module_t *)item->data;
+    if(IS_NULL_PTR(module->gui) || IS_NULL_PTR(module->gui->expander)) continue;
+
+    // Several instances of the same module share a name: keep them apart in the tree, and
+    // therefore in the file names too.
+    gchar *label = (module->multi_name[0] != '\0')
+                       ? g_strdup_printf("%s (%s)", module->common_fields.name, module->multi_name)
+                       : g_strdup(module->common_fields.name);
+    dt_gui_doc_screenshot_add_target(inventory, module->gui->expander, label);
+    dt_free(label);
+  }
+}
+
 static void _xmp_mode_preferences_changed(gpointer instance, gpointer user_data)
 {
   (void)instance;
@@ -1252,6 +1295,8 @@ int dt_init(int argc, char *argv[], const gboolean init_gui, const gboolean load
           argv[k] = NULL;
         }
         dt_gui_doc_screenshot_enable();
+        dt_gui_doc_screenshot_register_source(_("Tool modules"), _doc_screenshot_lib_modules);
+        dt_gui_doc_screenshot_register_source(_("Darkroom modules"), _doc_screenshot_iop_modules);
       }
       else if(!strcmp(argv[k], "--debug"))
       {

--- a/src/gui/actions/doc_screenshot.c
+++ b/src/gui/actions/doc_screenshot.c
@@ -20,12 +20,8 @@
 
 #include "common/conf.h"          // dt_conf_get_string(), dt_conf_set_string()
 #include "common/l10n.h"          // dt_l10n_get_global(), dt_l10n_get_current_code()
-#include "develop/develop.h"      // dt_dev_get_global(), dev->iop
-#include "develop/imageop.h"      // dt_iop_module_t
-#include "develop/imageop_gui.h"  // dt_iop_module_gui_t, module->gui->expander
 #include "gui/application.h"      // dt_gui_get_ui(), dt_gui_main_window()
 #include "gui/window_manager.h"   // dt_ui_t, dt_ui_center_base(), DT_UI_PANEL_*
-#include "libs/lib.h"             // dt_lib_get_global(), dt_lib_module_t
 #include "system/macros.h"        // IS_NULL_PTR
 #include "system/mem_alloc.h"     // dt_free
 #include "widgets/bauhaus.h"      // DT_IS_BAUHAUS_WIDGET(), dt_bauhaus_widget_get_label()
@@ -508,6 +504,37 @@ static void _append_row(GtkTreeIter *parent, GtkWidget *target, const char *labe
 }
 
 
+/* Registered module inventories. Filled from src/darktable.c -- see the header for why the
+ * panel cannot look the modules up itself. Sections appear in registration order. */
+typedef struct _doc_source_t
+{
+  gchar *section;
+  dt_gui_doc_screenshot_source_t fill;
+} _doc_source_t;
+
+static GList *_sources = NULL; // _doc_source_t*, owned here, alive for the process
+
+void dt_gui_doc_screenshot_register_source(const char *section, dt_gui_doc_screenshot_source_t source)
+{
+  if(IS_NULL_PTR(section) || IS_NULL_PTR(source)) return;
+
+  _doc_source_t *entry = (_doc_source_t *)g_malloc0(sizeof(_doc_source_t));
+  entry->section = g_strdup(section);
+  entry->fill = source;
+  _sources = g_list_append(_sources, entry);
+}
+
+/** The sink a source calls back into, once per widget. @p inventory is the section iterator
+ * handed to the source; the name is copied into the widget-to-name table the capture and the
+ * file naming both read. */
+void dt_gui_doc_screenshot_add_target(void *inventory, GtkWidget *widget, const char *name)
+{
+  if(IS_NULL_PTR(inventory) || IS_NULL_PTR(widget) || IS_NULL_PTR(name)) return;
+
+  g_hash_table_insert(_g.names, widget, g_strdup(name));
+  _append_row((GtkTreeIter *)inventory, widget, NULL, 0);
+}
+
 /** Append a top-level grouping row. It captures nothing: it is a way in, not a target. */
 static void _append_section(const char *title, GtkTreeIter *section)
 {
@@ -684,33 +711,15 @@ static void _populate(GtkWidget *widget, gpointer user_data)
   dt_ui_t *const ui = dt_gui_get_ui();
   GtkTreeIter section;
 
-  // Tool modules of every view: the ones belonging to the view we are not in are unmapped,
-  // so they show up greyed out instead of disappearing from the inventory.
-  _append_section(_("Tool modules"), &section);
-  for(GList *item = dt_lib_get_global()->plugins; item; item = g_list_next(item))
+  // Module inventories, in registration order. The panel does not know what a module is --
+  // see dt_gui_doc_screenshot_register_source() and its callers in src/darktable.c. The
+  // sections are appended even when a source yields nothing, so the inventory reads the same
+  // whichever view is current: the darkroom list is only populated while an image is open.
+  for(GList *item = _sources; item; item = g_list_next(item))
   {
-    dt_lib_module_t *module = (dt_lib_module_t *)item->data;
-    GtkWidget *target = IS_NULL_PTR(module->expander) ? module->widget : module->expander;
-    if(IS_NULL_PTR(target) || IS_NULL_PTR(module->common_fields.name)) continue;
-
-    g_hash_table_insert(_g.names, target, g_strdup(module->common_fields.name));
-    _append_row(&section, target, NULL, 0);
-  }
-
-  // Darkroom modules: this list is only populated while an image is open in darkroom.
-  _append_section(_("Darkroom modules"), &section);
-  for(GList *item = dt_dev_get_global()->iop; item; item = g_list_next(item))
-  {
-    dt_iop_module_t *module = (dt_iop_module_t *)item->data;
-    if(IS_NULL_PTR(module->gui) || IS_NULL_PTR(module->gui->expander)) continue;
-
-    // Several instances of the same module share a name: keep them apart in the tree, and
-    // therefore in the file names too.
-    gchar *label = (module->multi_name[0] != '\0')
-                       ? g_strdup_printf("%s (%s)", module->common_fields.name, module->multi_name)
-                       : g_strdup(module->common_fields.name);
-    g_hash_table_insert(_g.names, module->gui->expander, label); // the table owns it now
-    _append_row(&section, module->gui->expander, NULL, 0);
+    const _doc_source_t *const src = (const _doc_source_t *)item->data;
+    _append_section(src->section, &section);
+    src->fill(&section);
   }
 
   // Named before use, so drilling down into the window finds them under these names too.

--- a/src/gui/actions/doc_screenshot.h
+++ b/src/gui/actions/doc_screenshot.h
@@ -19,7 +19,7 @@
 #ifndef DT_GUI_ACTIONS_DOC_SCREENSHOT_H
 #define DT_GUI_ACTIONS_DOC_SCREENSHOT_H
 
-#include <glib.h>
+#include <gtk/gtk.h>
 
 /** @file doc_screenshot.h
  *
@@ -56,5 +56,31 @@ void dt_gui_doc_screenshot_set_directory(const char *path);
  * window down to a single slider, with a check box on every row, a destination folder and a
  * capture button. */
 void dt_gui_doc_screenshot_window_show(void);
+
+/* Where the module inventories come from.
+ *
+ * The panel lists tool modules and darkroom modules by name, which are `dt_lib_module_t`
+ * and `dt_iop_module_t` -- and those live two and three layers ABOVE gui/. Reading them
+ * from here inverted the dependency graph four times over (tools/check_layering.sh), so the
+ * panel no longer knows what a module is: it asks for (widget, name) pairs and whoever
+ * knows how to produce them hands them over.
+ *
+ * src/darktable.c is where they are supplied from. That is not a fallback: the orchestrator
+ * is the one place that sits above every module by construction, so it is the only place
+ * that may legally see both lists. */
+
+/** Hand the panel one capture target. Call it from a source callback, once per widget;
+ * @p name is copied. A NULL @p widget is ignored, so a source can pass a module's optional
+ * container without testing it first. */
+void dt_gui_doc_screenshot_add_target(void *inventory, GtkWidget *widget, const char *name);
+
+/** Collect one section's worth of targets by calling dt_gui_doc_screenshot_add_target()
+ * with the @p inventory handed in. Called every time the panel refreshes, so it reads the
+ * live module lists rather than a snapshot taken at registration time. */
+typedef void (*dt_gui_doc_screenshot_source_t)(void *inventory);
+
+/** Register a named section of the panel's tree and the callback that fills it. The order of
+ * registration is the order the sections appear in. @p section is copied. */
+void dt_gui_doc_screenshot_register_source(const char *section, dt_gui_doc_screenshot_source_t source);
 
 #endif // DT_GUI_ACTIONS_DOC_SCREENSHOT_H


### PR DESCRIPTION
`3fb232a289` added `src/gui/actions/doc_screenshot.c`, which lists tool modules and darkroom modules by name. Those are `dt_lib_module_t` and `dt_iop_module_t`, and the include graph puts them at layers **7** and **5** against `gui/`'s **4** — so reading them from there inverted the dependency four times over:

```
develop/develop.h   develop/imageop.h   develop/imageop_gui.h   libs/lib.h
```

`tools/check_layering.sh` has been failing **183 → 187** on every branch since. Measured directly: old master `930865e8ca` = 183, current master `3fb232a289` = 187. Master's own last CI run predates the commit, which is why nothing caught it.

## What changes

The panel no longer knows what a module is. It asks for `(widget, name)` pairs:

- `dt_gui_doc_screenshot_register_source()` names a section and the callback that fills it;
- `dt_gui_doc_screenshot_add_target()` is what that callback hands them back through.

Sources are called on **every refresh**, not snapshotted, so the darkroom list still populates and empties as an image is opened and closed.

The two loops move **verbatim** into `src/darktable.c`, where `--doc` is already parsed and where `develop/` and `libs/` are already included. That is not a dumping ground: the orchestrator is the one place that sits above every module by construction — the layer table says so in as many words, *"the orchestrator sits ABOVE every module, so nothing it includes can be an inversion"* — and it is therefore the only non-plugin location that may legally see both lists at once. (`libs/`, `views/` and `chart/` are the only other layer-≥7 directories, and all three build plugins with a force-included module API.)

## Considered and rejected

Giving `dt_gui_module_t` a container-widget accessor would have been the tidier abstraction — it already exists in `common/` precisely as the shared prefix of both module types. But its own comment demands that all three stay in sync, so adding a field shifts every member of `dt_lib_module_t` **and** `dt_iop_module_t`. That is an ABI change of the kind that makes a stale plugin silently misread its own struct. Not worth it to save one indirection.

## Behaviour

Unchanged: same two sections, same order, same names, same multi-instance suffix. The one functional difference is that a section now appears even when its source yields nothing — which the darkroom list already did whenever no image was open.

Verified: `check_layering.sh` back to **183 (baseline 183)**, `check_module_boundaries.sh` clean, and both changed translation units compile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)