### PR TITLE
Sentry: an out-of-bounds read and two missing NULL checks

### DIFF
--- a/src/develop/masks/polygon.c
+++ b/src/develop/masks/polygon.c
@@ -1270,7 +1270,16 @@ static void _polygon_get_sizes(struct dt_iop_module_t *module, dt_masks_form_t *
     p1[1] = fminf(p1[1], y);
     p2[1] = fmaxf(p2[1], y);
 
-    if(!IS_NULL_PTR(border_size))
+    // Bounded by border_count, not by the loop's points_count. points/points_count and
+    // border/border_count are separate arrays with separate lengths -- the other border loops
+    // in this file spell it `i < border_count` -- so indexing border[] with an index only
+    // checked against points_count reads past its end whenever the border is the shorter of
+    // the two. That is Sentry 142390966: EXCEPTION_ACCESS_VIOLATION here, reached from the
+    // interaction slider (dt_masks_form_set_interaction_value -> _change_size). border can
+    // also be NULL outright when none was rasterised.
+    if(!IS_NULL_PTR(border_size)
+       && !IS_NULL_PTR(gui_points->border)
+       && i < gui_points->border_count)
     {
       // border
       const float fx = gui_points->border[i * 2];

--- a/src/iop/colorin.c
+++ b/src/iop/colorin.c
@@ -1001,8 +1001,10 @@ static void update_profile_list(dt_iop_module_t *self)
   int pos = -1;
   // some file formats like jpeg can have an embedded color profile
   // currently we only support jpeg, j2k, tiff and png
+  // dt_image_cache_get() returns NULL for an id it cannot load, and this runs from
+  // reload_defaults() on a GUI reset -- Sentry 140151023: SIGSEGV on the very next line.
   const dt_image_t *cimg = dt_image_cache_get(self->dev->image_storage.id, 'r');
-  if(cimg->profile)
+  if(!IS_NULL_PTR(cimg) && cimg->profile)
   {
     dt_colorprofile_desc_t *prof = (dt_colorprofile_desc_t *)calloc(1, sizeof(dt_colorprofile_desc_t));
     g_strlcpy(prof->name, dt_colorspaces_get_name(DT_COLORSPACE_EMBEDDED_ICC, ""), sizeof(prof->name));
@@ -1010,7 +1012,7 @@ static void update_profile_list(dt_iop_module_t *self)
     g->image_profiles = g_list_append(g->image_profiles, prof);
       pos++;
   }
-  dt_image_cache_read_release(cimg);
+  if(!IS_NULL_PTR(cimg)) dt_image_cache_read_release(cimg);
   // use the matrix embedded in some DNGs and EXRs
   if(!isnan(self->dev->image_storage.d65_color_matrix[0]))
   {

--- a/src/libs/lib.c
+++ b/src/libs/lib.c
@@ -922,6 +922,10 @@ gboolean dt_lib_gui_get_expanded(dt_lib_module_t *module)
   {
     char var[1024];
     const dt_view_t *current_view = dt_view_manager_get_current_view(dt_view_manager_get_global());
+    // Same check the identical block above already makes. There is no current view while the
+    // manager is switching between them, and this is called from the darkroom expose --
+    // Sentry 139067518: EXCEPTION_ACCESS_VIOLATION reading current_view->module_name here.
+    if(IS_NULL_PTR(current_view)) return true;
     snprintf(var, sizeof(var), "plugins/%s/%s/expanded", current_view->module_name, module->plugin_name);
     return dt_conf_get_bool(var);
   }

--- a/src/libs/lib.c
+++ b/src/libs/lib.c
@@ -113,6 +113,11 @@ typedef struct dt_lib_presets_edit_dialog_t
 
 gboolean dt_lib_is_visible_in_view(dt_lib_module_t *module, const dt_view_t *view)
 {
+  // No view means nothing is visible in it. Callers in views/view.c guard before calling,
+  // but _toggle_expanded() passes dt_view_manager_get_current_view() straight through, and
+  // that is NULL mid-switch -- the loop below reads view->module_name.
+  if(IS_NULL_PTR(view)) return FALSE;
+
   if(!module->views)
   {
     fprintf(stderr, "module %s doesn't have views flags\n", module->name(module));
@@ -897,6 +902,11 @@ void dt_lib_gui_set_expanded(dt_lib_module_t *module, gboolean expanded)
   /* store expanded state of module */
   char var[1024];
   const dt_view_t *current_view = dt_view_manager_get_current_view(dt_view_manager_get_global());
+  // There is no current view while the view manager is switching between them, and the conf
+  // key is built from its name -- so with no view there is no key to write, and nothing to
+  // store. dt_lib_gui_get_expanded() below makes the same check on the reading side, where
+  // omitting it crashed (Sentry 139067518).
+  if(IS_NULL_PTR(current_view)) return;
   snprintf(var, sizeof(var), "plugins/%s/%s/expanded", current_view->module_name, module->plugin_name);
   dt_conf_set_bool(var, expanded);
 }


### PR DESCRIPTION
Three more crashes from the Sentry list, worked by most recently seen. Independent of #1284,
which is still open — this branch is cut off master.

### 142390966 — polygon size slider, out-of-bounds read

```c
for(int i = node_count * 3; i < gui_points->points_count; i++)
{
  const float x  = gui_points->points[i * 2];    // bounded by points_count
  ...
  const float fx = gui_points->border[i * 2];    // NOT bounded by border_count
```

`points`/`points_count` and `border`/`border_count` are **separate arrays with separate lengths**
in `dt_masks_form_gui_points_t`. This loop bounds on one and indexes both, reading past the end of
`border[]` whenever the border is the shorter — the access violation, reached from
`dt_masks_form_set_interaction_value` → `_change_size`.

Not a judgement call: the other two border loops in the same file already spell it
`i < border_count` with `border[2 * i]`. `border` can also be NULL when none was rasterised, so
that is checked too.

### 140151023 — colorin, unchecked image-cache lookup

```c
const dt_image_t *cimg = dt_image_cache_get(self->dev->image_storage.id, 'r');
if(cimg->profile)
```

`dt_image_cache_get()` returns NULL for an id it cannot load. The function checks its gui data on
the line above and this lookup not at all. Reached from `reload_defaults()` on a GUI reset. The
matching read release is guarded with it.

### 139067518 — lib, one of two identical blocks missing its check

`dt_lib_gui_get_expanded()` builds the same conf key in two places. The first checks the view:

```c
if(IS_NULL_PTR(current_view)) return true;
snprintf(var, ..., current_view->module_name, ...);
```

The second reads `current_view->module_name` with no check. There is no current view while the
view manager is switching between them, which is exactly when an expose can still run.

## One defect deliberately left

`_polygon_get_sizes()` seeds `p2`/`fp2` with `FLT_MIN` — the smallest **positive** normal float
(~1.2e-38), not the most negative — so `fmaxf()` never updates them for a coordinate `<= 1.2e-38`,
and a polygon at negative image coordinates gets a bounding box that keeps the sentinel. It wants
`-FLT_MAX`.

That is a real bug, but it changes computed geometry rather than fixing a crash, so it should be a
deliberate decision about how off-canvas polygons size — not a quiet rider on a crash fix.

## Verification

GCC Release and clang Debug, **0 errors**, no new warnings. `tools/check_it_runs.sh` passes on
ASCII and non-ASCII paths.

These three stay **unresolved** in Sentry until this merges.