### PR TITLE
Janitorial §2: make the quality gate mean something again

### DIFF
--- a/.sonarcloud.properties
+++ b/.sonarcloud.properties
@@ -19,9 +19,20 @@ sonar.cpd.exclusions=src/iop/highlights/**
 # compiler prove non-aliasing and vectorize (with -ftree-vectorize / __DT_CLONE_TARGETS__).
 # `restrict` is a deliberate, load-bearing optimization here, not a hazard — removing the ~424
 # qualifiers would silently de-vectorize the hot paths. Suppressed only under src/iop/highlights/.
-sonar.issue.ignore.multicriteria=restrict1
+# cpp:S1669 ("Replace `module` with another name") fires because `module` became a keyword
+# in C++20. This is a C codebase in which `module` is THE central domain noun --
+# dt_iop_module_t, dt_lib_module_t, dt_view_t's module list, the whole plugin API -- and the
+# C standard has no such keyword, so nothing here is at risk. Renaming it is not on the
+# table: it is the vocabulary the code, the docs and the issue tracker are written in.
+#
+# It is suppressed because of what it costs, not merely because it is wrong: 119 of the 209
+# open BLOCKER issues are this one rule -- 57% -- and they bury the findings that matter.
+# The quality gate is only useful if a BLOCKER means something. Measured 2026-08-26.
+sonar.issue.ignore.multicriteria=restrict1,cxx20keyword1
 sonar.issue.ignore.multicriteria.restrict1.ruleKey=c:S1836
 sonar.issue.ignore.multicriteria.restrict1.resourceKey=src/iop/highlights/**
+sonar.issue.ignore.multicriteria.cxx20keyword1.ruleKey=cpp:S1669
+sonar.issue.ignore.multicriteria.cxx20keyword1.resourceKey=**/*
 
 # Analysis exclusions — third-party code Ansel vendors but does not author.
 #
@@ -61,8 +72,12 @@ sonar.issue.ignore.multicriteria.restrict1.resourceKey=src/iop/highlights/**
 # toolbox than the frozen darktable 5.0 reference tree it is compared against, so
 # counting it flatters neither side honestly. Only C, C++ and Objective-C are
 # measured, matching the allowlist in tools/code_health.py.
+# src/math/attic/ is archived by its own README: "Nothing here is compiled: these files
+# appear in no CMake target and no file includes them." Same case as src/apps/ansel-chart/
+# below -- findings there are neither reachable nor actionable, and fixing them would mean
+# editing code that cannot be compiled to check the edit.
 sonar.exclusions=src/external/**, doc/doxygen-awesome-css/**, tests/image_test/samples/**, \
-  src/apps/ansel-chart/**, \
+  src/apps/ansel-chart/**, src/math/attic/**, \
   **/*.py, **/*.sh, **/*.bash, **/*.pl, **/*.rb, **/*.lua, \
   **/*.yml, **/*.yaml, **/*.md, **/*.xsl, **/*.xslt, \
   **/CMakeLists.txt, **/*.cmake

--- a/src/common/hash.h
+++ b/src/common/hash.h
@@ -22,6 +22,8 @@
  * caches). Pure and dependency-free on purpose: low-level compute units include this
  * instead of darktable.h. */
 
+#include "system/macros.h"  // DT_FALLTHROUGH
+
 #include <stddef.h>
 #include <stdint.h>
 
@@ -80,13 +82,13 @@ static inline uint64_t dt_hash(uint64_t hash, const char *str, size_t size)
   uint64_t b = (uint64_t)size << 56;
   switch(size & 7)
   {
-    case 7: b |= (uint64_t)in[i + 6] << 48; /* fall through */
-    case 6: b |= (uint64_t)in[i + 5] << 40; /* fall through */
-    case 5: b |= (uint64_t)in[i + 4] << 32; /* fall through */
-    case 4: b |= (uint64_t)in[i + 3] << 24; /* fall through */
-    case 3: b |= (uint64_t)in[i + 2] << 16; /* fall through */
-    case 2: b |= (uint64_t)in[i + 1] << 8;  /* fall through */
-    case 1: b |= (uint64_t)in[i + 0];       /* fall through */
+    case 7: b |= (uint64_t)in[i + 6] << 48; DT_FALLTHROUGH;
+    case 6: b |= (uint64_t)in[i + 5] << 40; DT_FALLTHROUGH;
+    case 5: b |= (uint64_t)in[i + 4] << 32; DT_FALLTHROUGH;
+    case 4: b |= (uint64_t)in[i + 3] << 24; DT_FALLTHROUGH;
+    case 3: b |= (uint64_t)in[i + 2] << 16; DT_FALLTHROUGH;
+    case 2: b |= (uint64_t)in[i + 1] << 8;  DT_FALLTHROUGH;
+    case 1: b |= (uint64_t)in[i + 0];       DT_FALLTHROUGH;
     case 0: break;
   }
   v3 ^= b;

--- a/src/system/macros.h
+++ b/src/system/macros.h
@@ -104,6 +104,29 @@ extern "C" {
 
 /** @brief Mark a branch as impossible, naming it @p D in the message. @see
  * dt_unreachable_codepath() */
+/** @brief Mark a deliberate `switch` fall-through so compilers and analysers stop warning.
+ *
+ * @details Write it as a statement where the `break` would go:
+ * `case 7: b |= ...; DT_FALLTHROUGH;`
+ *
+ * The conventional "fall through" COMMENT is understood by GCC's -Wimplicit-fallthrough
+ * and by clang-tidy, but not by every analyser -- SonarCloud reports each one as `c:S128`
+ * ("switch case should end with an unconditional break"), which is 7 findings on one
+ * intentionally-unrolled loop in common/hash.h. The attribute is a token the parser sees,
+ * so it settles the question everywhere at once.
+ *
+ * Expands to nothing on a toolchain without the attribute, where the comment convention
+ * (or nothing at all) was the only option anyway.
+ */
+#if defined(__has_attribute)
+#if __has_attribute(fallthrough)
+#define DT_FALLTHROUGH __attribute__((fallthrough))
+#endif
+#endif
+#ifndef DT_FALLTHROUGH
+#define DT_FALLTHROUGH ((void)0)
+#endif
+
 #define dt_unreachable_codepath_with_desc(D)                                                                 \
   dt_unreachable_codepath_with_caller(D, __FILE__, __LINE__, __FUNCTION__)
 


### PR DESCRIPTION
Third janitorial step from #1207 — **§2**, the part that is about the gate rather than the code. Three commits, one topic each, based on `master`.

## §2.1 — one rule is 57% of all BLOCKERs

`cpp:S1669` ("Replace `module` with another name") exists because `module` became a keyword in **C++20**. This is a C codebase in which `module` is *the* central domain noun — `dt_iop_module_t`, `dt_lib_module_t`, the whole plugin API — and C has no such keyword, so nothing here is at risk. Renaming is not on the table: it is the vocabulary the code, the docs and the issue tracker are written in.

Measured today, not taken from the survey:

| | |
| --- | ---: |
| Open BLOCKER issues | 209 |
| …of which `cpp:S1669` | **119 (57%)** |
| Next largest rule | `c:S3519`, 29 |

#1207 recorded 165/219; it is 119/209 now. Either way the rule dominates and buries everything worth reading. Suppressed through the existing `sonar.issue.ignore.multicriteria` mechanism — **issue-level, not file exclusion**: every other rule still runs on every file.

Also excluded `src/math/attic/**`. Its own README opens with *"Archived, not built — Nothing here is compiled: these files appear in no CMake target and no file includes them."* Same grounds as `src/apps/ansel-chart/`, already excluded: findings there are unreachable, and fixing them would mean editing code that cannot be compiled to check the edit. It holds 2 of the `c:S128` findings below.

## §2.4 — a fall-through marker analysers can actually see

`common/hash.h`'s SipHash tail switch deliberately falls through all seven cases — that is how the trailing 0..7 bytes accumulate — and said so in comments. GCC's `-Wimplicit-fallthrough` and clang-tidy understand that convention; Sonar does not, and counted **7 `c:S128`** findings.

Added `DT_FALLTHROUGH` to `system/macros.h` (`__attribute__((fallthrough))` behind `__has_attribute`, expanding to `((void)0)` where unsupported — unreachable in practice) and applied it. The attribute is a token the parser sees, so it settles the question for every analyser at once. No code is emitted; behaviour is identical.

## Not in this PR: §2.2 needs your hand

The 9 `src/system/dtpthread.h` lock findings — **4× `c:S5486`, 3× `c:S5487`, 2× `c:S5489`** (#1207 estimates 6; it is 9) — are genuine false positives, verified against the source rather than taken on trust:

```c
if(pthread_equal(rwlock->writer, pthread_self()) && rwlock->writer_depth >= 1)
{
  __sync_fetch_and_add(&(rwlock->cnt), 1);
  rwlock->writer_depth++;
  ...
  return 0;                      // never touches the pthread lock
}
```

`dt_pthread_rwlock_rdlock` and `_unlock` short-circuit when the calling thread already holds the write lock, tracking `writer_depth` instead of re-entering pthread. Sonar's lock model cannot represent that, so it reports "this lock has already been acquired", "this lock is still locked" and "possible lock order reversal". This is the deliberate same-thread reentrancy documented in CLAUDE.md.

Marking them requires changing issue status on SonarCloud, which my tooling is not permitted to do. **Please mark them Won't Fix / False Positive in the UI** — or say so and I will, if the permission is granted. Issue keys:

```
c:S5486  AZ4Iwaf6i2zGCx4xH1X7  AZyF0B51O4OmJVEXE0ra  AZyF0B51O4OmJVEXE0rb  AZPbr_bUGJ_5CLY3Ibn8
c:S5487  AZPbr_bUGJ_5CLY3Ibn9  AZ_Xo6byEAb1sO3FWoUN  AZ_Xo6byEAb1sO3FWoUO
c:S5489  AZwEZr13m5_2G2gcXxRT  AZ_Xo6byEAb1sO3FWoUP
```

Those are the findings holding the reliability rating at E.

## Verification

Clean build; `include_graph.py --summary` cycles 0; `check_layering.sh` 183/183 (baseline).

One thing worth recording: the first draft of the `DT_FALLTHROUGH` doc comment quoted the marker's literal comment syntax *inside* a block comment, which made `-Wcomment` fire in **every one of the 271 translation units** that include `macros.h` and would have failed any `-Werror` job. Caught by the local build, not by review.

## Expected effect

- `cpp:S1669`: −119 BLOCKERs
- `c:S128`: −9 (7 in hash.h, 2 in the excluded attic)
- with §2.2 done by hand: −9 more, and the reliability rating should stop being pinned at E

## Next

§2.3 — the mechanical `sprintf`→`snprintf` sweep (21 flagged hotspots plus the unflagged sites in `libs/export.c`, `iop/diffuse.c`, `iop/colorbalance.c`), then the two remaining §3 conversions, `_lrop` and `gui_changed`.