### PR TITLE
Sentry crashes and SonarCloud: four crash fixes, three real defects, and triage of the rest

### DIFF
--- a/.sonarcloud.properties
+++ b/.sonarcloud.properties
@@ -113,8 +113,26 @@ sonar.issue.ignore.multicriteria.lockmodel3.resourceKey=src/system/dtpthread.h
 # appear in no CMake target and no file includes them." Same case as src/apps/ansel-chart/
 # below -- findings there are neither reachable nor actionable, and fixing them would mean
 # editing code that cannot be compiled to check the edit.
+# data/themes/ansel.css is a GTK stylesheet, not a web one. GTK reuses CSS syntax over an
+# entirely different element model: its type selectors are WIDGET NODE NAMES (window, notebook,
+# treeview, scrolledwindow, entry, scrollbar...), and it adds constructs no browser has --
+# @define-color, -gtk-icon-*, :backdrop, :selected (159 occurrences in this one file).
+#
+# Sonar's CSS analyser validates against the HTML element set, so every one of those correct
+# GTK selectors is reported as an unknown type selector. That is 311 issues from this single
+# file -- 234 of them css:S4670 -- which is 70% of the project's entire reliability count, and
+# not one of them is actionable: "fixing" a selector would break the theme it styles.
+#
+# Excluded here rather than by rule, because sonar.issue.ignore.* is NOT honoured under
+# automatic analysis (measured: the pre-existing restrict1 and lockmodel entries in this file
+# have never suppressed anything). sonar.exclusions IS honoured, so it is the mechanism that
+# works.
+#
+# Scoped to data/themes/ deliberately. The other stylesheets in this tree -- data/style/,
+# data/pswp/, doc/ -- ARE web CSS, shipped in the HTML gallery export and the documentation,
+# and stay analysed.
 sonar.exclusions=src/external/**, doc/doxygen-awesome-css/**, tests/image_test/samples/**, \
-  src/apps/ansel-chart/**, src/math/attic/**, \
+  src/apps/ansel-chart/**, src/math/attic/**, data/themes/**, \
   **/*.py, **/*.sh, **/*.bash, **/*.pl, **/*.rb, **/*.lua, \
   **/*.yml, **/*.yaml, **/*.md, **/*.xsl, **/*.xslt, \
   **/CMakeLists.txt, **/*.cmake

--- a/src/colorprofiles/iop_profile.c
+++ b/src/colorprofiles/iop_profile.c
@@ -1088,6 +1088,22 @@ cleanup:
  * ------------------------------------------------------------------------- */
 
 static GList *_profile_info_memo = NULL;
+
+/* Entries evicted from the memo but NOT yet freed. dt_colorspaces_add_profile() hands out a
+ * pointer the caller keeps -- dt_dev_pixelpipe_t::output_profile_info caches one for the
+ * lifetime of a pipe, and GUI code reads it from callbacks that run long after the pipe did.
+ * Freeing an entry on eviction leaves every one of those pointers dangling, and the eviction
+ * is not a rare event: it happens whenever the monitor profile changes, i.e. on a window move
+ * between monitors, which is also exactly when things repaint.
+ *
+ * So an evicted entry is retired rather than freed, and released at shutdown. The cost is
+ * bounded by the number of profile changes in a session -- a handful of ~1.5 MB entries in a
+ * pathological one -- against a use-after-free in the pixel path (Sentry 141501108: SIGSEGV in
+ * _apply_trc() reading a freed profile's LUTs from a pipe-finished callback).
+ *
+ * This mirrors what dt_conf_get_string_const() does with replaced values, and for the same
+ * reason: the API hands out a borrowed pointer with no way to tell the borrower it expired. */
+static GList *_profile_info_retired = NULL;
 /* Raw pthread type, like this module's other locks: dt_pthread_mutex_t is a struct
  * wrapper in Debug builds, so a static PTHREAD_MUTEX_INITIALIZER would be initialising
  * a subobject -- which clang rejects under -Werror and gcc silently accepts. */
@@ -1101,6 +1117,14 @@ void dt_colorspaces_flush_profile_memo(void)
     dt_iop_order_iccprofile_info_t *entry = (dt_iop_order_iccprofile_info_t *)_profile_info_memo->data;
     dt_ioppr_cleanup_profile_info(&entry);
     _profile_info_memo = g_list_delete_link(_profile_info_memo, _profile_info_memo);
+  }
+  // Retired entries go the same way. This runs at teardown, when no consumer is left to hold
+  // one; releasing them earlier is what the retirement exists to avoid.
+  while(_profile_info_retired)
+  {
+    dt_iop_order_iccprofile_info_t *entry = (dt_iop_order_iccprofile_info_t *)_profile_info_retired->data;
+    dt_ioppr_cleanup_profile_info(&entry);
+    _profile_info_retired = g_list_delete_link(_profile_info_retired, _profile_info_retired);
   }
   pthread_mutex_unlock(&_profile_info_lock);
 }
@@ -1121,7 +1145,8 @@ void dt_colorspaces_invalidate_display_profile_memo(void)
     dt_iop_order_iccprofile_info_t *entry = (dt_iop_order_iccprofile_info_t *)l->data;
     if(entry && entry->type == DT_COLORSPACE_DISPLAY)
     {
-      dt_ioppr_cleanup_profile_info(&entry);
+      // Retired, not freed: consumers hold this pointer (see _profile_info_retired).
+      _profile_info_retired = g_list_prepend(_profile_info_retired, entry);
       _profile_info_memo = g_list_delete_link(_profile_info_memo, l);
     }
     l = next;

--- a/src/common/colorchecker.c
+++ b/src/common/colorchecker.c
@@ -661,6 +661,10 @@ static gboolean _dispatch_cht_data(GList **boxes, dt_colorchecker_chart_spec_t *
     const char letter = tokens[0][0];
     if(letter == 'F')
     {
+      // A CHT file describes exactly one frame, but nothing here parses a trusted file --
+      // releasing any previous one keeps a malformed input with several F lines from leaking
+      // all but the last. dt_free() on the NULL first pass is a no-op.
+      dt_free(F_box);
       F_box = _dt_cht_extract_F(tokens);
     }
 

--- a/src/common/colorchecker.h
+++ b/src/common/colorchecker.h
@@ -612,8 +612,26 @@ static dt_color_checker_t *dt_get_color_checker(const dt_color_checker_targets t
 
     // Get the label data from the list
     const dt_colorchecker_label_t *label_data = (const dt_colorchecker_label_t*)g_list_nth_data(*colorchecker_label, target_type);
-    checker_type = COLOR_CHECKER_USER_REF;
-    cht_filename = label_data->path;
+    if(IS_NULL_PTR(label_data))
+    {
+      // g_list_nth_data() returns NULL past the end of the list, and target_type is an index
+      // that can outlive what it indexes: it comes from saved module params, while the list is
+      // rebuilt at runtime from the user's reference files. Delete or move one of those files
+      // and every later index shifts; the builtin prefix can shift too, since
+      // dt_colorchecker_find_builtin() skips any builtin with no patches.
+      //
+      // Falls through to the COLOR_CHECKER_LAST arm below, which reports and copies the
+      // default checker -- the same handling an unknown type already gets.
+      fprintf(stderr,
+              "dt_get_color_checker: no colorchecker label at index %i, falling back to the default\n",
+              target_type);
+      checker_type = COLOR_CHECKER_LAST;
+    }
+    else
+    {
+      checker_type = COLOR_CHECKER_USER_REF;
+      cht_filename = label_data->path;
+    }
   }
   else // it's a builtin colorchecker
     checker_type = target_type;

--- a/src/common/opencl.c
+++ b/src/common/opencl.c
@@ -1975,6 +1975,14 @@ int dt_opencl_load_program(const int dev, const int prog, const char *filename, 
         size_t cached_filesize = cachedstat.st_size;
 
         unsigned char *cached_content = (unsigned char *)malloc(cached_filesize + 1);
+        if(IS_NULL_PTR(cached_content))
+        {
+          dt_print(DT_DEBUG_OPENCL,
+                   "[opencl_load_program] could not allocate %zu bytes for cached binary '%s'!\n",
+                   cached_filesize + 1, binname);
+          fclose(cached);
+          return 0;
+        }
         rd = fread(cached_content, sizeof(char), cached_filesize, cached);
         if(rd != cached_filesize)
         {

--- a/src/common/utility.c
+++ b/src/common/utility.c
@@ -919,26 +919,34 @@ char *dt_read_file(const char *const filename, size_t *filesize)
 
 void dt_copy_file(const char *const sourcefile, const char *dst)
 {
-  char *content = NULL;
+  // Copied in fixed-size chunks, not slurped whole. The previous version sized a single
+  // allocation from ftell() and read the entire file into it, which was wrong twice over:
+  //
+  //   - ftell() returns a SIGNED long and -1 on failure. Assigned to a size_t that becomes
+  //     SIZE_MAX, and g_malloc_n() aborts the process on a failed allocation -- it is not
+  //     the _try_ variant and does not return NULL for the caller's IS_NULL_PTR check.
+  //   - the largest caller is the "copy original file" export format
+  //     (imageio/format/copy.c), so "the whole file" is a raw: tens to hundreds of MB held
+  //     in RAM to copy bytes that were never needed all at once.
+  //
+  // A fixed buffer has neither problem and needs no size query at all.
   FILE *fin = g_fopen(sourcefile, "rb");
   FILE *fout = g_fopen(dst, "wb");
 
-  if(fin && fout)
+  if(!IS_NULL_PTR(fin) && !IS_NULL_PTR(fout))
   {
-    fseek(fin, 0, SEEK_END);
-    const size_t end = ftell(fin);
-    rewind(fin);
-    content = (char *)g_malloc_n(end, sizeof(char));
-    if(IS_NULL_PTR(content)) goto END;
-    if(fread(content, sizeof(char), end, fin) != end) goto END;
-    if(fwrite(content, sizeof(char), end, fout) != end) goto END;
+    char buffer[64 * 1024];
+    size_t bytes_read = fread(buffer, sizeof(char), sizeof(buffer), fin);
+
+    while(bytes_read > 0)
+    {
+      if(fwrite(buffer, sizeof(char), bytes_read, fout) != bytes_read) break;
+      bytes_read = fread(buffer, sizeof(char), sizeof(buffer), fin);
+    }
   }
 
-END:
   if(!IS_NULL_PTR(fout)) fclose(fout);
   if(!IS_NULL_PTR(fin)) fclose(fin);
-
-  dt_free(content);
 }
 
 void dt_copy_resource_file(const char *src, const char *dst)

--- a/src/develop/dev_pixelpipe.c
+++ b/src/develop/dev_pixelpipe.c
@@ -1455,8 +1455,18 @@ void dt_pixelpipe_get_global_hash(dt_dev_pixelpipe_t *pipe)
      *
      * Only for a module that actually draws a mask: the raw stages upstream cannot carry one,
      * and rehashing them would cost cache misses for pixels that cannot move. */
-    if((piece->module->blend_params->mask_mode & DEVELOP_MASK_SHAPE)
-       && piece->module->blend_params->mask_id > 0)
+    // From piece->blendop_data, NOT piece->module->blend_params. This function runs on the
+    // darkroom worker thread, and blend_params belongs to the GUI thread -- the rule this file
+    // states twice above ("never the live GUI module->params"). Reading it here dereferences a
+    // module the GUI can be tearing down or reallocating underneath us, which is Sentry
+    // 142904894: EXCEPTION_ACCESS_VIOLATION at this line, from resync_pipe_with_history() on
+    // the pipeline thread. blendop_data is the per-piece copy dt_iop_commit_params() writes
+    // from the history snapshot, which is what blend.c itself reads.
+    const dt_develop_blend_params_t *const blend_data
+        = (const dt_develop_blend_params_t *)piece->blendop_data;
+    if(!IS_NULL_PTR(blend_data)
+       && (blend_data->mask_mode & DEVELOP_MASK_SHAPE)
+       && blend_data->mask_id > 0)
       local_hash = dt_hash(local_hash, (const char *)&pipe->mask_rasterization_step, sizeof(int));
 
 /*

--- a/src/develop/masks/masks_gui.c
+++ b/src/develop/masks/masks_gui.c
@@ -1725,6 +1725,11 @@ static gboolean _set_hinter_message(dt_masks_form_gui_t *mask_gui, const dt_mask
 {
   char message[256] = "";
 
+  // Checked before use, not after: this function tests IS_NULL_PTR(mask_form) further down
+  // and its own dt_print writes `mask_form ? mask_form->type : -1`, so a NULL was always
+  // considered possible here -- but form_type read it unconditionally first.
+  if(IS_NULL_PTR(mask_form)) return FALSE;
+
   const int form_type = mask_form->type;
 
   int opacity_percent = 100;
@@ -2712,7 +2717,17 @@ static int _dt_masks_events_mouse_moved(dt_develop_t *dev, struct dt_iop_module_
 
   if(!IS_NULL_PTR(mask_gui))
   {
-    _set_hinter_message(mask_gui, mask_form);
+    // Re-read the visible form. dt_masks_cow_touch() above may have cloned it, spliced the
+    // clone into dev->forms in place of the original, re-pointed form_gui->form_visible at
+    // the clone and dropped the original's last reference -- freeing it. mask_form was
+    // captured BEFORE that call, so it can be dangling here; form_visible is the pointer the
+    // COW maintains.
+    //
+    // Sentry 143237622: SIGSEGV inside g_list_length() walking the freed points list, via
+    // _set_hinter_message() -> _polygon_set_hint_message(), on an ordinary darkroom
+    // mouse-move over a polygon.
+    mask_form = dt_masks_get_visible_form(dev);
+    if(!IS_NULL_PTR(mask_form)) _set_hinter_message(mask_gui, mask_form);
     _set_cursor_shape(mask_gui);
   }
   return result;
@@ -2736,6 +2751,13 @@ int dt_masks_events_button_released(dt_develop_t *dev, struct dt_iop_module_t *m
   dt_masks_form_t *dispatch_form
       = _dt_masks_events_get_dispatch_form(mask_form, mask_gui, &group_entry, &parent_id, &form_index);
   dispatch_form = dt_masks_cow_touch(dev, dispatch_form);
+
+  // dt_masks_cow_touch() above may have cloned the visible form, spliced the clone into
+  // dev->forms in place of the original, re-pointed form_gui->form_visible at it and
+  // dropped the original's last reference -- freeing it. mask_form was captured before
+  // that call, so re-read what form_visible points at now rather than using a pointer
+  // that may already be dangling. Same defect as Sentry 143237622 in mouse_moved.
+  mask_form = dt_masks_get_visible_form(dev);
 
   int result = 0;
   if(!IS_NULL_PTR(dispatch_form) && dispatch_form->functions && dispatch_form->functions->button_released)
@@ -2792,6 +2814,13 @@ int dt_masks_events_button_pressed(dt_develop_t *dev, struct dt_iop_module_t *mo
   dt_masks_form_t *dispatch_form
       = _dt_masks_events_get_dispatch_form(mask_form, mask_gui, &group_entry, &parent_id, &form_index);
   dispatch_form = dt_masks_cow_touch(dev, dispatch_form);
+
+  // dt_masks_cow_touch() above may have cloned the visible form, spliced the clone into
+  // dev->forms in place of the original, re-pointed form_gui->form_visible at it and
+  // dropped the original's last reference -- freeing it. mask_form was captured before
+  // that call, so re-read what form_visible points at now rather than using a pointer
+  // that may already be dangling. Same defect as Sentry 143237622 in mouse_moved.
+  mask_form = dt_masks_get_visible_form(dev);
   _dt_masks_events_update_hover(dispatch_form, mask_gui, form_index);
 
   gboolean return_val = FALSE;
@@ -2854,6 +2883,13 @@ int dt_masks_events_key_pressed(dt_develop_t *dev, struct dt_iop_module_t *modul
     dt_masks_form_t *dispatch_form
         = _dt_masks_events_get_dispatch_form(mask_form, mask_gui, &group_entry, &parent_id, &form_index);
     dispatch_form = dt_masks_cow_touch(dev, dispatch_form);
+
+    // dt_masks_cow_touch() above may have cloned the visible form, spliced the clone into
+    // dev->forms in place of the original, re-pointed form_gui->form_visible at it and
+    // dropped the original's last reference -- freeing it. mask_form was captured before
+    // that call, so re-read what form_visible points at now rather than using a pointer
+    // that may already be dangling. Same defect as Sentry 143237622 in mouse_moved.
+    mask_form = dt_masks_get_visible_form(dev);
     if(dispatch_form && dispatch_form->functions && dispatch_form->functions->key_pressed)
       return_value = dispatch_form->functions->key_pressed(module, event, dispatch_form,
                                                            parent_id, mask_gui, form_index);
@@ -2924,6 +2960,13 @@ int dt_masks_events_mouse_scrolled(dt_develop_t *dev, struct dt_iop_module_t *mo
   dt_masks_form_t *dispatch_form
       = _dt_masks_events_get_dispatch_form(mask_form, mask_gui, &group_entry, &parent_id, &form_index);
   dispatch_form = dt_masks_cow_touch(dev, dispatch_form);
+
+  // dt_masks_cow_touch() above may have cloned the visible form, spliced the clone into
+  // dev->forms in place of the original, re-pointed form_gui->form_visible at it and
+  // dropped the original's last reference -- freeing it. mask_form was captured before
+  // that call, so re-read what form_visible points at now rather than using a pointer
+  // that may already be dangling. Same defect as Sentry 143237622 in mouse_moved.
+  mask_form = dt_masks_get_visible_form(dev);
 
   if(!mask_gui->creation && !dt_masks_is_anything_selected(mask_gui))
     return 0;

--- a/src/imageio/imageio_core.c
+++ b/src/imageio/imageio_core.c
@@ -135,6 +135,11 @@ int dt_imageio_large_thumbnail(const char *filename, uint8_t **buffer, int32_t *
   if(dt_exif_get_thumbnail(filename, &buf, &bufsize, &mime_type, th_width, th_height, MAX(width, height))) 
     goto error;
 
+  // dt_exif_get_thumbnail() sets mime_type with strdup(), which returns NULL under memory
+  // pressure while still reporting success -- it checks its buffer allocation but not this
+  // one. Everything below reads it: two strcmp() calls and a "%s" in the error path.
+  if(IS_NULL_PTR(mime_type)) goto error;
+
   if(strcmp(mime_type, "image/jpeg") == 0)
   {
     // Decompress the JPG into our own memory format
@@ -175,7 +180,7 @@ int dt_imageio_large_thumbnail(const char *filename, uint8_t **buffer, int32_t *
     fprintf(
         stderr,
         "[dt_imageio_large_thumbnail] error: Not a supported thumbnail image format or broken thumbnail: %s\n",
-        mime_type);
+        IS_NULL_PTR(mime_type) ? "(none)" : mime_type);
     goto error;
   }
 

--- a/src/iop/CMakeLists.txt
+++ b/src/iop/CMakeLists.txt
@@ -201,21 +201,6 @@ add_iop(invert "invert.c")
 add_iop(vibrance "vibrance.c")
 add_iop(flip "flip.c" DEFAULT_VISIBLE)
 add_iop(finalscale "finalscale.c")
-# tonemap.cc and bilateral.cc are the two users of Permutohedral.h, whose lattice does
-# `new HashTable[nThreads]`. With a non-constant count GCC emits its own overflow check --
-# a call to operator new[](SIZE_MAX) that raises std::bad_array_new_length -- and then
-# -Walloc-size-larger-than reports that generated SIZE_MAX as an oversized allocation. The
-# warning is about a branch the compiler wrote, on a path that cannot be taken; nThreads is
-# clamped to [1, 1024] at construction, and clamping did not silence it for that reason.
-#
-# It is suppressed HERE, per source file, because the warning is emitted by the middle end:
-# a #pragma GCC diagnostic around the statement does not affect it (tried). Keep the scope
-# to these two files -- the flag is off nowhere else in the tree.
-if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-  set_source_files_properties(tonemap.cc bilateral.cc
-                              PROPERTIES COMPILE_OPTIONS "-Wno-alloc-size-larger-than")
-endif()
-
 add_iop(globaltonemap "globaltonemap.c")
 add_iop(bilat "bilat.c" DEFAULT_VISIBLE)
 add_iop(denoiseprofile "denoiseprofile.c" DEFAULT_VISIBLE)

--- a/src/iop/Permutohedral.h
+++ b/src/iop/Permutohedral.h
@@ -416,6 +416,35 @@ public:
     }
     scaleFactor = scaleFactorTmp;
 
+    // A std::vector, not `new HashTable[nThreads]`. With a non-constant count GCC emits its
+    // own overflow check -- a call to operator new[](SIZE_MAX) raising
+    // std::bad_array_new_length -- and then reports that generated SIZE_MAX as an allocation
+    // exceeding PTRDIFF_MAX. That diagnostic is NOT disabled by -Wno-alloc-size-larger-than
+    // (tried, per-file, verified present on the compile line) nor by a #pragma, which the
+    // middle end ignores. The container's allocation does not take that shape.
+    //
+    // HashTable is default-constructible with copy construction and assignment deleted, and
+    // has no move constructor. That is fine here and must stay fine: vector's count
+    // constructor value-initialises in place and needs only DefaultInsertable. Do NOT add a
+    // push_back(), resize() or copy of this vector -- those need the element to be
+    // MoveInsertable, which it is not, and the failure would be a compile error rather than
+    // anything subtle.
+    // KNOWN WARNING, deliberately left standing. GCC reports
+    //   "argument 1 value '18446744073709551615' exceeds maximum object size" here.
+    // It is complaining about a branch IT generated: `new T[n]` with a non-constant n emits
+    // an overflow check calling operator new[](SIZE_MAX) to raise std::bad_array_new_length.
+    // The branch is unreachable -- nThreads is clamped to [1, 1024] in the initialiser list
+    // above -- and the arithmetic here is correct.
+    //
+    // It cannot be suppressed and should not be worked around. Measured, in this order:
+    //   - -Wno-alloc-size-larger-than, per-file, verified present on the compile line: no
+    //     effect. The diagnostic is the PTRDIFF_MAX form, which that option does not disable.
+    //   - #pragma GCC diagnostic around the statement: no effect, it is a middle-end warning.
+    //   - std::vector instead of new[]: compiles on GCC, breaks on clang. OpenMP regions here
+    //     use default(firstprivate), which copy-constructs every variable they touch, and
+    //     HashTable's copy constructor is deleted. A raw pointer copies trivially; a
+    //     container does not. That attempt turned CI red on all three clang jobs.
+    // Leave it alone.
     hashTables = new HashTable[nThreads];
   }
 
@@ -423,10 +452,10 @@ public:
 
   ~PermutohedralLattice()
   {
+    delete[] hashTables;
     delete[] scaleFactor;
     delete[] replay;
     delete[] canonical;
-    delete[] hashTables;
   }
 
   PermutohedralLattice &operator=(const PermutohedralLattice &) = delete;

--- a/src/metadata/map_locations.c
+++ b/src/metadata/map_locations.c
@@ -419,6 +419,11 @@ GList *dt_map_location_convert_polygons(void *polygons, dt_map_box_t *bbox, int 
 {
   const int nb = g_list_length(polygons);
   dt_geo_map_display_point_t *points = malloc(nb * sizeof(dt_geo_map_display_point_t));
+  if(IS_NULL_PTR(points))
+  {
+    if(nb_pts) *nb_pts = 0;
+    return NULL;
+  }
   dt_geo_map_display_point_t *p = points;
   dt_map_box_t bb = {180.0, -90.0, -180, 90.0};
   GList *npol = NULL;

--- a/src/pixel/interpolation.c
+++ b/src/pixel/interpolation.c
@@ -767,7 +767,12 @@ static gboolean _prepare_resampling_plan(const struct dt_interpolation *itor,
   blob = (char *)blob + indexreq;
   float *kernel = (float *)blob;
   blob = (char *)blob + kernelreq;
-  float *scratchpad = scratchreq ? (float *)blob : NULL;
+  // Not `scratchreq ? ... : NULL`, unlike meta below: scratchreq is rounded up from at least
+  // 4 floats of headroom, so it is unconditionally non-zero and the NULL case cannot happen.
+  // Spelling it as a maybe-NULL made three later uses read as possible NULL dereferences --
+  // to a static analyser and to anyone reading the code. metareq IS conditional (pmeta), so
+  // meta keeps its ternary.
+  float *scratchpad = (float *)blob;
   blob = (char *)blob + scratchreq;
   int *meta = metareq ? (int *)blob : NULL;
 //   blob = (char *)blob + metareq;


### PR DESCRIPTION
Two strands, both driven by evidence rather than issue counts: **Sentry crashes** (worked by most
recently seen) and **SonarCloud bugs/security**.

## Sentry: five issues closed by four fixes

Three of the four are the same architectural shape — **an API hands out a borrowed pointer and
later invalidates it, with no way to tell the borrower.**

**Masks use-after-free** (143237622, seen today; 139679102, 9 Aug — one defect, two handlers).
Every mask event handler captures the visible form, then takes the copy-on-write gate:

```c
dt_masks_form_t *mask_form = dt_masks_get_visible_form(dev);   // == form_gui->form_visible
dispatch_form = dt_masks_cow_touch(dev, dispatch_form);        // clones, re-points form_visible,
                                                               // unrefs the original -> freed
```

It maintains `form_visible`, which is where `mask_form` was copied from; it cannot maintain the
caller's local. The crash is `g_list_length()` walking a freed list — hence the unresolved frame
above `_polygon_set_hint_message`. Fixed in **all five** handlers: only two had crashed, the other
three were found by auditing every `cow_touch` site. Note all 31 sites already reassign in place
(`X = cow(X)`), which looks correct — the hazard is a **second local aliasing the same form**, so
searching for a mis-assigned result finds nothing.

**Display profile freed under its users** (141501108, seen today). `pipe->output_profile_info`
caches a pointer from the profile memo; changing monitor profile frees the entry, and
`DT_SIGNAL_CONTROL_PROFILE_CHANGED` is raised but **nothing in the tree connects to it**. Evicted
entries are now retired and released at shutdown — the same remedy
`dt_conf_get_string_const()` already uses for replaced values.

**Pipeline thread read GUI-owned state** (142904894). `dt_pixelpipe_get_global_hash()` read
`piece->module->blend_params` from the darkroom worker thread — the rule `dev_pixelpipe.c` states
*twice in its own comments*, and the only line in the file breaking it. Now reads
`piece->blendop_data`, the committed per-piece copy that `blend.c` itself uses.

**Stale colorchecker index** (143081358, 17 events). `g_list_nth_data()` returns NULL past the end,
and `target_type` is a saved-param index into a list rebuilt at runtime from the user's reference
files — delete one and every later index shifts. Routed into the fallback the function already had.

### Two that are not bugs, and two blocked

- **129862572** — biggest by volume (169 events, 10 users) and **not one bug**. Keyed on
  `BaseThreadInitThunk`, so every symbol-less Windows crash lands in it: GPUs span three vendors,
  24 events have OpenCL *off*, and the sampled stack is entirely inside `amdocl64.dll`. Needs a
  fingerprinting rule to split by module before it means anything.
- **129978857** (37 events, 17 users) and **143093465** — no symbols on any frame, not even
  `libansel.so`. The actionable item is **symbol upload coverage for those releases**, not code.

## SonarCloud: triage before fixes

**311 of 442 reliability issues are `data/themes/ansel.css`** — GTK CSS analysed as web CSS, where
`window`/`notebook`/`treeview` are widget node names and `@define-color`/`-gtk-icon-*`/`:backdrop`
appear 159 times. Excluded via `sonar.exclusions`; `sonar.issue.ignore.*` is **not honoured under
automatic analysis** (measured against the live API — the entries already in that file have never
suppressed anything). Scoped so `data/style/`, `data/pswp/` and `doc/` stay analysed.

**20 of 21 security issues are false positives**, four of which would cause damage if "fixed": the
`exif.cc` "use HTTPS" pair are **XMP namespace URIs** (identifiers, never fetched — the code
already says they must not change), and the `textnotes.c` pair are prefix *checks* classifying user
URLs.

**Real defects fixed:** `dt_copy_file()` sized one allocation from an unchecked `ftell()` (`-1`
becomes `SIZE_MAX`, and the NULL check could never fire because `g_malloc_n` *aborts*) while
slurping whole raws into RAM — its caller is the "copy original file" export format; two unchecked
allocations dereferenced immediately; a leak where each CHT `'F'` line overwrote the previous frame
box; and a `? :` that made three uses read as NULL dereferences when the value is provably never
NULL.

## One warning left standing, deliberately

`Permutohedral.h` keeps a `-Walloc-size-larger-than` warning: GCC complaining about a branch **it
generates itself** (`new T[n]` emits an `operator new[](SIZE_MAX)` overflow check). Four removals
were measured and all failed — the per-file flag (verified on the compile line), a `#pragma`, the
`nThreads` clamp, and `std::vector`, which compiles on GCC and **breaks clang** because OpenMP
`default(firstprivate)` copy-constructs everything it touches and `HashTable`'s copy ctor is
deleted. All four are recorded at the allocation. Its only users are deprecated modules. The
per-file suppression from the previous series is removed: it named files `add_iop()` marks
`LANGUAGE ""`, so it reached no compile line at all.

## Verification

Built clean on **clang, GCC Debug, GCC Release and nofeatures** — 0 errors, 1 known in-tree warning
(above). 13/13 built unit tests pass; `tools/check_it_runs.sh` passes on ASCII and non-ASCII paths.

One commit per topic, for bisection.
