### PR TITLE
Show a new module instance without waiting for the next click (#1265)

### DIFF
--- a/src/develop/imageop_gui.c
+++ b/src/develop/imageop_gui.c
@@ -617,6 +617,27 @@ dt_iop_module_t *dt_iop_gui_duplicate(dt_iop_module_t *base, gboolean copy_param
 
     // we save the new instance creation
     dt_dev_add_history_item(module->dev, module, TRUE, TRUE);
+
+    // ...and run it NOW, before returning to the main loop.
+    //
+    // dt_dev_add_history_item() only QUEUES: dev_history_gui.c holds the request behind the
+    // "Pipe recompute timeout" preference (processing/timeout, 200 ms by default) so that a
+    // slider drag does not commit once per step. Creating an instance is not a drag -- there
+    // is nothing to coalesce, and the delay is load-bearing here in a way it is not anywhere
+    // else, because two things read the module's state before the timeout fires:
+    //
+    //   - libs/modulegroups.c shows an extra instance only when it is in history
+    //     (`in_history || multi_priority == 0`), and its refresh is a g_idle queued by the
+    //     dt_iop_request_focus() above -- so it runs a few ms from now, long before 200 ms;
+    //   - that module deliberately does NOT listen to history changes (expander reparenting
+    //     stole keyboard focus from Bauhaus widgets), so nothing refreshes the panel again
+    //     when the commit finally lands.
+    //
+    // The new instance was therefore judged "not in history yet", hidden, and stayed hidden
+    // until an unrelated event queued another refresh -- clicking the base module's header,
+    // which is exactly what users reported doing to make their new copy appear (#1265).
+    // Measured with -d dev: idle at +100 ms saw in_history=0 enabled=0 -> HIDE.
+    dt_dev_history_flush_pending_commits(module->dev);
   }
 
   /* update ui to new parameters */


### PR DESCRIPTION
Fixes the second symptom of #1265: after **new instance**, the copy does not appear in the right panel until you click something else — usually the base module's header.

## Root cause

`dt_dev_add_history_item()` does not commit. It **queues**, behind the *Pipe recompute timeout* preference (`processing/timeout`, **200 ms** by default), so that dragging a slider does not commit once per step.

Every other caller can afford that. `dt_iop_gui_duplicate()` cannot, because two things read the module's state inside those 200 ms:

- `libs/modulegroups.c` shows an extra instance only once it is in history (`in_history || multi_priority == 0`), and schedules that decision with `g_idle_add()` — from the `dt_iop_request_focus()` call a few lines above. It runs on the **next main-loop turn**.
- That module deliberately does **not** listen to history changes: doing so reparents expanders, which drops keyboard focus from Bauhaus widgets (see the comment on its signal connections). So nothing revisits the decision when the commit finally lands.

The new instance is judged "not in history yet", hidden, and stays hidden until an unrelated event queues another refresh.

## Evidence

From `ansel -d history -d dev` around one *new instance* click, with per-call instrumentation:

```
9.672816  [mg]  refresh queued (modulegroups-set for channelmixerrgb(3))
9.683693  [dup] before add_history_item: channelmixerrgb(3) prio=3 enabled=0
9.683732  [dup] after  add_history_item: channelmixerrgb(3) prio=3 enabled=0   <- no commit
9.783325  [mg]  === _update_iop_visibility RUNS: history_end=9 ===             <- +100 ms
9.783457  [mg]    channelmixerrgb(3) enabled=0 in_history=0 -> HIDE
...
11.690831 [mg]  refresh queued          <- user clicks the base module's header
11.792009 [mg]    channelmixerrgb(3) enabled=1 in_history=1 -> SHOW
```

`enabled` is unchanged across the `add_history_item` call, `history_end` is unchanged, and no `[dt_dev_add_history_item_ext]` line is emitted — the commit had not run. It only lands later, and by then the panel has already decided.

The same statement from the other side: **with `processing/timeout` set to 0** the commit path is immediate (`_queue_pending_commit` early-returns into `dt_dev_history_commit_item_now`) and the bug does not reproduce. That is a cheap independent check anyone can run on an unpatched build.

## Fix

Drain the queue before returning to the main loop, via the documented `dt_dev_history_flush_pending_commits()`. Since `g_idle_add` callbacks only run once the current callback returns, a synchronous flush here always wins the race — regardless of how the refresh is scheduled.

The flush also covers the `FALSE` commit on the **base** module at the top of the same function, whose comment ("make sure the duplicated module appears in the history") asks for a precondition that a queued request does not establish either. The queue is FIFO, so both land in the intended order.

## Alternative considered

Making `modulegroups.c` listen to history changes. That is the fix that was **already tried and reverted** — it is the expander-reparenting/focus-stealing regression its current comment warns about. This change leaves that untouched.

## Testing

Compiles clean. Behavioural verification wants a GUI click, so please confirm on your side: create a second and third instance of any module and check each appears immediately, with `processing/timeout` left at its default 200 ms.

Note this is a *different* bug from the instance-numbering one in #1269 — both were reported under #1265.