### PR TITLE
Fix master: GUARDED_BY on clang 18, the silent warning-flag probe, and two unlocked reads of dev->history

### DIFF
--- a/.sonarcloud.properties
+++ b/.sonarcloud.properties
@@ -57,8 +57,13 @@ sonar.issue.ignore.multicriteria.cxx20keyword1.resourceKey=**/*
 #
 # This is not a substitute for lock checking: clang's -Wthread-safety does the real work
 # here, and unlike symbolic execution it does not assume non-recursion -- it verifies a
-# declared contract (GUARDED_BY / REQUIRES). See doc/lock-audit.md for what it now proves
-# and the 30 findings it has open.
+# declared contract rather than counting acquisitions. The contract is REQUIRES /
+# REQUIRES_SHARED on the functions, checked against ACQUIRE / RELEASE on the wrappers.
+# NOT GUARDED_BY on the data: that half is unavailable to us, because clang cannot bind a
+# guarded_by naming a struct member to the object being accessed in C, and ours are
+# per-instance locks. See doc/lock-audit.md for the measurement, for what the contract half
+# does prove -- it found two unlocked reads of dev->history -- and for the 30 findings it
+# has open.
 sonar.issue.ignore.multicriteria.lockmodel1.ruleKey=c:S5486
 sonar.issue.ignore.multicriteria.lockmodel1.resourceKey=src/system/dtpthread.h
 sonar.issue.ignore.multicriteria.lockmodel2.ruleKey=c:S5487

--- a/cmake/modules/CheckCCompilerFlagAndEnableIt.cmake
+++ b/cmake/modules/CheckCCompilerFlagAndEnableIt.cmake
@@ -1,7 +1,15 @@
 include(CheckCCompilerFlag)
 
 macro (CHECK_C_COMPILER_FLAG_AND_ENABLE_IT _FLAG)
-  set(_RESULT "C_COMPILER_UNDERSTANDS_${_FLAG}")
+  # The result variable name is passed to the compiler as -D<name>, so it must be a valid
+  # macro name. Interpolating the raw flag left a '-' in it -- "-DC_COMPILER_UNDERSTANDS_-Wall"
+  # -- which clang reports as "ISO C99 requires whitespace after the macro name". Harmless on
+  # its own, but CMAKE_REQUIRED_FLAGS below carries the project's -Werror, so EVERY probe
+  # failed under clang and every flag checked this way was silently never enabled. That
+  # included -Wthread-safety, i.e. the entire lock-annotation analysis, on every clean clang
+  # build. Sanitise to an identifier.
+  string(REGEX REPLACE "[^A-Za-z0-9]" "_" _FLAG_ID "${_FLAG}")
+  set(_RESULT "C_COMPILER_UNDERSTANDS_${_FLAG_ID}")
 
   set(CMAKE_REQUIRED_FLAGS_ORIG "${CMAKE_REQUIRED_FLAGS}")
   set(CMAKE_REQUIRED_FLAGS "${CMAKE_C_FLAGS}")

--- a/cmake/modules/CheckCXXCompilerFlagAndEnableIt.cmake
+++ b/cmake/modules/CheckCXXCompilerFlagAndEnableIt.cmake
@@ -1,7 +1,15 @@
 include(CheckCXXCompilerFlag)
 
 macro (CHECK_CXX_COMPILER_FLAG_AND_ENABLE_IT _FLAG)
-  set(_RESULT "CXX_COMPILER_UNDERSTANDS_${_FLAG}")
+  # The result variable name is passed to the compiler as -D<name>, so it must be a valid
+  # macro name. Interpolating the raw flag left a '-' in it -- "-DC_COMPILER_UNDERSTANDS_-Wall"
+  # -- which clang reports as "ISO C99 requires whitespace after the macro name". Harmless on
+  # its own, but CMAKE_REQUIRED_FLAGS below carries the project's -Werror, so EVERY probe
+  # failed under clang and every flag checked this way was silently never enabled. That
+  # included -Wthread-safety, i.e. the entire lock-annotation analysis, on every clean clang
+  # build. Sanitise to an identifier.
+  string(REGEX REPLACE "[^A-Za-z0-9]" "_" _FLAG_ID "${_FLAG}")
+  set(_RESULT "CXX_COMPILER_UNDERSTANDS_${_FLAG_ID}")
 
   set(CMAKE_REQUIRED_FLAGS_ORIG "${CMAKE_REQUIRED_FLAGS}")
   set(CMAKE_REQUIRED_FLAGS "${CMAKE_CXX_FLAGS}")

--- a/data/kernels/CMakeLists.txt
+++ b/data/kernels/CMakeLists.txt
@@ -1,8 +1,13 @@
 #
 # install opencl kernel source files
 #
-FILE(GLOB DT_OPENCL_KERNELS "*.cl" "common.h")
-FILE(GLOB DT_OPENCL_EXTRA "programs.conf" "rgb_norms.h" "noise_generator.h" "color_conversion.h" "colorspace.h")
+# common.h belongs with the other kernel HEADERS below, not with the programs. It is
+# #included by 31 of the 34 .cl files, so its contents are already compiled 31 times over;
+# listing it here additionally test-compiled it as a translation unit of its own, which is
+# not how it is ever used and which warns "#pragma once in main file". Both lists install to
+# the same directory, so this changes what gets test-compiled and nothing else.
+FILE(GLOB DT_OPENCL_KERNELS "*.cl")
+FILE(GLOB DT_OPENCL_EXTRA "programs.conf" "common.h" "rgb_norms.h" "noise_generator.h" "color_conversion.h" "colorspace.h")
 
 # The lens kernels evaluate LensSerious's closed forms directly, from the very header
 # liblensserious compiles as C99 -- one source text for CPU and GPU (see

--- a/doc/lock-audit.md
+++ b/doc/lock-audit.md
@@ -250,17 +250,49 @@ previous attempt: *"the non-`_DEBUG` arm stopped compiling — and nobody found 
 
 ## Machine-checked lock discipline
 
-`-Wthread-safety` has been enabled in `cmake/compiler-warnings.cmake` all along, and the
-mutex wrapper has carried `CAPABILITY`/`ACQUIRE`/`RELEASE` for as long. It was checking
-almost nothing, for one reason:
+`cmake/compiler-warnings.cmake` has asked for `-Wthread-safety` all along, and the mutex
+wrapper has carried `CAPABILITY`/`ACQUIRE`/`RELEASE` for as long. It was checking nothing
+whatsoever, for two reasons — and the first one is the embarrassing one:
+
+**The flag never reached the compiler.** `CHECK_COMPILER_FLAG_AND_ENABLE_IT(-Wthread-safety)`
+built the probe's result variable out of the flag text and passed it as `-D`:
+
+    -DC_COMPILER_UNDERSTANDS_-Wthread-safety
+
+which is not a valid macro name, so the probe compile failed, the flag was recorded as
+unsupported, and it was dropped. Silently — a failed probe looks exactly like a compiler that
+lacks the flag. Every flag containing a character illegal in an identifier went the same way.
+Worse, clang does not resolve a thread-safety attribute's argument when the analysis is off,
+so annotations that could not possibly work still compiled clean locally. Fixed by sanitising
+the flag text into an identifier; the analysis then found real defects on its first run.
+
+**And there was no data annotated:**
 
     GUARDED_BY across the tree:  0
 
-`GUARDED_BY` is the annotation that does the work. Clang's analysis is **declarative** — you
-state that a field is guarded by a lock and it proves every access holds it — as opposed to
-symbolic execution guessing at lock state from control flow. With no data annotated it only
-verified that locks balance within a function, and never that any data was protected. The
-machinery was installed and wired to nothing.
+`GUARDED_BY` is the annotation that does the work — where it is available. Clang's analysis
+is **declarative**: you state that a field is guarded by a lock and it proves every access
+holds it, as opposed to symbolic execution guessing at lock state from control flow. With no
+data annotated it only verified that locks balance within a function, and never that any data
+was protected.
+
+**In C, `GUARDED_BY` is available only for file-scope locks.** Ours are per-instance —
+`history_mutex` lives in `dt_develop_t`, one per develop context — and for a lock that is a
+struct member the annotation cannot be satisfied by anything. In C++ a member's
+`guarded_by(mu)` implicitly means `this->mu`, so an access to `obj.field` requires `obj.mu`
+and a method's `REQUIRES(mu)` matches. C has no `this` and clang does not synthesise one: the
+requirement stays the bare identifier. Measured on clang 19, two files, one variable each:
+
+| Lock | Annotated function | Unannotated function |
+| --- | --- | --- |
+| file-scope | satisfied, no warning | warned — correct |
+| struct member | **warned** | warned |
+
+Clang states it outright — `requires holding rw 'm'`, unqualified, never `s->m`. Before
+clang 19 it was worse: the attribute was rejected at parse time with "use of undeclared
+identifier", which is how it reached master and broke the build for every distro clang.
+
+So the declarative half is off the table here, and what remains is the contract half.
 
 This also answers "can we do better than suppressing SonarCloud's pthread findings?".
 `c:S5486` and friends are symbolic-execution rules whose own documentation says they *assume
@@ -271,13 +303,29 @@ it is checking a declared contract — and it runs on every LLVM build we alread
 ### Done
 
 `dt_pthread_rwlock_t` is a `CAPABILITY`, so the locks guarding the most concurrency-sensitive
-state can be named at all. `dev->history` and `dev->history_end` are `GUARDED_BY(history_mutex)`,
-and the functions that run with the lock held declare `REQUIRES`/`REQUIRES_SHARED` — including
-the ones whose names already claimed it (`_ext`, `_locked`) and enforced nothing.
+state can be named at all. The functions that run with `history_mutex` held declare
+`REQUIRES`/`REQUIRES_SHARED` — including the ones whose names already claimed it (`_ext`,
+`_locked`) and enforced nothing. Clang then verifies the lock is held on every path into such
+a function and released on every path out.
 
-Measured: **20 findings in `dev_history.c` before, 0 after**, no suppressions, every one fixed
-by declaring an existing contract. Tree-wide, no history finding appears in any other file, so
-every consumer already accesses it correctly.
+That is weaker than guarding the fields, and it still found real defects — which is the
+argument for keeping it. `dev_history.c` went from **26 findings to 0**, and the fixes were
+not all bookkeeping:
+
+- `dt_dev_history_commit_item_now()` released the write lock and then walked `dev->history`
+  twice with nothing held, while the background write job can be walking and dropping
+  references on the same items. Reading `hist->forms` off an item that job is releasing is a
+  use-after-free, not a stale read.
+- `dt_dev_history_notify_change()` walked `dev->history` with no lock, from all eight of its
+  call sites — one of which unlocks on the line immediately above the call.
+
+Four contracts were also inverted: the function acquired the lock itself *and* demanded it
+from callers. Those annotations described something the code did not do, which is worse than
+no annotation, and they were caught the same way — by turning the analysis on and reading
+what it said rather than trusting the labels.
+
+The lesson for the rest of this backlog: an annotation is a claim to verify, not documentation
+to add. Four of twenty here were wrong on the first pass.
 
 ### The backlog, measured
 
@@ -291,6 +339,13 @@ findings in 5 files**:
 | `gui/lut_viewer.c` | 5 |
 | `caches/cache.c` | 3 |
 | `pixel/colorequal_shared.c` | 2 |
+
+`src/tests/unittests/test_dtpthread_recursive.c` is deliberately **not** in that table. Its
+four cases re-acquire a lock they already hold, which is the property under test and exactly
+what the analysis is built to reject — it models a lock as held or not held, so the second
+acquisition reads as "already held" and the matching release as "was not held". The bodies
+carry `NO_THREAD_SAFETY_ANALYSIS`. Left unexempted they contributed 8 findings that nobody
+could ever fix, which is precisely the noise that hides the ones that can be.
 
 **They are not pre-existing.** Every one names an `rwlock`, and they exist because
 `dt_pthread_rwlock_t` became a `CAPABILITY` in this same work — before that, clang had
@@ -307,9 +362,14 @@ clang they are hard errors:
 which is why the macOS and LLVM CI jobs failed while every GCC job passed — GCC ignores
 `-Wthread-safety` entirely. A local GCC build cannot vouch for any of this.
 
-Until they are resolved, `cmake/compiler-warnings.cmake` carries
+Until they are resolved, the Debug flags in `CMakeLists.txt` carry
 `-Wno-error=thread-safety-analysis`: the findings stay visible on every clang build but do
 not break it. That flag is a ratchet to remove, not a setting to keep.
+
+It is appended **only for clang**. GCC has no such warning, and `-Wno-error=` naming an option
+it does not know is a hard error there, not a no-op — adding it unguarded broke every GCC
+Debug build at once. It also has to be appended after `CMAKE_C_FLAGS`, since
+`CMAKE_C_FLAGS_DEBUG` lands later on the command line and a `-Werror` after it would win.
 
 All are conditional-locking shapes: *"not held on every path through here"*, *"expecting
 rwlock to be held at start of each loop"*, *"releasing rwlock that was not held"*. Those are

--- a/src/apps/ansel-lens-db-update/main.c
+++ b/src/apps/ansel-lens-db-update/main.c
@@ -236,8 +236,13 @@ int main(int argc, char *argv[])
    * user wrote themselves. That file is not wrong, but installing it WOULD be: iop/lens.c
    * prefers the configuration directory and never falls back once it opens something, so
    * a three-lens database would silently replace the fifteen hundred that shipped. */
+  // g_strlcpy/g_strlcat rather than snprintf("%s.incoming"): both truncate safely, but the
+  // format version makes GCC warn that out_path can fill the buffer with no room for the
+  // suffix. dt_concat_path_file() is not usable here -- it inserts a separator, and this is
+  // a suffix on the same name.
   char staged_path[DT_PATH_MAX] = { 0 };
-  snprintf(staged_path, sizeof(staged_path), "%s.incoming", out_path);
+  g_strlcpy(staged_path, out_path, sizeof(staged_path));
+  g_strlcat(staged_path, ".incoming", sizeof(staged_path));
 
   const int rc = ls_import_run(schema_path, staged_path, base, xml_dir);
   if(rc)

--- a/src/develop/dev_history.c
+++ b/src/develop/dev_history.c
@@ -452,7 +452,7 @@ static dt_dev_history_item_t *_search_history_by_op(dt_develop_t *dev, const dt_
 static dt_iop_module_t *_history_merge_resolve_dest_instance(dt_develop_t *dev_dest,
                                                              const dt_iop_module_t *mod_src,
                                                              gboolean *created,
-                                                             gboolean *reused_base)
+                                                             gboolean *reused_base) REQUIRES_SHARED(dev_dest->history_mutex)
 {
   *created = FALSE;
   *reused_base = FALSE;
@@ -482,6 +482,7 @@ static dt_iop_module_t *_history_merge_resolve_dest_instance(dt_develop_t *dev_d
 
 // dev_src is used only to copy masks, if no mask will be copied it can be null
 int dt_history_merge_module_into_history(dt_develop_t *dev_dest, dt_develop_t *dev_src, dt_iop_module_t *mod_src)
+  REQUIRES(dev_dest->history_mutex)
 {
   gboolean created = FALSE;
   gboolean reused_base = FALSE;
@@ -645,7 +646,10 @@ static void _history_undo_data_free(gpointer data)
  * @param action Undo/redo action.
  * @param imgs Unused.
  */
-static void _pop_undo(gpointer user_data, dt_undo_type_t type, dt_undo_data_t data, dt_undo_action_t action, GList **imgs)
+/* No REQUIRES: this is a dt_undo_t callback, so its signature is fixed and carries no
+ * dt_develop_t to name the lock on -- it reaches the dev through user_data. The lock is
+ * taken inside. NO_THREAD_SAFETY_ANALYSIS rather than a contract clang cannot express. */
+static void _pop_undo(gpointer user_data, dt_undo_type_t type, dt_undo_data_t data, dt_undo_action_t action, GList **imgs) NO_THREAD_SAFETY_ANALYSIS
 {
   if(type != DT_UNDO_HISTORY) return;
 
@@ -1046,19 +1050,27 @@ void dt_dev_history_commit_item_now(dt_develop_t *dev, dt_iop_module_t *module, 
   // resets; pipelines only read dev->proxy. (Bulk history loads go through pop_history_items_ext.)
   if(!IS_NULL_PTR(module) && !IS_NULL_PTR(module->commit_proxy)) module->commit_proxy(module);
 
-  // Figure out if the current history item includes masks/forms
-  GList *last_history = g_list_nth(dev->history, dt_dev_get_history_end_ext(dev) - 1);
-  dt_dev_history_item_t *hist = NULL;
+  // Figure out if the current history item includes masks/forms.
+  // Read under the lock: the write lock was released above, so the background
+  // dt_dev_write_history() job can be walking (and dropping references on) this very list.
+  // Held only for the two list walks -- the image-cache update below stays outside it, so
+  // the history_mutex -> image_cache order used by the write job is not introduced here.
   gboolean has_forms = FALSE;
+  uint64_t history_hash = DT_PIXELPIPE_CACHE_HASH_INVALID;
+  dt_pthread_rwlock_rdlock(&dev->history_mutex);
+  GList *last_history = g_list_nth(dev->history, dt_dev_get_history_end_ext(dev) - 1);
   if(last_history)
   {
-    hist = (dt_dev_history_item_t *)last_history->data;
+    dt_dev_history_item_t *hist = (dt_dev_history_item_t *)last_history->data;
     has_forms = (!IS_NULL_PTR(hist->forms));
   }
 
   // We don't update history hash in dt_dev_add_history_item_ext
   // because it can be called within loops, so that can be expensive.
-  dt_dev_set_history_hash(dev, dt_dev_history_compute_hash(dev));
+  history_hash = dt_dev_history_compute_hash(dev);
+  dt_pthread_rwlock_unlock(&dev->history_mutex);
+
+  dt_dev_set_history_hash(dev, history_hash);
   if(dev->image_storage.id > 0)
   {
     dt_image_t *cache_img = dt_image_cache_get(dev->image_storage.id, 'w');
@@ -1217,7 +1229,7 @@ void dt_dev_history_release_snapshot(GList *snapshot)
   g_list_free_full(snapshot, dt_dev_free_history_item);
 }
 
-void dt_dev_history_free_history(dt_develop_t *dev)
+void dt_dev_history_free_history(dt_develop_t *dev) REQUIRES(dev->history_mutex)
 {
   if(IS_NULL_PTR(dev->history)) return;
   // Canonical history is being cleared (image unload, compress rebuild, ...):
@@ -1331,7 +1343,7 @@ static inline void _history_to_module(const dt_dev_history_item_t *const hist, d
 }
 
 
-void dt_dev_pop_history_items_ext(dt_develop_t *dev)
+void dt_dev_pop_history_items_ext(dt_develop_t *dev) REQUIRES_SHARED(dev->history_mutex)
 {
   dt_print(DT_DEBUG_HISTORY, "[dt_dev_pop_history_items_ext] loading history entries into modules...\n");
 
@@ -1463,7 +1475,14 @@ void dt_dev_history_notify_change(dt_develop_t *dev, const int32_t imgid)
 
   if(dev->gui_attached)
   {
+    // Every caller reaches this from an unlocked context (the write job unlocks immediately
+    // before calling; the GUI and IOP call sites never hold it), so the walk of dev->history
+    // takes the read lock here rather than demanding it from callers. Released before
+    // dt_image_history_changed() below, which does mipmap and thumbnail work far too
+    // expensive to hold history_mutex across.
+    dt_pthread_rwlock_rdlock(&dev->history_mutex);
     const guint states = dt_dev_mask_history_overload(dev->history, 250);
+    dt_pthread_rwlock_unlock(&dev->history_mutex);
     if(states > 250)
       dt_history_toast(_("Image #%i history is storing %d mask states. n"
                      "Consider compressing history and removing unused masks to keep reads/writes manageable."),
@@ -1518,7 +1537,7 @@ void dt_dev_history_cleanup(void)
 
 
 
-void dt_dev_write_history_ext(dt_develop_t *dev, const int32_t imgid)
+void dt_dev_write_history_ext(dt_develop_t *dev, const int32_t imgid) REQUIRES_SHARED(dev->history_mutex)
 {
   dt_image_t *cache_img = dt_image_cache_get(imgid, 'w');
   if(IS_NULL_PTR(cache_img)) return;
@@ -1684,7 +1703,7 @@ static gboolean _dev_auto_apply_presets(dt_develop_t *dev, int32_t imgid)
  * @param module Module instance to consider.
  * @param is_inited TRUE if auto-presets were already applied.
  */
-static void _insert_default_modules(dt_develop_t *dev, dt_iop_module_t *module, gboolean is_inited)
+static void _insert_default_modules(dt_develop_t *dev, dt_iop_module_t *module, gboolean is_inited) REQUIRES(dev->history_mutex)
 {
   // Module already in history: don't prepend extra entries.
   //
@@ -1761,6 +1780,7 @@ static void _insert_default_modules(dt_develop_t *dev, dt_iop_module_t *module, 
 // Returns TRUE if this is a freshly-inited history on which we just applied auto presets and defaults,
 // FALSE if we had an earlier history
 gboolean dt_dev_init_default_history(dt_develop_t *dev, const int32_t imgid, gboolean apply_auto_presets)
+  REQUIRES(dev->history_mutex)
 {
   const gboolean is_inited = (dev->image_storage.flags & DT_IMAGE_AUTO_PRESETS_APPLIED);
 
@@ -1789,6 +1809,10 @@ int dt_dev_replace_history_on_image(dt_develop_t *dev_src, const int32_t dest_im
 
   dt_dev_ensure_image_storage(dev_src, dest_imgid);
 
+  // Same shape as dt_dev_reload_history_items(): the whole rebuild runs under the write lock,
+  // released before dt_dev_write_history(), which takes the read lock itself.
+  dt_pthread_rwlock_wrlock(&dev_src->history_mutex);
+
   if(reload_defaults)
   {
     dt_dev_init_default_history(dev_src, dest_imgid, FALSE);
@@ -1796,6 +1820,8 @@ int dt_dev_replace_history_on_image(dt_develop_t *dev_src, const int32_t dest_im
   }
 
   dt_dev_pop_history_items_ext(dev_src);
+  dt_pthread_rwlock_unlock(&dev_src->history_mutex);
+
   dt_dev_write_history(dev_src, FALSE);
 
   return 0;
@@ -1997,7 +2023,7 @@ static void _process_history_db_entry(dt_develop_t *dev, const int32_t imgid, co
                                       const int param_length, const gboolean enabled, const void *blendop_params,
                                       const int bl_length, const int blendop_version, const int multi_priority,
                                       const char *multi_name, const char *preset_name, int *legacy_params,
-                                      const gboolean presets)
+                                      const gboolean presets) REQUIRES(dev->history_mutex)
 {
   // Sanity checks
   const gboolean is_valid_id = (id == imgid);
@@ -2142,7 +2168,7 @@ static void _process_history_db_entry(dt_develop_t *dev, const int32_t imgid, co
 }
 
 
-gboolean dt_dev_read_history_ext(dt_develop_t *dev, const int32_t imgid)
+gboolean dt_dev_read_history_ext(dt_develop_t *dev, const int32_t imgid) REQUIRES(dev->history_mutex)
 {
   if(imgid == UNKNOWN_IMAGE) return FALSE;
 
@@ -2358,7 +2384,7 @@ typedef gboolean (*dt_iop_module_filter_t)(dt_iop_module_t *module);
  * @param dev Develop context.
  * @param filter Predicate deciding whether a module should be added.
  */
-static void _dev_history_add_filtered(dt_develop_t *dev, dt_iop_module_filter_t filter)
+static void _dev_history_add_filtered(dt_develop_t *dev, dt_iop_module_filter_t filter) REQUIRES(dev->history_mutex)
 {
   for(GList *item = g_list_first(dev->iop); item; item = g_list_next(item))
   {
@@ -2503,7 +2529,7 @@ void dt_dev_history_truncate(dt_develop_t *dev, const int32_t imgid)
   dt_pthread_rwlock_unlock(&dev->history_mutex);
 }
 
-void dt_dev_history_compress_or_truncate(dt_develop_t *dev)
+void dt_dev_history_compress_or_truncate(dt_develop_t *dev) REQUIRES_SHARED(dev->history_mutex)
 {
   if(dt_dev_get_history_end_ext(dev) == g_list_length(dev->history))
     dt_dev_history_compress(dev);

--- a/src/develop/develop.h
+++ b/src/develop/develop.h
@@ -227,19 +227,24 @@ typedef struct dt_develop_t
   /* Protect read & write to dev->history and dev->forms
    * and other related stuff like history_end, hashes, etc.
    *
-   * The fields below carry GUARDED_BY(history_mutex), which turns that sentence into
-   * something the compiler checks: clang's -Wthread-safety refuses any access to them that
-   * is not demonstrably under this lock. It is the same rule CLAUDE.md states in prose --
-   * "the ONLY thread-safe interface between the pixel pipeline and an IOP module is
-   * history" -- enforced instead of described.
+   * The fields below CANNOT carry GUARDED_BY(history_mutex), much as they should.
+   * Referring to a sibling struct member from a thread-safety attribute is a C++ feature:
+   * in C it only started working in clang 19. clang 18 and older reject it outright with
+   * "use of undeclared identifier 'history_mutex'", which broke the build for anyone on a
+   * distro clang -- reported against master, verified here as clang-18 failing and clang-19
+   * accepting the identical code.
+   *
+   * It looked fine locally for the worse of two reasons: the -Wthread-safety probe in
+   * cmake/modules/ was silently failing, so no local clang build had the analysis on at all,
+   * and clang does not resolve the attribute's argument when the analysis is off.
    *
    * A function that legitimately runs with the lock already held by its caller says so with
    * REQUIRES(history_mutex) rather than being exempted -- but on its DEFINITION, not its
    * declaration. dev_history.h only forward-declares dt_develop_t, and an attribute naming
    * dev->history_mutex needs the complete type; completing it there would mean including
    * this header, which includes dev_history.h back. The cycle is not worth the annotation,
-   * and little is lost: GUARDED_BY on the fields below is what actually checks every access,
-   * in every translation unit, whether or not the enclosing function declares a contract. */
+   * and with GUARDED_BY unavailable in C before clang 19 (see above), those REQUIRES on the
+   * definitions are now the only machine-checked part of this rule. */
   dt_pthread_rwlock_t history_mutex;
 
   // We don't always apply the full history to modules,
@@ -249,10 +254,10 @@ typedef struct dt_develop_t
   // (no IOP, no history entry, no item on the GList). 
   // So the index of the history
   // entry matching history_end is history_end - 1,
-  int32_t history_end GUARDED_BY(history_mutex);
+  int32_t history_end;
 
   // history stack
-  GList *history GUARDED_BY(history_mutex);
+  GList *history;
 
   // Set to 1 while a dt_dev_write_history() background job is queued or running for this
   // dev, 0 otherwise. Lets dt_dev_write_history() skip queuing a redundant full history+masks

--- a/src/develop/develop.h
+++ b/src/develop/develop.h
@@ -227,24 +227,23 @@ typedef struct dt_develop_t
   /* Protect read & write to dev->history and dev->forms
    * and other related stuff like history_end, hashes, etc.
    *
-   * The fields below CANNOT carry GUARDED_BY(history_mutex), much as they should.
-   * Referring to a sibling struct member from a thread-safety attribute is a C++ feature:
-   * in C it only started working in clang 19. clang 18 and older reject it outright with
-   * "use of undeclared identifier 'history_mutex'", which broke the build for anyone on a
-   * distro clang -- reported against master, verified here as clang-18 failing and clang-19
-   * accepting the identical code.
+   * The fields below deliberately carry NO GUARDED_BY. It cannot work for a lock that is a
+   * struct member in C: clang never rebinds the member name to the accessed object, so the
+   * requirement stays an unresolved identifier that no REQUIRES can satisfy, and every
+   * access warns forever. Measured, not assumed -- see external/ThreadSafetyAnalysis.h.
    *
-   * It looked fine locally for the worse of two reasons: the -Wthread-safety probe in
-   * cmake/modules/ was silently failing, so no local clang build had the analysis on at all,
-   * and clang does not resolve the attribute's argument when the analysis is off.
+   * What DOES check is REQUIRES/REQUIRES_SHARED on the functions themselves, against the
+   * ACQUIRE/RELEASE annotations on the dt_pthread_rwlock_t wrappers: a function that runs
+   * with the lock already held by its caller declares it, and clang then verifies the lock
+   * is actually held on every path that reaches it, and released on every path out. That
+   * catches the unbalanced and unheld-on-some-path cases, which is most of what goes wrong
+   * here. It does not catch a stray dev->history read in a function that declares nothing --
+   * that gap is the price of the C limitation above, not an oversight.
    *
-   * A function that legitimately runs with the lock already held by its caller says so with
-   * REQUIRES(history_mutex) rather than being exempted -- but on its DEFINITION, not its
-   * declaration. dev_history.h only forward-declares dt_develop_t, and an attribute naming
-   * dev->history_mutex needs the complete type; completing it there would mean including
-   * this header, which includes dev_history.h back. The cycle is not worth the annotation,
-   * and with GUARDED_BY unavailable in C before clang 19 (see above), those REQUIRES on the
-   * definitions are now the only machine-checked part of this rule. */
+   * Put those contracts on the DEFINITION, not the declaration: dev_history.h only
+   * forward-declares dt_develop_t, and an attribute naming dev->history_mutex needs the
+   * complete type; completing it there would mean including this header, which includes
+   * dev_history.h back. The cycle is not worth the annotation. */
   dt_pthread_rwlock_t history_mutex;
 
   // We don't always apply the full history to modules,

--- a/src/external/ThreadSafetyAnalysis.h
+++ b/src/external/ThreadSafetyAnalysis.h
@@ -19,6 +19,25 @@
 
 #define GUARDED_BY(x) THREAD_ANNOTATION_ATTRIBUTE__(guarded_by(x))
 
+// NOTE: do not add a GUARDED_BY variant for a lock that is a STRUCT MEMBER. It cannot work
+// in C, and the failure is silent rather than loud.
+//
+// In C++ a member's guarded_by(mu) implicitly means this->mu, so an access to obj.field
+// requires obj.mu and a method's REQUIRES(mu) satisfies it. C has no `this` and clang does
+// not synthesise one: the requirement stays the bare identifier, which no lock expression
+// can produce. Measured on clang 19 -- with a global lock, REQUIRES(g_lock) satisfies
+// GUARDED_BY(g_lock) and only the unannotated function is flagged; with a member lock,
+// REQUIRES(s->m) satisfies nothing and every access warns forever. Clang says as much:
+// "requires holding rw 'm'", unqualified.
+//
+// So GUARDED_BY is usable here only for file-scope locks. For per-instance locks, the
+// checking that does work is REQUIRES/REQUIRES_SHARED on functions, against the
+// ACQUIRE/RELEASE annotations on the lock wrappers -- that catches unbalanced and
+// unheld-on-some-path locking, which is most of what goes wrong.
+//
+// Older clang made this worse: before 19 it rejected the attribute outright with "use of
+// undeclared identifier", breaking the build rather than silently checking nothing.
+
 #define PT_GUARDED_BY(x) THREAD_ANNOTATION_ATTRIBUTE__(pt_guarded_by(x))
 
 #define ACQUIRED_BEFORE(...)                                                   \

--- a/src/iop/lens.c
+++ b/src/iop/lens.c
@@ -721,7 +721,7 @@ static ls_db_t *_ls_db(void)
   char config_detail[256] = { 0 };
 
   dt_loc_get_user_config_dir(dir, sizeof(dir));
-  snprintf(config_path, sizeof(config_path), "%s/lenses.db", dir);
+  dt_concat_path_file(config_path, dir, "lenses.db");
   tls->db = ls_db_open_diagnostic(config_path, &config_status, &config_version, config_detail,
                                   sizeof(config_detail));
 
@@ -731,7 +731,7 @@ static ls_db_t *_ls_db(void)
   if(IS_NULL_PTR(tls->db))
   {
     dt_loc_get_datadir(dir, sizeof(dir));
-    snprintf(path, sizeof(path), "%s/lenses.db", dir);
+    dt_concat_path_file(path, dir, "lenses.db");
     tls->db = ls_db_open_diagnostic(path, &data_status, &data_version, data_detail,
                                     sizeof(data_detail));
   }
@@ -2666,7 +2666,10 @@ static void camera_set(dt_iop_module_t *self, long long camera_id)
   gtk_label_set_text(GTK_LABEL(gtk_bin_get_child(GTK_BIN(g->camera_model))), fm);
   dt_free(fm);
 
-  char _variant[128];
+  // sizeof(variant) + 4, not 128: the format adds " (" and ")" around a string that can
+  // itself fill variant[], so an equal-sized buffer drops the closing parenthesis on a long
+  // camera variant. Derived from variant's size so it stays right if that changes.
+  char _variant[sizeof(variant) + 4];
   if(variant[0])
     snprintf(_variant, sizeof(_variant), " (%s)", variant);
   else

--- a/src/iop/rawdenoiseai.c
+++ b/src/iop/rawdenoiseai.c
@@ -242,12 +242,12 @@ static dt_nn_model_t *_get_model(dt_iop_rawdenoiseai_global_data_t *gd, dt_iop_r
     char path[DT_PATH_MAX] = { 0 };
     char err[256] = "";
     dt_loc_get_user_config_dir(dir, sizeof(dir));
-    snprintf(path, sizeof(path), "%s/%s", dir, name);
+    dt_concat_path_file(path, dir, name);
     gd->models[ver][sz][sc] = dt_nn_model_load(path, err, sizeof(err));
     if(!gd->models[ver][sz][sc])
     {
       dt_loc_get_datadir(dir, sizeof(dir));
-      snprintf(path, sizeof(path), "%s/%s", dir, name);
+      dt_concat_path_file(path, dir, name);
       gd->models[ver][sz][sc] = dt_nn_model_load(path, err, sizeof(err));
     }
     if(gd->models[ver][sz][sc])
@@ -277,7 +277,7 @@ static dt_nn_model_t *_get_custom_model(dt_iop_rawdenoiseai_global_data_t *gd, c
     char path[DT_PATH_MAX] = { 0 };
     char err[256] = "";
     dt_loc_get_user_config_dir(dir, sizeof(dir));
-    snprintf(path, sizeof(path), "%s/%s", dir, base);
+    dt_concat_path_file(path, dir, base);
     m = dt_nn_model_load(path, err, sizeof(err));
     g_hash_table_insert(gd->custom, g_strdup(base), m);
     if(m)

--- a/src/tests/unittests/test_dtpthread_recursive.c
+++ b/src/tests/unittests/test_dtpthread_recursive.c
@@ -30,6 +30,7 @@
  * cannot block.
  */
 
+#include "external/ThreadSafetyAnalysis.h"
 #include "system/dtpthread.h"
 
 #include <pthread.h>
@@ -41,8 +42,18 @@
 #include <stdint.h>
 #include <cmocka.h>
 
+/*
+ * These four exercise re-entrant locking on purpose, which is exactly the pattern clang's
+ * thread-safety analysis is built to reject: it models a lock as held or not held, so a
+ * second acquisition by the owner reads as "acquiring a lock that is already held" and the
+ * matching second release as "releasing a lock that was not held". The behaviour under test
+ * is real and deliberate (see dtpthread.h); the analysis simply has no way to express it.
+ * Exempting the test bodies keeps the tree's finding count honest -- these are not defects
+ * anyone can fix, and left in they would mask ones that are.
+ */
+
 /** The property, stated without risking a hang: the owner can take it again. */
-static void _a_null_attr_mutex_is_recursive(void **state)
+static void _a_null_attr_mutex_is_recursive(void **state) NO_THREAD_SAFETY_ANALYSIS
 {
   (void)state;
   dt_pthread_mutex_t mutex;
@@ -60,7 +71,7 @@ static void _a_null_attr_mutex_is_recursive(void **state)
 
 /** The same through the blocking entry point, which is what callers actually use.
  * Safe to run only because the test above already proved it cannot block. */
-static void _the_blocking_lock_also_re_enters(void **state)
+static void _the_blocking_lock_also_re_enters(void **state) NO_THREAD_SAFETY_ANALYSIS
 {
   (void)state;
   dt_pthread_mutex_t mutex;
@@ -76,7 +87,7 @@ static void _the_blocking_lock_also_re_enters(void **state)
 }
 
 /** An explicit attribute still wins: this is the override path, not a hardcoded policy. */
-static void _an_explicit_attribute_is_honoured(void **state)
+static void _an_explicit_attribute_is_honoured(void **state) NO_THREAD_SAFETY_ANALYSIS
 {
   (void)state;
   pthread_mutexattr_t errorcheck;
@@ -100,7 +111,7 @@ static void _an_explicit_attribute_is_honoured(void **state)
  * This is the deadlock fix rather than a convenience: glibc's default
  * PREFER_WRITER_NONRECURSIVE policy blocks a re-entering thread as soon as another writer
  * is queued, and dt_dev_pixelpipe_change() can re-enter while holding history_mutex. */
-static void _an_rwlock_writer_may_re_enter(void **state)
+static void _an_rwlock_writer_may_re_enter(void **state) NO_THREAD_SAFETY_ANALYSIS
 {
   (void)state;
   dt_pthread_rwlock_t lock;


### PR DESCRIPTION
Started as a hotfix for master being unbuildable on clang 18 and older. Pulling on it found
the reason nobody noticed locally, and then two real races.

### The reported breakage

```
develop.h:252:34: error: use of undeclared identifier 'history_mutex'
  252 |   int32_t history_end GUARDED_BY(history_mutex);
```

Referring to a sibling struct member from a thread-safety attribute is a C++ feature; in C it
only started parsing in clang 19. Verified both directions on the same minimal file.

### Why it looked fine locally, which is the worse half

`CHECK_COMPILER_FLAG_AND_ENABLE_IT(-Wthread-safety)` built the probe's result variable out of
the flag text and passed it as `-D`:

```
-DC_COMPILER_UNDERSTANDS_-Wthread-safety
```

Not a valid macro name. The probe compile failed, the flag was recorded as unsupported, and it
was dropped — silently, because a failed probe is indistinguishable from a compiler that lacks
the flag. **Every flag containing a character illegal in an identifier went the same way.** And
clang does not resolve a thread-safety attribute's argument when the analysis is off, so
annotations that could not possibly work still compiled clean.

### GUARDED_BY cannot work here at all

Reinstating it behind a `__clang_major__ >= 19` guard was the plan. Measuring killed it:

| Lock | Annotated function | Unannotated function |
| --- | --- | --- |
| file-scope | satisfied, no warning | warned — correct |
| struct member | **warned** | warned |

Clang reports the requirement as `requires holding rw 'm'` — unqualified, never `s->m`. In C++
a member's `guarded_by(mu)` means `this->mu`; C has no `this` and clang does not synthesise
one. For a per-instance lock it is unsatisfiable on **every** version — it would have meant 68
permanent warnings on `src/develop` alone. The measurement now lives next to the macro.

### What the analysis did find, once it actually ran

`dev_history.c` reported 26 findings. Four were annotations pointing backwards — functions that
acquire the lock *and* demanded it from callers. Correcting those left two genuine defects:

- **`dt_dev_history_commit_item_now()`** released the write lock, then walked `dev->history`
  twice with nothing held, while the background write job can be walking and dropping
  references on the same items. Reading `hist->forms` off an item that job is releasing is a
  use-after-free, not a stale read.
- **`dt_dev_history_notify_change()`** walked `dev->history` unlocked from all eight of its call
  sites — one of which unlocks on the line immediately above the call.

`dev_history.c` is now clean under `-Wthread-safety`.

### Also here

- Three `-Wformat-truncation` fixes, one a **real truncation**: `lens.c` formatted `" (%s)"` of
  a `char[128]` into a `char[128]`, losing the last three characters and the closing paren.
- `common.h` moved out of the test-compiled OpenCL program list; it is a header included by 31
  of the 34 `.cl` files. Installed output unchanged.
- `doc/lock-audit.md` corrected — it claimed the fields were `GUARDED_BY` and credited that for
  taking `dev_history.c` to zero. Both halves were wrong.
- The four re-entrant cases in `test_dtpthread_recursive.c` carry `NO_THREAD_SAFETY_ANALYSIS`:
  they re-acquire a lock they hold on purpose, which is the property under test and precisely
  what the analysis is built to reject. 8 findings nobody could ever fix.

### Verification

- **GCC Debug**: 1155 targets, 0 errors, 0 warnings. The probe fix correctly reports
  `-Wthread-safety` as unsupported for GCC rather than smuggling it in — GCC treats
  `-Wno-error=` naming an unknown option as a hard error, which broke every GCC Debug build
  once already.
- **clang-18**: compiles `dev_history.c` cleanly — the reported breakage is gone.
- **clang Debug tree-wide**: 514 TUs, 0 compile errors, 30 thread-safety findings in 5 files —
  the pre-existing backlog, unchanged, with `dev_history.c` and the test file absent.
- **Runtime**: 13/13 built unit tests pass including `test_dtpthread_recursive`; a CLI export
  runs and exits cleanly.

One commit per topic, for bisection.