### PR TITLE
Sentry: two more use-after-frees — film-roll import and mask teardown

### DIFF
--- a/src/common/image.c
+++ b/src/common/image.c
@@ -1526,13 +1526,27 @@ int dt_image_read_duplicates(const uint32_t id, const char *filename, const gboo
       // this has the xmp for the duplicate is read just below.
       newid = dt_image_repository_duplicate(id, version);
       const dt_image_t *img = dt_image_cache_get(id, 'r');
-      grpid = img->group_id;
-      dt_image_cache_read_release(img);
+      if(!IS_NULL_PTR(img))
+      {
+        grpid = img->group_id;
+        dt_image_cache_read_release(img);
+      }
     }
     // make sure newid is not selected
     if(clear_selection) dt_selection_clear(dt_selection_get_global());
 
-    dt_image_t *img = dt_image_cache_get(newid, 'w');
+    // dt_image_repository_duplicate() above returns -1 when it cannot create the duplicate,
+    // and dt_image_cache_get() returns NULL for an id it cannot load. Both were dereferenced
+    // unchecked, which is Sentry 140350855: SIGSEGV on `img->version = version` while
+    // importing a film roll whose sidecars name versions the duplicate could not be created
+    // for. Skipping this sidecar leaves the rest of the import to proceed.
+    dt_image_t *img = (newid > 0) ? dt_image_cache_get(newid, 'w') : NULL;
+    if(IS_NULL_PTR(img))
+    {
+      fprintf(stderr, "[dt_image_read_duplicates] could not load image %i for sidecar '%s', skipping it\n",
+              newid, xmpfilename);
+      continue;
+    }
     (void)dt_exif_xmp_read(img, xmpfilename, 0);
     img->version = version;
     dt_image_cache_write_release(img, DT_IMAGE_CACHE_RELAXED);

--- a/src/develop/masks/masks_gui.c
+++ b/src/develop/masks/masks_gui.c
@@ -3895,7 +3895,25 @@ void dt_masks_change_form_gui(dt_develop_t *dev, dt_masks_form_t *new_form)
 
     // Free only fully orphan temporary previews. Forms tracked in either list
     // are owned by develop and will be released by its teardown path.
-    if(!is_registered && !is_registered_for_cleanup) dt_masks_free_form(old_form);
+    //
+    // form_visible is cleared BEFORE the release, not after. old_form IS what it points at
+    // -- it came from dt_masks_get_visible_form(dev) at the top -- so releasing it first
+    // leaves the field holding freed memory until dt_masks_set_visible_form() below, and
+    // dt_masks_clear_form_gui() runs inside that window. Re-entering this function there
+    // reads the dangling form_visible as its own old_form, finds it in neither list because
+    // it is already gone, and releases it a second time (Sentry 140265757: SIGSEGV in
+    // dt_masks_change_form_gui, two frames of it, from the view-leave teardown path).
+    // The creation-exit path in this file already orders it this way.
+    //
+    // Released through unref rather than dt_masks_free_form(): forms are refcounted and
+    // free_form is the destructor unref calls at zero. Calling it directly frees the form
+    // even when a history snapshot still references it. An orphan preview holds the single
+    // reference it was created with, so this frees it exactly as before.
+    if(!is_registered && !is_registered_for_cleanup)
+    {
+      dt_masks_set_visible_form(dev, NULL);
+      dt_masks_form_unref(old_form);
+    }
   }
 
   dt_masks_clear_form_gui(dev);


### PR DESCRIPTION
The two commits that were pushed to #1281's branch after it merged, so they never reached master.
Both are crashes from the Sentry list, worked by most recently seen.

### 140350855 — film-roll import, 5 events / 2 users

```c
newid = dt_image_repository_duplicate(id, version);   // returns -1 when it cannot duplicate
...
dt_image_t *img = dt_image_cache_get(newid, 'w');     // NULL for an id it cannot load
(void)dt_exif_xmp_read(img, xmpfilename, 0);
img->version = version;                                // <- the reported line
```

`dt_image_repository_duplicate()` initialises its result to `-1` and returns that on failure;
`dt_image_cache_get()` returns NULL for an unloadable id. Neither was checked, and both are
dereferenced immediately — there is a second unchecked lookup four lines above, read for
`img->group_id`.

So importing a film roll whose sidecars name a version the duplicate could not be created for
takes down the **whole import**, not just that sidecar. Both are checked now and the failing
sidecar is skipped with a message, so the rest of the roll still imports. The read-lock case
leaves `grpid` at `-1`, which the existing `if(grpid != -1)` guard already treats as "no group".

### 140265757 — mask teardown on view leave

```c
if(!is_registered && !is_registered_for_cleanup) dt_masks_free_form(old_form);  // free
}
dt_masks_clear_form_gui(dev);              // runs holding the freed pointer
dt_masks_set_visible_form(dev, new_form);  // cleared only here
```

`old_form` **is** what `form_visible` points at — it came from `dt_masks_get_visible_form(dev)` at
the top. Releasing it before clearing the field leaves `form_visible` holding freed memory for two
statements, and `dt_masks_clear_form_gui()` runs inside that window. Re-entering the function there
(the crash stack shows two of its frames) reads the dangling `form_visible` as its own `old_form`,
finds it in **neither** list because it is already gone, and releases it a second time.

The two list walks do not protect against this: they compare pointers and never dereference, so a
dangling form passes both and lands in the free branch. The check that looks protective is what
routes the bad case into the free.

Cleared before the release now — the order the creation-exit path in the same file already uses —
and released through `dt_masks_form_unref()` rather than `dt_masks_free_form()`. Forms are
refcounted and `free_form` is the destructor `unref` calls at zero, so calling it directly frees
the form even when a history snapshot still references it. An orphan preview holds the single
reference it was created with, so it is freed here exactly as before.

### Known, not fixed here

`form_visible` is a raw pointer to a refcounted object that **does not hold a reference**. This PR
fixes the two paths that crashed; the field itself stays unowned, so the next path that frees a
form without clearing it reproduces this. Making it hold a reference is the structural fix and is
larger than a crash-fix PR should carry.

### Verification

Rebuilt against current master (which gained 11 commits from #1281): **GCC Release and clang Debug,
0 errors**, no new warnings — the 2 remaining are the known `Permutohedral` GCC false positive.
`tools/check_it_runs.sh` passes on ASCII and non-ASCII paths.

Sentry issues fixed by #1281 and already in master (143237622, 139679102, 141501108, 141925657,
143081358, 142904894) have been marked resolved. These two stay **unresolved** until this merges.