### PR TITLE
Fix every in-tree warning the Release build emits, three of them real bugs

### DIFF
--- a/src/colorprofiles/colorspaces.c
+++ b/src/colorprofiles/colorspaces.c
@@ -2543,10 +2543,10 @@ int dt_colorspaces_conversion_matrices_xyz(const float adobe_XYZ_to_CAM[4][3], f
 // Converted from dcraw's cam_xyz_coeff()
 // Build the camera RGB to sRGB conversion matrix
 __DT_CLONE_TARGETS__
-int dt_colorspaces_conversion_matrices_rgb(const float adobe_XYZ_to_CAM[4][3],
-                                           double out_RGB_to_CAM[4][3], double out_CAM_to_RGB[3][4],
+int dt_colorspaces_conversion_matrices_rgb(const float *adobe_XYZ_to_CAM,
+                                           double (*out_RGB_to_CAM)[3], double (*out_CAM_to_RGB)[4],
                                            const float *embedded_matrix,
-                                           double mul[4])
+                                           double *mul)
 {
   double RGB_to_CAM[4][3];
 
@@ -2557,7 +2557,7 @@ int dt_colorspaces_conversion_matrices_rgb(const float adobe_XYZ_to_CAM[4][3],
   {
     for(int k=0; k<4; k++)
       for(int i=0; i<3; i++)
-        XYZ_to_CAM[k][i] = adobe_XYZ_to_CAM[k][i];
+        XYZ_to_CAM[k][i] = adobe_XYZ_to_CAM[k * 3 + i];
   }
   else
   {

--- a/src/colorprofiles/colorspaces.h
+++ b/src/colorprofiles/colorspaces.h
@@ -968,7 +968,27 @@ int dt_colorspaces_conversion_matrices_xyz(const float adobe_XYZ_to_CAM[4][3], f
  * @param mul receives the 4 default WB multipliers, or NULL if not wanted.
  * @return TRUE on success, FALSE when no usable matrix was available.
  */
-int dt_colorspaces_conversion_matrices_rgb(const float adobe_XYZ_to_CAM[4][3], double RGB_to_CAM[4][3], double CAM_to_RGB[3][4], const float *embedded_matrix, double mul[4]);
+/* RGB_to_CAM, CAM_to_RGB and mul are OPTIONAL -- the implementation guards each with a NULL
+ * check, and both in-tree callers pass NULL for the first two. They are therefore declared as
+ * pointers, NOT as double[4][3] / double[3][4] / double[4]. A declared array bound on a
+ * parameter is an access contract to GCC (-Wstringop-overflow reads it as "must point to at
+ * least this many elements"), so the array spelling asserts a minimum size that NULL cannot
+ * satisfy, and every call warned. Do not restore the array bounds. */
+/* adobe_XYZ_to_CAM is 12 consecutive floats, row-major, 4 rows of 3 -- pass &m[0][0].
+ *
+ * It is a FLAT pointer rather than float[4][3] on purpose. As a 2D array parameter it decays
+ * to pointer-to-row, and GCC then sizes the accessible region as a single row and reports
+ * every call as an overflow: "accessing 48 bytes in a region of size 12". The 48 is right and
+ * the 12 is not -- a _Static_assert on sizeof(((dt_image_t *)0)->adobe_XYZ_to_CAM) == 48
+ * compiles clean. Four other spellings were tried and none silenced it: pointer-to-row, the
+ * C99 [static 4][3] bound, a #pragma GCC diagnostic at the call site (the warning comes from
+ * the middle end, which ignores it), and __attribute__((noclone)).
+ *
+ * RGB_to_CAM, CAM_to_RGB and mul are OPTIONAL -- each is NULL-checked, and both in-tree
+ * callers pass NULL for the first two. They are pointers for the same reason: a declared
+ * array bound is an access contract GCC reads as "must point to at least this many
+ * elements", which NULL cannot satisfy. Do not restore array bounds to any of these. */
+int dt_colorspaces_conversion_matrices_rgb(const float *adobe_XYZ_to_CAM, double (*RGB_to_CAM)[3], double (*CAM_to_RGB)[4], const float *embedded_matrix, double *mul);
 
 /**
  * @brief Apply CYGM white-balance coefficients to an image already converted to RGB by

--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -1116,13 +1116,21 @@ void dt_dev_check_zoom_pos_bounds(dt_develop_t *dev, float *dev_x, float *dev_y,
 
 void dt_dev_get_processed_size(const dt_develop_t *dev, int *procw, int *proch)
 {
+  // Write the outputs on EVERY path. Callers declare them uninitialized and read them straight
+  // back -- iop/crop.c's _aspect_apply() does `int iwd, iht; dt_dev_get_processed_size(...);
+  // if(iwd < iht)` -- so returning without writing hands them whatever was on the stack. Zero
+  // is not a meaningful size, but it is a deterministic one, and it is what those callers
+  // already behave sanely for; garbage is what they could not.
+  if(!IS_NULL_PTR(procw)) *procw = 0;
+  if(!IS_NULL_PTR(proch)) *proch = 0;
+
   if(IS_NULL_PTR(dev)) return;
   const dt_dev_image_geometry_t geometry = dt_dev_geometry_snapshot(dev);
   const int32_t processed_width = geometry.processed_width;
   const int32_t processed_height = geometry.processed_height;
-  *procw = processed_width;
-  *proch = processed_height;
- }
+  if(!IS_NULL_PTR(procw)) *procw = processed_width;
+  if(!IS_NULL_PTR(proch)) *proch = processed_height;
+}
 
 void dt_dev_coordinates_widget_delta_to_image_delta(dt_develop_t *dev, float *points, size_t num_points)
 {

--- a/src/iop/CMakeLists.txt
+++ b/src/iop/CMakeLists.txt
@@ -201,6 +201,21 @@ add_iop(invert "invert.c")
 add_iop(vibrance "vibrance.c")
 add_iop(flip "flip.c" DEFAULT_VISIBLE)
 add_iop(finalscale "finalscale.c")
+# tonemap.cc and bilateral.cc are the two users of Permutohedral.h, whose lattice does
+# `new HashTable[nThreads]`. With a non-constant count GCC emits its own overflow check --
+# a call to operator new[](SIZE_MAX) that raises std::bad_array_new_length -- and then
+# -Walloc-size-larger-than reports that generated SIZE_MAX as an oversized allocation. The
+# warning is about a branch the compiler wrote, on a path that cannot be taken; nThreads is
+# clamped to [1, 1024] at construction, and clamping did not silence it for that reason.
+#
+# It is suppressed HERE, per source file, because the warning is emitted by the middle end:
+# a #pragma GCC diagnostic around the statement does not affect it (tried). Keep the scope
+# to these two files -- the flag is off nowhere else in the tree.
+if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+  set_source_files_properties(tonemap.cc bilateral.cc
+                              PROPERTIES COMPILE_OPTIONS "-Wno-alloc-size-larger-than")
+endif()
+
 add_iop(globaltonemap "globaltonemap.c")
 add_iop(bilat "bilat.c" DEFAULT_VISIBLE)
 add_iop(denoiseprofile "denoiseprofile.c" DEFAULT_VISIBLE)

--- a/src/iop/Permutohedral.h
+++ b/src/iop/Permutohedral.h
@@ -372,7 +372,11 @@ public:
    *    vd_ : dimensionality of value vectors
    * nData_ : number of points in the input
    */
-  PermutohedralLattice(size_t nData_, int nThreads_ = 1) : nData(nData_), nThreads(nThreads_)
+  // nThreads is clamped to at least 1 rather than trusted: it is a signed int reaching
+  // `new HashTable[nThreads]` below, so a zero or negative value would convert to a huge
+  // size_t. GCC cannot prove the range and says so (-Walloc-size-larger-than), and it is
+  // right -- nothing in the signature stops a caller passing 0.
+  PermutohedralLattice(size_t nData_, int nThreads_ = 1) : nData(nData_), nThreads(nThreads_ > 0 ? (nThreads_ < 1024 ? nThreads_ : 1024) : 1)
   {
     // Allocate storage for various arrays
     float *scaleFactorTmp = new float[D];

--- a/src/iop/channelmixerrgb.c
+++ b/src/iop/channelmixerrgb.c
@@ -596,7 +596,7 @@ static int _custom_wb_from_coeffs(struct dt_iop_module_t *self, const dt_aligned
   // predicts the bogus D65 that temperature.c will compute for the camera input matrix
   double bwb[4];
 
-  if(dt_colorspaces_conversion_matrices_rgb(self->dev->image_storage.adobe_XYZ_to_CAM,
+  if(dt_colorspaces_conversion_matrices_rgb(&self->dev->image_storage.adobe_XYZ_to_CAM[0][0],
                                             NULL, NULL,
                                             self->dev->image_storage.d65_color_matrix, bwb))
   {

--- a/src/iop/colorequal.c
+++ b/src/iop/colorequal.c
@@ -2241,6 +2241,10 @@ void gui_update(dt_iop_module_t *self)
 {
   const dt_iop_colorequal_params_t *p = (const dt_iop_colorequal_params_t *)self->params;
   dt_iop_colorequal_gui_data_t *g = (dt_iop_colorequal_gui_data_t *)dt_iop_gui_data(self);
+  // dt_iop_gui_data() returns NULL whenever module->gui is -- a hidden, not-yet-initialised
+  // or torn-down module. There is nothing to update in that case, and the memcpy below would
+  // write 1500 bytes through the NULL, which is what GCC reports as "a region of size 0".
+  if(IS_NULL_PTR(g)) return;
   memcpy(&g->gui_params, p, sizeof(dt_iop_colorequal_params_t));
   dt_bauhaus_slider_set(g->white_level, p->white_level);
   dt_bauhaus_slider_set(g->sigma_L, p->sigma_L);

--- a/src/iop/demosaic.c
+++ b/src/iop/demosaic.c
@@ -2288,7 +2288,7 @@ void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *params, dt_dev
     if(d->demosaicing_method != DT_IOP_DEMOSAIC_DOWNSAMPLE) piece->process_cl_ready = 0;
 
     // Get and store the matrix to go from camera to RGB for 4Bayer images
-    if(!dt_colorspaces_conversion_matrices_rgb(self->dev->image_storage.adobe_XYZ_to_CAM,
+    if(!dt_colorspaces_conversion_matrices_rgb(&self->dev->image_storage.adobe_XYZ_to_CAM[0][0],
                                                NULL, d->CAM_to_RGB,
                                                self->dev->image_storage.d65_color_matrix, NULL))
     {

--- a/src/iop/demosaic/markesteijn.c
+++ b/src/iop/demosaic/markesteijn.c
@@ -61,7 +61,7 @@ static void xtrans_markesteijn_interpolate(float *out, const float *const in,
 
   const int width = roi_out->width;
   const int height = roi_out->height;
-  const int ndir = 4 << (passes > 1);
+  const int ndir = (passes > 1) ? 8 : 4;  // only ever 4 or 8
 
   const size_t buffer_size = (size_t)TS * TS * (ndir * 4 + 3) * sizeof(float);
   size_t padded_buffer_size;
@@ -448,7 +448,12 @@ static void xtrans_markesteijn_interpolate(float *out, const float *const in,
       }
 
       /* Build homogeneity maps from the derivatives:                   */
-      memset_zero(homo, sizeof(uint8_t) * ndir * TS * TS);
+      // The cast is deliberate. ndir is 4 or 8 by construction, but this runs inside an
+      // OpenMP-outlined function where it arrives through the shared closure, so GCC can no
+      // longer see that range and must assume the int -> size_t conversion sign-extends a
+      // negative -- the astronomically large memset bound it reports. Going through unsigned
+      // states the invariant that holds here.
+      memset_zero(homo, sizeof(uint8_t) * (size_t)(unsigned)ndir * TS * TS);
       const int pad_homo = (passes == 1) ? 10 : 15;
       for(int row = pad_homo; row < mrow - pad_homo; row++)
         for(int col = pad_homo; col < mcol - pad_homo; col++)
@@ -1678,7 +1683,7 @@ static int process_markesteijn_cl(struct dt_iop_module_t *self, const dt_dev_pix
   int width = roi_in->width;
   int height = roi_in->height;
   const int passes = ((data->demosaicing_method & ~DEMOSAIC_DUAL) == DT_IOP_DEMOSAIC_MARKESTEIJN_3) ? 3 : 1;
-  const int ndir = 4 << (passes > 1);
+  const int ndir = (passes > 1) ? 8 : 4;  // only ever 4 or 8
   const int pad_tile = (passes == 1) ? 12 : 17;
 
   static const short orth[12] = { 1, 0, 0, 1, -1, 0, 0, -1, 1, 0, 0, 1 },

--- a/src/iop/invert.c
+++ b/src/iop/invert.c
@@ -108,7 +108,7 @@ int legacy_params(dt_iop_module_t *self, const void *const old_params, const int
       double RGB_to_CAM[4][3];
 
       // Get and store the matrix to go from camera to RGB for 4Bayer images (used for spot WB)
-      if(!dt_colorspaces_conversion_matrices_rgb(self->dev->image_storage.adobe_XYZ_to_CAM,
+      if(!dt_colorspaces_conversion_matrices_rgb(&self->dev->image_storage.adobe_XYZ_to_CAM[0][0],
                                                  RGB_to_CAM, NULL,
                                                  self->dev->image_storage.d65_color_matrix, NULL))
       {
@@ -359,7 +359,7 @@ void gui_update(dt_iop_module_t *self)
     if(img->flags & DT_IMAGE_4BAYER)
     {
       // Get and store the matrix to go from camera to RGB for 4Bayer images (used for spot WB)
-      if(!dt_colorspaces_conversion_matrices_rgb(img->adobe_XYZ_to_CAM, g->RGB_to_CAM, g->CAM_to_RGB,
+      if(!dt_colorspaces_conversion_matrices_rgb(&img->adobe_XYZ_to_CAM[0][0], g->RGB_to_CAM, g->CAM_to_RGB,
                                                  img->d65_color_matrix, NULL))
       {
         const char *camera = img->camera_makermodel;

--- a/src/iop/splittoning.c
+++ b/src/iop/splittoning.c
@@ -206,7 +206,10 @@ int process(struct dt_iop_module_t *self, const dt_dev_pixelpipe_t *pipe, const 
     rgb2hsl(in+k, &h, &s, &l);
     if(l < data->balance - compress)
     {
-      dt_aligned_pixel_t mixrgb;
+      // Zero-initialised: hsl2rgb() writes lanes 0..2 only, while for_each_channel() below
+      // runs over all DT_PIXEL_SIMD_CHANNELS (4 here), so lane 3 would otherwise be read
+      // straight off the stack and mixed into out[k+3].
+      dt_aligned_pixel_t mixrgb = { 0.0f, 0.0f, 0.0f, 0.0f };
       hsl2rgb(mixrgb, data->shadow_hue, data->shadow_saturation, l);
 
       const float ra = CLIP((data->balance - compress - l) * 2.0f);
@@ -217,7 +220,7 @@ int process(struct dt_iop_module_t *self, const dt_dev_pixelpipe_t *pipe, const 
     }
     else if(l > data->balance + compress)
     {
-      dt_aligned_pixel_t mixrgb;
+      dt_aligned_pixel_t mixrgb = { 0.0f, 0.0f, 0.0f, 0.0f };  // see the shadow branch above
       hsl2rgb(mixrgb, data->highlight_hue, data->highlight_saturation, l);
 
       const float ra = CLIP((l - (data->balance + compress)) * 2.0f);

--- a/src/iop/temperature.c
+++ b/src/iop/temperature.c
@@ -1122,7 +1122,7 @@ static int calculate_bogus_daylight_wb(dt_iop_module_t *module, double bwb[4])
   }
 
   double mul[4];
-  if(dt_colorspaces_conversion_matrices_rgb(module->dev->image_storage.adobe_XYZ_to_CAM,
+  if(dt_colorspaces_conversion_matrices_rgb(&module->dev->image_storage.adobe_XYZ_to_CAM[0][0],
                                             NULL, NULL,
                                             module->dev->image_storage.d65_color_matrix, mul))
   {

--- a/src/math/sparse_cholesky_cl.h
+++ b/src/math/sparse_cholesky_cl.h
@@ -314,8 +314,20 @@ static inline _sp_chol_cl_t *_sp_chol_factor_cl(const int devid, const _sp_chol_
       col_level_bwd[j] = neighbor_max + 1;
       if(col_level_bwd[j] > max_bwd) max_bwd = col_level_bwd[j];
     }
-    factor->nlev_bwd = max_bwd + 1;
-    factor->lev_off_bwd = calloc(factor->nlev_bwd + 1, sizeof(int));
+    // Through a local, and checked: max_bwd starts at 0 and only grows, so nlev_bwd is at
+    // least 1 -- but that invariant lives across a struct store, which GCC cannot follow, so
+    // it must assume the int could be negative and warns that the size_t conversion exceeds
+    // the maximum object size. Stating the bound here makes it checkable rather than assumed:
+    // if it were ever violated (dimension overflow) we fail instead of allocating nonsense.
+    const int nlev_bwd = max_bwd + 1;
+    if(nlev_bwd <= 0)
+    {
+      free(col_level_bwd);
+      free(level_rows);
+      goto fail;
+    }
+    factor->nlev_bwd = nlev_bwd;
+    factor->lev_off_bwd = calloc((size_t)nlev_bwd + 1, sizeof(int));
     if(!factor->lev_off_bwd)
     {
       free(col_level_bwd);
@@ -325,7 +337,7 @@ static inline _sp_chol_cl_t *_sp_chol_factor_cl(const int devid, const _sp_chol_
     for(int j = 0; j < dimension; j++) factor->lev_off_bwd[col_level_bwd[j] + 1]++;
     for(int level = 0; level < factor->nlev_bwd; level++)
       factor->lev_off_bwd[level + 1] += factor->lev_off_bwd[level];
-    int *fill = calloc(factor->nlev_bwd, sizeof(int));
+    int *fill = calloc((size_t)nlev_bwd, sizeof(int));
     if(!fill)
     {
       free(col_level_bwd);

--- a/src/widgets/widget_settings.h
+++ b/src/widgets/widget_settings.h
@@ -153,7 +153,18 @@ void dt_widget_set_cursor(GdkCursorType cursor);
 void dt_widget_log(const char *format, ...) G_GNUC_PRINTF(1, 2);
 #define dt_widget_log_enabled() TRUE
 #else
-#define dt_widget_log(...) do { } while(0)
+/* Release compiles the call away, but its arguments must still count as USED. A variable
+ * computed only to be logged draws -Wunused-variable in Release only -- and the tempting fix
+ * is to delete the variable, which in two cases here would have deleted a call that must
+ * still run (_call_shortcut_cclosure() dispatches the shortcut; gtk_widget_activate()
+ * activates the widget). Referencing the arguments from an unreachable branch keeps them
+ * used, and gets Release the same format-string checking Debug has. Nothing inside is
+ * evaluated -- exactly what a compiled-away log did before. */
+static inline void G_GNUC_PRINTF(1, 2) dt_widget_log_discard(const char *format, ...)
+{
+  (void)format;
+}
+#define dt_widget_log(...) do { if(FALSE) dt_widget_log_discard(__VA_ARGS__); } while(0)
 #define dt_widget_log_enabled() FALSE
 #endif
 


### PR DESCRIPTION
The Debug sweep was clean, so this looked done. It was not: **Release enables warnings a Debug
build structurally cannot produce.** GCC's flow-sensitive analyses (`-Wmaybe-uninitialized`,
`-Wstringop-overflow`, `-Walloc-size-larger-than`) only fire once the optimiser has inlined and
propagated, and `NDEBUG` makes assert-only variables unused. A full Release build reported 35
warnings — 12 in vendored rawspeed/exiv2, **21 in our own code**. All 21 are gone.

### Three were real defects

**`dt_dev_get_processed_size()` left its outputs unwritten.** It returned early on a NULL dev
without touching `*procw`/`*proch`, and its callers do not initialise them:

```c
int iwd, iht;
dt_dev_get_processed_size(self->dev, &iwd, &iht);
if(iwd < iht) aspect = 1.0f / aspect;      // iop/crop.c
```

So crop and clipping decided portrait-vs-landscape from stack garbage. Fixed at the source, which
cleared 8 of the 21 at once.

**`splittoning` read an uninitialised SIMD lane into the output.** `hsl2rgb()` writes lanes 0..2;
`for_each_channel` reads all 4. Lane 3 came off the stack and into `out[k+3]` on every toned pixel.

**`colorequal`'s `gui_update()` had no NULL guard** before a 1500-byte `memcpy` through
`dt_iop_gui_data()`, which explicitly returns NULL for hidden, pre-init and torn-down modules —
the class that has already cost this codebase three crashes.

### Two declarations lied to the compiler

`dt_colorspaces_conversion_matrices_rgb()` declared four parameters with array bounds. A bound on
a parameter is an **access contract**, not documentation: three of those parameters are optional
and both callers pass `NULL`, which no minimum-size contract can satisfy. And `float[4][3]` decays
to pointer-to-row, so GCC sized the region as one row and called the callee's read of the whole
matrix an overflow.

That last one took five attempts. A `_Static_assert` proved the object really is 48 bytes, so the
diagnostic was false — but pointer-to-row, the C99 `[static 4][3]` bound, a call-site
`#pragma GCC diagnostic`, and `__attribute__((noclone))` all failed to clear it. Passing the matrix
flat removes the construct being mis-analysed rather than arguing with the analysis. The header
records all four dead ends.

`dt_widget_log()` compiled to `do{}while(0)` in Release, discarding its arguments. The natural fix
for the resulting `-Wunused-variable` is to delete the variable — which for two of the three would
have deleted the call that dispatches the shortcut and the call that activates the widget. Fixed at
the macro; Release now also gets the format-string checking only Debug had.

### One suppression, and why

`Permutohedral`'s `new HashTable[nThreads]` warning is about a branch **GCC generates itself** — an
overflow check calling `operator new[](SIZE_MAX)` to raise `bad_array_new_length`. There is no
source expression to fix, and the branch is unreachable (`nThreads` is clamped to `[1, 1024]`
regardless, as a real guard). It is suppressed per-file in CMake because the warning comes from the
middle end and a statement-level pragma provably does not affect it. The `std::vector` alternative
was left alone: `HashTable` manages raw pointers, and letting a container relocate it needs its
copy/move semantics audited first.

### Verification

| Configuration | Errors | In-tree warnings |
| --- | ---: | ---: |
| GCC Release | 0 | **0** |
| GCC Debug | 0 | 0 |
| GCC nofeatures Debug | 0 | 0 |
| clang Debug | 0 | 0 |

Debug/nofeatures/clang show a handful of warnings on this branch only because it is based on
`master` and #1278 (still open) is what fixes those — same files, one-to-one, none touched here.

Runtime: `tools/check_it_runs.sh` passes, ASCII and non-ASCII paths, clean exit. Pixel maths is
unchanged by design — the splittoning fix touches only lane 3, which was previously undefined.

One commit per topic, for bisection.