### PR TITLE
Janitorial pass: complexity hotspots and header documentation

### DIFF
--- a/src/common/color_vocabulary.c
+++ b/src/common/color_vocabulary.c
@@ -23,6 +23,7 @@
 
 #include "common/color_vocabulary.h"
 #include "common/utility.h"
+#include "system/macros.h"
 
 #include <glib/gi18n.h>
 
@@ -184,22 +185,54 @@ skin_color_t get_skin_color(const size_t index)
   return skin[index];
 }
 
-const char *Lch_to_color_name(dt_aligned_pixel_t color)
+/** Hue sectors of 24 degrees, read at chroma 80-100. */
+#define LCH_HUE_SECTORS 15
+
+/** Lightness sectors of 20 %. */
+#define LCH_LIGHTNESS_SECTORS 5
+
+/* Colour names by [hue sector][lightness sector].
+ *
+ * Reference: https://chromatone.center/theory/color/models/perceptual/ -- ignored in places
+ * where it gets too lyrical, in favour of more down-to-earth names.
+ *
+ * Sectors 10 (240 deg) and 11 (264 deg) hold the same names on purpose: CIE Lab 1976 is
+ * poor in the blues, so the two were collapsed when this was a branch ladder. The
+ * duplication is kept explicit rather than special-cased, so the table reads as a plain
+ * grid and a future correction to either sector does not have to untangle a shared branch.
+ *
+ * N_() registers each name for translation; the lookup translates with _() at use.
+ */
+static const char *const _lch_color_names[LCH_HUE_SECTORS][LCH_LIGHTNESS_SECTORS] = {
+  { N_("deep purple"), N_("fuchsia"), N_("medium magenta"), N_("violet pink"), N_("plum violet") },  // 0°
+  { N_("dark red"), N_("red"), N_("crimson"), N_("salmon"), N_("pink") },  // 24°
+  { N_("maroon"), N_("dark orange red"), N_("orange red"), N_("coral"), N_("khaki") },  // 48°
+  { N_("brown"), N_("chocolate"), N_("dark gold"), N_("gold"), N_("sandy brown") },  // 72°
+  { N_("dark green"), N_("dark olive green"), N_("olive"), N_("khaki"), N_("beige") },  // 96°
+  { N_("dark green"), N_("forest green"), N_("olive drab"), N_("yellow green"), N_("pale green") },  // 120°
+  { N_("dark green"), N_("green"), N_("forest green"), N_("lime green"), N_("pale green") },  // 144°
+  { N_("dark sea green"), N_("sea green"), N_("teal"), N_("light sea green"), N_("turquoise") },  // 168°
+  { N_("dark slate gray"), N_("light slate gray"), N_("dark cyan"), N_("aqua"), N_("cyan") },  // 192°
+  { N_("navy blue"), N_("teal"), N_("dark cyan"), N_("deep sky blue"), N_("aquamarine blue") },  // 216°
+  { N_("dark blue"), N_("medium blue"), N_("azure blue"), N_("deep sky blue"), N_("aqua") },  // 240°
+  { N_("dark blue"), N_("medium blue"), N_("azure blue"), N_("deep sky blue"), N_("aqua") },  // 264°
+  { N_("dark blue"), N_("medium blue"), N_("blue"), N_("light sky blue"), N_("light blue") },  // 288°
+  { N_("indigo"), N_("dark violet"), N_("blue violet"), N_("violet"), N_("plum") },  // 312°
+  { N_("purple"), N_("dark magenta"), N_("magenta"), N_("violet"), N_("lavender") },  // 336°
+};
+
+char *Lch_to_color_name(dt_aligned_pixel_t color)
 {
   // color must be Lch derivated from CIE Lab 1976 turned into polar coordinates
 
   // First check if we have a gray (chromacity < epsilon)
-
-  if(color[1] < 2.0f)
-    return _("gray");
+  if(color[1] < 2.0f) return g_strdup(_("gray"));
 
   // Start with special cases : skin tones
-
   dt_aligned_pixel_t Lab;
   dt_LCH_2_Lab(color, Lab);
 
   gchar *out = NULL;
-  int is_skin = FALSE;
   gboolean matches[ETHNIE_END] = { FALSE };
 
   // Find a match against any body part and write the associated ethnicity
@@ -210,10 +243,10 @@ const char *Lch_to_color_name(dt_aligned_pixel_t color)
     range_t a = _compute_range(skin.a, 1.5f);
     range_t b = _compute_range(skin.b, 1.5f);
 
-    const int match = (Lab[0] > L.bottom && Lab[0] < L.top) && (Lab[1] > a.bottom && Lab[1] < a.top)
-      && (Lab[2] > b.bottom && Lab[2] < b.top);
+    const gboolean match = (Lab[0] > L.bottom && Lab[0] < L.top)
+                        && (Lab[1] > a.bottom && Lab[1] < a.top)
+                        && (Lab[2] > b.bottom && Lab[2] < b.top);
 
-    is_skin = is_skin || match;
     if(match) matches[skin.ethnicity] = TRUE;
   }
 
@@ -222,149 +255,19 @@ const char *Lch_to_color_name(dt_aligned_pixel_t color)
     if(matches[elem])
       out = dt_util_dstrcat(out, _("average %s skin tone\n"), _get_ethnicity_name(elem));
 
-  if(is_skin) return out;
+  if(!IS_NULL_PTR(out)) return out;
 
-  // Reference for color names : https://chromatone.center/theory/color/models/perceptual/
-  // Though we ignore them sometimes when they get too lyrical for some more down-to-earth names
-  // Color are read for chroma = [80 - 100].
-  const float h = color[2] * 360.f; // °
-  const float L = color[0];
-  //const float c = color[1];
+  const float h = color[2] * 360.f; // degrees
+  const float L = color[0];         // percent
 
-  // h in degrees - split into 15 hue sectors of 24°
-  const int step_h = (int)(h) / 24;
-
-  // L in % - split into 5 L sectors of 20 %
+  const int step_h = (int)h / 24;
   const int step_L = (int)(fminf(L, 100.f)) / 20;
 
-  if(step_h == 0)
-  {
-    // 0° - pinkish red
-    if(step_L == 0) return _("deep purple");    // L = 10 %
-    if(step_L == 1) return _("fuchsia");        // L = 30 %
-    if(step_L == 2) return _("medium magenta"); // L = 50 %
-    if(step_L == 3) return _("violet pink");    // L = 70 %
-    if(step_L == 4) return _("plum violet");    // L = 90 %
-  }
-  else if(step_h == 1)
-  {
-    // 24° - red
-    if(step_L == 0) return _("dark red");
-    if(step_L == 1) return _("red");
-    if(step_L == 2) return _("crimson");
-    if(step_L == 3) return _("salmon");
-    if(step_L == 4) return _("pink");
-  }
-  else if(step_h == 2)
-  {
-    // 48° - orangy red
-    if(step_L == 0) return _("maroon");
-    if(step_L == 1) return _("dark orange red");
-    if(step_L == 2) return _("orange red");
-    if(step_L == 3) return _("coral");
-    if(step_L == 4) return _("khaki");
-  }
-  else if(step_h == 3)
-  {
-    // 72° - orange
-    if(step_L == 0) return _("brown");
-    if(step_L == 1) return _("chocolate");
-    if(step_L == 2) return _("dark gold");
-    if(step_L == 3) return _("gold");
-    if(step_L == 4) return _("sandy brown");
-  }
-  else if(step_h == 4)
-  {
-    // 96° - yellow olive
-    if(step_L == 0) return _("dark green");
-    if(step_L == 1) return _("dark olive green");
-    if(step_L == 2) return _("olive");
-    if(step_L == 3) return _("khaki");
-    if(step_L == 4) return _("beige");
-  }
-  else if(step_h == 5)
-  {
-    // 120° - green
-    if(step_L == 0) return _("dark green");
-    if(step_L == 1) return _("forest green");
-    if(step_L == 2) return _("olive drab");
-    if(step_L == 3) return _("yellow green");
-    if(step_L == 4) return _("pale green");
-  }
-  else if(step_h == 6)
-  {
-    // 144° - blueish green
-    if(step_L == 0) return _("dark green");
-    if(step_L == 1) return _("green");
-    if(step_L == 2) return _("forest green");
-    if(step_L == 3) return _("lime green");
-    if(step_L == 4) return _("pale green");
-  }
-  else if(step_h == 7)
-  {
-    // 168° - greenish cyian
-    if(step_L == 0) return _("dark sea green");
-    if(step_L == 1) return _("sea green");
-    if(step_L == 2) return _("teal");
-    if(step_L == 3) return _("light sea green");
-    if(step_L == 4) return _("turquoise");
-  }
-  else if(step_h == 8)
-  {
-    // 192° - cyan
-    if(step_L == 0) return _("dark slate gray");
-    if(step_L == 1) return _("light slate gray");
-    if(step_L == 2) return _("dark cyan");
-    if(step_L == 3) return _("aqua");
-    if(step_L == 4) return _("cyan");
-  }
-  else if(step_h == 9)
-  {
-    // 216° - medium blue
-    if(step_L == 0) return _("navy blue");
-    if(step_L == 1) return _("teal");
-    if(step_L == 2) return _("dark cyan");
-    if(step_L == 3) return _("deep sky blue");
-    if(step_L == 4) return _("aquamarine blue");
-  }
-  else if(step_h == 10 || step_h == 11)
-  {
-    // 240° - blue and 264° - bluer than blue
-    // these are collapsed because CIE Lab 1976 sucks for blues
-    if(step_L == 0) return _("dark blue");
-    if(step_L == 1) return _("medium blue");
-    if(step_L == 2) return _("azure blue");
-    if(step_L == 3) return _("deep sky blue");
-    if(step_L == 4) return _("aqua");
-  }
-  else if(step_h == 12)
-  {
-    // 288° - more blue
-    if(step_L == 0) return _("dark blue");
-    if(step_L == 1) return _("medium blue");
-    if(step_L == 2) return _("blue");
-    if(step_L == 3) return _("light sky blue");
-    if(step_L == 4) return _("light blue");
-  }
-  else if(step_h == 13)
-  {
-    // 312° - violet
-    if(step_L == 0) return _("indigo");
-    if(step_L == 1) return _("dark violet");
-    if(step_L == 2) return _("blue violet");
-    if(step_L == 3) return _("violet");
-    if(step_L == 4) return _("plum");
-  }
-  else if(step_h == 14)
-  {
-    if(step_L == 0) return _("purple");
-    if(step_L == 1) return _("dark magenta");
-    if(step_L == 2) return _("magenta");
-    if(step_L == 3) return _("violet");
-    if(step_L == 4) return _("lavender");
-  }
+  // h == 360 exactly (and any out-of-domain hue) lands outside the table.
+  if(step_h < 0 || step_h >= LCH_HUE_SECTORS) return g_strdup(_("color not found"));
+  if(step_L < 0 || step_L >= LCH_LIGHTNESS_SECTORS) return g_strdup(_("color not found"));
 
-  return _("color not found");
+  return g_strdup(_(_lch_color_names[step_h][step_L]));
 }
 
 void get_skin_tones_range()

--- a/src/common/color_vocabulary.h
+++ b/src/common/color_vocabulary.h
@@ -77,7 +77,28 @@ typedef struct skin_color_t
 #define SKINS 16
 
 // returns a color name for color
-const char *Lch_to_color_name(dt_aligned_pixel_t color);
+/**
+ * @brief Name the colour at @p color in plain language, e.g. "salmon" or "olive drab".
+ *
+ * @details Classifies by hue and lightness against a 15 x 5 grid of names, after two
+ * special cases: a chroma below 2.0 is "gray", and a colour falling inside the measured
+ * spread of any reference skin tone is named as such instead ("average Thai skin tone"),
+ * listing every ethnicity whose range it matches, one per line.
+ *
+ * @param color CIE Lab 1976 turned into polar coordinates (Lch), as produced by
+ * dt_Lab_2_LCH(): L in percent, chroma, and hue NORMALIZED to [0, 1] -- not degrees.
+ * Passing degrees puts every lookup out of the table's domain.
+ *
+ * @return a newly-allocated, translated, human-readable name. **The caller owns it and
+ * must g_free() it.** Never NULL: a colour outside the table's domain gives
+ * "color not found" rather than a NULL a "%s" would then read.
+ *
+ * @note Ownership used to depend on which branch answered -- the skin-tone path returned
+ * an allocated string while every other path returned a static literal, behind a
+ * `const char *` that told the caller neither. The one call site leaked whenever a skin
+ * tone matched. Allocating on every path is what makes the contract statable.
+ */
+char *Lch_to_color_name(dt_aligned_pixel_t color);
 
 // Parametric sweeping of Lch boundaries (in CIE Luv 1976) for all known skin tones +/- 2 std
 void get_skin_tones_range();

--- a/src/common/conf.c
+++ b/src/common/conf.c
@@ -119,22 +119,66 @@ static inline char *dt_conf_get_var(const char *name)
   return str;
 }
 
-/* set the value only if it hasn't been overridden from commandline
- * return 1 if key/value is still the one passed on commandline. */
+/** @brief Store @p str for @p name unless the command line pinned that key.
+ *
+ * @details This is the ONLY writer that can replace an existing value while the
+ * application is running -- the two inserts in _dt_conf_get_var_locked() only fire when the
+ * key is absent, and the two in dt_conf_init() run before any reader exists.
+ *
+ * That makes it the one place where dt_conf_get_string_const()'s borrowed pointer could be
+ * pulled out from under a reader. It used to be: g_hash_table_insert() destroys the value
+ * it replaces, and the table's value_destroy_func is a free. A reader that had taken the
+ * pointer and released the lock -- which dt_conf_get_var() does before returning -- was
+ * then reading freed memory. Rather than free the old value here, we RETIRE it: it is moved
+ * to darktable.conf->retired_values and released only at dt_conf_cleanup(). A stale read is
+ * possible where a use-after-free was; the pointer itself stays valid for the process
+ * lifetime.
+ *
+ * Retiring only happens when the value actually CHANGES. Writing a key back with the value
+ * it already holds -- which GUI state saving does constantly -- stores nothing and retires
+ * nothing, so the retired list grows with real edits and not with idle churn.
+ *
+ * @param name key to write.
+ * @param str the value. Ownership TRANSFERS to this function only when it returns 0.
+ * @return non-zero when the value was not stored -- either the command line pinned this key,
+ * or it already held exactly this value. **The caller still owns @p str and must free it.**
+ */
 static int dt_conf_set_if_not_overridden(const char *name, char *str)
 {
   dt_pthread_mutex_lock(&darktable.conf->mutex);
 
   char *over = (char *)g_hash_table_lookup(darktable.conf->override_entries, name);
-  const int is_overridden = (over && !strcmp(str, over));
-  if(!is_overridden)
+  int not_stored = (over && !strcmp(str, over));
+
+  if(!not_stored)
   {
-    g_hash_table_insert(darktable.conf->table, g_strdup(name), str);
+    const char *current = (const char *)g_hash_table_lookup(darktable.conf->table, name);
+    if(!IS_NULL_PTR(current) && !strcmp(current, str))
+    {
+      // Unchanged: storing it would retire a perfectly good string for nothing.
+      not_stored = 1;
+    }
+    else
+    {
+      // Take the old entry out WITHOUT running the destroy functions, so we decide what
+      // happens to each half: the key was never handed to anyone and is ours to free, the
+      // value may still be held by a reader and is retired instead.
+      gpointer old_key = NULL;
+      gpointer old_value = NULL;
+      if(g_hash_table_steal_extended(darktable.conf->table, name, &old_key, &old_value))
+      {
+        dt_free(old_key);
+        if(!IS_NULL_PTR(old_value))
+          g_ptr_array_add(darktable.conf->retired_values, old_value);
+      }
+
+      g_hash_table_insert(darktable.conf->table, g_strdup(name), str);
+    }
   }
 
   dt_pthread_mutex_unlock(&darktable.conf->mutex);
 
-  return is_overridden;
+  return not_stored;
 }
 
 void dt_conf_set_int(const char *name, int val)
@@ -497,6 +541,9 @@ void dt_conf_init(dt_conf_t *cf, const char *filename, GSList *override_entries)
   cf->x_confgen = g_hash_table_new_full(g_str_hash, g_str_equal, dt_free_gpointer, _free_confgen_value);
 
   cf->table = g_hash_table_new_full(g_str_hash, g_str_equal, dt_free_gpointer, dt_free_gpointer);
+  // Values replaced by a later write live on here until shutdown, because
+  // dt_conf_get_string_const() may have handed one out. See dt_conf_set_if_not_overridden().
+  cf->retired_values = g_ptr_array_new_with_free_func(g_free);
   cf->override_entries = g_hash_table_new_full(g_str_hash, g_str_equal, dt_free_gpointer, dt_free_gpointer);
   dt_pthread_mutex_init(&darktable.conf->mutex, NULL);
 
@@ -905,6 +952,10 @@ void dt_conf_cleanup(dt_conf_t *cf)
   dt_conf_save(cf);
   g_hash_table_unref(cf->table);
   g_hash_table_unref(cf->override_entries);
+  // Released last: every string here was handed out by dt_conf_get_string_const() at some
+  // point, so it stays alive for as long as any of the conf state does.
+  g_ptr_array_unref(cf->retired_values);
+  cf->retired_values = NULL;
   g_hash_table_unref(cf->x_confgen);
   dt_pthread_mutex_destroy(&darktable.conf->mutex);
 }

--- a/src/common/conf.h
+++ b/src/common/conf.h
@@ -105,8 +105,14 @@ typedef struct dt_conf_t
   GHashTable *table;
   /** Defaults, bounds and descriptions from the generated XML. Immutable after init. */
   GHashTable *x_confgen;
-  /** Keys forced on the command line; they win over @ref table on read. */
+  /** Keys forced on the command line; they win over @ref table on read. Written once by
+   * dt_conf_init() and read-only afterwards, so pointers into it are stable. */
   GHashTable *override_entries;
+  /** Values displaced by a later write, kept alive until dt_conf_cleanup().
+   * dt_conf_get_string_const() borrows pointers into @ref table and its readers hold them
+   * without the lock, so a replaced value cannot be freed at the moment it is replaced.
+   * Grows only when a key's value actually changes. */
+  GPtrArray *retired_values;
 } dt_conf_t;
 
 /**
@@ -166,21 +172,20 @@ int dt_conf_get_bool(const char *name);
 /**
  * @brief Borrow the stored string for @p name without copying it.
  *
- * @return a pointer straight INTO the live conf hash table. Do not free it.
+ * @return a pointer into the conf table. Do not free it. **Valid for the lifetime of the
+ * process**, and never NULL.
  *
- * @warning The lifetime is shorter than it looks, and shorter than this function's old
- * comment implied. It is not merely "until this thread next calls dt_conf_set_string()":
- * the lock is released before the pointer is returned, so ANY thread setting the same key
- * frees it -- g_hash_table_insert() destroys the value it replaces -- while the caller is
- * still holding it. Reading through it afterwards is a use-after-free, and the observed
- * symptom is a torn or garbage value rather than a crash.
+ * @warning It can go STALE. It is a snapshot: a later dt_conf_set_*() on the same key
+ * installs a new string and leaves this one behind, so a caller holding the pointer keeps
+ * reading the value as it was. Re-read the key when currency matters, or take a private
+ * copy with dt_conf_get_string() when the value must be carried somewhere.
  *
- * That is the exact mechanism behind a "write_sidecar_files silently flips to FALSE"
- * report: a key read from many threads, written from one. dt_conf_get_string() was given
- * a copy-under-lock to fix it; this variant was not.
- *
- * Safe only when the key cannot be written while the result is alive -- in practice, keys
- * touched from the GUI thread alone. When in doubt use dt_conf_get_string().
+ * @note This used to be a use-after-free rather than a staleness question: the value was
+ * freed the moment another thread replaced it, while the reader still held the pointer --
+ * the mechanism behind a "write_sidecar_files silently flips to FALSE" report.
+ * dt_conf_set_if_not_overridden() now retires displaced values instead of freeing them,
+ * which fixes every caller at once rather than asking 98 call sites to be audited
+ * individually.
  */
 const char *dt_conf_get_string_const(const char *name);
 

--- a/src/common/conf.h
+++ b/src/common/conf.h
@@ -78,18 +78,49 @@ typedef struct dt_confgen_value_t
   char *longdesc;
 } dt_confgen_value_t;
 
+/**
+ * @brief The whole configuration state. One instance lives at darktable.conf.
+ *
+ * @details Every dt_conf_*() call below reaches it through that global and dereferences it
+ * WITHOUT checking, so dt_conf_init() must have run before any of them. There is no
+ * "conf not ready" return value; calling early is a NULL dereference.
+ *
+ * The two hash tables have opposite lifetimes, and that difference decides which returned
+ * pointers are safe to hold:
+ *
+ *   - @ref table is LIVE. Any thread may replace a value through dt_conf_set_*(), and
+ *     g_hash_table_insert() frees the value it replaces. A pointer into it is therefore
+ *     only valid while @ref mutex is held.
+ *   - @ref x_confgen is built once by dt_conf_init() from the generated XML and only read
+ *     afterwards, until dt_conf_cleanup(). Pointers into it stay valid for the process
+ *     lifetime, which is why the dt_confgen_*() readers take no lock at all.
+ */
 typedef struct dt_conf_t
 {
+  /** Guards @ref table and @ref override_entries. Not needed for @ref x_confgen. */
   dt_pthread_mutex_t mutex;
+  /** Absolute path of the anselrc this instance loads from and saves to. */
   char filename[DT_PATH_MAX];
+  /** Live key -> value strings, user-writable. Values are replaced and freed at runtime. */
   GHashTable *table;
+  /** Defaults, bounds and descriptions from the generated XML. Immutable after init. */
   GHashTable *x_confgen;
+  /** Keys forced on the command line; they win over @ref table on read. */
   GHashTable *override_entries;
 } dt_conf_t;
 
+/**
+ * @brief One key/value pair handed back by dt_conf_all_string_entries().
+ *
+ * @details Both members are private copies owned by the entry, not pointers into the conf
+ * table -- which is what makes the returned list safe to hold after the lock is released.
+ * Release an entry with dt_conf_string_entry_free().
+ */
 typedef struct dt_conf_string_entry_t
 {
+  /** Key name, relative to the directory that was asked for. Owned by this entry. */
   char *key;
+  /** Value as a string. Owned by this entry. */
   char *value;
 } dt_conf_string_entry_t;
 
@@ -107,33 +138,122 @@ void dt_conf_set_float(const char *name, float val);
 void dt_conf_set_bool(const char *name, int val);
 void dt_conf_set_string(const char *name, const char *val);
 void dt_conf_set_folder_from_file_chooser(const char *name, GtkFileChooser *chooser);
+/* The _fast readers return the STORED value. The plain readers return the same value
+ * CLAMPED to the min/max declared for that key in the generated XML, at the cost of two
+ * extra confgen lookups. "fast" therefore means "unclamped": for any key that declares
+ * bounds, the two can disagree, and a value out of range is exactly the case where it
+ * matters. Prefer the plain reader unless the key has no bounds or the caller clamps.
+ *
+ * All of them accept an arithmetic expression as the stored text -- it goes through the
+ * calculator -- and fall back to the XML default, then to 0, when it does not parse. */
+
+/** @brief Stored integer for @p name, NOT clamped to its declared bounds. */
 int dt_conf_get_int_fast(const char *name);
+/** @brief Integer for @p name, clamped to the bounds declared in the XML. */
 int dt_conf_get_int(const char *name);
+/** @brief Stored 64-bit integer for @p name, NOT clamped. */
 int64_t dt_conf_get_int64_fast(const char *name);
+/** @brief 64-bit integer for @p name, clamped to its declared bounds. */
 int64_t dt_conf_get_int64(const char *name);
+/** @brief Stored float for @p name, NOT clamped. */
 float dt_conf_get_float_fast(const char *name);
+/** @brief Float for @p name, clamped to its declared bounds. */
 float dt_conf_get_float(const char *name);
 int dt_conf_get_and_sanitize_int(const char *name, int min, int max);
 int64_t dt_conf_get_and_sanitize_int64(const char *name, int64_t min, int64_t max);
 float dt_conf_get_and_sanitize_float(const char *name, float min, float max);
 int dt_conf_get_bool(const char *name);
-// get the configuration string without duplicating it; the returned string will be invalidated by any
-// subsequent dt_conf_set_string call
+/**
+ * @brief Borrow the stored string for @p name without copying it.
+ *
+ * @return a pointer straight INTO the live conf hash table. Do not free it.
+ *
+ * @warning The lifetime is shorter than it looks, and shorter than this function's old
+ * comment implied. It is not merely "until this thread next calls dt_conf_set_string()":
+ * the lock is released before the pointer is returned, so ANY thread setting the same key
+ * frees it -- g_hash_table_insert() destroys the value it replaces -- while the caller is
+ * still holding it. Reading through it afterwards is a use-after-free, and the observed
+ * symptom is a torn or garbage value rather than a crash.
+ *
+ * That is the exact mechanism behind a "write_sidecar_files silently flips to FALSE"
+ * report: a key read from many threads, written from one. dt_conf_get_string() was given
+ * a copy-under-lock to fix it; this variant was not.
+ *
+ * Safe only when the key cannot be written while the result is alive -- in practice, keys
+ * touched from the GUI thread alone. When in doubt use dt_conf_get_string().
+ */
 const char *dt_conf_get_string_const(const char *name);
-// get a freshly-allocated duplicate of the configuration string; safe to use even if calling dt_conf_set_string
+
+/**
+ * @brief Read the stored string for @p name as a private copy.
+ *
+ * @details The copy is taken while the lock is held, so it cannot race a concurrent
+ * dt_conf_set_*() on the same key.
+ *
+ * @return a newly-allocated string. **The caller owns it and must g_free() it.** Never
+ * NULL: an unknown key is created on demand and yields the XML default, or an empty value.
+ */
 gchar *dt_conf_get_string(const char *name);
 gboolean dt_conf_get_folder_to_file_chooser(const char *name, GtkFileChooser *chooser);
 gboolean dt_conf_is_equal(const char *name, const char *value);
+/**
+ * @brief Populate @p cf from @p filename and from the generated defaults.
+ *
+ * @details Must run before ANY other dt_conf_*() call: the rest of this API reaches
+ * darktable.conf unconditionally.
+ *
+ * @param cf storage to initialise, normally darktable.conf.
+ * @param filename anselrc to read; created from defaults when absent.
+ * @param override_entries command-line overrides, as dt_conf_string_entry_t. They win over
+ * stored values on read and are not written back on save.
+ */
 void dt_conf_init(dt_conf_t *cf, const char *filename, GSList *override_entries);
+
+/** @brief Free everything @p cf owns. No dt_conf_*() call is valid afterwards. */
 void dt_conf_cleanup(dt_conf_t *cf);
+
+/** @brief Write @p cf back to its file. Overridden keys keep their stored value. */
 void dt_conf_save(dt_conf_t *cf);
+
+/**
+ * @brief Does @p key have a value?
+ *
+ * @warning TRUE for every key declared in the generated XML, on a first run with no
+ * anselrc at all, because defaults are loaded at init. It answers "is this key known?",
+ * NOT "has the user ever chosen?". For the latter, write a NON-confgen sentinel key when
+ * the user acts and test that instead -- see the Sentry consent flow in common/sentry.c.
+ */
 int dt_conf_key_exists(const char *key);
 gboolean dt_conf_key_not_empty(const char *key);
+/**
+ * @brief Every key under @p dir, as a list of copies.
+ *
+ * @param dir key prefix to match, e.g. "plugins/lighttable".
+ * @return a newly-allocated GSList of dt_conf_string_entry_t. **The caller owns the list
+ * AND its elements**; release with
+ * `g_slist_free_full(list, dt_conf_string_entry_free)`. Empty (NULL) when nothing matches.
+ * The entries hold copies, so they outlive any concurrent dt_conf_set_*().
+ */
 GSList *dt_conf_all_string_entries(const char *dir);
+
+/** @brief Free one dt_conf_string_entry_t. Shaped as a GDestroyNotify so it can be handed
+ * to g_slist_free_full(). */
 void dt_conf_string_entry_free(gpointer data);
 
+/* These three carry their own trailing semicolon, so a call site that adds one produces an
+ * empty statement -- harmless alone, but it makes `if(c) DT_CONF_SET_SANITIZED_INT(...);
+ * else ...` fail to compile. Brace the branch. */
+
+/** @brief Clamp @p val to [@p min, @p max] and store it as an int. */
 #define DT_CONF_SET_SANITIZED_INT(name, val, min, max) dt_conf_set_int(name, CLAMPS(val, min,max));
+
+/** @brief Intended as the 64-bit form of DT_CONF_SET_SANITIZED_INT().
+ * @warning It calls dt_conf_set_int(), not dt_conf_set_int64(), so a value beyond 32 bits
+ * is truncated. Currently unused -- fix it before the first call site, and note the name
+ * says 6464. */
 #define DT_CONF_SET_SANITIZED_INT6464(name, val, min, max) dt_conf_set_int(name, CLAMPS(val, min,max));
+
+/** @brief Clamp @p val to [@p min, @p max] and store it as a float. */
 #define DT_CONF_SET_SANITIZED_FLOAT(name, val, min, max) dt_conf_set_float(name, CLAMPS(val, min,max));
 
 // conf generated from darktable config XML
@@ -147,12 +267,32 @@ int dt_confgen_get_int(const char *name, dt_confgen_value_kind_t kind);
 int64_t dt_confgen_get_int64(const char *name, dt_confgen_value_kind_t kind);
 gboolean dt_confgen_get_bool(const char *name, dt_confgen_value_kind_t kind);
 float dt_confgen_get_float(const char *name, dt_confgen_value_kind_t kind);
+/**
+ * @brief One declared attribute of @p name from the generated XML, as text.
+ *
+ * @param kind which attribute: default, min, max, or the enum's value list.
+ * @return a pointer into the confgen table, or NULL when @p name or @p kind is not
+ * declared. Do NOT free it. Unlike dt_conf_get_string_const(), this one is safe to hold:
+ * the confgen table is built once at init and never mutated, which is also why these
+ * readers take no lock.
+ */
 const char *dt_confgen_get(const char *name, dt_confgen_value_kind_t kind);
 
+/** @brief Translated short description of @p name, borrowed and valid for the process
+ * lifetime. NULL when @p name is not declared. */
 const char *dt_confgen_get_label(const char *name);
+
+/** @brief Translated long description of @p name, borrowed and valid for the process
+ * lifetime. NULL when @p name is not declared. */
 const char *dt_confgen_get_tooltip(const char *name);
 
+/** @brief Is @p name still at the value declared in the XML? FALSE for an undeclared key. */
 gboolean dt_conf_is_default(const char *name);
+
+/**
+ * @brief Expand the placeholders in a default directory string.
+ * @return a newly-allocated string. **The caller owns it and must g_free() it.**
+ */
 gchar* dt_conf_expand_default_dir(const char *dir);
 
 #ifdef __cplusplus

--- a/src/common/logging.h
+++ b/src/common/logging.h
@@ -29,6 +29,21 @@
 extern "C" {
 #endif
 
+/**
+ * @brief Debug channels, selected at runtime with -d <channel>.
+ *
+ * @details These are MASK BITS, combined into the runtime mask dt_get_debug_flags()
+ * returns, with two exceptions worth knowing before adding one:
+ *
+ *   - DT_DEBUG_ALWAYS is 0, so it matches nothing under a bitwise AND. The dt_print()
+ *     family special-cases it by equality. A new channel must never be 0.
+ *   - bit 6 (1 << 6) is FREE -- the list jumps from 1 << 5 to 1 << 7. The values are not
+ *     contiguous and nothing may assume they are.
+ *
+ * Bit 31 cannot be spelled as an enumerator (1 << 31 does not fit an `int`), so
+ * DT_DEBUG_SUPERVISOR is a macro below. The mask is an int32_t and is now FULL: a new
+ * channel needs bit 6, or a wider mask.
+ */
 typedef enum dt_debug_thread_t
 {
   DT_DEBUG_ALWAYS        = 0,       // always print regardless of debug flags
@@ -77,10 +92,30 @@ typedef enum dt_debug_thread_t
  * the application struct. Test with `dt_get_debug_flags() & DT_DEBUG_XXX`. */
 int32_t dt_get_debug_flags(void);
 
+/**
+ * @brief Print to stdout when @p thread is enabled, prefixed with seconds since startup.
+ *
+ * @param thread the channel to gate on, or DT_DEBUG_ALWAYS to print unconditionally.
+ * @param msg printf format string; the call is format-checked at compile time.
+ *
+ * @note Flushes stdout on every call, so output survives a crash immediately after -- the
+ * reason to use this rather than a bare fprintf(stderr) when tracing a crash.
+ *
+ * @note Format strings are checked against the GNU conversions on every platform,
+ * Windows included: src/CMakeLists.txt builds with __USE_MINGW_ANSI_STDIO=1, which is what
+ * makes `%z` and friends work under MinGW rather than falling back to the MS runtime's
+ * narrower set. Dropping that definition would silently change what these format strings
+ * mean on Windows only.
+ */
 void dt_print(dt_debug_thread_t thread, const char *msg, ...) __attribute__((format(printf, 2, 3)));
-/* same as above but without time stamp : nts = no time stamp */
+
+/** @brief dt_print() without the timestamp prefix (nts = no time stamp). */
 void dt_print_nts(dt_debug_thread_t thread, const char *msg, ...) __attribute__((format(printf, 2, 3)));
-/* same as above but requires additional DT_DEBUG_VERBOSE flag to be true */
+
+/** @brief dt_print() that additionally requires DT_DEBUG_VERBOSE to be enabled, i.e. both
+ * `-d <channel>` and `-d verbose`.
+ * @note The `v` is for VERBOSE, not for va_list -- this is variadic like the others, not a
+ * vprintf()-style counterpart. */
 void dt_vprint(dt_debug_thread_t thread, const char *msg, ...) __attribute__((format(printf, 2, 3)));
 
 #ifdef __cplusplus

--- a/src/common/module_versioning.h
+++ b/src/common/module_versioning.h
@@ -27,9 +27,36 @@
 extern "C" {
 #endif
 
+/** @brief Version of the module interface every dynamically-loaded module is checked
+ * against at load time.
+ *
+ * @warning Bumping it invalidates EVERY module at once: each one reports this value
+ * through DT_MODULE() at the version it was compiled with, and the loader refuses any
+ * mismatch. Bump it whenever the layout of a struct crossing the module boundary changes,
+ * and do not bump it for anything else. A module .so left over from a previous build that
+ * still reports the same number will be loaded and will misread the new layout -- silently.
+ */
 #define DT_MODULE_VERSION 23 // version of dt's module interface
 
 
+/** @brief Instantiate the version handshake every module must export. Use once, at file
+ * scope, in each module's main .c file.
+ *
+ * @details This DEFINES two functions -- dt_module_dt_version() and
+ * dt_module_mod_version() -- rather than declaring anything, so it is a definition site,
+ * not a header-style annotation: exactly one per shared object.
+ *
+ * @param MODVER the module's OWN parameter version, independent of DT_MODULE_VERSION.
+ * Bump it when that module's params struct changes, and provide legacy_params() to
+ * migrate old history and presets.
+ *
+ * @note In a _DEBUG build the reported interface version is NEGATED. That is deliberate:
+ * debug and release builds lay some shared structs out differently, so a debug module
+ * dropped into a release host (or the reverse) reports a version that cannot match and is
+ * refused at load, instead of loading and misreading every struct it is handed. If a
+ * module mysteriously fails to load, check that it was built in the same configuration as
+ * the host before looking anywhere else.
+ */
 // every module has to define this:
 #ifdef _DEBUG
 #define DT_MODULE(MODVER)                                                                                    \
@@ -53,8 +80,23 @@ extern "C" {
   }
 #endif
 
+/** @brief DT_MODULE() for a module whose params struct is introspected.
+ *
+ * @param MODVER as for DT_MODULE().
+ * @param PARAMSTYPE the params struct type.
+ *
+ * @warning @p PARAMSTYPE is IGNORED by the preprocessor -- this expands to plain
+ * DT_MODULE(MODVER). It is read at BUILD time by the introspection generator, which parses
+ * the source text and emits the field table into a generated header. Two consequences: the
+ * argument must name a type the generator can find by parsing, and a change to that
+ * struct's fields or $DEFAULT annotations only takes effect once the generated file is
+ * regenerated. A stale generated file compiles cleanly and silently keeps the old defaults.
+ */
 #define DT_MODULE_INTROSPECTION(MODVER, PARAMSTYPE) DT_MODULE(MODVER)
 
+/** @brief The interface version the HOST expects, in the host's own build configuration.
+ * @return DT_MODULE_VERSION, negated in a _DEBUG build. A module loads only when its
+ * dt_module_dt_version() returns the same value. */
 // ..to be able to compare it against this:
 static inline int dt_version()
 {
@@ -65,7 +107,8 @@ static inline int dt_version()
 #endif
 }
 
-// returns the darktable version as <major>.<minor>
+/** @brief The application version, truncated to `<major>.<minor>`.
+ * @return a newly-allocated string. **The caller owns it and must g_free() it.** */
 char *dt_version_major_minor();
 
 #ifdef __cplusplus

--- a/src/common/variables.c
+++ b/src/common/variables.c
@@ -330,14 +330,21 @@ static char *_variables_get_iso_timestamp(const GTimeSpan gts)
   g_date_time_unref(gdt);
   return result;
 }
-
-static char *_get_base_value(dt_variables_params_t *params, char **variable)
+/** @brief Expand the current time, and the import/change/export/print timestamps.
+ *
+ * @details One link of the ordered chain _get_base_value() walks; see the contract
+ * documented there. Branch order inside this function is load-bearing for the same
+ * reason it is across the chain.
+ *
+ * @param params expansion context.
+ * @param variable in/out: on a match, advanced past the name that was consumed.
+ * @param out written ONLY on a match, with a newly-allocated string the caller owns.
+ * @return TRUE if the variable was recognised and consumed, FALSE to try the next link.
+ */
+static gboolean _expand_datetime_now(dt_variables_params_t *params, char **variable, char **out)
 {
-  char *result = NULL;
-  gboolean escape = TRUE;
-
   char exif_datetime[DT_DATETIME_LENGTH];
-  GDateTime *datetime = params->data->have_exif_dt ? params->data->datetime : params->data->time;
+  char *result = NULL;
 
   if(_has_prefix(variable, "YEAR.SHORT") || _has_prefix(variable, "SHORT_YEAR") || _has_prefix(variable, "DATE.SHORT_YEAR"))
     result = g_date_time_format(params->data->time, "%y");
@@ -389,7 +396,30 @@ static char *_get_base_value(dt_variables_params_t *params, char **variable)
     result = g_strdup(exif_datetime);
   }
 
-  else if(_has_prefix(variable, "EXIF.YEAR.SHORT") || _has_prefix(variable, "EXIF.DATE.SHORT_YEAR"))
+  else return FALSE;
+
+  *out = result;
+  return TRUE;
+}
+
+/** @brief Expand the capture time read from EXIF.
+ *
+ * @details One link of the ordered chain _get_base_value() walks; see the contract
+ * documented there. Branch order inside this function is load-bearing for the same
+ * reason it is across the chain.
+ *
+ * @param params expansion context.
+ * @param variable in/out: on a match, advanced past the name that was consumed.
+ * @param out written ONLY on a match, with a newly-allocated string the caller owns.
+ * @return TRUE if the variable was recognised and consumed, FALSE to try the next link.
+ */
+static gboolean _expand_exif_datetime(dt_variables_params_t *params, char **variable, char **out)
+{
+  char exif_datetime[DT_DATETIME_LENGTH];
+  GDateTime *datetime = params->data->have_exif_dt ? params->data->datetime : params->data->time;
+  char *result = NULL;
+
+  if(_has_prefix(variable, "EXIF.YEAR.SHORT") || _has_prefix(variable, "EXIF.DATE.SHORT_YEAR"))
     result = g_date_time_format(datetime, "%y");
   else if(_has_prefix(variable, "EXIF.YEAR") || _has_prefix(variable, "EXIF_YEAR") || _has_prefix(variable, "EXIF.DATE.LONG_YEAR"))
     result = g_date_time_format(datetime, "%Y");
@@ -420,7 +450,28 @@ static char *_get_base_value(dt_variables_params_t *params, char **variable)
     dt_datetime_gdatetime_to_exif(exif_datetime, params->data->show_msec ? DT_DATETIME_LENGTH : DT_DATETIME_EXIF_LENGTH, datetime);
     result = g_strdup(exif_datetime);
   }
-  else if(_has_prefix(variable, "EXIF.ISO") || _has_prefix(variable, "EXIF_ISO"))
+  else return FALSE;
+
+  *out = result;
+  return TRUE;
+}
+
+/** @brief Expand EXIF exposure settings, GPS position and camera identity.
+ *
+ * @details One link of the ordered chain _get_base_value() walks; see the contract
+ * documented there. Branch order inside this function is load-bearing for the same
+ * reason it is across the chain.
+ *
+ * @param params expansion context.
+ * @param variable in/out: on a match, advanced past the name that was consumed.
+ * @param out written ONLY on a match, with a newly-allocated string the caller owns.
+ * @return TRUE if the variable was recognised and consumed, FALSE to try the next link.
+ */
+static gboolean _expand_exif_and_gps(dt_variables_params_t *params, char **variable, char **out)
+{
+  char *result = NULL;
+
+  if(_has_prefix(variable, "EXIF.ISO") || _has_prefix(variable, "EXIF_ISO"))
     result = g_strdup_printf("%d", params->data->exif_iso);
   else if(_has_prefix(variable, "NL") && g_strcmp0(params->jobcode, "infos") == 0)
     result = g_strdup_printf("\n");
@@ -470,7 +521,28 @@ static char *_get_base_value(dt_variables_params_t *params, char **variable)
     result = g_strdup(params->data->camera_alias);
   else if(_has_prefix(variable, "EXIF.LENS") || _has_prefix(variable, "LENS"))
     result = g_strdup(params->data->exif_lens);
-  else if(_has_prefix(variable, "ID") || _has_prefix(variable, "IMAGE.ID"))
+  else return FALSE;
+
+  *out = result;
+  return TRUE;
+}
+
+/** @brief Expand image id, duplicate version, job code and film roll.
+ *
+ * @details One link of the ordered chain _get_base_value() walks; see the contract
+ * documented there. Branch order inside this function is load-bearing for the same
+ * reason it is across the chain.
+ *
+ * @param params expansion context.
+ * @param variable in/out: on a match, advanced past the name that was consumed.
+ * @param out written ONLY on a match, with a newly-allocated string the caller owns.
+ * @return TRUE if the variable was recognised and consumed, FALSE to try the next link.
+ */
+static gboolean _expand_image_and_version(dt_variables_params_t *params, char **variable, char **out)
+{
+  char *result = NULL;
+
+  if(_has_prefix(variable, "ID") || _has_prefix(variable, "IMAGE.ID"))
     result = g_strdup_printf("%d", params->imgid);
   else if(_has_prefix(variable, "IMAGE.EXIF"))
   {
@@ -517,7 +589,28 @@ static char *_get_base_value(dt_variables_params_t *params, char **variable)
       dt_free(dirname);
     }
   }
-  else if(_has_prefix(variable, "FILE.DIRECTORY") || _has_prefix(variable, "FILE_DIRECTORY"))
+  else return FALSE;
+
+  *out = result;
+  return TRUE;
+}
+
+/** @brief Expand the source file's path, name and mtime, plus the user's folders.
+ *
+ * @details One link of the ordered chain _get_base_value() walks; see the contract
+ * documented there. Branch order inside this function is load-bearing for the same
+ * reason it is across the chain.
+ *
+ * @param params expansion context.
+ * @param variable in/out: on a match, advanced past the name that was consumed.
+ * @param out written ONLY on a match, with a newly-allocated string the caller owns.
+ * @return TRUE if the variable was recognised and consumed, FALSE to try the next link.
+ */
+static gboolean _expand_file_and_folder(dt_variables_params_t *params, char **variable, char **out)
+{
+  char *result = NULL;
+
+  if(_has_prefix(variable, "FILE.DIRECTORY") || _has_prefix(variable, "FILE_DIRECTORY"))
   {
     // undocumented : backward compatibility
     if(params->filename)
@@ -595,7 +688,29 @@ static char *_get_base_value(dt_variables_params_t *params, char **variable)
     result = g_strdup(g_get_user_special_dir(G_USER_DIRECTORY_DESKTOP)); // undocumented : backward compatibility
   else if(_has_prefix(variable, "DESKTOP"))
     result = g_strdup(g_get_user_special_dir(G_USER_DIRECTORY_DESKTOP));
-  else if(_has_prefix(variable, "STARS"))
+  else return FALSE;
+
+  *out = result;
+  return TRUE;
+}
+
+/** @brief Expand star rating, colour labels and the Dublin Core fields.
+ *
+ * @details One link of the ordered chain _get_base_value() walks; see the contract
+ * documented there. Branch order inside this function is load-bearing for the same
+ * reason it is across the chain.
+ *
+ * @param params expansion context.
+ * @param variable in/out: on a match, advanced past the name that was consumed.
+ * @param out written ONLY on a match, with a newly-allocated string the caller owns.
+ * @param escape cleared when the produced text must not be markup-escaped.
+ * @return TRUE if the variable was recognised and consumed, FALSE to try the next link.
+ */
+static gboolean _expand_rating_and_metadata(dt_variables_params_t *params, char **variable, char **out, gboolean *escape)
+{
+  char *result = NULL;
+
+  if(_has_prefix(variable, "STARS"))
     result = g_strdup_printf("%d", params->data->stars);
   else if(_has_prefix(variable, "RATING.ICONS") || _has_prefix(variable, "RATING_ICONS") || _has_prefix(variable, "Xmp.xmp.Rating"))
   {
@@ -628,7 +743,7 @@ static char *_get_base_value(dt_variables_params_t *params, char **variable)
            _has_prefix(variable, "LABELS.COLORICONS") || _has_prefix(variable, "LABELS_COLORICONS"))
           && g_strcmp0(params->jobcode, "infos") == 0)
   {
-    escape = FALSE;
+    *escape = FALSE;
     GList *res = dt_metadata_get(params->imgid, "Xmp.darktable.colorlabels", NULL);
     for(GList *res_iter = res; res_iter; res_iter = g_list_next(res_iter))
     {
@@ -718,7 +833,28 @@ static char *_get_base_value(dt_variables_params_t *params, char **variable)
     else
       result = g_strdup(_("no"));
   }
-  else if(_has_prefix(variable, "WIDTH.MAX") || _has_prefix(variable, "MAX_WIDTH"))
+  else return FALSE;
+
+  *out = result;
+  return TRUE;
+}
+
+/** @brief Expand image dimensions, category, tags and build identity.
+ *
+ * @details One link of the ordered chain _get_base_value() walks; see the contract
+ * documented there. Branch order inside this function is load-bearing for the same
+ * reason it is across the chain.
+ *
+ * @param params expansion context.
+ * @param variable in/out: on a match, advanced past the name that was consumed.
+ * @param out written ONLY on a match, with a newly-allocated string the caller owns.
+ * @return TRUE if the variable was recognised and consumed, FALSE to try the next link.
+ */
+static gboolean _expand_geometry_and_misc(dt_variables_params_t *params, char **variable, char **out)
+{
+  char *result = NULL;
+
+  if(_has_prefix(variable, "WIDTH.MAX") || _has_prefix(variable, "MAX_WIDTH"))
     result = g_strdup_printf("%d", params->data->max_width);
   else if(_has_prefix(variable, "WIDTH.SENSOR") || _has_prefix(variable, "SENSOR_WIDTH"))
     result = g_strdup_printf("%d", params->data->sensor_width);
@@ -795,7 +931,41 @@ static char *_get_base_value(dt_variables_params_t *params, char **variable)
   else if(_has_prefix(variable, "DARKTABLE.NAME") || _has_prefix(variable, "DARKTABLE_NAME")
        || _has_prefix(variable, "ANSEL.NAME"))
     result = g_strdup(PACKAGE_NAME);
-  else
+  else return FALSE;
+
+  *out = result;
+  return TRUE;
+}
+
+/** @brief Expand one $(VARIABLE) into its text.
+ *
+ * @details The chain below is ORDERED and that order is load-bearing: _has_prefix() is
+ * g_str_has_prefix() plus a side effect -- on a match it advances @p variable past the
+ * prefix -- and it does not require a word boundary. A shorter prefix tried earlier
+ * therefore swallows every longer one starting with it, silently. Adding a name means
+ * placing it BEFORE any prefix of itself, not merely somewhere in the right group.
+ *
+ * Split into one function per family only to keep each readable; the && short-circuit
+ * reproduces the single chain this used to be, link by link, in the same order.
+ *
+ * @param params expansion context.
+ * @param variable in/out: advanced past whatever was consumed, including the characters
+ * skipped when nothing matched.
+ * @return a newly-allocated string the caller owns and must free. NEVER NULL: an
+ * unrecognised variable yields "", and callers rely on that.
+ */
+static char *_get_base_value(dt_variables_params_t *params, char **variable)
+{
+  char *result = NULL;
+  gboolean escape = TRUE;
+
+  if(!_expand_datetime_now(params, variable, &result)
+     && !_expand_exif_datetime(params, variable, &result)
+     && !_expand_exif_and_gps(params, variable, &result)
+     && !_expand_image_and_version(params, variable, &result)
+     && !_expand_file_and_folder(params, variable, &result)
+     && !_expand_rating_and_metadata(params, variable, &result, &escape)
+     && !_expand_geometry_and_misc(params, variable, &result))
   {
     // go past what looks like an invalid variable. we only expect to see [a-zA-Z]* in a variable name.
     while(g_ascii_isalpha(**variable)) (*variable)++;
@@ -810,7 +980,6 @@ static char *_get_base_value(dt_variables_params_t *params, char **variable)
   }
   return result;
 }
-
 // bash style variable manipulation. all patterns are just simple string comparisons!
 // See here for bash examples and documentation:
 // http://www.tldp.org/LDP/abs/html/parameter-substitution.html

--- a/src/common/variables.c
+++ b/src/common/variables.c
@@ -364,12 +364,6 @@ static char *_get_base_value(dt_variables_params_t *params, char **variable)
     result = g_date_time_format(params->data->time, "%f");
     result[3] = '\0';
   }
-  // for watermark backward compatibility
-  else if(_has_prefix(variable, "DATE"))
-  {
-    dt_datetime_gdatetime_to_exif(exif_datetime, params->data->show_msec ? DT_DATETIME_LENGTH : DT_DATETIME_EXIF_LENGTH, params->data->time);
-    result = g_strdup(exif_datetime);
-  }
   else if(_has_prefix(variable, "IMPORT.DATE") || _has_prefix(variable, "DATE.IMPORT"))
   {
     result = _variables_get_iso_timestamp(params->data->import_timestamp);
@@ -385,6 +379,14 @@ static char *_get_base_value(dt_variables_params_t *params, char **variable)
   else if(_has_prefix(variable, "PRINT.DATE") || _has_prefix(variable, "DATE.PRINT"))
   {
     result = _variables_get_iso_timestamp(params->data->print_timestamp);
+  }
+  // for watermark backward compatibility.
+  // MUST stay after every DATE.* branch above: _has_prefix() is a plain prefix test, so
+  // this one also matches "DATE.IMPORT", "DATE.CHANGE", "DATE.EXPORT" and "DATE.PRINT".
+  else if(_has_prefix(variable, "DATE"))
+  {
+    dt_datetime_gdatetime_to_exif(exif_datetime, params->data->show_msec ? DT_DATETIME_LENGTH : DT_DATETIME_EXIF_LENGTH, params->data->time);
+    result = g_strdup(exif_datetime);
   }
 
   else if(_has_prefix(variable, "EXIF.YEAR.SHORT") || _has_prefix(variable, "EXIF.DATE.SHORT_YEAR"))

--- a/src/control/control.c
+++ b/src/control/control.c
@@ -121,95 +121,112 @@ void dt_control_init(dt_control_t *s)
   s->cursor.lock = FALSE;
 }
 
-// used for debugging, might remove later
-gchar *_get_cursor_name(dt_cursor_t cursor)
+/** @brief Human-readable name of a GDK cursor shape, for debug output.
+ *
+ * @details The returned string is a static literal owned by this table: it must NOT be
+ * freed, and it stays valid for the lifetime of the process. This used to g_strdup() its
+ * result from a 90-case switch, and neither of the two call sites freed it -- one of them
+ * could not, because it selected between the allocated name and a plain literal with a
+ * ternary. Static storage removes both the leak and the question.
+ *
+ * @param cursor the shape to name.
+ * @return the enum constant's spelling, never NULL. Unknown values -- GDK gained a shape,
+ * or the value is garbage -- give "GDK_CURSOR_UNKNOWN" rather than NULL, because every
+ * caller feeds this straight to a "%s" and passing NULL there is undefined behaviour.
+ */
+static const char *_get_cursor_name(dt_cursor_t cursor)
 {
-  gchar *shape_str = NULL;
-  switch(cursor)
+  static const struct
   {
-    case GDK_X_CURSOR: shape_str = g_strdup("GDK_X_CURSOR"); break;
-    case GDK_ARROW: shape_str = g_strdup("GDK_ARROW"); break;
-    case GDK_BASED_ARROW_DOWN: shape_str = g_strdup("GDK_BASED_ARROW_DOWN"); break;
-    case GDK_BASED_ARROW_UP: shape_str = g_strdup("GDK_BASED_ARROW_UP"); break;
-    case GDK_BOAT: shape_str = g_strdup("GDK_BOAT"); break;
-    case GDK_BOGOSITY: shape_str = g_strdup("GDK_BOGOSITY"); break;
-    case GDK_BOTTOM_LEFT_CORNER: shape_str = g_strdup("GDK_BOTTOM_LEFT_CORNER"); break;
-    case GDK_BOTTOM_RIGHT_CORNER: shape_str = g_strdup("GDK_BOTTOM_RIGHT_CORNER"); break;
-    case GDK_BOTTOM_SIDE: shape_str = g_strdup("GDK_BOTTOM_SIDE"); break;
-    case GDK_BOTTOM_TEE: shape_str = g_strdup("GDK_BOTTOM_TEE"); break;
-    case GDK_BOX_SPIRAL: shape_str = g_strdup("GDK_BOX_SPIRAL"); break;
-    case GDK_CENTER_PTR: shape_str = g_strdup("GDK_CENTER_PTR"); break;
-    case GDK_CIRCLE: shape_str = g_strdup("GDK_CIRCLE"); break;
-    case GDK_CLOCK: shape_str = g_strdup("GDK_CLOCK"); break;
-    case GDK_COFFEE_MUG: shape_str = g_strdup("GDK_COFFEE_MUG"); break;
-    case GDK_CROSS: shape_str = g_strdup("GDK_CROSS"); break;
-    case GDK_CROSS_REVERSE: shape_str = g_strdup("GDK_CROSS_REVERSE"); break;
-    case GDK_CROSSHAIR: shape_str = g_strdup("GDK_CROSSHAIR"); break;
-    case GDK_DIAMOND_CROSS: shape_str = g_strdup("GDK_DIAMOND_CROSS"); break;
-    case GDK_DOT: shape_str = g_strdup("GDK_DOT"); break;
-    case GDK_DOTBOX: shape_str = g_strdup("GDK_DOTBOX"); break;
-    case GDK_DOUBLE_ARROW: shape_str = g_strdup("GDK_DOUBLE_ARROW"); break;
-    case GDK_DRAFT_LARGE: shape_str = g_strdup("GDK_DRAFT_LARGE"); break;
-    case GDK_DRAFT_SMALL: shape_str = g_strdup("GDK_DRAFT_SMALL"); break;
-    case GDK_DRAPED_BOX: shape_str = g_strdup("GDK_DRAPED_BOX"); break;
-    case GDK_EXCHANGE: shape_str = g_strdup("GDK_EXCHANGE"); break;
-    case GDK_FLEUR: shape_str = g_strdup("GDK_FLEUR"); break;
-    case GDK_GOBBLER: shape_str = g_strdup("GDK_GOBBLER"); break;
-    case GDK_GUMBY: shape_str = g_strdup("GDK_GUMBY"); break;
-    case GDK_HAND1: shape_str = g_strdup("GDK_HAND1"); break;
-    case GDK_HAND2: shape_str = g_strdup("GDK_HAND2"); break;
-    case GDK_HEART: shape_str = g_strdup("GDK_HEART"); break;
-    case GDK_ICON: shape_str = g_strdup("GDK_ICON"); break;
-    case GDK_IRON_CROSS: shape_str = g_strdup("GDK_IRON_CROSS"); break;
-    case GDK_LEFT_PTR: shape_str = g_strdup("GDK_LEFT_PTR"); break;
-    case GDK_LEFT_SIDE: shape_str = g_strdup("GDK_LEFT_SIDE"); break;
-    case GDK_LEFT_TEE: shape_str = g_strdup("GDK_LEFT_TEE"); break;
-    case GDK_LEFTBUTTON: shape_str = g_strdup("GDK_LEFTBUTTON"); break;
-    case GDK_LL_ANGLE: shape_str = g_strdup("GDK_LL_ANGLE"); break;
-    case GDK_LR_ANGLE: shape_str = g_strdup("GDK_LR_ANGLE"); break;
-    case GDK_MAN: shape_str = g_strdup("GDK_MAN"); break;
-    case GDK_MIDDLEBUTTON: shape_str = g_strdup("GDK_MIDDLEBUTTON"); break;
-    case GDK_MOUSE: shape_str = g_strdup("GDK_MOUSE"); break;
-    case GDK_PENCIL: shape_str = g_strdup("GDK_PENCIL"); break;
-    case GDK_PIRATE: shape_str = g_strdup("GDK_PIRATE"); break;
-    case GDK_PLUS: shape_str = g_strdup("GDK_PLUS"); break;
-    case GDK_QUESTION_ARROW: shape_str = g_strdup("GDK_QUESTION_ARROW"); break;
-    case GDK_RIGHT_PTR: shape_str = g_strdup("GDK_RIGHT_PTR"); break;
-    case GDK_RIGHT_SIDE: shape_str = g_strdup("GDK_RIGHT_SIDE"); break;
-    case GDK_RIGHT_TEE: shape_str = g_strdup("GDK_RIGHT_TEE"); break;
-    case GDK_RIGHTBUTTON: shape_str = g_strdup("GDK_RIGHTBUTTON"); break;
-    case GDK_RTL_LOGO: shape_str = g_strdup("GDK_RTL_LOGO"); break;
-    case GDK_SAILBOAT: shape_str = g_strdup("GDK_SAILBOAT"); break;
-    case GDK_SB_DOWN_ARROW: shape_str = g_strdup("GDK_SB_DOWN_ARROW"); break;
-    case GDK_SB_H_DOUBLE_ARROW: shape_str = g_strdup("GDK_SB_H_DOUBLE_ARROW"); break;
-    case GDK_SB_LEFT_ARROW: shape_str = g_strdup("GDK_SB_LEFT_ARROW"); break;
-    case GDK_SB_RIGHT_ARROW: shape_str = g_strdup("GDK_SB_RIGHT_ARROW"); break;
-    case GDK_SB_UP_ARROW: shape_str = g_strdup("GDK_SB_UP_ARROW"); break;
-    case GDK_SB_V_DOUBLE_ARROW: shape_str = g_strdup("GDK_SB_V_DOUBLE_ARROW"); break;
-    case GDK_SHUTTLE: shape_str = g_strdup("GDK_SHUTTLE"); break;
-    case GDK_SIZING: shape_str = g_strdup("GDK_SIZING"); break;
-    case GDK_SPIDER: shape_str = g_strdup("GDK_SPIDER"); break;
-    case GDK_SPRAYCAN: shape_str = g_strdup("GDK_SPRAYCAN"); break;
-    case GDK_STAR: shape_str = g_strdup("GDK_STAR"); break;
-    case GDK_TARGET: shape_str = g_strdup("GDK_TARGET"); break;
-    case GDK_TCROSS: shape_str = g_strdup("GDK_TCROSS"); break;
-    case GDK_TOP_LEFT_ARROW: shape_str = g_strdup("GDK_TOP_LEFT_ARROW"); break;
-    case GDK_TOP_LEFT_CORNER: shape_str = g_strdup("GDK_TOP_LEFT_CORNER"); break;
-    case GDK_TOP_RIGHT_CORNER: shape_str = g_strdup("GDK_TOP_RIGHT_CORNER"); break;
-    case GDK_TOP_SIDE: shape_str = g_strdup("GDK_TOP_SIDE"); break;
-    case GDK_TOP_TEE: shape_str = g_strdup("GDK_TOP_TEE"); break;
-    case GDK_TREK: shape_str = g_strdup("GDK_TREK"); break;
-    case GDK_UL_ANGLE: shape_str = g_strdup("GDK_UL_ANGLE"); break;
-    case GDK_UMBRELLA: shape_str = g_strdup("GDK_UMBRELLA"); break;
-    case GDK_UR_ANGLE: shape_str = g_strdup("GDK_UR_ANGLE"); break;
-    case GDK_WATCH: shape_str = g_strdup("GDK_WATCH"); break;
-    case GDK_XTERM: shape_str = g_strdup("GDK_XTERM"); break;
-    case GDK_LAST_CURSOR: shape_str = g_strdup("GDK_LAST_CURSOR"); break;
-    case GDK_BLANK_CURSOR: shape_str = g_strdup("GDK_BLANK_CURSOR"); break;
-    case GDK_CURSOR_IS_PIXMAP: shape_str = g_strdup("GDK_CURSOR_IS_PIXMAP"); break;
-    default: break;
-  }
-  return shape_str;
+    dt_cursor_t shape;
+    const char *name;
+  } cursor_names[] = {
+  { GDK_X_CURSOR, "GDK_X_CURSOR" },
+  { GDK_ARROW, "GDK_ARROW" },
+  { GDK_BASED_ARROW_DOWN, "GDK_BASED_ARROW_DOWN" },
+  { GDK_BASED_ARROW_UP, "GDK_BASED_ARROW_UP" },
+  { GDK_BOAT, "GDK_BOAT" },
+  { GDK_BOGOSITY, "GDK_BOGOSITY" },
+  { GDK_BOTTOM_LEFT_CORNER, "GDK_BOTTOM_LEFT_CORNER" },
+  { GDK_BOTTOM_RIGHT_CORNER, "GDK_BOTTOM_RIGHT_CORNER" },
+  { GDK_BOTTOM_SIDE, "GDK_BOTTOM_SIDE" },
+  { GDK_BOTTOM_TEE, "GDK_BOTTOM_TEE" },
+  { GDK_BOX_SPIRAL, "GDK_BOX_SPIRAL" },
+  { GDK_CENTER_PTR, "GDK_CENTER_PTR" },
+  { GDK_CIRCLE, "GDK_CIRCLE" },
+  { GDK_CLOCK, "GDK_CLOCK" },
+  { GDK_COFFEE_MUG, "GDK_COFFEE_MUG" },
+  { GDK_CROSS, "GDK_CROSS" },
+  { GDK_CROSS_REVERSE, "GDK_CROSS_REVERSE" },
+  { GDK_CROSSHAIR, "GDK_CROSSHAIR" },
+  { GDK_DIAMOND_CROSS, "GDK_DIAMOND_CROSS" },
+  { GDK_DOT, "GDK_DOT" },
+  { GDK_DOTBOX, "GDK_DOTBOX" },
+  { GDK_DOUBLE_ARROW, "GDK_DOUBLE_ARROW" },
+  { GDK_DRAFT_LARGE, "GDK_DRAFT_LARGE" },
+  { GDK_DRAFT_SMALL, "GDK_DRAFT_SMALL" },
+  { GDK_DRAPED_BOX, "GDK_DRAPED_BOX" },
+  { GDK_EXCHANGE, "GDK_EXCHANGE" },
+  { GDK_FLEUR, "GDK_FLEUR" },
+  { GDK_GOBBLER, "GDK_GOBBLER" },
+  { GDK_GUMBY, "GDK_GUMBY" },
+  { GDK_HAND1, "GDK_HAND1" },
+  { GDK_HAND2, "GDK_HAND2" },
+  { GDK_HEART, "GDK_HEART" },
+  { GDK_ICON, "GDK_ICON" },
+  { GDK_IRON_CROSS, "GDK_IRON_CROSS" },
+  { GDK_LEFT_PTR, "GDK_LEFT_PTR" },
+  { GDK_LEFT_SIDE, "GDK_LEFT_SIDE" },
+  { GDK_LEFT_TEE, "GDK_LEFT_TEE" },
+  { GDK_LEFTBUTTON, "GDK_LEFTBUTTON" },
+  { GDK_LL_ANGLE, "GDK_LL_ANGLE" },
+  { GDK_LR_ANGLE, "GDK_LR_ANGLE" },
+  { GDK_MAN, "GDK_MAN" },
+  { GDK_MIDDLEBUTTON, "GDK_MIDDLEBUTTON" },
+  { GDK_MOUSE, "GDK_MOUSE" },
+  { GDK_PENCIL, "GDK_PENCIL" },
+  { GDK_PIRATE, "GDK_PIRATE" },
+  { GDK_PLUS, "GDK_PLUS" },
+  { GDK_QUESTION_ARROW, "GDK_QUESTION_ARROW" },
+  { GDK_RIGHT_PTR, "GDK_RIGHT_PTR" },
+  { GDK_RIGHT_SIDE, "GDK_RIGHT_SIDE" },
+  { GDK_RIGHT_TEE, "GDK_RIGHT_TEE" },
+  { GDK_RIGHTBUTTON, "GDK_RIGHTBUTTON" },
+  { GDK_RTL_LOGO, "GDK_RTL_LOGO" },
+  { GDK_SAILBOAT, "GDK_SAILBOAT" },
+  { GDK_SB_DOWN_ARROW, "GDK_SB_DOWN_ARROW" },
+  { GDK_SB_H_DOUBLE_ARROW, "GDK_SB_H_DOUBLE_ARROW" },
+  { GDK_SB_LEFT_ARROW, "GDK_SB_LEFT_ARROW" },
+  { GDK_SB_RIGHT_ARROW, "GDK_SB_RIGHT_ARROW" },
+  { GDK_SB_UP_ARROW, "GDK_SB_UP_ARROW" },
+  { GDK_SB_V_DOUBLE_ARROW, "GDK_SB_V_DOUBLE_ARROW" },
+  { GDK_SHUTTLE, "GDK_SHUTTLE" },
+  { GDK_SIZING, "GDK_SIZING" },
+  { GDK_SPIDER, "GDK_SPIDER" },
+  { GDK_SPRAYCAN, "GDK_SPRAYCAN" },
+  { GDK_STAR, "GDK_STAR" },
+  { GDK_TARGET, "GDK_TARGET" },
+  { GDK_TCROSS, "GDK_TCROSS" },
+  { GDK_TOP_LEFT_ARROW, "GDK_TOP_LEFT_ARROW" },
+  { GDK_TOP_LEFT_CORNER, "GDK_TOP_LEFT_CORNER" },
+  { GDK_TOP_RIGHT_CORNER, "GDK_TOP_RIGHT_CORNER" },
+  { GDK_TOP_SIDE, "GDK_TOP_SIDE" },
+  { GDK_TOP_TEE, "GDK_TOP_TEE" },
+  { GDK_TREK, "GDK_TREK" },
+  { GDK_UL_ANGLE, "GDK_UL_ANGLE" },
+  { GDK_UMBRELLA, "GDK_UMBRELLA" },
+  { GDK_UR_ANGLE, "GDK_UR_ANGLE" },
+  { GDK_WATCH, "GDK_WATCH" },
+  { GDK_XTERM, "GDK_XTERM" },
+  { GDK_LAST_CURSOR, "GDK_LAST_CURSOR" },
+  { GDK_BLANK_CURSOR, "GDK_BLANK_CURSOR" },
+  { GDK_CURSOR_IS_PIXMAP, "GDK_CURSOR_IS_PIXMAP" },
+  };
+
+  for(size_t i = 0; i < sizeof(cursor_names) / sizeof(cursor_names[0]); i++)
+    if(cursor_names[i].shape == cursor) return cursor_names[i].name;
+
+  return "GDK_CURSOR_UNKNOWN";
 }
 
 void dt_control_forbid_change_cursor()

--- a/src/develop/imageop.h
+++ b/src/develop/imageop.h
@@ -257,7 +257,12 @@ typedef struct dt_iop_module_t
 
   /** string identifying this operation. */
   dt_dev_operation_t op;
-  /** used to identify this module in the history stack. */
+  /** Identifies the FAMILY this module belongs to: a module and every extra instance
+   * duplicated from it share one value, and it is what the history stack matches on.
+   * Assigned once per base module at load time from dt_develop_t::iop_instance.
+   * Distinct from multi_priority, which orders the members WITHIN a family. Two different
+   * base modules sharing this value collide in history -- see dt_dev_module_duplicate(),
+   * which derives the next multi_priority by scanning for `mod->instance == base->instance`. */
   int32_t instance;
   /** order of the module on the pipe. the pipe will be sorted by iop_order. */
   int iop_order;
@@ -313,7 +318,18 @@ typedef struct dt_iop_module_t
   gboolean default_enabled;
 
   gboolean workflow_enabled;
-  /** parameters for the operation. will be replaced by history revert. */
+  /** Live parameters for the operation, and the module's defaults.
+   *
+   * @warning These belong to the GUI THREAD and are NOT thread-safe. The pixel pipeline
+   * must never read or write them: the only thread-safe interface between the pipeline and
+   * a module is HISTORY, guarded by dev->history_mutex. Pipeline code commits from the
+   * history snapshot (hist->params), never from here -- see dt_iop_commit_params(). To push
+   * live, uncommitted state to the pipe, either write it through history under that mutex
+   * or use dt_dev_transient_params_{set,clear,get,active}() in develop/dev_history.h.
+   *
+   * Both blocks are @ref params_size bytes and are owned by the module; they are allocated
+   * by dt_iop_load_module_by_so() and released by dt_iop_cleanup_module(). Replaced
+   * wholesale on a history revert, so a pointer INTO them does not survive one. */
   dt_iop_params_t *params, *default_params;
   /** size of individual params struct. */
   int32_t params_size;
@@ -336,6 +352,9 @@ typedef struct dt_iop_module_t
       /** if this module generates a mask, is it used later on? needed to decide if the mask should be stored.
           maps dt_iop_module_t* -> id
       */
+      /** Owned by this module and freed by dt_iop_cleanup_module(). Keys are borrowed
+       * dt_iop_module_t pointers into dev->iop, so an entry outliving its consumer
+       * dangles -- consumers must remove themselves. */
       GHashTable *users;
       /** the masks this module has to offer. maps id -> name.
        * So for there is only one mask per module and its id is always 0.
@@ -350,11 +369,21 @@ typedef struct dt_iop_module_t
   } raster_mask;
 
 
-  /** the corresponding SO object */
+  /** The shared object this instance was created from: the dlopen()ed plugin's function
+   * table and its process-wide global data. BORROWED -- owned by the module-so list, shared
+   * by every instance of this operation, and outliving all of them. Never free it through
+   * an instance. */
   dt_iop_module_so_t *so;
 
-  /** multi-instances things */
+  /** Position of this instance within its @ref instance family. 0 is the base module;
+   * duplicates get increasing values. Several places treat `multi_priority == 0` as "this
+   * is the base module" -- e.g. libs/modulegroups.c shows an extra instance only once it is
+   * in history, while the base is always shown. */
   int multi_priority; // user may change this
+
+  /** User-visible suffix distinguishing instances of one family, empty for the default
+   * name. Fixed-size, not a pointer: nothing to free, and it is written with g_strlcpy().
+   * Cleared when the rename entry loses focus while empty. */
   char multi_name[128]; // user may change this name
 
 
@@ -418,7 +447,21 @@ gboolean dt_iop_is_visible(dt_iop_module_t *module);
 /** enter/leave a GUI critical section by acquiring gui->gui_lock. Implemented in
  * imageop_gui.c; tolerate headless callers (no GUI, no GUI data to protect), so
  * common/iop-autoset.c and friends can call them without seeing the gui struct. */
+/**
+ * @brief Take the module's GUI lock, serialising access to its dt_iop_gui_data_t.
+ *
+ * @warning A NO-OP when module->gui is NULL, which is every headless module -- export,
+ * thumbnail generation, ansel-cli. It therefore protects GUI data only; it must not be used
+ * to serialise anything a non-GUI pipe also touches, because there it locks nothing and
+ * silently provides no mutual exclusion at all.
+ *
+ * Must be paired with dt_iop_gui_leave_critical_section() on every path. The pair uses the
+ * BAD_ lock variants because the acquire and release routinely sit in different functions,
+ * which the thread-safety analyser cannot model.
+ */
 void dt_iop_gui_enter_critical_section(dt_iop_module_t *const module);
+
+/** @brief Release what dt_iop_gui_enter_critical_section() took. Also a no-op headless. */
 void dt_iop_gui_leave_critical_section(dt_iop_module_t *const module);
 
 /** widget-identity helpers for gui/ callers that must not see the gui struct through this
@@ -440,6 +483,22 @@ void dt_iop_gui_set_expanded(dt_iop_module_t *module, gboolean expanded, gboolea
 /** refresh iop according to set expanded state */
 void dt_iop_gui_update_expanded(dt_iop_module_t *module);
 /* duplicate module and return new instance */
+/**
+ * @brief Create another instance of @p base, insert it into dev->iop and give it a GUI.
+ *
+ * @param base the module to duplicate.
+ * @param copy_params TRUE to carry over @p base's current parameters and blending.
+ *
+ * @return the new module, or NULL when loading it failed (dt_iop_load_module()); there is
+ * no cap on instances per family. **Borrowed**: owned by dev->iop, never freed by the
+ * caller.
+ *
+ * @note Commits the new instance to history and FLUSHES the pending-commit queue before
+ * returning, because the panel decides whether to show an extra instance from a g_idle that
+ * runs on the next main-loop turn and reads whether it is in history -- see the comment at
+ * the flush. Any future path that creates an instance owes history the same synchronous
+ * commit.
+ */
 dt_iop_module_t *dt_iop_gui_duplicate(dt_iop_module_t *base, gboolean copy_params);
 
 void dt_iop_gui_update_header(dt_iop_module_t *module);
@@ -460,6 +519,18 @@ void dt_iop_gui_update_header(dt_iop_module_t *module);
   dt_print(DT_DEBUG_PIPE, "[iop-fmt] %-14s " fmt "\n", (module)->op, ##__VA_ARGS__)
 
 /** commits params and updates piece hash. */
+/**
+ * @brief Copy @p params into the pipeline piece, so the next render uses them.
+ *
+ * @warning Pass the HISTORY SNAPSHOT's params (hist->params), never module->params, from
+ * anything running on the pipeline thread. dt_iop_module_t::params is GUI-thread state and
+ * reading it from the pipeline is a data race -- history is the only thread-safe interface
+ * between the two. This is the single most commonly broken rule in this header.
+ *
+ * @param module the module whose commit_params() callback is invoked.
+ * @param params the parameter block to commit; copied, not retained.
+ * @param piece the pipeline piece to configure. Must already be initialised for this pipe.
+ */
 void dt_iop_commit_params(dt_iop_module_t *module, dt_iop_params_t *params,
                           struct dt_develop_blend_params_t *blendop_params, struct dt_dev_pixelpipe_t *pipe,
                           struct dt_dev_pixelpipe_iop_t *piece);
@@ -478,6 +549,18 @@ GtkWidget *dt_iop_gui_get_pluginui(dt_iop_module_t *module);
  * which is handled when the parent panel changes size, which happens when
  * uncollapsing the module. So dt_iop_request_focus() needs to be called
  * before expanding modules (dt_iop_set_expanded) for auto-scroll to work properly.
+ */
+/**
+ * @brief Move darkroom focus to @p module, or clear it with NULL.
+ *
+ * @details Not a passive setter. It calls the outgoing module's gui_focus(FALSE) and the
+ * incoming one's gui_focus(TRUE) -- which modules use to enter and leave edit modes -- asks
+ * the panel to scroll the module into view, and triggers a module-visibility refresh that
+ * runs later, on the GTK main loop. Callers that change other state in the same callback
+ * should assume that refresh observes whatever is committed by the time control returns,
+ * not what is true at the moment of this call.
+ *
+ * No-op when the module already has focus, or while widgets are suppressed.
  */
 void dt_iop_request_focus(dt_iop_module_t *module);
 /** allocate and load default settings from introspection. */

--- a/src/libs/histogram.c
+++ b/src/libs/histogram.c
@@ -2680,7 +2680,9 @@ static gboolean _sample_tooltip_callback(GtkWidget *widget, gint x, gint y, gboo
   dt_aligned_pixel_t color;
   dt_Lab_2_LCH(sample->lab[DT_LIB_COLORPICKER_STATISTIC_MEAN], color);
   sample_parts[11] = g_strdup_printf("\n<big><b>%14s</b></big>", _("color"));
-  sample_parts[12] = g_strdup_printf("%6s", Lch_to_color_name(color));
+  char *color_name = Lch_to_color_name(color);
+  sample_parts[12] = g_strdup_printf("%6s", color_name);
+  g_free(color_name);
 
   gchar *tooltip_text = g_strjoinv("\n", sample_parts);
   g_strfreev(sample_parts);

--- a/src/system/macros.h
+++ b/src/system/macros.h
@@ -38,16 +38,35 @@
 extern "C" {
 #endif
 
+/** @brief Stringify @p x WITHOUT expanding it first. Implementation detail of STR(). */
 #undef STR_HELPER
 #define STR_HELPER(x) #x
 
+/** @brief Stringify @p x after macro-expanding it, e.g. STR(__LINE__) gives "42".
+ * @note The indirection through STR_HELPER() is what forces the expansion; stringifying
+ * directly would yield "__LINE__". */
 #undef STR
 #define STR(x) STR_HELPER(x)
 
+/** @brief Stringify @p x WITHOUT expanding it first. Implementation detail of
+ * DT_STRINGIFY(). */
 #define DT_STRINGIFY_HELPER(x) #x
+
+/** @brief Expand-then-stringify, identical in behaviour to STR().
+ * @note Both spellings exist for historical reasons and neither is deprecated. STR() is
+ * #undef'd before definition because windows.h and some third-party headers define a name
+ * that short; DT_STRINGIFY() is the collision-proof spelling and is the safer default in
+ * new code. */
 #define DT_STRINGIFY(x) DT_STRINGIFY_HELPER(x)
 
-// When included by a C++ file, restrict qualifiers are not allowed
+/** @brief `restrict` in C, nothing in C++.
+ *
+ * @details `restrict` is not a C++ keyword, so a header shared with a .cc file cannot spell
+ * it directly. Where it survives (C), it is a PROMISE that the pointed-to memory is not
+ * reached through any other pointer for that object's lifetime; breaking the promise is
+ * undefined behaviour the compiler will happily optimise around, and the symptom is wrong
+ * pixels rather than a crash. Note the promise silently disappears in C++ translation
+ * units, so a bug it hides can behave differently in .c and .cc code. */
 #ifdef __cplusplus
 #define DT_RESTRICT
 #else
@@ -59,8 +78,20 @@ extern "C" {
  * too many things depending on what we compare. We force here a semantic NULL check
  * for pointers types that will fail for anything else than pointers,
  * and make the code more explicit about what is checked.
- * This will fail at compile time on function pointers and anything that is not a pointer.
+ * Rejected at COMPILE time: integers, floats, structs, and arrays -- an array's
+ * `__typeof__` cannot initialise a local, which is what stops `IS_NULL_PTR(some_array)`
+ * from quietly testing a never-NULL decayed address.
  *
+ * ACCEPTED, contrary to what this comment claimed for a long time: function pointers.
+ * __builtin_classify_type() reports them as pointers, so `IS_NULL_PTR(callback)` compiles
+ * and does the obvious, useful thing. Verified rather than assumed.
+ *
+ * @param p any pointer expression. Evaluated EXACTLY ONCE -- it is bound to a local first
+ * -- so `IS_NULL_PTR(*iter++)` is safe.
+ * @return TRUE when @p p is NULL.
+ *
+ * @note Uses a GNU statement expression and __typeof__, so this header requires GCC or
+ * Clang. That is already true of the whole tree, MinGW included.
  */
 #define IS_NULL_PTR(p)                                            \
   ({                                                              \
@@ -71,9 +102,32 @@ extern "C" {
     _tmp == NULL;                                                 \
   })
 
+/** @brief Mark a branch as impossible, naming it @p D in the message. @see
+ * dt_unreachable_codepath() */
 #define dt_unreachable_codepath_with_desc(D)                                                                 \
   dt_unreachable_codepath_with_caller(D, __FILE__, __LINE__, __FUNCTION__)
+
+/** @brief Mark a branch as impossible.
+ *
+ * @warning This is an ASSERTION OF FACT, not a guard. It ends in
+ * __builtin_unreachable(), which tells the optimiser the branch cannot be entered; if it
+ * ever is, the program has undefined behaviour and the printed message is no guarantee --
+ * the compiler may already have deleted the surrounding test. Use it only where the
+ * impossibility is structural. To HANDLE an unexpected value, return an error instead.
+ */
 #define dt_unreachable_codepath() dt_unreachable_codepath_with_caller("unreachable", __FILE__, __LINE__, __FUNCTION__)
+
+/** @brief Back-end of the dt_unreachable_codepath() macros; call those, so the call site
+ * is recorded automatically.
+ *
+ * @param description short label for the impossible branch.
+ * @param file,line,function the call site, supplied by the macros.
+ * @return never: the function does not come back.
+ *
+ * @note Writes to stderr WITHOUT a trailing newline, so the message runs into whatever is
+ * printed next -- and stderr is unbuffered, so it does survive a crash immediately after,
+ * which is the point.
+ */
 static inline void dt_unreachable_codepath_with_caller(const char *description, const char *file,
                                                        const int line, const char *function)
 {

--- a/src/system/mem_alloc.h
+++ b/src/system/mem_alloc.h
@@ -39,11 +39,25 @@
 extern "C" {
 #endif
 
-/* Helper to force stack vectors to be aligned on DT_CACHELINE_BYTES blocks to enable AVX2 */
+/** @brief Promise the compiler that @p x is already cacheline-aligned, and return it.
+ *
+ * @warning This ASSERTS, it does not align: the compiler is free to emit aligned loads
+ * and stores on the strength of the promise. Applying it to a pointer that is not in
+ * fact aligned is undefined behaviour, and typically shows up as a SIGSEGV in vectorised
+ * code far from the allocation. Only use it on memory from dt_alloc_align() and friends,
+ * or on a stack object declared DT_ALIGNED_ARRAY. Use dt_check_sse_aligned() when the
+ * alignment is not known statically.
+ */
 #define DT_IS_ALIGNED(x) __builtin_assume_aligned(x, DT_CACHELINE_BYTES)
 
-// Configure the size of a CPU cacheline in bytes, floats, and pixels.  On most current architectures,
-// a cacheline contains 64 bytes, but Apple Silicon (M-series processors) uses 128-byte cache lines.
+/* Size of a CPU cacheline, in bytes, floats and 4-float pixels.
+ *
+ * These are COMPILE-TIME constants chosen per target, not the running machine's real
+ * cacheline: a binary built for x86-64 and run under emulation on Apple Silicon keeps 64.
+ * They set the alignment of every dt_alloc_align() buffer and of DT_ALIGNED_ARRAY, so a
+ * value smaller than the hardware's costs performance, and one larger costs memory --
+ * neither is a correctness problem, which is why the mismatch is easy to miss.
+ */
 #if defined(__APPLE__) && defined(__aarch64__)
   #define DT_CACHELINE_BYTES 128
   #define DT_CACHELINE_FLOATS 32
@@ -54,29 +68,57 @@ extern "C" {
   #define DT_CACHELINE_PIXELS 4
 #endif /* __APPLE__ && __aarch64__ */
 
-// Helper to force heap vectors to be aligned on 64 byte blocks to enable AVX2
-// If this is applied to a struct member and the struct is allocated on the heap, then it must be allocated
-// on a 64 byte boundary to avoid crashes or undefined behavior because of unaligned memory access.
+/** @brief Align an object on a cacheline boundary, so AVX2 can load it whole.
+ *
+ * @warning On a STRUCT MEMBER this attribute constrains the member's offset within the
+ * struct -- it cannot constrain where the struct itself lands. A struct carrying one of
+ * these must therefore be allocated by dt_alloc_align() (or live on the stack, where the
+ * compiler honours it); plain malloc()/g_malloc() guarantee far less alignment, and the
+ * member then straddles a cacheline. The result is a crash or silently wrong pixels in
+ * vectorised code, at the point of USE, with nothing wrong at the point of allocation.
+ */
 #define DT_ALIGNED_ARRAY __attribute__((aligned(DT_CACHELINE_BYTES)))
+
+/** @brief Align a 4-float pixel on 16 bytes, enough for SSE. Same struct-member caveat as
+ * DT_ALIGNED_ARRAY, with a weaker requirement that malloc() happens to meet on most
+ * platforms -- which is exactly why misuse survives testing here and not there. */
 #define DT_ALIGNED_PIXEL __attribute__((aligned(16)))
 
+/** @brief Is @p pointer aligned on a @p byte_count boundary? Pure test, no side effect. */
 static inline gboolean dt_is_aligned(const void *pointer, size_t byte_count)
 {
     return (uintptr_t)pointer % byte_count == 0;
 }
 
+/** @brief Round @p size UP to the next multiple of @p alignment.
+ *
+ * @param size byte count to round. Zero rounds to zero.
+ * @param alignment must be non-zero; zero divides by zero.
+ * @return the rounded size, always >= @p size.
+ */
 static inline size_t dt_round_size(const size_t size, const size_t alignment)
 {
   // Round the size of a buffer to the closest higher multiple
   return ((size % alignment) == 0) ? size : ((size - 1) / alignment + 1) * alignment;
 }
 
+/** @brief Round @p size up to the next multiple of 64.
+ *
+ * @note Hardcoded 64, NOT DT_CACHELINE_BYTES: on Apple Silicon a cacheline is 128, so this
+ * rounds to half a cacheline there. It is named for the SSE register width it was written
+ * for; do not substitute it for dt_round_size(size, DT_CACHELINE_BYTES).
+ */
 static inline size_t dt_round_size_sse(const size_t size)
 {
   // Round the size of a buffer to the closest 64 higher multiple
   return dt_round_size(size, 64);
 }
 
+/** @brief Platform back-end for dt_alloc_align(). Call dt_alloc_align() instead.
+ *
+ * @return cacheline-aligned memory of at least @p size bytes (rounded up), or NULL if the
+ * allocation failed. Must be released with dt_free_align().
+ */
 static inline void *dt_alloc_align_internal(size_t size)
 {
   const size_t alignment = DT_CACHELINE_BYTES;
@@ -92,8 +134,40 @@ static inline void *dt_alloc_align_internal(size_t size)
 #endif
 }
 
+/** @brief Allocate cacheline-aligned memory.
+ *
+ * @details The single entry point for buffers that vectorised code will touch. The
+ * returned block is aligned on DT_CACHELINE_BYTES and its usable size is @p size rounded
+ * UP to that boundary, so writing the rounded size is safe and reading it is defined.
+ *
+ * @param size requested byte count.
+ *
+ * @return the block, or **NULL when the allocation fails** -- which happens in practice on
+ * the pixel path, where buffers are hundreds of megabytes. Callers must check.
+ *
+ * @warning Release ONLY with dt_free_align(). On Windows this comes from _aligned_malloc()
+ * and passing it to free()/g_free()/dt_free() corrupts the heap; on POSIX the two paths
+ * happen to coincide, which is precisely why such a mismatch passes every Linux test and
+ * fails on Windows only.
+ *
+ * @see dt_calloc_align() for the zeroed variant, dt_alloc_align_float() for float counts.
+ */
 void *dt_alloc_align(size_t size);
 
+/** @brief g_free() @p ptr and set it to NULL, skipping both if it is already NULL.
+ *
+ * @param ptr an **lvalue** holding a pointer. It is assigned NULL, so a temporary, a cast
+ * expression or a function result does not compile -- deliberately: the whole point is
+ * that no caller is left holding a dangling copy.
+ *
+ * @warning Pairs with g_malloc()/g_strdup() and the rest of the GLib family, NOT with
+ * dt_alloc_align(). Use dt_free_align() for that.
+ *
+ * @warning Expands to a bare `if` with no `do { } while(0)` wrapper, so
+ * `if(c) dt_free(p); else ...` fails to compile with "else without a previous if". Brace
+ * the branch. It is a compile error rather than a silent misbinding, so it cannot reach
+ * runtime -- but it does force braces where none should be needed.
+ */
 #define dt_free(ptr)           \
   if(!IS_NULL_PTR(ptr))        \
   {                            \
@@ -101,12 +175,20 @@ void *dt_alloc_align(size_t size);
     *(void **)(&(ptr)) = NULL; \
   }
 
+/** @brief g_free() one pointer, with the signature GDestroyNotify wants.
+ *
+ * @param ptr taken BY VALUE, so unlike the dt_free() macro this cannot NULL the caller's
+ * variable -- the assignment in the body only clears the local copy and is dead. Use it
+ * where a GLib container needs a free function, not as a general-purpose free.
+ */
 static inline void dt_free_gpointer(gpointer ptr)
 {
   g_free(ptr);
   ptr = NULL;
 }
 
+/** @brief Platform back-end for dt_free_align(). Call dt_free_align() instead: this one
+ * takes the pointer by value and so cannot NULL the caller's variable. */
 #ifdef _WIN32
   static inline void dt_free_align_ptr(void *mem)
   {
@@ -119,6 +201,16 @@ static inline void dt_free_gpointer(gpointer ptr)
   }
 #endif
 
+/** @brief Release memory from dt_alloc_align() and set @p ptr to NULL.
+ *
+ * @param ptr an **lvalue**, for the same reason as dt_free(). NULL is accepted and ignored.
+ *
+ * @warning Must be used for -- and only for -- dt_alloc_align(), dt_calloc_align(),
+ * dt_alloc_align_float() and dt_calloc_align_float(). See dt_alloc_align() for what
+ * crossing the two families costs on Windows.
+ *
+ * @warning Same bare-`if` expansion as dt_free(): brace the branch in an if/else.
+ */
 #define dt_free_align(ptr)            \
   if(!IS_NULL_PTR(ptr))               \
   {                                   \
@@ -126,22 +218,36 @@ static inline void dt_free_gpointer(gpointer ptr)
     *(void **)(&(ptr)) = NULL;        \
   }
 
+/** @brief dt_alloc_align() followed by a zero fill.
+ * @return the zeroed block, or NULL on failure. Release with dt_free_align().
+ * @note Only the @p size bytes asked for are zeroed, not the padding dt_alloc_align()
+ * rounds the block up to. */
 static inline void* dt_calloc_align(size_t size)
 {
   void *buf = dt_alloc_align(size);
   if(buf) memset(buf, 0, size);
   return buf;
 }
+/** @brief Allocate @p pixels floats, cacheline-aligned and marked as such.
+ * @return the block, or NULL on failure. Release with dt_free_align().
+ * @warning @p pixels is a COUNT OF FLOATS, not a byte count, and the multiplication is not
+ * checked for overflow -- validate suspicious dimensions before calling. */
 static inline float *dt_alloc_align_float(size_t pixels)
 {
   return (float*)__builtin_assume_aligned(dt_alloc_align(pixels * sizeof(float)), DT_CACHELINE_BYTES);
 }
+/** @brief dt_alloc_align_float() followed by a zero fill.
+ * @return the zeroed block, or NULL on failure. Release with dt_free_align(). */
 static inline float *dt_calloc_align_float(size_t pixels)
 {
   float *const buf = (float*)dt_alloc_align(pixels * sizeof(float));
   if(buf) memset(buf, 0, pixels * sizeof(float));
   return (float*)__builtin_assume_aligned(buf, DT_CACHELINE_BYTES);
 }
+/** @brief Runtime-checked counterpart to DT_IS_ALIGNED().
+ * @return @p pointer marked aligned for the compiler when it really is cacheline-aligned,
+ * and **NULL when it is not** -- the return value is the test result, so ignoring it and
+ * using @p pointer anyway defeats the purpose. Does not allocate; ownership is unchanged. */
 static inline void * dt_check_sse_aligned(void * pointer)
 {
   if(dt_is_aligned(pointer, DT_CACHELINE_BYTES))
@@ -153,8 +259,13 @@ static inline void * dt_check_sse_aligned(void * pointer)
 /**
  * @brief Set the memory buffer to zero as a pack of unsigned char
  *
- * @param buffer void buffer
- * @param size size of the memory stride. NEEDS TO BE A MULTIPLE OF 8.
+ * @param buffer destination, at least @p size bytes. Not NULL-checked.
+ * @param size number of bytes to clear. The body writes one unsigned char at a time, so
+ * any size is handled; the "multiple of 8" this once required is no longer a constraint.
+ *
+ * @note The intent is a zero fill a compiler may not elide, as memset_s() guarantees in
+ * C11. A plain byte loop is not that guarantee -- an optimiser is allowed to recognise it
+ * and call memset() anyway -- so do not rely on this to scrub secrets.
  */
 static inline void memset_zero(void *const buffer, size_t size)
 {

--- a/src/system/openmp.h
+++ b/src/system/openmp.h
@@ -37,7 +37,30 @@
 #endif
 #endif /* dt_omp_nontemporal */
 
+/** @brief Emit an `omp` pragma from a macro body. Implementation detail of the wrappers. */
 #define OMP_PRAGMA(x) _Pragma(#x)
+
+/* Every wrapper below injects TWO clauses the call site does not write, and both change
+ * what the loop means:
+ *
+ *   default(firstprivate) -- each thread gets its OWN COPY of every variable the body
+ *     mentions and that is not named in an explicit clause, initialised from the value on
+ *     entry. Reads see the right value, which is why this is convenient. WRITES DO NOT
+ *     ESCAPE: accumulating into an outer variable silently produces nothing, and the loop
+ *     still compiles and still gives the correct answer when OpenMP is disabled or the
+ *     thread count is 1 -- so it passes casual testing. Name such a variable in an explicit
+ *     shared()/reduction() clause. Pointers are copied as POINTERS, so writes THROUGH one
+ *     are shared as usual; it is the scalar accumulators that are the trap.
+ *
+ *   schedule(static) -- iterations are split into equal contiguous blocks up front, which
+ *     is right for uniform per-pixel work and wrong when cost varies by row or when a tile
+ *     may exit early. Pass an explicit schedule() for those.
+ *
+ * All of them expand to NOTHING when _OPENMP is undefined, so a body that relies on being
+ * parallel for correctness -- rather than merely for speed -- is silently serialised.
+ */
+
+/** @brief `omp parallel`, with default(firstprivate). @see the note above. */
 #define __OMP_PARALLEL__(...) OMP_PRAGMA(omp parallel default(firstprivate) __VA_ARGS__)
 #define __OMP_PARALLEL_FOR__(...) OMP_PRAGMA(omp parallel for default(firstprivate) schedule(static) __VA_ARGS__)
 #define __OMP_PARALLEL_FOR_SIMD__(...) OMP_PRAGMA(omp parallel for simd default(firstprivate) schedule(simd:static) __VA_ARGS__)
@@ -46,9 +69,16 @@
 #define __OMP_SIMD__(...) OMP_PRAGMA(omp simd __VA_ARGS__)
 #define __OMP_DECLARE_SIMD__(...) OMP_PRAGMA(omp declare simd __VA_ARGS__)
 
-// CLang 20 supports OpenMP 5.1 default(firstprivate) but only for C files.
-// C++ files still need to use default(none) until further notice.
-// Change that when baseline CLang is upgraded.
+/** @brief The C++ form of __OMP_PARALLEL_FOR__.
+ *
+ * @warning It injects `default(none)`, NOT `default(firstprivate)`: Clang supports the
+ * OpenMP 5.1 default only for C. The two are opposites in practice -- `none` requires EVERY
+ * variable to be listed in an explicit clause and refuses to compile otherwise, while
+ * `firstprivate` silently copies them. So moving a loop between a .c and a .cc file is not
+ * a copy-paste: the C version grows a compile error listing every unlisted variable, and
+ * the C++ version, pasted into C, loses that check and starts privatising accumulators
+ * silently. Revisit when the baseline Clang is raised.
+ */
 #define __OMP_PARALLEL_FOR_CPP__(...) OMP_PRAGMA(omp parallel for default(none) schedule(static) __VA_ARGS__)
 
 // TRUE while the caller runs inside a parallel region. Diagnostics belong outside one: a message
@@ -81,11 +111,21 @@
 extern "C" {
 #endif
 
-/** Number of OpenMP threads the application decided to use. DECLARED here so
+/** @brief Number of OpenMP threads the application decided to use.
+ *
+ * @details This is the APPLICATION's budget, not omp_get_max_threads(): it is seeded from
+ * that value and then overridden by the -t command-line option (clamped to 1..100), so the
+ * two disagree whenever the user asked for a specific count. Size
+ * per-thread buffers with this one, index them with dt_get_thread_num().
+ *
+ * Number of OpenMP threads the application decided to use. DECLARED here so
  * low-level compute code can size per-thread buffers without importing
  * darktable.h; BOUND by the orchestrator (darktable.c). */
 int dt_get_num_openmp_threads(void);
 
+/** @brief Index of the calling thread within its parallel region, 0 outside one.
+ * @return 0 always when built without OpenMP. Safe to use as an index into a per-thread
+ * array sized by dt_get_num_openmp_threads(). */
 static inline int dt_get_thread_num()
 {
 #ifdef _OPENMP

--- a/src/tests/unittests/CMakeLists.txt
+++ b/src/tests/unittests/CMakeLists.txt
@@ -16,6 +16,7 @@ set(DATABASE_UNIT_TESTS
   # and splitting the list to say so would be more ceremony than it is worth.
   test_pipe_cache_policy
   test_backbuf_publish
+  test_conf_value_lifetime
 )
 
 foreach(test ${DATABASE_UNIT_TESTS})

--- a/src/tests/unittests/test_conf_value_lifetime.c
+++ b/src/tests/unittests/test_conf_value_lifetime.c
@@ -1,0 +1,178 @@
+/*
+    This file is part of Ansel,
+    Copyright (C) 2026 Aurélien PIERRE.
+
+    Ansel is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Ansel is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Ansel.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+/** Lifetime of the string dt_conf_get_string_const() hands out.
+ *
+ * That function returns a pointer INTO the conf hash table, and dt_conf_get_var() releases
+ * the lock before returning it. Replacing the value used to free it on the spot -- the
+ * table's value_destroy_func is a free -- so any reader still holding the pointer was
+ * reading freed memory. With 98 call sites and no way to tell from a signature which of
+ * them could race a writer, the fix was made in the writer: displaced values are retired
+ * and released only at cleanup.
+ *
+ * These tests pin that. The first one is the bug: read, overwrite, read again through the
+ * ORIGINAL pointer.
+ *
+ * Checked against the defect rather than only against the fix. Reverting the writer to its
+ * free-on-replace form and running under MALLOC_PERTURB_=170 -- which fills freed memory,
+ * so a use-after-free stops being silent without needing a full ASAN build -- fails three
+ * of the four, reporting the fill pattern where the value should be:
+ *
+ *     [  ERROR   ] --- "\357\277\275\357\277\275" != "11"
+ *
+ * The fourth, _rewriting_the_same_value_retires_nothing(), passes EITHER WAY and is not a
+ * regression detector: it asserts pointer identity, and the old code frees then immediately
+ * reallocates the same size, so the allocator hands back the same address. It is here to
+ * pin the dedup property -- that an unchanged write retires nothing -- not the lifetime.
+ */
+
+#include "common/conf.h"
+#include "darktable.h"
+
+#include <glib.h>
+#include <glib/gstdio.h>
+#include <stdarg.h>
+#include <stddef.h>
+// cmocka.h declares `extern jmp_buf global_expect_assert_env' at file scope without including
+// <setjmp.h> itself. Same suppression as test_pipe_cache_policy.c, and for the same reason.
+#include <setjmp.h>  // NOLINT(misc-include-cleaner)
+#include <stdint.h>
+#include <string.h>
+#include <cmocka.h>
+
+/** A key with no confgen declaration, so nothing clamps or sanitises what we store. */
+#define TEST_KEY "plugins/test/conf_value_lifetime"
+
+static char *_rcfile = NULL;
+
+static int _setup(void **state)
+{
+  (void)state;
+  // dt_conf_init() writes through the darktable.conf global, so it must point at the
+  // instance being initialised before the call -- exactly as dt_init() does it.
+  _rcfile = g_build_filename(g_get_tmp_dir(), "ansel_test_conf_lifetime.rc", NULL);
+  g_remove(_rcfile);
+  darktable.conf = (dt_conf_t *)calloc(1, sizeof(dt_conf_t));
+  dt_conf_init(darktable.conf, _rcfile, NULL);
+  return 0;
+}
+
+static int _teardown(void **state)
+{
+  (void)state;
+  dt_conf_cleanup(darktable.conf);
+  free(darktable.conf);
+  darktable.conf = NULL;
+  g_remove(_rcfile);
+  g_free(_rcfile);
+  _rcfile = NULL;
+  return 0;
+}
+
+/** The bug, pinned: a borrowed pointer survives the write that displaces it. */
+static void _borrowed_value_survives_being_replaced(void **state)
+{
+  (void)state;
+  dt_conf_set_string(TEST_KEY, "first");
+
+  const char *borrowed = dt_conf_get_string_const(TEST_KEY);
+  assert_string_equal(borrowed, "first");
+
+  // The write that used to free `borrowed` out from under us.
+  dt_conf_set_string(TEST_KEY, "second");
+
+  // Still readable, and still the value it was read as. Under ASAN, a regression here is a
+  // heap-use-after-free rather than a failed assertion.
+  assert_string_equal(borrowed, "first");
+
+  // ... while a fresh read observes the new value. Stale, not wrong.
+  assert_string_equal(dt_conf_get_string_const(TEST_KEY), "second");
+}
+
+/** Many successive writes, all of them retired rather than freed. */
+static void _every_displaced_value_stays_readable(void **state)
+{
+  (void)state;
+  const char *held[8];
+
+  for(int i = 0; i < 8; i++)
+  {
+    char *value = g_strdup_printf("value-%d", i);
+    dt_conf_set_string(TEST_KEY, value);
+    g_free(value);
+    held[i] = dt_conf_get_string_const(TEST_KEY);
+  }
+
+  // Every pointer taken along the way still reads as what it was when taken.
+  for(int i = 0; i < 8; i++)
+  {
+    char *expected = g_strdup_printf("value-%d", i);
+    assert_string_equal(held[i], expected);
+    g_free(expected);
+  }
+}
+
+/** Rewriting a key with the value it already holds must change nothing at all.
+ *
+ * This is what keeps the retired list proportional to real edits: GUI state is written back
+ * constantly with values that did not change, and retiring a string for each of those would
+ * make the list grow with idle churn instead. Pointer IDENTITY is the observable. */
+static void _rewriting_the_same_value_retires_nothing(void **state)
+{
+  (void)state;
+  dt_conf_set_string(TEST_KEY, "unchanged");
+  const char *before = dt_conf_get_string_const(TEST_KEY);
+
+  for(int i = 0; i < 16; i++) dt_conf_set_string(TEST_KEY, "unchanged");
+
+  // Same allocation, so nothing was displaced and nothing was retired.
+  assert_ptr_equal(before, dt_conf_get_string_const(TEST_KEY));
+  assert_string_equal(before, "unchanged");
+}
+
+/** The typed setters go through the same writer, so they inherit the same guarantee. */
+static void _typed_setters_retire_too(void **state)
+{
+  (void)state;
+  dt_conf_set_int(TEST_KEY, 11);
+  const char *borrowed = dt_conf_get_string_const(TEST_KEY);
+  assert_string_equal(borrowed, "11");
+
+  dt_conf_set_int(TEST_KEY, 22);
+
+  assert_string_equal(borrowed, "11");
+  assert_int_equal(dt_conf_get_int_fast(TEST_KEY), 22);
+}
+
+int main(void)
+{
+  const struct CMUnitTest tests[] = {
+    cmocka_unit_test(_borrowed_value_survives_being_replaced),
+    cmocka_unit_test(_every_displaced_value_stays_readable),
+    cmocka_unit_test(_rewriting_the_same_value_retires_nothing),
+    cmocka_unit_test(_typed_setters_retire_too),
+  };
+
+  return cmocka_run_group_tests(tests, _setup, _teardown);
+}
+
+// clang-format off
+// modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py
+// vim: shiftwidth=2 expandtab tabstop=2 cindent
+// kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;
+// clang-format on

--- a/src/tests/unittests/test_conf_value_lifetime.c
+++ b/src/tests/unittests/test_conf_value_lifetime.c
@@ -48,11 +48,11 @@
 #include <glib/gstdio.h>
 #include <stdarg.h>
 #include <stddef.h>
+#include <stdlib.h>  // calloc/free, used directly below
 // cmocka.h declares `extern jmp_buf global_expect_assert_env' at file scope without including
 // <setjmp.h> itself. Same suppression as test_pipe_cache_policy.c, and for the same reason.
 #include <setjmp.h>  // NOLINT(misc-include-cleaner)
 #include <stdint.h>
-#include <string.h>
 #include <cmocka.h>
 
 /** A key with no confgen declaration, so nothing clamps or sanitises what we store. */


### PR DESCRIPTION
Two halves of #1207: simplify the worst cyclomatic-complexity offenders, and document the most-included headers. **Eleven commits, one topic each**, so a bisect can attribute any regression precisely — in particular the one behaviour fix is kept apart from the refactor of the same file.

## Complexity

Ranked with `lizard` over `src/`, excluding vendored trees, then **filtered by provenance**: AMaZE, Markesteijn and CA-correct sit high on the list but are transcriptions that get diffed against upstream when bugs surface, so restructuring them destroys that. What is left is ours:

| Function | CCN | After |
| --- | ---: | --- |
| `_get_base_value` @ `common/variables.c` | **229** | 12, split into 7 links, largest 39 |
| `Lch_to_color_name` @ `common/color_vocabulary.c` | **98** | 6 |
| `_get_cursor_name` @ `control/control.c` | **81** | 3 |

`_get_base_value` was 95 `else if` branches testing 173 prefixes. Order is the whole correctness argument — `_has_prefix()` advances the caller's pointer on a match and requires no word boundary — so the split was done mechanically and checked the same way: **the 173 prefixes appear in the new file in byte-identical order**.

## Bugs this turned up

Found by reading, not by the analysers.

**`$(DATE.IMPORT)`, `$(DATE.CHANGE)`, `$(DATE.EXPORT)`, `$(DATE.PRINT)` were unreachable.** The bare `DATE` branch, added for watermark backward compatibility, sat above them and swallowed all four: each expanded to the current date/time instead of the requested timestamp. The reversed spellings (`$(IMPORT.DATE)`…) don't start with `DATE` and always worked, which is why it survived — every variable had a working alias. Fixed in its own commit; afterwards no prefix in the chain shadows a later one.

**Two leaks**, both from ownership that depended on which branch answered:
- `_get_cursor_name()` `g_strdup`'d into two `dt_print` calls that freed nothing. One *couldn't*: it selected between the allocated name and a plain literal with a ternary.
- `Lch_to_color_name()` returned an allocated string on the skin-tone path and static literals everywhere else, behind a `const char *` that told the caller neither. Its single call site leaked on every colour matching a reference skin tone.

**Two NULL-into-`%s` paths**, tolerated by glibc, not guaranteed elsewhere.

## Documentation

The complete top of the header ranking by real include count, vendored trees excluded. All diffs are **comments only**, verified to touch no code.

| Header | Files | Was |
| --- | ---: | --- |
| `system/macros.h` | 271 | 2 doc comments / 11 symbols |
| `system/mem_alloc.h` | 247 | 2 / 23 |
| `develop/imageop.h` | 154 | 7 / 73 |
| `common/module_versioning.h` | 143 | 0 / 5 |
| `system/openmp.h` | 133 | 0 / 23 |
| `common/logging.h` | 125 | 0 / 4 |
| `common/conf.h` | 123 | 0 / 40+ |

Per the brief: what each symbol assumes, what must be initialised first, which returned pointers are owned versus borrowed, and who frees them. The ones that matter:

- **`dt_conf_get_string_const()` is unsafe by construction, at 96 call sites.** `dt_conf_get_var()` releases the lock *before* returning a pointer into the live hash table, so any other thread setting that key frees it. `conf.c` already documents this on `_dt_conf_get_var_locked()`, and it is the mechanism behind the "write_sidecar_files silently flips to FALSE" report — fixed in `dt_conf_get_string()` (copy under lock), never in this variant. **Documented, not changed:** auditing 96 sites is its own job and its own decision. By contrast `dt_confgen_get()`'s borrowed pointer *is* safe, because that table is immutable after init — two functions returning `const char *` with opposite lifetimes and nothing saying so.
- **`dt_iop_module_t::params` belongs to the GUI thread.** The pipeline must never touch it; history under `history_mutex` is the only thread-safe interface, and `dt_iop_commit_params()` must be handed `hist->params`. The rule is in CLAUDE.md and was nowhere in the header.
- **`dt_iop_gui_enter_critical_section()` is a no-op when `module->gui` is NULL** — every headless module. A lock that silently does nothing on half the pipes.
- **The OpenMP wrappers inject `default(firstprivate)`**, so writes to scalar accumulators do not escape — while still compiling and still being correct at one thread. `__OMP_PARALLEL_FOR_CPP__` injects `default(none)` instead, so moving a loop between `.c` and `.cc` is not a copy-paste.
- **`DT_MODULE()` negates its version in `_DEBUG` builds** — the guard that stops a debug `.so` loading into a release host. `DT_MODULE_INTROSPECTION()`'s `PARAMSTYPE` is ignored by the preprocessor and read at build time, so a stale generated file compiles cleanly and keeps the old defaults.
- **`dt_alloc_align()` must be released only with `dt_free_align()`** — `_aligned_malloc` on Windows, so a mismatch corrupts the heap there while passing every Linux test.
- **The `_fast` conf readers are the *unclamped* ones.**

## Four claims checked rather than propagated

Each was written, then verified, then corrected:

- `macros.h` said `IS_NULL_PTR` "will fail at compile time on function pointers". It does not — compiled all four cases: function and object pointers compile, arrays and integers are rejected. The array rejection is the valuable half and is now stated as the reason.
- A drafted warning that `%z` is unusable under MinGW: `src/CMakeLists.txt` defines `__USE_MINGW_ANSI_STDIO=1`, so it is fine. The note records that dependency instead.
- `dt_iop_gui_duplicate()` does **not** return NULL when "the family is full" — there is no cap; NULL means `dt_iop_load_module()` failed.
- `dt_get_num_openmp_threads()` honours `-t`, but not memory limits as first drafted.

## Verification

- Clean build at every commit; CI green.
- `include_graph.py --summary`: cycles 0. `check_layering.sh`: 183 violations, baseline 183. `pragma_once_to_guards.py --verify`: clean.
- Functional test of the refactor via `ansel-cli` export with a filename template, against a **freshly staged** build (`--version` confirmed to be this HEAD — the default `check_it_runs.sh` path points at a different, stale tree, exactly as its own comment warns). All seven links resolved:
  - `2017.11.09_01025__y2026__iso400__s1__w800__id1__imp2026-08-26 17:32:52.png`
  - `exif_2017-11-09_09h55_makerNikon_v0_export.png` — the capture date, not today, so EXIF is genuinely read.

  The first also demonstrates the bug fix: `$(DATE.IMPORT)` now yields an ISO timestamp. Before, it produced the EXIF-style form with colons **and left a literal `.IMPORT` in the name**.

## Not done

Remaining non-vendored hotspots: `dt_init` (163), `_lrop` (163), `ansel-cli main` (152), `gui_changed` @ channelmixerrgb (136), `get_query_string` (132). Remaining documentation: `imageop.h`'s 58 other public functions, `develop/develop.h` (890 lines), `common/image.h` (88 symbols), `control/signal.h`.