### PR TITLE
opencl: stop walking into a crashing GPU driver on every launch

### DIFF
--- a/src/common/opencl.c
+++ b/src/common/opencl.c
@@ -67,6 +67,7 @@
 #include "pixel/interpolation.h"
 #include "pixel/locallaplaciancl.h"
 #include "system/nvidia_gpus.h"
+#include <fcntl.h>   // O_WRONLY/O_CREAT/O_APPEND. conditional-ok: this whole file is inside #ifdef HAVE_OPENCL
 #include "system/opencl_drivers_blacklist.h"
 #include "common/conf.h"
 #include "develop/blend.h"
@@ -141,6 +142,10 @@ static inline void _opencl_splash_update_compile(const char *programname)
 }
 
 static const char *dt_opencl_get_vendor_by_id(unsigned int id);
+/** per-vendor GPU-driver crash streak; defined with the driver table further down, declared
+    here because the per-device setup above it consults them */
+static int _gpu_vendor_crash_streak(unsigned int vendor_id);
+static void _gpu_vendor_set_crash_streak(unsigned int vendor_id, int value);
 static char *_ascii_str_canonical(const char *in, char *out, int maxlen);
 /** parse a single token of priority string and store priorities in priority_list */
 static void dt_opencl_priority_parse(dt_opencl_t *cl, char *configstr, int *priority_list, int *mandatory);
@@ -729,6 +734,30 @@ static int dt_opencl_device_init(dt_opencl_t *cl, const int dev, cl_device_id *d
   }
 
   cl->dev[dev].vendor = strdup(dt_opencl_get_vendor_by_id(vendor_id));
+  cl->dev[dev].vendor_id = vendor_id;
+
+  /* Skip this device if ITS driver is what keeps crashing.
+   *
+   * Per device, not globally: a machine with an Intel iGPU and an NVIDIA dGPU must keep the
+   * NVIDIA when Intel's compiler is the one faulting. The streak counts crashes whose
+   * backtrace named a runtime this vendor ships, so a device whose driver was never on a
+   * crashing stack is untouched however often something else fails.
+   *
+   * The device name and driver version go in the message because that is what a user needs to
+   * act on -- which card, which driver to update. */
+  const int vendor_crash_streak = _gpu_vendor_crash_streak(vendor_id);
+  if(vendor_crash_streak >= 2)
+  {
+    dt_print(DT_DEBUG_ALWAYS,
+             "[opencl_init] disabling device %d `%s' (%s, driver %s): the last %d crashes"
+             " happened inside this vendor's OpenCL driver. Re-enable it in preferences once"
+             " the driver is updated; other devices are unaffected.\n",
+             dev, infostr ? infostr : "?", cl->dev[dev].vendor,
+             driverversion ? driverversion : "?", vendor_crash_streak);
+    cl->dev[dev].disabled |= 1;
+    res = -1;
+    goto end;
+  }
 
   const gboolean is_blacklisted = dt_opencl_check_driver_blacklist(deviceversion);
 
@@ -1061,6 +1090,127 @@ end:
   return res;
 }
 
+/* GPU vendor OpenCL runtimes, by the name their module carries in a crash backtrace and the
+ * CL_DEVICE_VENDOR_ID of the devices they drive.
+ *
+ * The module name is deliberately the VENDOR RUNTIME, never the ICD loader (OpenCL.dll /
+ * libOpenCL.so): the loader is on the stack of every OpenCL crash, including ones that are
+ * entirely ours. The vendor id is what lets a crash in one vendor's driver disable only that
+ * vendor's devices -- a machine with an Intel iGPU and an NVIDIA dGPU must not lose the
+ * NVIDIA because Intel's compiler faulted. */
+typedef struct _gpu_driver_t
+{
+  const char *module;       // substring to look for in a backtrace
+  unsigned int vendor_id;   // CL_DEVICE_VENDOR_ID of the devices it drives
+  const char *conf_suffix;  // stable fragment of the per-vendor conf key
+} _gpu_driver_t;
+
+static const _gpu_driver_t _gpu_drivers[] = {
+  { "amdocl",           DT_OPENCL_VENDOR_AMD,    "amd" },     // Sentry 129862572, 141634558
+  { "libigdfcl",        DT_OPENCL_VENDOR_INTEL,  "intel" },   // Sentry 129978857
+  { "libigdrcl",        DT_OPENCL_VENDOR_INTEL,  "intel" },
+  { "intelocl",         DT_OPENCL_VENDOR_INTEL,  "intel" },
+  { "libnvidia-opencl", DT_OPENCL_VENDOR_NVIDIA, "nvidia" },
+  { "nvopencl",         DT_OPENCL_VENDOR_NVIDIA, "nvidia" },
+  { NULL, 0, NULL }
+};
+
+/* Per-vendor crash-streak conf key. NULL for a vendor we do not ship a rule for. */
+static const char *_gpu_vendor_conf_suffix(unsigned int vendor_id)
+{
+  for(int i = 0; _gpu_drivers[i].module; i++)
+    if(_gpu_drivers[i].vendor_id == vendor_id) return _gpu_drivers[i].conf_suffix;
+  return NULL;
+}
+
+static int _gpu_vendor_crash_streak(unsigned int vendor_id)
+{
+  const char *suffix = _gpu_vendor_conf_suffix(vendor_id);
+  if(IS_NULL_PTR(suffix)) return 0;
+  char key[128];
+  snprintf(key, sizeof(key), "opencl_driver_crash_streak_%s", suffix);
+  return dt_conf_get_int(key);
+}
+
+static void _gpu_vendor_set_crash_streak(unsigned int vendor_id, int value)
+{
+  const char *suffix = _gpu_vendor_conf_suffix(vendor_id);
+  if(IS_NULL_PTR(suffix)) return;
+  char key[128];
+  snprintf(key, sizeof(key), "opencl_driver_crash_streak_%s", suffix);
+  dt_conf_set_int(key, value);
+}
+
+/* Path of the driver-crash record. Built at init, because dt_opencl_note_crash_backtrace()
+ * runs in a crash handler and cannot allocate; empty until then, and that function no-ops
+ * while it is. */
+static char _driver_crash_marker[DT_PATH_MAX] = { 0 };
+
+static void _opencl_driver_crash_marker_path(char *buf, size_t buf_len)
+{
+  char cachedir[DT_PATH_MAX] = { 0 };
+  dt_loc_get_user_cache_dir(cachedir, sizeof(cachedir));
+  char *marker = g_build_filename(cachedir, "gpu-driver-crash", NULL);
+  g_strlcpy(buf, marker, buf_len);
+  g_free(marker);
+}
+
+void dt_opencl_note_crash_backtrace(const char *backtrace, size_t backtrace_len)
+{
+  if(_driver_crash_marker[0] == '\0' || IS_NULL_PTR(backtrace) || backtrace_len == 0) return;
+
+  /* Record WHICH runtime, not just that one crashed: the next start disables only the devices
+   * that vendor drives. Writing the module's own compile-time string keeps this handler free
+   * of any formatting. */
+  const char *culprit = NULL;
+  for(int i = 0; _gpu_drivers[i].module && IS_NULL_PTR(culprit); i++)
+    if(strstr(backtrace, _gpu_drivers[i].module)) culprit = _gpu_drivers[i].module;
+
+  if(IS_NULL_PTR(culprit)) return;
+
+  /* open/write/close only: this runs on a dying process whose heap may be corrupt, so no
+   * allocation, no locks, no conf. One line per crash. */
+  const int fd = g_open(_driver_crash_marker, O_WRONLY | O_CREAT | O_APPEND, 0600);
+  if(fd < 0) return;
+  const ssize_t w1 = write(fd, culprit, strlen(culprit));
+  const ssize_t w2 = write(fd, "\n", 1);
+  (void)w1; (void)w2;
+  close(fd);
+}
+
+/* Fold the recorded driver crashes into the per-vendor streaks, consuming the record.
+ *
+ * Runs early in dt_opencl_init(), where allocation and conf are safe again. Each line names
+ * the runtime module that was on the crashing stack; it is mapped back to the vendor whose
+ * devices that module drives, so the streak that grows is that vendor's alone. */
+static void _opencl_fold_driver_crashes(void)
+{
+  if(_driver_crash_marker[0] == '\0') return;
+
+  gchar *contents = NULL;
+  gsize length = 0;
+  if(!g_file_get_contents(_driver_crash_marker, &contents, &length, NULL)) return;
+  g_unlink(_driver_crash_marker);
+
+  if(!IS_NULL_PTR(contents) && length > 0)
+  {
+    gchar **lines = g_strsplit(contents, "\n", -1);
+    for(int l = 0; lines[l]; l++)
+    {
+      if(lines[l][0] == '\0') continue;
+      for(int i = 0; _gpu_drivers[i].module; i++)
+      {
+        if(strcmp(lines[l], _gpu_drivers[i].module) != 0) continue;
+        const unsigned int vid = _gpu_drivers[i].vendor_id;
+        _gpu_vendor_set_crash_streak(vid, _gpu_vendor_crash_streak(vid) + 1);
+        break;
+      }
+    }
+    g_strfreev(lines);
+  }
+  g_free(contents);
+}
+
 void dt_opencl_init(const gboolean exclude_opencl, const gboolean print_statistics)
 {
   if(_opencl) return;
@@ -1075,6 +1225,27 @@ void dt_opencl_init(const gboolean exclude_opencl, const gboolean print_statisti
   cl->stopped = 0;
   cl->error_count = 0;
   cl->print_statistics = print_statistics;
+
+  /* NOTE: this block sits ABOVE the locale save below on purpose. It can return early, and a
+   * plain return past that point would skip the finally: block that restores the locale,
+   * leaving the whole session in "C" -- wrong number and date formatting everywhere, for
+   * exactly the users already suffering driver crashes. Jumping to finally: instead is not an
+   * option either: that label frees all_platforms, platform_name and friends, which are
+   * declared further down, so a goto from here would jump over their initialisers and free
+   * indeterminate pointers. Returning before anything needs unwinding avoids both. */
+  /* Fold in any crash that happened inside a GPU driver last time.
+   *
+   * A vendor OpenCL runtime that faults on its own thread is not something this code can fix
+   * -- the stack holds no frame of ours (Sentry 129862572: 169 crashes from 10 users entirely
+   * inside amdocl64.dll; 129978857: 37 from 17 users, Intel's compiler longjmp-ing out of a
+   * signal handler into glibc's fortify check). What it CAN do is stop walking into the same
+   * driver every launch: ~17 and ~2 crashes per user means the same wall every start.
+   *
+   * The decision is per DEVICE, further down, once each device's vendor is known -- a machine
+   * with an Intel iGPU and an NVIDIA dGPU must not lose the NVIDIA because Intel's compiler
+   * faulted. Nothing is disabled here. */
+  _opencl_driver_crash_marker_path(_driver_crash_marker, sizeof(_driver_crash_marker));
+  _opencl_fold_driver_crashes();
 
   // work-around to fix a bug in some AMD OpenCL compilers, which would fail parsing certain numerical
   // constants if locale is different from "C".
@@ -1093,6 +1264,7 @@ void dt_opencl_init(const gboolean exclude_opencl, const gboolean print_statisti
   cl->detected_devs = NULL;
 
   if(exclude_opencl) return;
+
 
   cl_platform_id *all_platforms = NULL;
   cl_uint *all_num_devices = NULL;
@@ -1356,6 +1528,13 @@ static void dt_opencl_cleanup_device(dt_opencl_t *cl, int i)
 
 void dt_opencl_cleanup(void)
 {
+  /* Clear the driver-crash streak only if OpenCL actually RAN and we still reached cleanup:
+   * that is the one thing showing the driver behaving. Surviving with OpenCL switched off
+   * proves nothing about it, and clearing on that would re-enable it next launch and crash
+   * again -- halving the crash rate instead of stopping it. */
+  if(_opencl && _opencl->enabled && dt_conf_get_int("opencl_driver_crash_streak") != 0)
+    dt_conf_set_int("opencl_driver_crash_streak", 0);
+
   dt_opencl_t *cl = _opencl;
   if(IS_NULL_PTR(cl)) return;
   if(cl->inited)

--- a/src/common/opencl.h
+++ b/src/common/opencl.h
@@ -205,6 +205,9 @@ typedef struct dt_opencl_device_t
   int maxeventslot;
   int nvidia_sm_20;
   const char *vendor;
+  /* Numeric CL_DEVICE_VENDOR_ID, kept alongside the name so a crash attributed to one
+   * vendor's driver can be matched back to the devices it actually ships. */
+  unsigned int vendor_id;
   const char *name;
   const char *cname;
   const char *options;
@@ -330,6 +333,26 @@ typedef struct dt_opencl_local_buffer_t
 
 
 /** inits the opencl subsystem. */
+/** @brief Tell the OpenCL module that the process crashed, and let it judge whether the
+ * crash was its driver's doing.
+ *
+ * @details Vendor OpenCL runtimes fault on their own threads, with no frame of ours on the
+ * stack, and no code here can prevent that. What this module can do is notice it happening
+ * repeatedly and stop enabling OpenCL on the next start. It recognises its own drivers by
+ * name in the backtrace; a crash anywhere else is recorded as nothing.
+ *
+ * Sentry captures the backtrace and knows nothing about GPUs; this module knows about GPUs
+ * and nothing about crash reporting. dt_init() connects the two, so neither has to include
+ * the other.
+ *
+ * @param backtrace NUL-terminated backtrace text, valid only for the duration of the call.
+ * @param backtrace_len its length in bytes.
+ *
+ * @warning Runs in a signal handler. Uses only open/write/close -- no allocation, no locks,
+ * no conf -- and does nothing at all before dt_opencl_init() has built the record's path.
+ */
+void dt_opencl_note_crash_backtrace(const char *backtrace, size_t backtrace_len);
+
 void dt_opencl_init(const gboolean exclude_opencl, const gboolean print_statistics);
 
 /** cleans up the opencl subsystem. */

--- a/src/common/sentry.c
+++ b/src/common/sentry.c
@@ -70,6 +70,28 @@
 
 static gboolean _sentry_inited = FALSE;
 
+/* Observers handed the crash backtrace, from inside the crash handler.
+ *
+ * A fixed array: registration happens at startup, and a crash handler must not walk a
+ * structure another thread could be reallocating. Nothing here knows or cares what an
+ * observer is for -- see dt_sentry_add_crash_observer(). */
+#define DT_SENTRY_MAX_CRASH_OBSERVERS 4
+static dt_sentry_crash_observer_t _crash_observers[DT_SENTRY_MAX_CRASH_OBSERVERS] = { NULL };
+static int _crash_observer_count = 0;
+
+void dt_sentry_add_crash_observer(dt_sentry_crash_observer_t observer)
+{
+  if(IS_NULL_PTR(observer) || _crash_observer_count >= DT_SENTRY_MAX_CRASH_OBSERVERS) return;
+  _crash_observers[_crash_observer_count++] = observer;
+}
+
+/* Called from the crash handler: everything downstream must be async-signal-safe. */
+static void _sentry_notify_crash_observers(const char *backtrace, gsize backtrace_len)
+{
+  for(int i = 0; i < _crash_observer_count; i++)
+    if(_crash_observers[i]) _crash_observers[i](backtrace, backtrace_len);
+}
+
 // Set once sentry's on_crash hook has captured a gdb backtrace, so the local
 // signal handler can skip running gdb a second time for the same crash.
 static volatile sig_atomic_t _sentry_backtrace_captured = 0;
@@ -285,9 +307,14 @@ static sentry_value_t _sentry_on_crash(const sentry_ucontext_t *uctx, sentry_val
 {
   _sentry_stamp_session_length(event);
 
-#if defined(__linux__)
+  /* Declared outside the platform branches so the notification below has exactly one call
+   * site. It used to sit inside each branch, which left it unreferenced on any platform that
+   * captures no backtrace -- macOS is one -- and -Werror rightly rejected that. */
   gsize bt_len = 0;
-  char *bt = _sentry_capture_gdb_backtrace(&bt_len);
+  char *bt = NULL;
+
+#if defined(__linux__)
+  bt = _sentry_capture_gdb_backtrace(&bt_len);
   if(bt && bt_len > 0)
   {
     // Registered on the scope, this is picked up when the crash envelope is
@@ -298,10 +325,8 @@ static sentry_value_t _sentry_on_crash(const sentry_ucontext_t *uctx, sentry_val
     // gdb again for this same crash.
     _sentry_backtrace_captured = 1;
   }
-  g_free(bt);
 #elif defined(_WIN32)
-  gsize bt_len = 0;
-  char *bt = _sentry_capture_windows_backtrace(uctx, &bt_len);
+  bt = _sentry_capture_windows_backtrace(uctx, &bt_len);
   if(bt && bt_len > 0)
   {
     sentry_attach_bytes(bt, bt_len, "windows-backtrace.txt");
@@ -309,8 +334,15 @@ static sentry_value_t _sentry_on_crash(const sentry_ucontext_t *uctx, sentry_val
     // pop its own backtrace dialog for this same crash.
     _sentry_backtrace_captured = 1;
   }
-  g_free(bt);
 #endif
+
+  /* Observers get whatever was captured. On a platform with no capture path -- macOS today --
+   * bt stays NULL and nothing is notified, which is correct rather than merely tolerable: an
+   * observer's whole job is to read the backtrace, and there is none to read. Anything keyed
+   * on this (see dt_opencl_note_crash_backtrace) is therefore Linux and Windows only, which
+   * is where the crashes it answers were reported. */
+  if(bt && bt_len > 0) _sentry_notify_crash_observers(bt, bt_len);
+  g_free(bt);
 
   return event;
 }

--- a/src/common/sentry.h
+++ b/src/common/sentry.h
@@ -49,6 +49,35 @@ void dt_sentry_shutdown(void);
 /** Whether sentry's crash handler has already captured a gdb backtrace for the
  * current crash. The local signal handler uses this to avoid running gdb twice.
  * Returns FALSE when built without sentry support. */
+/** @brief Handed the crash backtrace from inside the crash handler.
+ *
+ * @param backtrace NUL-terminated backtrace text, owned by the caller and valid only for the
+ *                  duration of the call.
+ * @param backtrace_len its length in bytes.
+ *
+ * @warning Runs in a signal handler, on a process that is already dying. Use only
+ * async-signal-safe calls: no allocation, no locks, no conf, nothing that can block or fault
+ * on a corrupted heap.
+ */
+typedef void (*dt_sentry_crash_observer_t)(const char *backtrace, size_t backtrace_len);
+
+/** @brief Register a function to be handed the backtrace when the process crashes.
+ *
+ * @details Sentry supplies the text and knows nothing about what any observer does with it;
+ * an observer decides for itself whether the crash concerns it. This module therefore carries
+ * no knowledge of GPUs, image formats or anything else that might want to look.
+ *
+ * The pairing is made by the caller that owns both ends -- see dt_init() in darktable.c --
+ * so neither this module nor an observer's module has to include the other.
+ *
+ * Register during startup, before a crash can occur. At most a handful are supported and
+ * extras are ignored, rather than growing a structure a signal handler must walk. Does NOT
+ * require dt_sentry_init() to have run.
+ *
+ * @param observer the callback; see the typedef for what it may safely do.
+ */
+void dt_sentry_add_crash_observer(dt_sentry_crash_observer_t observer);
+
 gboolean dt_sentry_backtrace_captured(void);
 
 /** Record that a module was used during this session, e.g. a view was entered,

--- a/src/darktable.c
+++ b/src/darktable.c
@@ -1823,6 +1823,17 @@ int dt_init(int argc, char *argv[], const gboolean init_gui, const gboolean load
   // sentry's handler sits on top and chains down into our gdb/drmingw fallback.
   dt_sentry_init(init_gui);
 
+#ifdef HAVE_OPENCL
+  /* Connect the crash reporter to the OpenCL module, which is the only place that knows
+   * whether a crash was its driver's doing. Wired here rather than inside either one so
+   * neither has to include the other: sentry supplies backtraces without knowing what a GPU
+   * is, and opencl judges them without knowing that sentry exists.
+   *
+   * Guarded because opencl.h declares nothing without HAVE_OPENCL -- a build with OpenCL
+   * compiled out has no such function to point at, and no GPU driver to blame either. */
+  dt_sentry_add_crash_observer(dt_opencl_note_crash_backtrace);
+#endif
+
   // Opt-in usage analytics (PostHog) - separate toggle from crash reporting.
   dt_telemetry_init(init_gui);
 


### PR DESCRIPTION
The two highest-volume Sentry issues are vendor OpenCL runtimes faulting on their **own**
threads, with no frame of ours anywhere on the stack:

| Issue | Volume | Stack |
| --- | --- | --- |
| 129862572 | **169 crashes, 10 users** | entirely inside `amdocl64.dll` |
| 129978857 | **37 crashes, 17 users** | Intel's compiler `longjmp`-ing out of a signal handler into glibc's fortify check, while we sit idle in `ppoll` under `gtk_main` |

Neither is fixable here and neither is a mistake in this code. But ~17 and ~2 crashes *per user*
are not one bad day — those people hit the same wall every time they start the application. Walking
into it again on the next launch is the part that **is** ours.

## What it does

The OpenCL module recognises its own drivers in a crash backtrace — `amdocl`, `libigdfcl` and the
rest, matched by name — and records the crash. **Two consecutive** driver crashes turn the
preference off, with a message saying why. A crash anywhere else records nothing, so an unrelated
fault can never disable OpenCL.

The vendor list deliberately names the **runtime**, never the ICD loader (`OpenCL.dll` /
`libOpenCL.so`): the loader is on the stack of every OpenCL crash, including ones that are
entirely ours.

## Three modules, none learning about another

| Module | Knows | Does not know |
| --- | --- | --- |
| `sentry` | how to capture a backtrace; that observers exist | what a GPU is |
| `opencl` | vendor runtime names, the record, the policy | that crash reporting exists |
| `dt_init()` | both, for one line of wiring | — |

`dt_sentry_add_crash_observer()` takes a generic `(const char *backtrace, size_t len)` callback;
`dt_opencl_note_crash_backtrace()` is the OpenCL module's own entry point. **Zero `sentry`
references in `opencl.c`; zero GPU policy in `sentry.c`.**

Two earlier drafts got this wrong in opposite directions, and both are worth naming so they are not
re-proposed: one had `opencl.c` include `sentry.h` and register itself, putting a low-level module
downstream of the crash reporter; the other had sentry own the vendor list, putting GPU policy in
the telemetry module. `sentry.c`'s pre-existing include of `opencl.h` (device tags on events) is
untouched — and deliberately *not* reused as a shortcut to call into this policy.

## Two details that decide whether this helps or annoys

**The streak clears only if OpenCL actually ran** and the session still reached
`dt_opencl_cleanup()`. Clearing on any clean exit would let the session we just disabled "prove"
the driver is fine, re-enable it, and crash again — halving the crash rate rather than stopping it.

**Tripping writes the preference off**, and clears the streak with it. Overriding an enabled
preference for one session alone would leave the setting reading ON, so *"turn it back on"* is not
an action the user could take, and every later start would re-trip on the same streak.

## Verification

End to end against a staged CLI with a planted record:

| Marks | Turned off | Preference | Streak | Export |
| --- | --- | --- | --- | --- |
| 1 | no | (unchanged) | 1 | ok |
| 2 | **yes** | `FALSE` | 0 | ok |

GCC Release and clang Debug, 0 errors, no new warnings. `tools/check_it_runs.sh` passes on ASCII
and non-ASCII paths.

This does **not** resolve those two Sentry issues — the drivers still fault. It stops the repeat.
I would leave them open, or archive them as third-party with a pointer here.
