### PR TITLE
init: stop making ansel-cli pay for the GUI's state

### DIFF
--- a/src/common/collection.c
+++ b/src/common/collection.c
@@ -121,6 +121,36 @@ static int _resolve_iop_order_name(const char *text)
  *  strings, so the array can be handed over and borrowed. */
 static const char *_order_names[DT_IOP_ORDER_LAST];
 
+/* The application-wide collection.
+ *
+ * Owned HERE, not by darktable_t, and created by the GUI bootstrap (dt_gui_gtk_init())
+ * rather than by dt_init(): the collection is the lighttable's query state, and ansel-cli
+ * has no lighttable. Instantiating it in dt_init() made every CLI run pay for the user's
+ * collection query against their whole library before exporting a single pixel.
+ *
+ * In a GUI-less process the accessor therefore returns NULL, and every public entry point
+ * of this module treats a NULL collection as "the module is not up": a query update is a
+ * no-op, a count is 0. The guard lives at this module boundary ONCE, so callers shared
+ * between GUI and CLI (film import, image removal) stay free of if(darktable.gui) tests.
+ */
+static dt_collection_t *_collection_global = NULL;
+
+dt_collection_t *dt_collection_get_global(void)
+{
+  return _collection_global;
+}
+
+void dt_collection_init_global(void)
+{
+  if(IS_NULL_PTR(_collection_global)) _collection_global = dt_collection_new();
+}
+
+void dt_collection_cleanup_global(void)
+{
+  dt_collection_free(_collection_global);
+  _collection_global = NULL;
+}
+
 dt_collection_t *dt_collection_new()
 {
   dt_collection_t *collection = g_malloc0(sizeof(dt_collection_t));
@@ -137,6 +167,7 @@ dt_collection_t *dt_collection_new()
 
 void dt_collection_free(const dt_collection_t *collection)
 {
+  if(IS_NULL_PTR(collection)) return;
   dt_free(collection->params.text_filter);
   for(int i = 0; i < collection->n_rules; i++)
   {
@@ -153,6 +184,7 @@ void dt_collection_free(const dt_collection_t *collection)
 
 const dt_collection_params_t *dt_collection_params(const dt_collection_t *collection)
 {
+  if(IS_NULL_PTR(collection)) return NULL;
   return &collection->params;
 }
 
@@ -165,6 +197,7 @@ const dt_collection_params_t *dt_collection_params(const dt_collection_t *collec
 
 int dt_collection_update(const dt_collection_t *collection)
 {
+  if(IS_NULL_PTR(collection)) return 0;
   /* store flags to conf */
   if(collection == dt_collection_get_global())
   {
@@ -241,6 +274,7 @@ uint32_t dt_collection_get_count(const dt_collection_t *collection)
 
 void dt_collection_reset(const dt_collection_t *collection)
 {
+  if(IS_NULL_PTR(collection)) return;
   dt_collection_params_t *params = (dt_collection_params_t *)&collection->params;
 
   /* setup defaults */
@@ -262,22 +296,26 @@ void dt_collection_reset(const dt_collection_t *collection)
 
 dt_collection_filter_flag_t dt_collection_get_filter_flags(const dt_collection_t *collection)
 {
+  if(IS_NULL_PTR(collection)) return COLLECTION_FILTER_ALL;
   return collection->params.filter_flags;
 }
 
 void dt_collection_set_filter_flags(const dt_collection_t *collection, dt_collection_filter_flag_t flags)
 {
+  if(IS_NULL_PTR(collection)) return;
   dt_collection_params_t *params = (dt_collection_params_t *)&collection->params;
   params->filter_flags = flags;
 }
 
 char *dt_collection_get_text_filter(const dt_collection_t *collection)
 {
+  if(IS_NULL_PTR(collection)) return NULL;
   return collection->params.text_filter;
 }
 
 void dt_collection_set_text_filter(const dt_collection_t *collection, char *text_filter)
 {
+  if(IS_NULL_PTR(collection)) { dt_free(text_filter); return; } // takes ownership even when down
   dt_collection_params_t *params = (dt_collection_params_t *)&collection->params;
   dt_free(params->text_filter);
   params->text_filter = text_filter;
@@ -285,11 +323,13 @@ void dt_collection_set_text_filter(const dt_collection_t *collection, char *text
 
 dt_collection_query_flags_t dt_collection_get_query_flags(const dt_collection_t *collection)
 {
+  if(IS_NULL_PTR(collection)) return COLLECTION_QUERY_FULL;
   return collection->params.query_flags;
 }
 
 void dt_collection_set_query_flags(const dt_collection_t *collection, dt_collection_query_flags_t flags)
 {
+  if(IS_NULL_PTR(collection)) return;
   dt_collection_params_t *params = (dt_collection_params_t *)&collection->params;
   params->query_flags = flags;
 }
@@ -297,6 +337,7 @@ void dt_collection_set_query_flags(const dt_collection_t *collection, dt_collect
 void dt_collection_set_rules(const dt_collection_t *collection, const dt_collection_rule_t *rules,
                              const int n_rules)
 {
+  if(IS_NULL_PTR(collection)) return;
   dt_collection_t *c = (dt_collection_t *)collection;
 
   for(int i = 0; i < c->n_rules; i++)
@@ -319,11 +360,13 @@ void dt_collection_set_rules(const dt_collection_t *collection, const dt_collect
 
 void dt_collection_set_tag_id(dt_collection_t *collection, const uint32_t tagid)
 {
+  if(IS_NULL_PTR(collection)) return;
   collection->tagid = tagid;
 }
 
 void dt_collection_set_sort(const dt_collection_t *collection, dt_collection_sort_t sort, gboolean reverse)
 {
+  if(IS_NULL_PTR(collection)) return;
   dt_collection_params_t *params = (dt_collection_params_t *)&collection->params;
 
   if(sort != DT_COLLECTION_SORT_NONE)
@@ -334,11 +377,13 @@ void dt_collection_set_sort(const dt_collection_t *collection, dt_collection_sor
 
 dt_collection_sort_t dt_collection_get_sort_field(const dt_collection_t *collection)
 {
+  if(IS_NULL_PTR(collection)) return DT_COLLECTION_SORT_NONE;
   return collection->params.sort;
 }
 
 gboolean dt_collection_get_sort_descending(const dt_collection_t *collection)
 {
+  if(IS_NULL_PTR(collection)) return FALSE;
   return collection->params.descending;
 }
 
@@ -792,6 +837,9 @@ void dt_collection_set_recents_handler(dt_collection_recents_handler_t handler)
 void dt_collection_update_query(const dt_collection_t *collection, dt_collection_change_t query_change,
                                 dt_collection_properties_t changed_property, GList *list)
 {
+  // Import and removal paths shared with ansel-cli land here; without a GUI there is no
+  // collection to re-query and nobody listening. The one guard that keeps them CLI-clean.
+  if(IS_NULL_PTR(collection)) return;
   int next = -1;
   if(list)
   {
@@ -863,6 +911,7 @@ gboolean dt_collection_hint_message_internal(void *message)
 
 void dt_collection_hint_message(const dt_collection_t *collection)
 {
+  if(IS_NULL_PTR(collection)) return;
   /* collection hinting */
   gchar *message;
 
@@ -1032,6 +1081,7 @@ void dt_collection_notify_imported(const int32_t imgid, const gchar *known_image
 void dt_collection_load_filmroll(dt_collection_t *collection, const int32_t imgid, gboolean open_single_image,
                                  gboolean set_mouse_over)
 {
+  if(IS_NULL_PTR(collection)) return;
   const dt_view_t *current_atelier = dt_view_manager_get_current_view(dt_view_manager_get_global());
 
   // Without a real image there is nothing to switch to or open.

--- a/src/common/collection.h
+++ b/src/common/collection.h
@@ -217,8 +217,15 @@ typedef struct dt_collection_t
 const char *dt_collection_name(dt_collection_properties_t prop);
 
 /** instantiates a collection context */
-// Interim accessor (Strategy B, doc/globals-migration.md): implemented by the orchestrator; long-term the handle should be carried on the job/view context (Strategy C).
+// Interim accessor (Strategy B, doc/globals-migration.md): implemented by the module itself; long-term the handle should be carried on the job/view context (Strategy C).
+// NULL in a GUI-less process (ansel-cli): the collection is lighttable query state, created by
+// dt_gui_gtk_init() through dt_collection_init_global(). Every public function here accepts a
+// NULL collection and degrades to a no-op / neutral result, so shared code paths need no guard.
 dt_collection_t *dt_collection_get_global(void);
+/** creates the application-wide collection. Called by the GUI bootstrap only. */
+void dt_collection_init_global(void);
+/** frees the application-wide collection. */
+void dt_collection_cleanup_global(void);
 
 dt_collection_t *dt_collection_new();
 /** frees a collection context. */

--- a/src/common/noiseprofiles.c
+++ b/src/common/noiseprofiles.c
@@ -39,9 +39,30 @@
 const dt_noiseprofile_t dt_noiseprofile_generic = {N_("generic poissonian"), "", "", 0, {0.0001f, 0.0001f, 0.0001}, {0.0f, 0.0f, 0.0f}};
 static GMutex _noiseprofiles_parser_mutex;
 
+/* The parsed noiseprofiles.json, module-owned and LAZY.
+ *
+ * Parsing and verifying the JSON costs ~60 ms -- measured as the single largest item of
+ * dt_init(), over half of a warm ansel-cli startup -- and its only consumer is
+ * dt_noiseprofile_get_matching(), which the denoise IOPs call when a module actually needs
+ * a profile for an image. So the file is read on the first such call, under the same mutex
+ * that already serializes every walk of the parser tree, and a process that never opens a
+ * denoise module (every plain CLI export) never reads it at all.
+ *
+ * _parser_tried keeps a missing or invalid file from being re-parsed on every lookup:
+ * one attempt, then the NULL answer is as final as a parsed tree. */
+static JsonParser *_noiseprofiles_parser = NULL;
+static gboolean _noiseprofiles_tried = FALSE;
+static char *_noiseprofiles_alternative = NULL; // --noiseprofiles override, owned here
+
+void dt_noiseprofile_set_path(const char *alternative)
+{
+  dt_free(_noiseprofiles_alternative);
+  _noiseprofiles_alternative = g_strdup(alternative);
+}
+
 static gboolean dt_noiseprofile_verify(JsonParser *parser);
 
-JsonParser *dt_noiseprofile_init(const char *alternative)
+static JsonParser *_noiseprofile_load(const char *alternative)
 {
   GError *error = NULL;
   char filename[DT_PATH_MAX] = { 0 };
@@ -234,21 +255,44 @@ end:
 }
 #undef _ERROR
 
+// Callers hold _noiseprofiles_parser_mutex.
+static JsonParser *_get_parser_locked(void)
+{
+  if(!_noiseprofiles_tried)
+  {
+    _noiseprofiles_tried = TRUE;
+    _noiseprofiles_parser = _noiseprofile_load(_noiseprofiles_alternative);
+  }
+  return _noiseprofiles_parser;
+}
+
+void dt_noiseprofile_cleanup(void)
+{
+  g_mutex_lock(&_noiseprofiles_parser_mutex);
+  if(_noiseprofiles_parser) g_object_unref(_noiseprofiles_parser);
+  _noiseprofiles_parser = NULL;
+  _noiseprofiles_tried = FALSE;
+  dt_free(_noiseprofiles_alternative);
+  g_mutex_unlock(&_noiseprofiles_parser_mutex);
+}
+
 GList *dt_noiseprofile_get_matching(const dt_image_t *cimg)
 {
-  JsonParser *parser = dt_noiseprofile_get_parser_global();
   JsonReader *reader = NULL;
   GList *result = NULL;
   gboolean parser_locked = FALSE;
 
   if(IS_NULL_PTR(cimg)) goto end;
   if(cimg->camera_maker[0] == '\0' || cimg->camera_model[0] == '\0') goto end;
-  if(IS_NULL_PTR(parser)) goto end;
 
   // Json-glib parser/tree access is shared process-wide and not re-entrant.
-  // Serialize lookup while creating and walking readers from the global parser.
+  // Serialize lookup while creating and walking readers from the global parser --
+  // including the lazy first parse itself.
   g_mutex_lock(&_noiseprofiles_parser_mutex);
   parser_locked = TRUE;
+
+  JsonParser *parser = _get_parser_locked();
+  if(IS_NULL_PTR(parser)) goto end;
 
   JsonNode *root = json_parser_get_root(parser);
   if(IS_NULL_PTR(root)) goto end;

--- a/src/common/noiseprofiles.h
+++ b/src/common/noiseprofiles.h
@@ -43,9 +43,11 @@
 #include <glib.h>
 #include <json-glib/json-glib.h>
 
-/* Process-wide singleton with no per-call context to ride on: this accessor is the
- * intended end state (same category as dt_conf_*), implemented by the orchestrator. */
-JsonParser *dt_noiseprofile_get_parser_global(void);
+/** Point the module at an alternative noiseprofiles.json (--noiseprofiles). The file is
+ * parsed lazily, on the first dt_noiseprofile_get_matching() call -- never at startup. */
+void dt_noiseprofile_set_path(const char *alternative);
+/** drops the parsed profiles, if any. */
+void dt_noiseprofile_cleanup(void);
 
 typedef struct dt_noiseprofile_t
 {
@@ -61,7 +63,6 @@ dt_noiseprofile_t;
 extern const dt_noiseprofile_t dt_noiseprofile_generic;
 
 /** read the noiseprofile file once on startup (kind of)*/
-JsonParser *dt_noiseprofile_init(const char *alternative);
 
 /*
  * returns the noiseprofiles matching the image's exif data.

--- a/src/common/selection.c
+++ b/src/common/selection.c
@@ -66,6 +66,33 @@ typedef struct dt_selection_t
 
 
 // Signal the GUI that selection got changed and trigger a selected images counter update
+
+/* The application-wide selection.
+ *
+ * Owned HERE, not by darktable_t, and created by the GUI bootstrap (dt_gui_gtk_init()):
+ * a selection is a lighttable concept, and ansel-cli has none -- instantiating it in
+ * dt_init() made every CLI run reload the user's selection from the database for nothing.
+ * In a GUI-less process the accessor returns NULL, and every public entry point below
+ * treats that as "the module is not up" and degrades to a no-op / neutral result, so the
+ * code paths shared with the CLI (tag attach, image removal) need no if(darktable.gui). */
+static dt_selection_t *_selection_global = NULL;
+
+struct dt_selection_t *dt_selection_get_global(void)
+{
+  return _selection_global;
+}
+
+void dt_selection_init_global(void)
+{
+  if(IS_NULL_PTR(_selection_global)) _selection_global = dt_selection_new();
+}
+
+void dt_selection_cleanup_global(void)
+{
+  dt_selection_free(_selection_global);
+  _selection_global = NULL;
+}
+
 static void _update_gui()
 {
   dt_collection_hint_message(dt_collection_get_global());
@@ -75,6 +102,7 @@ static void _update_gui()
 
 int32_t dt_selection_get_first_id(struct dt_selection_t *selection)
 {
+  if(IS_NULL_PTR(selection)) return -1;
   return selection->last_single_id;
 }
 
@@ -113,6 +141,7 @@ static GList *_selection_database_to_glist(dt_selection_t *selection)
 
  void dt_selection_reload_from_database_real(dt_selection_t *selection)
 {
+  if(IS_NULL_PTR(selection)) return;
   _reset_ids_list(selection);
   selection->ids = _selection_database_to_glist(selection);
   selection->length = g_list_length(selection->ids);
@@ -155,6 +184,7 @@ static void _add_id_link(dt_selection_t *selection, int32_t imgid)
 
 GList *dt_selection_get_list(struct dt_selection_t *selection)
 {
+  if(IS_NULL_PTR(selection)) return NULL;
   if(IS_NULL_PTR(selection->ids)) return NULL;
 
   return g_list_copy(selection->ids);
@@ -183,6 +213,7 @@ static void _selection_deselect(dt_selection_t *selection, int32_t imgid)
 
 void dt_selection_push(dt_selection_t *selection)
 {
+  if(IS_NULL_PTR(selection)) return;
   // Backup current selection
   if(!selection->stacked)
   {
@@ -198,6 +229,7 @@ void dt_selection_push(dt_selection_t *selection)
 
 void dt_selection_pop(dt_selection_t *selection)
 {
+  if(IS_NULL_PTR(selection)) return;
   // Restore current selection
   if(selection->stacked)
   {
@@ -227,6 +259,7 @@ dt_selection_t *dt_selection_new()
 
 void dt_selection_free(dt_selection_t *selection)
 {
+  if(IS_NULL_PTR(selection)) return;
   DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(dt_control_signal_get_global(), G_CALLBACK(_selection_update_collection),
                                      (gpointer)selection);
   g_list_free(selection->ids);
@@ -237,6 +270,7 @@ void dt_selection_free(dt_selection_t *selection)
 
 void dt_selection_clear(dt_selection_t *selection)
 {
+  if(IS_NULL_PTR(selection)) return;
   dt_selection_repository_clear();
   _reset_ids_list(selection);
   _update_gui();
@@ -244,6 +278,7 @@ void dt_selection_clear(dt_selection_t *selection)
 
 void dt_selection_select(dt_selection_t *selection, int32_t imgid)
 {
+  if(IS_NULL_PTR(selection)) return;
   if(imgid == UNKNOWN_IMAGE) return;
   _selection_select(selection, imgid);
   _add_id_link(selection, imgid);
@@ -252,6 +287,7 @@ void dt_selection_select(dt_selection_t *selection, int32_t imgid)
 
 void dt_selection_deselect(dt_selection_t *selection, int32_t imgid)
 {
+  if(IS_NULL_PTR(selection)) return;
   if(imgid == UNKNOWN_IMAGE) return;
   _selection_deselect(selection, imgid);
   _remove_id_link(selection, imgid);
@@ -260,6 +296,7 @@ void dt_selection_deselect(dt_selection_t *selection, int32_t imgid)
 
 void dt_selection_select_single(dt_selection_t *selection, int32_t imgid)
 {
+  if(IS_NULL_PTR(selection)) return;
   if(imgid == UNKNOWN_IMAGE) return;
   dt_selection_clear(selection);
   dt_selection_select(selection, imgid);
@@ -267,6 +304,7 @@ void dt_selection_select_single(dt_selection_t *selection, int32_t imgid)
 
 void dt_selection_toggle(dt_selection_t *selection, int32_t imgid)
 {
+  if(IS_NULL_PTR(selection)) return;
   if(imgid == UNKNOWN_IMAGE) return;
 
   if(g_list_find(selection->ids, GINT_TO_POINTER(imgid)))
@@ -291,6 +329,7 @@ static int32_t _list_iterate(struct dt_selection_t *selection, GList **list, int
 
 void dt_selection_select_list(struct dt_selection_t *selection, const GList *const l)
 {
+  if(IS_NULL_PTR(selection)) return;
   if(IS_NULL_PTR(l)) return;
   GList *list = (GList *)l;
 
@@ -314,6 +353,7 @@ void dt_selection_select_list(struct dt_selection_t *selection, const GList *con
 
 void dt_selection_deselect_list(struct dt_selection_t *selection, const GList *const l)
 {
+  if(IS_NULL_PTR(selection)) return;
   if(IS_NULL_PTR(l)) return;
   GList *list = (GList *)l;
 
@@ -336,6 +376,7 @@ void dt_selection_deselect_list(struct dt_selection_t *selection, const GList *c
 
 gchar *dt_selection_ids_to_string(struct dt_selection_t *selection)
 {
+  if(IS_NULL_PTR(selection)) return NULL;
   // There is no selection even after init, abort
   if(IS_NULL_PTR(selection->ids)) return NULL;
 
@@ -362,6 +403,7 @@ gchar *dt_selection_ids_to_string(struct dt_selection_t *selection)
 
 gboolean dt_selection_is_id_selected(struct dt_selection_t *selection, int32_t imgid)
 {
+  if(IS_NULL_PTR(selection)) return FALSE;
   if(IS_NULL_PTR(selection) || !selection->ids) return FALSE;
   return (g_list_find(selection->ids, GINT_TO_POINTER(imgid)) != NULL);
 }

--- a/src/common/selection.h
+++ b/src/common/selection.h
@@ -74,8 +74,15 @@ struct dt_selection_t;
 struct dt_selection_t *dt_selection_new();
 void dt_selection_free(struct dt_selection_t *selection);
 
-// Interim accessor (Strategy B, doc/globals-migration.md): implemented by the orchestrator; long-term the handle should be carried on the job/view context (Strategy C).
+// Interim accessor (Strategy B, doc/globals-migration.md): implemented by the module itself; long-term the handle should be carried on the job/view context (Strategy C).
+// NULL in a GUI-less process (ansel-cli): the selection is lighttable state, created by
+// dt_gui_gtk_init() through dt_selection_init_global(). Every public function here accepts a
+// NULL selection and degrades to a no-op / neutral result, so shared code paths need no guard.
 struct dt_selection_t *dt_selection_get_global(void);
+/** creates the application-wide selection. Called by the GUI bootstrap only. */
+void dt_selection_init_global(void);
+/** frees the application-wide selection. */
+void dt_selection_cleanup_global(void);
 
 /** Get the first imgid of a selection */
 int32_t dt_selection_get_first_id(struct dt_selection_t *selection);

--- a/src/control/signal.c
+++ b/src/control/signal.c
@@ -368,6 +368,7 @@ static void _print_trace (const char* op)
 
 void dt_control_signal_raise(const dt_control_signal_t *ctlsig, dt_signal_t signal, ...)
 {
+  if(IS_NULL_PTR(ctlsig)) return; // no signal system in this process (GUI-less)
   // ignore all signals on shutdown
   if(!dt_control_running()) return;
 
@@ -464,6 +465,7 @@ void dt_control_signal_raise(const dt_control_signal_t *ctlsig, dt_signal_t sign
 void dt_control_signal_connect(const dt_control_signal_t *ctlsig, dt_signal_t signal, GCallback cb,
                                gpointer user_data)
 {
+  if(IS_NULL_PTR(ctlsig)) return;
   if(dt_get_signal_debug_acts() & DT_DEBUG_SIGNAL_ACT_CONNECT && dt_get_signal_debug(signal))
   {
     dt_print(DT_DEBUG_SIGNAL, "[signal] connected: %s\n", _signal_description[signal].name);
@@ -474,6 +476,7 @@ void dt_control_signal_connect(const dt_control_signal_t *ctlsig, dt_signal_t si
 
 void dt_control_signal_disconnect(const struct dt_control_signal_t *ctlsig, GCallback cb, gpointer user_data)
 {
+  if(IS_NULL_PTR(ctlsig)) return;
   if(dt_get_signal_debug_acts() & DT_DEBUG_SIGNAL_ACT_DISCONNECT)
   {
     dt_print(DT_DEBUG_SIGNAL, "[signal] disconnected\n");
@@ -500,11 +503,13 @@ void dt_control_signal_disconnect_all(const struct dt_control_signal_t *ctlsig, 
 
 void dt_control_signal_block_by_func(const struct dt_control_signal_t *ctlsig, GCallback cb, gpointer user_data)
 {
+  if(IS_NULL_PTR(ctlsig)) return;
   g_signal_handlers_block_by_func(G_OBJECT(ctlsig->sink), cb, user_data);
 }
 
 void dt_control_signal_unblock_by_func(const struct dt_control_signal_t *ctlsig, GCallback cb, gpointer user_data)
 {
+  if(IS_NULL_PTR(ctlsig)) return;
   g_signal_handlers_unblock_by_func(G_OBJECT(ctlsig->sink), cb, user_data);
 }
 

--- a/src/darktable.c
+++ b/src/darktable.c
@@ -629,19 +629,9 @@ dt_pthread_mutex_t *dt_readfile_mutex(void)
 
 
 
-struct dt_selection_t *dt_selection_get_global(void)
-{
-  return darktable.selection;
-}
-
 struct dt_undo_t *dt_undo_get_global(void)
 {
   return darktable.undo;
-}
-
-struct dt_collection_t *dt_collection_get_global(void)
-{
-  return darktable.collection;
 }
 
 struct dt_control_signal_t *dt_control_signal_get_global(void)
@@ -1623,11 +1613,9 @@ int dt_init(int argc, char *argv[], const gboolean init_gui, const gboolean load
     dt_film_set_folder_status();
   }
 
-  // initialize collection query
-  darktable.collection = dt_collection_new();
-
-  /* initialize selection */
-  darktable.selection = dt_selection_new();
+  // The collection and selection are lighttable state: dt_gui_gtk_init() creates them.
+  // A GUI-less process (ansel-cli) runs without either -- their modules' public entry
+  // points treat "not created" as a no-op, so shared code needs no guards.
 
   /* capabilities set to NULL */
   darktable.capabilities = NULL;
@@ -1987,8 +1975,8 @@ void dt_cleanup()
   dt_tags_cleanup();
   dt_styles_cleanup();
 
-  dt_collection_free(darktable.collection);
-  dt_selection_free(darktable.selection);
+  dt_collection_cleanup_global(); // no-ops in a GUI-less process: never created there
+  dt_selection_cleanup_global();
 
   // Mipmap cleanup may still consult the image cache for paths.
   dt_mipmap_cache_cleanup();

--- a/src/darktable.c
+++ b/src/darktable.c
@@ -142,8 +142,6 @@
 #include "common/l10n.h"
 #include "metadata/metadata.h"
 #include "common/image_notify.h"
-#include "develop/dev_history_gui.h"
-#include "gui/import.h"
 #include "develop/pipeline_notify.h"
 #include "history/notify.h"
 #include "history/presets.h"
@@ -1554,8 +1552,6 @@ int dt_init(int argc, char *argv[], const gboolean init_gui, const gboolean load
    * further up: the signal system does not exist until the line above, and nothing can
    * edit a tag before it does. */
   dt_metadata_set_tags_changed_handler(_metadata_tags_changed);
-  dt_dev_history_gui_init();
-  dt_gui_import_init_handlers();
   dt_metadata_set_geotags_changed_handler(_metadata_geotags_changed);
   dt_image_notify_set_imported_handler(_image_imported);
   dt_pipeline_set_message_handler(_pipeline_message);

--- a/src/darktable.c
+++ b/src/darktable.c
@@ -1544,8 +1544,11 @@ int dt_init(int argc, char *argv[], const gboolean init_gui, const gboolean load
   // init darktable tags table
   dt_set_darktable_tags();
 
-  // Initialize the signal system
-  darktable.signals = dt_control_signal_init();
+  // The signal system exists to tell GUI widgets about backend events -- every raise is
+  // already dead in a GUI-less process (dt_control_signal_raise() bails when the control
+  // system is not running, and only the GUI starts it), so only the GUI gets the machinery.
+  // The connect/raise surface treats a NULL system as "not in this process" and no-ops.
+  darktable.signals = init_gui ? dt_control_signal_init() : NULL;
 
   /* src/metadata reports that the tag vocabulary changed; turning that into the GTK signal
    * its consumers already listen for is ours. Installed HERE, not with the other handlers

--- a/src/darktable.c
+++ b/src/darktable.c
@@ -544,16 +544,6 @@ void dt_dev_set_global(struct dt_develop_t *dev)
   darktable.develop = dev;
 }
 
-GList *dt_guides_get_list(void)
-{
-  return darktable.guides;
-}
-
-GList **dt_guides_get_list_ref(void)
-{
-  return &darktable.guides;
-}
-
 GList *dt_gui_get_themes(void)
 {
   return darktable.themes;
@@ -1620,7 +1610,6 @@ int dt_init(int argc, char *argv[], const gboolean init_gui, const gboolean load
   /* capabilities set to NULL */
   darktable.capabilities = NULL;
 
-  darktable.guides = dt_guides_init();
 
   // Re-assert our handlers once the third-party libraries above are up. This used to compensate
   // for GraphicsMagick's InitializeMagick(), which stole all of them; that library is gone, but
@@ -2008,7 +1997,7 @@ void dt_cleanup()
 
   dt_opencl_cleanup();
 
-  dt_guides_cleanup(darktable.guides);
+  dt_guides_cleanup(); // module-private list: a no-op when the GUI never registered any
 
   if(perform_maintenance)
   {

--- a/src/darktable.c
+++ b/src/darktable.c
@@ -654,11 +654,6 @@ struct dt_dbus_t *dt_dbus_get_global(void)
   return darktable.dbus;
 }
 
-JsonParser *dt_noiseprofile_get_parser_global(void)
-{
-  return darktable.noiseprofile_parser;
-}
-
 struct dt_bauhaus_t *dt_bauhaus_get_global(void)
 {
   return darktable.bauhaus;
@@ -1636,7 +1631,9 @@ int dt_init(int argc, char *argv[], const gboolean init_gui, const gboolean load
   omp_set_num_threads(darktable.num_openmp_threads);
 #endif
 
-  darktable.noiseprofile_parser = dt_noiseprofile_init(noiseprofiles_from_command);
+  // noiseprofiles.json is parsed lazily by common/noiseprofiles.c on first lookup;
+  // only the --noiseprofiles override needs to reach it now.
+  if(noiseprofiles_from_command) dt_noiseprofile_set_path(noiseprofiles_from_command);
 
   // The GUI must be initialized before the views, because the init()
   // functions of the views depend on darktable.control->accels_* to register
@@ -2033,11 +2030,7 @@ void dt_cleanup()
     dt_bauhaus_cleanup(darktable.bauhaus);
   }
 
-  if (darktable.noiseprofile_parser)
-  {
-    g_object_unref(darktable.noiseprofile_parser);
-    darktable.noiseprofile_parser = NULL;
-  }
+  dt_noiseprofile_cleanup();
 
   if(init_gui)
   {

--- a/src/darktable.h
+++ b/src/darktable.h
@@ -108,7 +108,6 @@
 #include "control/signal.h"     // DT_SIGNAL_COUNT sizes the unmuted_signal_dbg array
 
 #include <glib.h>
-#include <json-glib/json-glib.h>
 #include <stdint.h>
 
 /* win/win.h (windows.h/psapi + the #undef of the legacy `near`/`grp2`/`interface`
@@ -117,10 +116,16 @@
  * a MinGW-only breakage, far from its cause. Nothing to do here any more. */
 
 #ifndef _RELEASE
-/* poison.h #pragma-poisons malloc/fopen/... so they cannot be used unqualified. It
- * MUST come after every system header that legitimately declares them -- glib/gstdio.h
- * is included here for exactly that reason, not for the benefit of consumers. */
+/* poison.h #pragma-poisons malloc/fopen/unlink/... so they cannot be used unqualified.
+ * It MUST come after every system header that legitimately declares them --
+ * glib/gstdio.h and unistd.h are included here for exactly that reason, not for the
+ * benefit of consumers. (unistd.h used to arrive by accident through json-glib, whose
+ * include left with the noiseprofiles parser; the poison on unlink then fired inside
+ * any consumer including unistd.h after this header.) */
 #include <glib/gstdio.h>
+#ifndef _WIN32
+#include <unistd.h> // conditional-ok: exists only to land BEFORE poison.h, which is itself conditional on !_RELEASE; nothing outside this block uses it
+#endif
 #include "common/poison.h"
 #endif
 
@@ -176,7 +181,6 @@ typedef struct darktable_t
   // Keep track of optional features that may depend on environnement
   // and compiling options : OpenCL
   GList *capabilities;
-  JsonParser *noiseprofile_parser;
   struct dt_conf_t *conf;
   struct dt_develop_t *develop;
   struct dt_lib_t *lib;

--- a/src/darktable.h
+++ b/src/darktable.h
@@ -186,8 +186,6 @@ typedef struct darktable_t
   struct dt_gui_gtk_t *gui;
   struct dt_bauhaus_t *bauhaus;
   const struct dt_database_t *db;
-  struct dt_collection_t *collection;
-  struct dt_selection_t *selection;
   struct dt_points_t *points;
   struct dt_imageio_t *imageio;
   struct dt_dbus_t *dbus;

--- a/src/darktable.h
+++ b/src/darktable.h
@@ -226,7 +226,6 @@ typedef struct darktable_t
   char *configdir;
   char *cachedir;
   char *kerneldir;
-  GList *guides;
   double start_wtime;
   GList *themes;
   int32_t unmuted_signal_dbg_acts;

--- a/src/database/collection_query.c
+++ b/src/database/collection_query.c
@@ -34,7 +34,8 @@
 #include "system/macros.h"
 #include "system/mem_alloc.h"
 
-// The one collection. dt_collection_new() has a single call site (darktable.c), so there is no
+// The one collection. dt_collection_new() has a single call site (dt_collection_init_global(),
+// reached from the GUI bootstrap only), so there is no
 // handle to pass around -- an argument no caller chooses is not a parameter.
 //
 // The composed SQL never leaves this file. Callers describe what they want with

--- a/src/gui/application.c
+++ b/src/gui/application.c
@@ -84,6 +84,8 @@
 #include "gui/guides.h"
 #include "widgets/expander.h"
 
+#include "common/collection.h"
+#include "common/selection.h"
 #include "gui/application.h"
 #include "common/thumbnail_notify.h"
 #include "gui/common/film_gui.h"
@@ -1089,6 +1091,14 @@ int dt_gui_gtk_init(dt_gui_gtk_t *gui)
 {
   /* lets zero mem */
   memset(gui, 0, sizeof(dt_gui_gtk_t));
+
+  // The collection and the selection are lighttable state -- which images the grid shows,
+  // which of them are picked -- so the GUI creates them, not dt_init(): a GUI-less process
+  // (ansel-cli) must not pay for the user's collection query and selection reload just to
+  // export one file. Both modules treat "never created" as a no-op at their own boundary.
+  // Created before any widget below, so everything the GUI builds can already read them.
+  dt_collection_init_global();
+  dt_selection_init_global();
 
   dt_pthread_mutex_init(&gui->mutex, NULL);
 

--- a/src/gui/application.c
+++ b/src/gui/application.c
@@ -1099,6 +1099,7 @@ int dt_gui_gtk_init(dt_gui_gtk_t *gui)
   // Created before any widget below, so everything the GUI builds can already read them.
   dt_collection_init_global();
   dt_selection_init_global();
+  dt_guides_init(); // darkroom overlay registry: same argument, nothing to overlay without a GUI
 
   dt_pthread_mutex_init(&gui->mutex, NULL);
 

--- a/src/gui/application.c
+++ b/src/gui/application.c
@@ -82,6 +82,7 @@
 #include "common/file_location.h"
 #include "common/utility.h"
 #include "gui/guides.h"
+#include "gui/import.h"
 #include "widgets/expander.h"
 
 #include "common/collection.h"
@@ -1100,6 +1101,13 @@ int dt_gui_gtk_init(dt_gui_gtk_t *gui)
   dt_collection_init_global();
   dt_selection_init_global();
   dt_guides_init(); // darkroom overlay registry: same argument, nothing to overlay without a GUI
+
+  // GUI-side handler for backend import events (an inverted dependency): registered here
+  // rather than in dt_init() -- the handler drives GTK widgets, and the registration site
+  // in import_jobs.c NULL-checks before calling, so a GUI-less process simply runs with
+  // the slot empty. dt_dev_history_gui_init() is its darkroom sibling and registers from
+  // views/darkroom.c gui_init(), the layer entitled to see develop/.
+  dt_gui_import_init_handlers();
 
   dt_pthread_mutex_init(&gui->mutex, NULL);
 

--- a/src/gui/guides.c
+++ b/src/gui/guides.c
@@ -40,6 +40,18 @@
 #include "develop/develop.h"
 #include "widgets/widget_style.h"
 
+/* The registered guide overlays. Module-private: every reader and the registration path
+ * live in this file, so the list no longer sits on darktable_t behind a pair of accessors
+ * whose only consumers were... this file. Populated by dt_guides_init() from the GUI
+ * bootstrap; a GUI-less process never calls it and never carries the list. */
+static GList *_guides = NULL;
+
+static GList *dt_guides_get_list(void)
+{
+  return _guides;
+}
+
+
 #define DEFAULT_GUIDE_NAME "rules of thirds"
 
 static const char *_guide_names[]
@@ -574,12 +586,12 @@ static void _guides_add_guide(GList **list, const char *name,
 
 void dt_guides_add_guide(const char *name, dt_guides_draw_callback draw, dt_guides_widget_callback widget, void *user_data, GDestroyNotify free)
 {
-  _guides_add_guide(dt_guides_get_list_ref(), name, draw, widget, user_data, free, TRUE);
+  _guides_add_guide(&_guides, name, draw, widget, user_data, free, TRUE);
 
   dt_bauhaus_combobox_add(dt_view_manager_get_global()->guides, _(name));
 }
 
-GList *dt_guides_init()
+void dt_guides_init(void)
 {
   GList *guides = NULL;
 
@@ -595,7 +607,7 @@ GList *dt_guides_init()
   _guides_add_guide(&guides, *names++, _guides_draw_golden_mean, NULL, GINT_TO_POINTER(GOLDEN_SPIRAL_SECTION), NULL, TRUE);
   _guides_add_guide(&guides, *names++, _guides_draw_golden_mean, NULL, GINT_TO_POINTER(GOLDEN_ALL), NULL, TRUE);
 
-  return guides;
+  _guides = guides;
 }
 
 static void _settings_update_visibility(_guides_settings_t *gw)
@@ -843,10 +855,10 @@ static void free_guide(void *data)
   dt_free(guide);
 }
 
-void dt_guides_cleanup(GList *guides)
+void dt_guides_cleanup(void)
 {
-  g_list_free_full(guides, free_guide);
-  guides = NULL;
+  g_list_free_full(_guides, free_guide);
+  _guides = NULL;
 }
 
 void dt_guides_update_popover_values()

--- a/src/gui/guides.h
+++ b/src/gui/guides.h
@@ -45,14 +45,10 @@ typedef struct dt_guides_t
   gboolean support_flip;
 } dt_guides_t;
 
-/** The registered guide overlays. dt_guides_get_list() is read-only; the `_ref` form
- * returns the address of the list head and exists because registration appends to it —
- * only darktable.c's owner and gui/guides.c's registration path may use it. */
-GList *dt_guides_get_list(void);
-GList **dt_guides_get_list_ref(void);
-
-GList *dt_guides_init();
-void dt_guides_cleanup(GList *guides);
+/** Register the built-in guide overlays. Called by the GUI bootstrap; the list itself is
+ * module-private to gui/guides.c -- every reader lives there. */
+void dt_guides_init(void);
+void dt_guides_cleanup(void);
 
 void dt_guides_add_guide(const char *name, dt_guides_draw_callback draw, dt_guides_widget_callback widget, void *user_data, GDestroyNotify free);
 

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -102,6 +102,7 @@
 #include "control/jobs.h"
 #include "develop/dev_pixelpipe.h"
 #include "develop/develop.h"
+#include "develop/dev_history_gui.h"
 #include "develop/imageop.h"
 #include "develop/supervisor.h"
 #include "develop/masks.h"
@@ -1587,6 +1588,12 @@ static void _darkroom_autoset_popover_refresh(gpointer instance, gpointer user_d
 void gui_init(dt_view_t *self)
 {
   dt_develop_t *dev = (dt_develop_t *)self->data;
+
+  // Register the GTK-driving handlers for history commits and undo restores (the inverted
+  // dependency dev_history.c exposes). Done here, not in dt_init(): the call sites
+  // NULL-check, so a GUI-less process runs with the slots empty instead of registering
+  // callbacks that must never fire.
+  dt_dev_history_gui_init();
 
   DT_DEBUG_CONTROL_SIGNAL_CONNECT(dt_control_signal_get_global(), DT_SIGNAL_DEVELOP_PREVIEW_PIPE_FINISHED,
                                   G_CALLBACK(_preview_pipe_finished), self);


### PR DESCRIPTION
Measured with per-stage timestamps in `dt_init()` (Release, warm cache, scratch config): **102 ms of init, of which 63 ms was parsing `noiseprofiles.json`** — a file whose only consumer is a denoise module asking for a profile — and the rest included building the lighttable's collection and selection, running the user's collection query against their whole library on every CLI export. After this branch the same run takes **38 ms**, and on a real library the saving is larger, since the collection query scales with the library.

## What moves, and where to

| component | was | now |
|---|---|---|
| collection, selection | created unconditionally in `dt_init()` | module-owned globals (the colorprofiles pattern), created by `dt_gui_gtk_init()` |
| guides overlay registry | a `GList` on `darktable_t` behind two accessors **whose every consumer was `gui/guides.c` itself** | a static in `gui/guides.c`, populated from the GUI bootstrap |
| `noiseprofiles.json` | parsed eagerly at startup, 63 ms | parsed lazily on the first `dt_noiseprofile_get_matching()`, under the mutex that already serializes every tree walk; missing/invalid file remembered as final |
| `dt_dev_history_gui_init()`, `dt_gui_import_init_handlers()` | registered unconditionally — a CLI process installing GTK-driving callbacks that must never fire | registered from the layer entitled to: darkroom's `gui_init()` and `dt_gui_gtk_init()` respectively |

`darktable_t` loses four members (`collection`, `selection`, `guides`, `noiseprofile_parser`) and `darktable.h` loses `<json-glib/json-glib.h>`.

## No `if(darktable.gui)` spaghetti

In a GUI-less process the accessors return NULL, and **every public entry point of `common/collection.c` and `common/selection.c` treats that as "the module is not up"**: a query update is a no-op, a count is 0, a first-id is -1. The guard sits at the module boundary once, because the shared paths genuinely land there — `dt_film_import()` calls `dt_collection_update_query()`, image removal clears the selection, tag attachment counts it — and the alternative is sprinkling `if(darktable.gui)` over every such caller. (`grouping.c` already carried one of those caller-side guards; it is now redundant but harmless.)

The missing-guard failure mode is real, not theoretical: the first test run segfaulted in `dt_collection_free(NULL)` at shutdown, which is how `dt_collection_free`, `dt_collection_params` and the full swept API got their guards.

## A supply line uncovered

Dropping `<json-glib/json-glib.h>` from `darktable.h` broke the build in an unrelated place: json-glib happened to pull `<unistd.h>` in **ahead of `common/poison.h`**, so the `#pragma GCC poison unlink` never fired inside consumers that include `unistd.h` after `darktable.h`. `unistd.h` is now included there deliberately, next to `glib/gstdio.h` which exists for the same reason — the same class of bug CLAUDE.md documents for `sqlite3.h`/`points.h`.

## Verified

- CLI export end to end, 5 runs, including the re-import path — imports call `dt_collection_update_query(NULL)` and no-op; no crash, no backtrace files.
- `[init] startup took`: **0.102 s → 0.038 s** on the same machine, same scratch config.
- Debug/`-Werror` build clean; 11/11 real unit tests pass (the 5 "Not Run" are LensSerious's `EXCLUDE_FROM_ALL` binaries, pre-existing).
- `check_layering.sh` **183 (baseline 183)** — the first draft registered the darkroom history handlers from `gui/application.c` and the ratchet caught the gui→develop inversion; they register from `views/darkroom.c` instead.
- `check_module_boundaries.sh`, `pragma_once_to_guards --verify` clean.

## Not addressed here

- The GUI-side teardown of collection/selection still runs from `dt_cleanup()` (orchestrator calling module cleanups is the existing pattern; the calls no-op when nothing was created).
- Existing `if(darktable.gui)` guards elsewhere in the tree — this PR removes the *need* for new ones on collection/selection paths; sweeping the old ones is separate work.
- `dt_gui_throttle_init()` stays unconditional: microsecond-cheap, and `develop/develop.c` calls throttle functions on CLI paths, so its mutex must exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)