### PR TITLE
develop: give every base module its own instance id again (#1265)

### DIFF
--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -116,10 +116,25 @@ GList *dt_dev_load_modules(dt_develop_t *dev)
     iop = g_list_next(iop);
   }
 
+  /* Give every base module a distinct `instance`.
+   *
+   * `instance` identifies a module FAMILY: a base module and every extra instance
+   * duplicated from it share one value, and dt_dev_module_duplicate() scans dev->iop for
+   * `mod->instance == base->instance` to find the next free multi_priority and multi_name.
+   * With every module left at the calloc'd 0, that scan matches every module of every
+   * operation, so duplicating `retouch` picked up the numbering of an unrelated `exposure`
+   * copy and produced retouch "2" with no "1" -- issue #1265.
+   *
+   * Runtime-only: the database and XMP store multi_priority and multi_name, never this, so
+   * the numbering does not have to be stable across sessions -- only distinct within a dev.
+   *
+   * 214cc1cc8e removed this line while tidying dt_develop_t and left the loop empty; the
+   * counter it uses stayed on the struct, unread, which is why nothing complained. */
   GList *it = res;
   while(it)
   {
     module = (dt_iop_module_t *)it->data;
+    module->instance = dev->iop_instance++;
     it = g_list_next(it);
   }
   return res;


### PR DESCRIPTION
Fixes the numbering half of #1265. Not the multi-instance/static-linking work — a line deleted in `214cc1cc8e`.

## What users see

Ask for a second `retouch` and you get **"retouch 2" with no "1"**, because the number came from whatever copy of `exposure` you had made earlier.

## Cause

`dt_dev_module_duplicate()` picks the new copy's `multi_priority` and `multi_name` by scanning `dev->iop` for modules of the **same family**:

```c
if(mod->instance == base->instance)
  if(pmax < mod->multi_priority) pmax = mod->multi_priority;
```

`instance` is what makes that a family — a base module and every copy made from it share one value. `dt_dev_load_modules()` used to hand each base module its own:

```c
module->instance = dev->iop_instance++;
```

`214cc1cc8e` ("Tidy up the dt_develop_t structure") removed that line and left behind **a loop with an empty body**:

```c
  GList *it = res;
  while(it)
  {
    module = (dt_iop_module_t *)it->data;
    it = g_list_next(it);
  }
```

`dev->iop_instance` stayed on the struct — written nowhere, read nowhere — which is why nothing pointed at it. Every module then kept the `0` it got from `calloc`, so the family test matched **everything** and the scan ran over every operation at once.

## Measured

A counting probe over `dev->iop` after load, in an `ansel-cli` export (which builds a dev like any other):

| | modules | distinct instances | collisions |
|---|---|---|---|
| before | 91 | **1** | **90** |
| after | 91 | **91** | **0** |

The value is runtime-only — the database and XMP carry `multi_priority` and `multi_name`, never this — so it need only be distinct within one dev, not stable across sessions. No migration, no stored-history impact.

## What this does *not* fix

The other half of #1265 — **a new copy not appearing in the right panel until you click the base module's header**. This is not it, and I would rather say so than let a plausible story stand in for a finding.

What I traced and ruled out:

- `dt_iop_gui_duplicate()` does add the new module to history (`dt_dev_add_history_item(..., TRUE, TRUE)`), and `dt_dev_add_history_item_ext()` advances `history_end` to `g_list_length(dev->history)` — so the `in_history` test in `_update_iop_visibility()` should pass.
- That refresh is a `g_idle_add`, queued by `dt_iop_request_focus()` → `DT_SIGNAL_DEVELOP_MODULEGROUPS_SET`, so it runs **after** `dt_iop_gui_duplicate()` returns, not before. Nothing in that path pumps the main loop (the only `gtk_main_iteration` in the tree is `gui/splash.c`).
- `_is_module_in_tab()` and `dt_dev_history_get_last_item_by_module()` do not consult `instance`, so the bug fixed here does not reach them.

One thing worth flagging for whoever picks it up: `libs/modulegroups.c` deliberately does **not** listen to history changes (see the comment at its signal connections — it was dropped because expander reparenting stole focus from Bauhaus widgets). So a module that becomes visible *as a consequence of a history change* has no refresh of its own. That is the shape of the remaining bug, but I could not confirm the trigger by reading, and it needs someone who can reproduce it in the GUI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)