### PR TITLE
Janitorial §1: the P0 verified defects (re-landed on master)

### DIFF
--- a/src/colorprofiles/colorspaces.c
+++ b/src/colorprofiles/colorspaces.c
@@ -2255,13 +2255,19 @@ static gboolean _colorspaces_is_base_name(const char *profile)
 
 static const char *_colorspaces_get_base_name(const char *profile)
 {
-  const char* f = profile + strlen(profile);
-  for (; f >= profile; f--)
+  // Walk backwards from the last character, never past the first one. The previous form
+  // started at the NUL and decremented while `f >= profile`, so a name with NO separator
+  // ran the loop one final time at f == profile and left with f == profile - 1: forming
+  // that pointer is undefined behaviour (only one-past-the-END is legal), and the "base
+  // name" it returned carried one byte of whatever preceded the string. Which is exactly
+  // the case this function exists to serve -- old iops that stored a bare basename.
+  for(const char *f = profile + strlen(profile); f > profile;)
   {
+    f--;
     if(*f == '/' || *f == '\\')
-      return ++f;   // path separator found - return the filename only, without the leading separator
+      return f + 1; // path separator found - return the filename only, without the leading separator
   }
-  return f;         // no separator found - consider profile_name to be a "base" one
+  return profile;   // no separator found - consider profile_name to be a "base" one
 }
 
 gboolean dt_colorspaces_is_profile_equal(const char *fullname, const char *filename)

--- a/src/common/image_extensions.c
+++ b/src/common/image_extensions.c
@@ -80,7 +80,11 @@ static gboolean _ext_in_list(const char *ext, const char *const *list)
 {
   if(IS_NULL_PTR(ext)) return FALSE;
   for(; *list; list++)
-    if(!g_ascii_strncasecmp(ext, *list, strlen(*list)))
+    // Whole-string compare. This was g_ascii_strncasecmp(ext, *list, strlen(*list)), which
+    // only looks at the first strlen(*list) characters and so matched any extension that
+    // merely STARTS WITH a known one: "foo.nefarious" was routed as a raw because it begins
+    // with "nef".
+    if(!g_ascii_strcasecmp(ext, *list))
       return TRUE;
   return FALSE;
 }

--- a/src/common/opencl.c
+++ b/src/common/opencl.c
@@ -1814,6 +1814,7 @@ static FILE *fopen_stat(const char *filename, struct stat *st)
   if(fstat(fd, st) < 0)
   {
     dt_print(DT_DEBUG_OPENCL, "[opencl_fopen_stat] could not stat file `%s'!\n", filename);
+    fclose(f); // the open succeeded; only the stat failed, and the handle is still ours
     return NULL;
   }
   return f;

--- a/src/database/film_repository.c
+++ b/src/database/film_repository.c
@@ -32,13 +32,16 @@ int32_t dt_film_repository_find_by_folder(const char *folder)
 
   int32_t filmroll_id = -1;
   sqlite3_stmt *stmt;
-  DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get_sqlite3_global(),
+  // Hoisted out of the macro call: a preprocessing directive inside the argument list of a
+  // function-like macro is undefined behaviour (C11 6.10.3p11). GCC and Clang accept it,
+  // which is exactly why it survives until a toolchain bump.
 #ifdef _WIN32
-                              "SELECT id FROM main.film_rolls WHERE folder LIKE ?1",
+  // Windows paths are matched case-insensitively, which LIKE gives us and = does not.
+  const char *query = "SELECT id FROM main.film_rolls WHERE folder LIKE ?1";
 #else
-                              "SELECT id FROM main.film_rolls WHERE folder = ?1",
+  const char *query = "SELECT id FROM main.film_rolls WHERE folder = ?1";
 #endif
-                              -1, &stmt, NULL);
+  DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get_sqlite3_global(), query, -1, &stmt, NULL);
   DT_DEBUG_SQLITE3_BIND_TEXT(stmt, 1, folder, -1, SQLITE_STATIC);
   if(sqlite3_step(stmt) == SQLITE_ROW) filmroll_id = sqlite3_column_int(stmt, 0);
   sqlite3_finalize(stmt);

--- a/src/imageio/imageio_core.c
+++ b/src/imageio/imageio_core.c
@@ -407,20 +407,33 @@ int dt_imageio_is_hdr(const char *filename)
   return dt_image_ext_is_hdr(c + 1);
 }
 
-static gboolean _is_in_list(char *elem, char *list)
+/** @brief Is @p elem one of the comma-separated entries of @p list?
+ *
+ * @param elem the value to look for; NULL is never in any list.
+ * @param list a MUTABLE, comma-separated string. It is tokenised in place, so the caller's
+ * buffer is modified and must be a private copy.
+ * @return TRUE on a case-insensitive match of a WHOLE entry.
+ *
+ * @note Two things were wrong here and both are fixed. The comparison was
+ * `g_ascii_strncasecmp(list, elem, strlen(elem))`, which succeeds when the list entry
+ * merely STARTS WITH elem -- so "nef" matched an entry "nefarious", and a partial camera
+ * maker matched a longer one. And the tokeniser was strtok(), which keeps static state:
+ * this runs on worker threads during import, export and mipmap generation, so two of them
+ * tokenising at once corrupted each other and made "is this handled by LibRaw?" answer
+ * non-deterministically. strtok_r() keeps its state in the caller's frame.
+ */
+static gboolean _is_in_list(const char *elem, char *list)
 {
-  // Search if elem is contained in the coma-separated list string
-  gboolean success = FALSE;
-  if(elem && list)
+  if(IS_NULL_PTR(elem) || IS_NULL_PTR(list)) return FALSE;
+
+  char *saveptr = NULL;
+  for(char *entry = strtok_r(list, ",", &saveptr); !IS_NULL_PTR(entry);
+      entry = strtok_r(NULL, ",", &saveptr))
   {
-    while(!IS_NULL_PTR(list) && !success)
-    {
-      success = !g_ascii_strncasecmp(list, elem, strlen(elem));
-      list = strtok(NULL, ",");
-    }
+    if(!g_ascii_strcasecmp(entry, elem)) return TRUE;
   }
 
-  return success;
+  return FALSE;
 }
 
 gboolean dt_imageio_is_handled_by_libraw(dt_image_t *img, const char *filename)
@@ -428,14 +441,21 @@ gboolean dt_imageio_is_handled_by_libraw(dt_image_t *img, const char *filename)
   // Allow users to define some extensions, makers and models that should be handled by Libraw
   gboolean is_handled = FALSE;
 
-  char *ext = g_strrstr(filename, ".") + 1; // move the pointer after the extension dot
+  // g_strrstr() returns NULL when the name has no dot at all, and NULL + 1 is undefined
+  // behaviour before _is_in_list() ever gets to dereference it. An extensionless file in an
+  // imported folder is enough to reach this.
+  const char *dot = g_strrstr(filename, ".");
+  const char *ext = IS_NULL_PTR(dot) ? NULL : dot + 1;
+
   char *extensions = dt_conf_get_string("libraw/extensions");
   char *makers = dt_conf_get_string("libraw/makers");
   char *models = dt_conf_get_string("libraw/models");
 
-  is_handled |= _is_in_list(ext, strtok(extensions, ","));
-  is_handled |= _is_in_list(img->exif_maker, strtok(makers, ","));
-  is_handled |= _is_in_list(img->exif_model, strtok(models, ","));
+  // _is_in_list() tokenises its list argument in place; these are private copies from
+  // dt_conf_get_string(), so that is safe.
+  is_handled |= _is_in_list(ext, extensions);
+  is_handled |= _is_in_list(img->exif_maker, makers);
+  is_handled |= _is_in_list(img->exif_model, models);
 
   dt_free(extensions);
   dt_free(makers);

--- a/src/imageio/imageio_core.c
+++ b/src/imageio/imageio_core.c
@@ -878,7 +878,11 @@ int dt_imageio_export_with_flags(const int32_t imgid, const char *filename,
     goto error;
   }
 
-  struct dt_pixel_cache_entry_t *cache_entry;
+  // Initialised because the failure path below tests it. It is currently reached only after
+  // dt_dev_pixelpipe_cache_ref_entry_by_hash() has written NULL into it on every early
+  // return -- a callee-side contract propping up a caller-side assumption, on a path whose
+  // failure mode is unreffing a garbage pointer.
+  struct dt_pixel_cache_entry_t *cache_entry = NULL;
   void *data = NULL;
   /* Atomically look up the final pipeline output and increment its refcount under the cache
    * mutex.  peek() + separate ref_count_entry() has a TOCTOU window: peek releases its


### PR DESCRIPTION
The §1 P0 verified defects from #1207. Six commits, one defect each, **based on `master`**.

> **Re-land of #1274.** That PR was based on `janitorial-complexity-docs` rather than `master`. The base merged to master first, then #1274 merged into the now-dead base — so it reads "merged" while **none of its commits reached master**. Verified: `strtok_r` and the hoisted `query` are both absent from `origin/master`. These are the same six commits, cherry-picked onto master (they applied cleanly) and rebuilt. Nothing else changed.

## What is fixed

| § | Defect | Established by |
| --- | --- | --- |
| 1.1 | `_colorspaces_get_base_name()` returned `profile - 1` | compiled repro |
| 1.2a | `g_strrstr(name, ".") + 1` is `NULL + 1` for an extensionless file | inspection |
| 1.2b | `strtok`'s static state, reached from worker threads | inspection; last `strtok` uses in `src/` |
| 1.2c | `_is_in_list()` matched on a prefix | compiled repro |
| 1.3 | same prefix bug in extension routing | compiled repro |
| 1.4 | `#ifdef` inside a macro argument list — C11 6.10.3p11 UB | inspection; only occurrence in the tree |
| 1.5 | `fopen_stat()` leaked the `FILE*` when `fstat` failed | inspection |
| 1.7 | uninitialised `cache_entry` read on the export error path | inspection |

### §1.1 — reproduced

With a deliberate `'X'` placed immediately before the string:

```
input=sRGB.icc            old=XsRGB.icc  new=sRGB.icc  old_off=-1 new_off=0
input=/usr/share/sRGB.icc old=sRGB.icc   new=sRGB.icc  old_off=11 new_off=11
input=a                   old=(empty)    new=a         old_off=-1 new_off=0

strcmp(old, "sRGB.icc") = -27      strcmp(new, "sRGB.icc") = 0
```

The separator case was always right. Only the no-separator case was broken — the very case three header doc-comments say this function exists to serve (basename-tolerance for old iops that stored a bare basename).

### §1.2c / §1.3 — reproduced, and the direction bounds the risk

```
1.3  extension routing (list: nef,cr2,raf)      1.2c  _is_in_list (list: nikon,canon)
   nef          old=1 new=1                        elem=nikon  old=1 new=1
   nefarious    old=1 new=0   <-- changed          elem=nik    old=1 new=0   <-- changed
   NEF          old=1 new=1                        elem=n      old=1 new=0   <-- changed
   cr2x         old=1 new=0   <-- changed          elem=canon  old=1 new=1
```

Both compared with `g_ascii_strncasecmp(entry, elem, strlen(elem))`, which matches when the **entry starts with the element** — a *short* element matching a *longer* entry. `foo.nefarious` was routed to the raw loader.

That direction matters: the configuration a user would intuitively write — entry `NIKON` against an `exif_maker` of `NIKON CORPORATION` — **never worked**, since it compares 17 characters against a 5-character entry. Nobody can have depended on the direction that did work, so the whole-entry compare is safe as well as correct. It is nonetheless the one user-visible behaviour change here, if you want it in a release note.

## Not fixed: §1.6 is a false positive

The issue predicts `d->rule[-1]` "when `_rules_count()` returns 0". It cannot:

```c
static int _rules_count()
{
  return CLAMP(dt_conf_get_int("plugins/lighttable/collect/num_rules"), 1, MAX_RULES);
}
```

`_rules_count()` is itself clamped to **≥ 1**, and was already so at the survey date. `d->active_rule` has exactly three writers — that clamp and two `= 0` initialisers — so it is never negative, and `d->rule` is a fixed `[MAX_RULES]` array. Sonar `c:S3519` cannot see through the `CLAMP` macro.

I wrote the guard, checked, and reverted it. Reported to the issue's §5 instead.

## Verification

- Clean build on master; `strtok_r` compiles under MinGW with `-Wall -Werror` (it is POSIX, and MSVCRT offers `strtok_s` instead — the one portability risk here, checked locally rather than in CI).
- §1.2 and §1.3 sit on the raw-vs-LDR routing decision, so that path was exercised end to end against a freshly staged build: `_DSC0002.NEF` still logs `loaded with Rawspeed` (maker `NIKON CORPORATION`) and both a raw and a JPEG export.
- The full CI matrix passed on this commit set — 13/13 jobs — when it ran on the previous branch.