### PR TITLE
Sentry: fix the fetch tool (it never downloaded a backtrace), and eleven unchecked init_pipe allocations

### DIFF
--- a/src/iop/atrous.c
+++ b/src/iop/atrous.c
@@ -772,6 +772,12 @@ void init_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pi
   dt_iop_atrous_params_t *default_params = (dt_iop_atrous_params_t *)self->default_params;
   piece->data = (void *)d;
   piece->data_size = sizeof(dt_iop_atrous_data_t);
+  // Checked AFTER both piece->data and piece->data_size are set, deliberately.
+  // dt_iop_init_pipe() disables the node for us when it sees data_size > 0 with a NULL
+  // data -- returning before data_size is assigned skips that and leaves the node enabled
+  // with no storage. dt_calloc_align() returns NULL on failure and pipe nodes are built
+  // exactly when memory is tightest (Sentry 134134395 faulted in atrous's init_pipe).
+  if(IS_NULL_PTR(piece->data)) return;
   for(int ch = 0; ch < atrous_none; ch++)
   {
     d->curve[ch] = dt_draw_curve_new(0.0, 1.0, CATMULL_ROM);

--- a/src/iop/atrous.c
+++ b/src/iop/atrous.c
@@ -798,6 +798,8 @@ void init_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pi
 
 void cleanup_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
 {
+  /* init_pipe() may have failed to allocate, and cleanup runs regardless. */
+  if(IS_NULL_PTR(piece->data)) return;
   dt_iop_atrous_data_t *d = (dt_iop_atrous_data_t *)(piece->data);
   for(int ch = 0; ch < atrous_none; ch++)
     dt_draw_curve_destroy(d->curve[ch]);

--- a/src/iop/basecurve.c
+++ b/src/iop/basecurve.c
@@ -952,6 +952,8 @@ void init_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pi
 
 void cleanup_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
 {
+  /* init_pipe() may have failed to allocate, and cleanup runs regardless. */
+  if(IS_NULL_PTR(piece->data)) return;
   // clean up everything again.
   dt_iop_basecurve_data_t *d = (dt_iop_basecurve_data_t *)(piece->data);
   if(d->curve) dt_draw_curve_destroy(d->curve);

--- a/src/iop/colisa.c
+++ b/src/iop/colisa.c
@@ -211,6 +211,12 @@ void init_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pi
   dt_iop_colisa_data_t *d = (dt_iop_colisa_data_t *)dt_calloc_align(sizeof(dt_iop_colisa_data_t));
   piece->data = (void *)d;
   piece->data_size = sizeof(dt_iop_colisa_data_t);
+  // Checked AFTER both piece->data and piece->data_size are set, deliberately.
+  // dt_iop_init_pipe() disables the node for us when it sees data_size > 0 with a NULL
+  // data -- returning before data_size is assigned skips that and leaves the node enabled
+  // with no storage. dt_calloc_align() returns NULL on failure and pipe nodes are built
+  // exactly when memory is tightest (Sentry 134134395 faulted in atrous's init_pipe).
+  if(IS_NULL_PTR(piece->data)) return;
   for(int k = 0; k < 0x10000; k++) d->ctable[k] = d->ltable[k] = 100.0f * k / 0x10000; // identity
 }
 

--- a/src/iop/colorbalancergb.c
+++ b/src/iop/colorbalancergb.c
@@ -1369,6 +1369,8 @@ void init_pipe(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe
 
 void cleanup_pipe(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
 {
+  /* init_pipe() may have failed to allocate, and cleanup runs regardless. */
+  if(IS_NULL_PTR(piece->data)) return;
   dt_iop_colorbalancergb_data_t *d = (dt_iop_colorbalancergb_data_t *)(piece->data);
   dt_free_align(d->gamut_LUT);
   d->gamut_LUT = NULL;

--- a/src/iop/colorequal.c
+++ b/src/iop/colorequal.c
@@ -810,6 +810,12 @@ void init_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pi
   dt_iop_colorequal_data_t *d = dt_calloc_align(sizeof(dt_iop_colorequal_data_t));
   piece->data = d;
   piece->data_size = sizeof(dt_iop_colorequal_data_t);
+  // Checked AFTER both piece->data and piece->data_size are set, deliberately.
+  // dt_iop_init_pipe() disables the node for us when it sees data_size > 0 with a NULL
+  // data -- returning before data_size is assigned skips that and leaves the node enabled
+  // with no storage. dt_calloc_align() returns NULL on failure and pipe nodes are built
+  // exactly when memory is tightest (Sentry 134134395 faulted in atrous's init_pipe).
+  if(IS_NULL_PTR(piece->data)) return;
   d->clut = NULL;
   d->clut_level = 0;
   d->white_level = 1.f;

--- a/src/iop/colorprimaries.c
+++ b/src/iop/colorprimaries.c
@@ -837,6 +837,12 @@ void init_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pi
   dt_iop_colorprimaries_data_t *d = dt_calloc_align(sizeof(dt_iop_colorprimaries_data_t));
   piece->data = d;
   piece->data_size = sizeof(dt_iop_colorprimaries_data_t);
+  // Checked AFTER both piece->data and piece->data_size are set, deliberately.
+  // dt_iop_init_pipe() disables the node for us when it sees data_size > 0 with a NULL
+  // data -- returning before data_size is assigned skips that and leaves the node enabled
+  // with no storage. dt_calloc_align() returns NULL on failure and pipe nodes are built
+  // exactly when memory is tightest (Sentry 134134395 faulted in atrous's init_pipe).
+  if(IS_NULL_PTR(piece->data)) return;
   d->white_level = 1.f;
   d->interpolation = DT_LUT3D_INTERP_TETRAHEDRAL;
 }

--- a/src/iop/colorzones.c
+++ b/src/iop/colorzones.c
@@ -2583,6 +2583,8 @@ void init_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pi
 
 void cleanup_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
 {
+  /* init_pipe() may have failed to allocate, and cleanup runs regardless. */
+  if(IS_NULL_PTR(piece->data)) return;
   // clean up everything again.
   dt_iop_colorzones_data_t *d = (dt_iop_colorzones_data_t *)(piece->data);
 

--- a/src/iop/colorzones.c
+++ b/src/iop/colorzones.c
@@ -2562,6 +2562,12 @@ void init_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pi
   dt_iop_colorzones_params_t *default_params = (dt_iop_colorzones_params_t *)self->default_params;
   piece->data = d;
   piece->data_size = sizeof(dt_iop_colorzones_data_t);
+  // Checked AFTER both piece->data and piece->data_size are set, deliberately.
+  // dt_iop_init_pipe() disables the node for us when it sees data_size > 0 with a NULL
+  // data -- returning before data_size is assigned skips that and leaves the node enabled
+  // with no storage. dt_calloc_align() returns NULL on failure and pipe nodes are built
+  // exactly when memory is tightest (Sentry 134134395 faulted in atrous's init_pipe).
+  if(IS_NULL_PTR(piece->data)) return;
 
   for(int ch = 0; ch < DT_IOP_COLORZONES_MAX_CHANNELS; ch++)
   {

--- a/src/iop/denoiseprofile.c
+++ b/src/iop/denoiseprofile.c
@@ -2900,6 +2900,8 @@ void init_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pi
 
 void cleanup_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
 {
+  /* init_pipe() may have failed to allocate, and cleanup runs regardless. */
+  if(IS_NULL_PTR(piece->data)) return;
   dt_iop_denoiseprofile_data_t *d = (dt_iop_denoiseprofile_data_t *)(piece->data);
   for(int ch = 0; ch < DT_DENOISE_PROFILE_NONE; ch++) dt_draw_curve_destroy(d->curve[ch]);
   dt_free_align(piece->data);

--- a/src/iop/denoiseprofile.c
+++ b/src/iop/denoiseprofile.c
@@ -2884,6 +2884,12 @@ void init_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pi
 
   piece->data = (void *)d;
   piece->data_size = sizeof(dt_iop_denoiseprofile_data_t);
+  // Checked AFTER both piece->data and piece->data_size are set, deliberately.
+  // dt_iop_init_pipe() disables the node for us when it sees data_size > 0 with a NULL
+  // data -- returning before data_size is assigned skips that and leaves the node enabled
+  // with no storage. dt_calloc_align() returns NULL on failure and pipe nodes are built
+  // exactly when memory is tightest (Sentry 134134395 faulted in atrous's init_pipe).
+  if(IS_NULL_PTR(piece->data)) return;
   for(int ch = 0; ch < DT_DENOISE_PROFILE_NONE; ch++)
   {
     d->curve[ch] = dt_draw_curve_new(0.0, 1.0, CATMULL_ROM);

--- a/src/iop/lowlight.c
+++ b/src/iop/lowlight.c
@@ -248,6 +248,8 @@ void init_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pi
 
 void cleanup_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
 {
+  /* init_pipe() may have failed to allocate, and cleanup runs regardless. */
+  if(IS_NULL_PTR(piece->data)) return;
   // clean up everything again.
   dt_iop_lowlight_data_t *d = (dt_iop_lowlight_data_t *)(piece->data);
   dt_draw_curve_destroy(d->curve);

--- a/src/iop/lowlight.c
+++ b/src/iop/lowlight.c
@@ -231,6 +231,12 @@ void init_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pi
   dt_iop_lowlight_params_t *default_params = (dt_iop_lowlight_params_t *)self->default_params;
   piece->data = (void *)d;
   piece->data_size = sizeof(dt_iop_lowlight_data_t);
+  // Checked AFTER both piece->data and piece->data_size are set, deliberately.
+  // dt_iop_init_pipe() disables the node for us when it sees data_size > 0 with a NULL
+  // data -- returning before data_size is assigned skips that and leaves the node enabled
+  // with no storage. dt_calloc_align() returns NULL on failure and pipe nodes are built
+  // exactly when memory is tightest (Sentry 134134395 faulted in atrous's init_pipe).
+  if(IS_NULL_PTR(piece->data)) return;
   d->curve = dt_draw_curve_new(0.0, 1.0, CATMULL_ROM);
   (void)dt_draw_curve_add_point(d->curve, default_params->transition_x[DT_IOP_LOWLIGHT_BANDS - 2] - 1.0,
                                 default_params->transition_y[DT_IOP_LOWLIGHT_BANDS - 2]);

--- a/src/iop/lowpass.c
+++ b/src/iop/lowpass.c
@@ -545,6 +545,12 @@ void init_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pi
   dt_iop_lowpass_data_t *d = (dt_iop_lowpass_data_t *)dt_calloc_align(sizeof(dt_iop_lowpass_data_t));
   piece->data = (void *)d;
   piece->data_size = sizeof(dt_iop_lowpass_data_t);
+  // Checked AFTER both piece->data and piece->data_size are set, deliberately.
+  // dt_iop_init_pipe() disables the node for us when it sees data_size > 0 with a NULL
+  // data -- returning before data_size is assigned skips that and leaves the node enabled
+  // with no storage. dt_calloc_align() returns NULL on failure and pipe nodes are built
+  // exactly when memory is tightest (Sentry 134134395 faulted in atrous's init_pipe).
+  if(IS_NULL_PTR(piece->data)) return;
   for(int k = 0; k < 0x10000; k++) d->ctable[k] = d->ltable[k] = 100.0f * k / 0x10000; // identity
 }
 

--- a/src/iop/rawdenoise.c
+++ b/src/iop/rawdenoise.c
@@ -613,6 +613,12 @@ void init_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pi
 
   piece->data = (void *)d;
   piece->data_size = sizeof(dt_iop_rawdenoise_data_t);
+  // Checked AFTER both piece->data and piece->data_size are set, deliberately.
+  // dt_iop_init_pipe() disables the node for us when it sees data_size > 0 with a NULL
+  // data -- returning before data_size is assigned skips that and leaves the node enabled
+  // with no storage. dt_calloc_align() returns NULL on failure and pipe nodes are built
+  // exactly when memory is tightest (Sentry 134134395 faulted in atrous's init_pipe).
+  if(IS_NULL_PTR(piece->data)) return;
   for(int ch = 0; ch < DT_RAWDENOISE_NONE; ch++)
   {
     d->curve[ch] = dt_draw_curve_new(0.0, 1.0, CATMULL_ROM);

--- a/src/iop/rawdenoise.c
+++ b/src/iop/rawdenoise.c
@@ -629,6 +629,8 @@ void init_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pi
 
 void cleanup_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
 {
+  /* init_pipe() may have failed to allocate, and cleanup runs regardless. */
+  if(IS_NULL_PTR(piece->data)) return;
   dt_iop_rawdenoise_data_t *d = (dt_iop_rawdenoise_data_t *)(piece->data);
   for(int ch = 0; ch < DT_RAWDENOISE_NONE; ch++) dt_draw_curve_destroy(d->curve[ch]);
   dt_free_align(piece->data);

--- a/src/iop/rgbcurve.c
+++ b/src/iop/rgbcurve.c
@@ -1441,6 +1441,8 @@ void init_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pi
 
 void cleanup_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
 {
+  /* init_pipe() may have failed to allocate, and cleanup runs regardless. */
+  if(IS_NULL_PTR(piece->data)) return;
   // clean up everything again.
   dt_iop_rgbcurve_data_t *d = (dt_iop_rgbcurve_data_t *)(piece->data);
   for(int ch = 0; ch < DT_IOP_RGBCURVE_MAX_CHANNELS; ch++) dt_draw_curve_destroy(d->curve[ch]);

--- a/src/iop/rgbcurve.c
+++ b/src/iop/rgbcurve.c
@@ -1416,6 +1416,12 @@ void init_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pi
   dt_iop_rgbcurve_params_t *default_params = (dt_iop_rgbcurve_params_t *)self->default_params;
   piece->data = (void *)d;
   piece->data_size = sizeof(dt_iop_rgbcurve_data_t);
+  // Checked AFTER both piece->data and piece->data_size are set, deliberately.
+  // dt_iop_init_pipe() disables the node for us when it sees data_size > 0 with a NULL
+  // data -- returning before data_size is assigned skips that and leaves the node enabled
+  // with no storage. dt_calloc_align() returns NULL on failure and pipe nodes are built
+  // exactly when memory is tightest (Sentry 134134395 faulted in atrous's init_pipe).
+  if(IS_NULL_PTR(piece->data)) return;
   memcpy(&d->params, default_params, sizeof(dt_iop_rgbcurve_params_t));
 
   for(int ch = 0; ch < DT_IOP_RGBCURVE_MAX_CHANNELS; ch++)

--- a/src/iop/tonecurve.c
+++ b/src/iop/tonecurve.c
@@ -740,6 +740,12 @@ void init_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pi
   dt_iop_tonecurve_params_t *default_params = (dt_iop_tonecurve_params_t *)self->default_params;
   piece->data = (void *)d;
   piece->data_size = sizeof(dt_iop_tonecurve_data_t);
+  // Checked AFTER both piece->data and piece->data_size are set, deliberately.
+  // dt_iop_init_pipe() disables the node for us when it sees data_size > 0 with a NULL
+  // data -- returning before data_size is assigned skips that and leaves the node enabled
+  // with no storage. dt_calloc_align() returns NULL on failure and pipe nodes are built
+  // exactly when memory is tightest (Sentry 134134395 faulted in atrous's init_pipe).
+  if(IS_NULL_PTR(piece->data)) return;
   d->autoscale_ab = DT_S_SCALE_AUTOMATIC;
   d->unbound_ab = 1;
   for(int ch = 0; ch < ch_max; ch++)

--- a/src/iop/tonecurve.c
+++ b/src/iop/tonecurve.c
@@ -764,6 +764,8 @@ void init_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pi
 
 void cleanup_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
 {
+  /* init_pipe() may have failed to allocate, and cleanup runs regardless. */
+  if(IS_NULL_PTR(piece->data)) return;
   // clean up everything again.
   dt_iop_tonecurve_data_t *d = (dt_iop_tonecurve_data_t *)(piece->data);
   for(int ch = 0; ch < ch_max; ch++) dt_draw_curve_destroy(d->curve[ch]);

--- a/tools/sentry-fetch-issue.sh
+++ b/tools/sentry-fetch-issue.sh
@@ -134,9 +134,27 @@ if api_get "/projects/${SENTRY_ORG}/${SENTRY_PROJECT}/events/${EVENT_ID}/attachm
     jq -r '.[] | "\(.id)\t\(.name)"' "$ATTACH_JSON" | while IFS=$'\t' read -r aid aname; do
       [ -n "$aid" ] || continue
       safe="$(printf '%s' "$aname" | tr -c 'A-Za-z0-9._-' '_')"
-      curl -fsS "${AUTH[@]}" \
-        "${API}/projects/${SENTRY_ORG}/${SENTRY_PROJECT}/events/${EVENT_ID}/attachments/${aid}/?download" \
-        -o "${OUT_DIR}/${safe}" && err "    ${safe}"
+      dest="${OUT_DIR}/${safe}"
+      # -L is load-bearing: Sentry answers this endpoint with a 302 to blob storage. Without
+      # it curl writes the empty redirect body -- and -f does NOT make a 302 an error, so the
+      # command still exits 0 and the download looks like it worked. That is how every
+      # gdb-backtrace.txt landed here as a 0-byte file while the tool reported success, and
+      # why several crashes were written off as "no symbols" when a fully symbolised
+      # backtrace of every thread was sitting in the attachment.
+      if curl -fsSL "${AUTH[@]}" \
+           "${API}/projects/${SENTRY_ORG}/${SENTRY_PROJECT}/events/${EVENT_ID}/attachments/${aid}/?download=1" \
+           -o "$dest"; then
+        size="$(wc -c < "$dest" 2>/dev/null || echo 0)"
+        if [ "${size:-0}" -gt 0 ]; then
+          err "    ${safe} (${size} bytes)"
+        else
+          err "    ${safe}: EMPTY -- download produced no data, removing"
+          rm -f "$dest"
+        fi
+      else
+        err "    ${safe}: download FAILED"
+        rm -f "$dest"
+      fi
     done
   else
     err "==> no attachments on this event"


### PR DESCRIPTION
## The tool fix is the important half

`tools/sentry-fetch-issue.sh` has never downloaded a single attachment:

```sh
curl -fsS "${AUTH[@]}" ".../attachments/${aid}/?download" -o "${OUT_DIR}/${safe}" && err "    ${safe}"
```

Sentry answers that endpoint with a **302 to blob storage**. Without `-L`, curl writes the empty
redirect body — and `-f` does not treat a 302 as an error, so it exits 0 and the `&&` prints the
filename as though it worked. Every attachment landed as a **0-byte file, reported as success**.

That matters because Ansel attaches a full DbgHelp or gdb backtrace to its crash reports — every
thread, with file names and line numbers — and it is frequently the *only* symbolised view. The
frames Sentry itself renders are often pure `libc`/`ntdll` with no function names.

**Six issues had been triaged as "no symbols, not diagnosable" while a symbolised backtrace sat in
the attachment.** With the tool fixed, they resolved in minutes:

| Issue | Verdict from the attached backtrace |
| --- | --- |
| 129978857 (37 events, 17 users) | **Not ours.** Intel's OpenCL compiler installs a signal handler that `longjmp`s out of signal context; glibc's `__longjmp_chk` fortify check rejects it → `abort`. We are idle in `ppoll` inside `gtk_main`. |
| 129862572 (169 events), 141634558 | **Not ours.** Entirely inside `amdocl64.dll` on driver-spawned threads. |
| 143093465 | **Third-party.** Malformed JPEG-in-TIFF embedded preview; libjpeg longjmps out of libtiff, the Windows unwind fails. |
| 142561119 | **Already fixed** — and the existing fix's comment cites this exact issue number. Resolved. |
| 134134395 | **Ours** — fixed below. |

Also added: an empty download is now reported as `EMPTY` and the file removed, instead of being
left behind looking like a success.

## Eleven unchecked init_pipe() allocations

Sentry 134134395's backtrace puts the fault directly in atrous's `init_pipe()`:

```c
dt_iop_atrous_data_t *d = dt_calloc_align(sizeof(dt_iop_atrous_data_t));
...
d->curve[ch] = dt_draw_curve_new(...);      // d unchecked
```

`dt_calloc_align()` returns NULL on failure, and pipe nodes are built exactly when memory is
tightest. Sweeping every module found the same shape in **eleven**: atrous, colisa, colorequal,
colorprimaries, colorzones, denoiseprofile, lowlight, lowpass, rawdenoise, rgbcurve, tonecurve.
Only `drawlayer.c` checked at all.

**Where the check goes is the subtle part.** `dt_iop_init_pipe()` already recovers:

```c
if(piece->data_size > 0 && IS_NULL_PTR(piece->data))
{
  dt_print(... "the node stays disabled");
  piece->data_size = 0;
  piece->enabled = 0;
}
```

So the guard must come **after** both `piece->data` and `piece->data_size` are assigned. Returning
as soon as the allocation fails — which is what my first pass did, and what `drawlayer.c` does
today — leaves `data_size` at 0, so that recovery never fires and the node stays **enabled** with
no storage. The crash just moves to whoever reads `piece->data` next.

Placed correctly, a failed allocation now ends with the node disabled and a message naming the
module: the behaviour the pipeline was already written for.

`drawlayer.c` has the early-return form and is worth a separate look; its own NULL check is
present, so this sweep left it alone rather than reshuffling a module it did not need to touch.

## Verification

GCC Release and clang Debug, **0 errors**, no new warnings (the 2 remaining are the known
`Permutohedral` GCC false positive). `tools/check_it_runs.sh` passes on ASCII and non-ASCII paths.