### PR TITLE
win: a macro override of install() emptied the DLL bundling script

### DIFF
--- a/packaging/CMakeLists.txt
+++ b/packaging/CMakeLists.txt
@@ -49,6 +49,20 @@ IF(WIN32 AND NOT BUILD_MSYS2_INSTALL)
         list(REMOVE_DUPLICATES EXTRA_DEPS)
       endif()
 
+      # A Windows build ALWAYS needs third-party DLLs -- GTK alone is a dozen. An empty list
+      # here does not mean 'nothing to copy', it means this script did not run as written, and
+      # the only symptom otherwise is an installer that is quietly tens of megabytes lighter
+      # and an application that will not start on a machine without MSYS2. That shipped once
+      # already: a macro override of install() re-expanded this very block and emptied every
+      # \${...} in it (see src/external/CMakeLists.txt). Fail the install instead.
+      list(LENGTH EXTRA_DEPS _ansel_dep_count)
+      if(_ansel_dep_count LESS 10)
+        message(FATAL_ERROR
+          \"Windows dependency collection found only \${_ansel_dep_count} DLL(s) under ${DIRS}. \"
+          \"Expected dozens. The package would be missing its runtime libraries.\")
+      endif()
+      message(STATUS \"Bundling \${_ansel_dep_count} third-party DLLs\")
+
       # install(...) doesn't work in here, and file(INSTALL ...) doesn't put anything into installers,
       # so we have to go over the list of files and do it manually
       foreach(filename IN LISTS EXTRA_DEPS)

--- a/src/external/CMakeLists.txt
+++ b/src/external/CMakeLists.txt
@@ -291,11 +291,28 @@ if(USE_BUNDLED_EXIV2)
   # the only lever a sub-project offers: the real command stays reachable as _install(),
   # and ANSEL_SUPPRESS_INSTALL is a directory variable, so it is set here and is invisible
   # to every other directory in the tree.
-  macro(install)
+  #
+  # A FUNCTION, and never a macro. Overriding a command this way makes the override GLOBAL
+  # for the rest of the configure -- it outlives this directory and every install() in the
+  # tree goes through it, packaging/CMakeLists.txt included. In a macro, ${ARGV} is textual
+  # substitution: the argument is pasted into the body and then PARSED AGAIN, so every
+  # ${...} inside a string argument is expanded a second time and every backslash escape is
+  # eaten once more. install(CODE "<script>") is exactly the shape that destroys -- it
+  # carries \${...} deliberately, to be expanded at install time and not now.
+  #
+  # That is not hypothetical. It shipped: the Windows installer's third-party DLL collection
+  # (packaging/CMakeLists.txt) is an install(CODE) block, and the macro reduced it to a
+  # script whose ${filename}, ${FILES} and ${EXTRA_DEPS} were all empty and whose regex had
+  # lost its escapes. It copied nothing, the .exe went from 144 MB to 118 MB, and users got
+  # an application missing libcurl, libheif, libopenexr and exchndl.dll.
+  #
+  # In a function ARGV is a real variable; expanding it yields the argument VALUES, and
+  # CMake does not re-expand what a variable expansion produced. The forwarding is faithful.
+  function(install)
     if(NOT ANSEL_SUPPRESS_INSTALL)
       _install(${ARGV})
     endif()
-  endmacro()
+  endfunction()
   set(ANSEL_SUPPRESS_INSTALL TRUE)
 
   add_subdirectory(exiv2)


### PR DESCRIPTION
Fixes the missing-library reports on the Windows nightlies. **My regression, from #1258.**

## What users see

The `.exe` ships without any third-party DLL — libcurl, libheif, libopenexr, `exchndl.dll`, and GTK with them.

The installer sizes name the commit exactly:

| build | date | size |
|---|---|---|
| `d147c86810` | 2026-08-25 05:45 | **144 MB** |
| `16ece2b7cb` — exiv2 merged | 2026-08-25 15:44 | **118 MB** |
| `e7a16eff89` | 2026-08-26 05:37 | **118 MB** |

## Cause

`6ac9d02a3a` gave Exiv2 an `install()` override so its headers, static archive, pkg-config file and man page would stay out of our install tree. Overriding a CMake command is **global and outlives the directory that does it**, so every `install()` in the tree went through mine — `packaging/CMakeLists.txt` included, since it is descended into after `src/`.

It was a **macro**. In a macro `${ARGV}` is textual substitution: the argument is pasted into the body and **parsed a second time**. `install(CODE "<script>")` is precisely the shape that cannot survive that — it carries `\${...}` on purpose, to be expanded when the install runs, not at configure time.

Reduced side by side in a scratch project, the Windows dependency collection became:

```diff
-  execute_process(COMMAND "cygcheck" "${filename}" OUTPUT_VARIABLE FILES ...)
+  execute_process(COMMAND "cygcheck" ""           OUTPUT_VARIABLE FILES ...)
-  string(REGEX MATCHALL "C:\\msys64\\ucrt64\\bin[^\n\r]*[dD][lL][lL]" L "${FILES}")
+  string(REGEX MATCHALL "C:\msys64\ucrt64\bin[^<newline>]*[dD][lL][lL]"  L "")
-  set(EXTRA_DEPS ${EXTRA_DEPS} ${FILES_LIST} PARENT_SCOPE)
+  set(EXTRA_DEPS                             PARENT_SCOPE)
```

It inspected nothing, matched nothing, copied nothing, and reported success.

## Fix

A **function**: there `ARGV` is a real variable, expanding it yields the argument *values*, and CMake does not re-expand what a variable expansion produced. Verified in the same scratch project that the generated install script is now byte-identical to the one produced with **no override at all**, that Exiv2's installs are still suppressed, and that `install()` calls made after the override are untouched.

## The part that matters more

This was invisible. It compiled, packaged, uploaded and installed, and the only signal was a number in a file listing — **every nightly was green**.

The collection step now counts what it found and **fails the install below ten DLLs**. A Windows build always needs dozens, so an empty list never means "nothing to copy", it means the script did not run as written. Tested both ways against the real block lifted verbatim out of `packaging/CMakeLists.txt`: aborts on zero, passes and copies on twelve.

## Verified

- Scratch reproduction of the exact macro/function difference, before and after, with an unshadowed control.
- Real tree configures; Exiv2 install rules still suppressed (`file(INSTALL` count 0 in both its install scripts), Ansel's own preserved.
- Guard driven with the real `INSTALL(CODE)` block: `FATAL_ERROR` at zero DLLs, `-- Bundling 12 third-party DLLs` and 12/12 copied at twelve.

I could not verify against the shipped `.exe` directly — the runner's p7zip 16.02 cannot open this NSIS version and the payload is LZMA-solid, so `strings` sees nothing. The size drop and the reproduction are the two independent lines of evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)