### PR TITLE
Import: fix which image opens, which folder the library shows, and what an automatic import is allowed to move

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1197,6 +1197,16 @@ non-tree drop target or `tagging.c`-style full source+dest.
 (`control/jobs/import_jobs.c`, `control/jobs/film_jobs.c`) call to make a freshly imported image
 visible. It runs on the **import job's thread**.
 
+**Following the imported image's folder** is the Collect module's persisted tab's business, and
+deliberately NOT the current atelier's: rule 0 gets overwritten with the imported image's folder,
+which is legitimate on the "Folders" tab and destructive on "Collections" and "Queries" where the
+rules belong to the user. The collection is global, so an import started from the darkroom must
+re-point it too, or the library still shows the previously browsed folder when the user goes back
+to the grid. Studio Capture has no Collect module UI and therefore no rules to protect, so it
+always follows. `_collection_folder_ui_inactive()` is a different predicate for a different
+question (which folder the import dialog considers "currently browsed") and does gate on the
+atelier; do not merge the two.
+
 **Opening a single imported image in the darkroom** goes through
 `dt_ctl_open_image_in_darkroom(imgid)` (`control/control.c`), never through a view switch alone.
 The darkroom's `try_enter()` picks its target from `dt_control_get_mouse_over_id()`, falling back

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1191,6 +1191,25 @@ with a manual `gtk_drag_dest_set` reliably receives motion but does not deliver 
 models. DnD was removed entirely at the maintainer's request; do not re-add without a
 non-tree drop target or `tagging.c`-style full source+dest.
 
+### After an import: which image opens, and which folder the library shows
+
+`dt_collection_load_filmroll()` (`common/collection.c`) is what both import paths
+(`control/jobs/import_jobs.c`, `control/jobs/film_jobs.c`) call to make a freshly imported image
+visible. It runs on the **import job's thread**.
+
+**Opening a single imported image in the darkroom** goes through
+`dt_ctl_open_image_in_darkroom(imgid)` (`control/control.c`), never through a view switch alone.
+The darkroom's `try_enter()` picks its target from `dt_control_get_mouse_over_id()`, falling back
+on the selection, and both are volatile across the lighttable round-trip the switch performs: any
+pointer motion over the grid rewrites the mouse-over id, and the darkroom's own `leave()` calls
+`dt_selection_select_single(dt_view_active_images_get_first())`, i.e. restores the selection to
+the image it was editing. Publishing the target from the job thread and requesting the switch
+separately therefore re-opens the previous image about as often as the intended one, depending on
+where the pointer happens to sit. `dt_ctl_open_image_in_darkroom()` marshals the whole sequence
+into one GUI-thread callback — leave the darkroom via the lighttable, publish mouse-over id and
+selection, then enter the darkroom — so nothing can run in between. Any other worker-thread code
+that needs a specific image opened must use it rather than setting those globals itself.
+
 ---
 
 ## GTK / UI

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1210,6 +1210,11 @@ into one GUI-thread callback — leave the darkroom via the lighttable, publish 
 selection, then enter the darkroom — so nothing can run in between. Any other worker-thread code
 that needs a specific image opened must use it rather than setting those globals itself.
 
+The import job only asks for that when it imported exactly one image *and* at most one XMP
+(`index == 1 && xmps <= 1`): two or more sidecars mean the file produced several DB images
+(duplicates) and none of them is the obvious one to open. Zero is the ordinary no-sidecar case
+and still opens.
+
 ---
 
 ## GTK / UI

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1197,15 +1197,33 @@ non-tree drop target or `tagging.c`-style full source+dest.
 (`control/jobs/import_jobs.c`, `control/jobs/film_jobs.c`) call to make a freshly imported image
 visible. It runs on the **import job's thread**.
 
-**Following the imported image's folder** is the Collect module's persisted tab's business, and
-deliberately NOT the current atelier's: rule 0 gets overwritten with the imported image's folder,
-which is legitimate on the "Folders" tab and destructive on "Collections" and "Queries" where the
-rules belong to the user. The collection is global, so an import started from the darkroom must
-re-point it too, or the library still shows the previously browsed folder when the user goes back
-to the grid. Studio Capture has no Collect module UI and therefore no rules to protect, so it
-always follows. `_collection_folder_ui_inactive()` is a different predicate for a different
-question (which folder the import dialog considers "currently browsed") and does gate on the
-atelier; do not merge the two.
+**Whether the user is moved at all** is the caller's decision, expressed as a
+`dt_collection_import_view_t` policy (`common/collection.h`): `KEEP` (never move), `GRID`
+(lighttable), `IMAGE` (open that one image in the darkroom). Every **automatic** import passes
+`KEEP` — Studio Capture's folder survey (`data->folder_survey`, `common/folder_survey.c`) imports
+on its own schedule, in whatever view the user happens to be, and displays the capture itself
+from `DT_SIGNAL_IMAGE_IMPORT` without leaving its atelier. The policy has to come from what the
+import *is*, not from what is on screen when the job ends: the survey keeps running after the
+user leaves the Studio Capture atelier, so a capture landing mid-edit would otherwise throw them
+out of the darkroom (or into it).
+
+**Following the imported image's folder** asks two questions. Did the user ask for this import?
+An automatic one follows the folder in Studio Capture's own atelier, whose filmstrip tracks the
+shooting session, and nowhere else — the same reason `KEEP` does not switch views, applied to the
+collection. Then, may rule 0 be overwritten with a folder? That is the Collect module's persisted
+tab: legitimate on "Folders", destructive on "Collections" and "Queries" where the rules are the
+user's. That second question is deliberately NOT about the current atelier — the collection is
+global, so a manual import started from the darkroom must re-point it too, or the library still
+shows the previously browsed folder when the user goes back to the grid.
+`_collection_folder_ui_inactive()` is a different predicate for a different question (which
+folder the import dialog considers "currently browsed") and does gate on the atelier; do not
+merge the two.
+
+**The hovered image and the selection** follow the same rule: `dt_collection_load_filmroll()`
+points them at the imported image only for a user-requested import. Under `KEEP` it leaves both
+alone — Studio Capture sets them itself for the capture it displays (`_studio_set_image()`), and
+anywhere else adding an unrequested image to the selection also hands it to the next darkroom
+entry, whose `try_enter()` reads the mouse-over id first.
 
 **Opening a single imported image in the darkroom** goes through
 `dt_ctl_open_image_in_darkroom(imgid)` (`control/control.c`), never through a view switch alone.
@@ -1220,7 +1238,7 @@ into one GUI-thread callback — leave the darkroom via the lighttable, publish 
 selection, then enter the darkroom — so nothing can run in between. Any other worker-thread code
 that needs a specific image opened must use it rather than setting those globals itself.
 
-The import job only asks for that when it imported exactly one image *and* at most one XMP
+The import job only asks for `IMAGE` when it imported exactly one image *and* at most one XMP
 (`index == 1 && xmps <= 1`): two or more sidecars mean the file produced several DB images
 (duplicates) and none of them is the obvious one to open. Zero is the ordinary no-sidecar case
 and still opens.

--- a/doc/studio-capture.md
+++ b/doc/studio-capture.md
@@ -219,6 +219,16 @@ keys pan at 100%, and Ctrl+/- toggles zoom the same as double-click since
 there is no continuous scale to step through). Every new import becomes the
 displayed image, so the view follows the shooting session.
 
+That following is this atelier's own doing, and only here. An automatic import
+carries the `DT_COLLECTION_IMPORT_VIEW_KEEP` policy
+(`dt_collection_load_filmroll()`, `common/collection.c`), which moves nothing:
+no view switch, no re-pointing of the collection onto the capture folder, no
+forced hover or selection. The survey keeps running after the user leaves this
+atelier — a capture landing while they browse or edit elsewhere must not drag
+them anywhere. Studio Capture is the one exception on the collection side, so
+its filmstrip still follows the session, and `_studio_set_image()` below is
+what keeps the selection and the hovered image on the displayed capture.
+
 Keyboard navigation must go through `d->zoom`/`pan_x`/`pan_y` — the same
 fields the mouse handlers use — never through `d->dev->roi`: that develop
 only feeds the Scopes module in the background (see below) and never reaches

--- a/src/common/collection.c
+++ b/src/common/collection.c
@@ -1089,14 +1089,22 @@ void dt_collection_load_filmroll(dt_collection_t *collection, const int32_t imgi
   if(imgid == UNKNOWN_IMAGE)
     return;
 
-  // _collection_folder_ui_inactive() also gates on the atelier (only lighttable/Studio Capture
-  // have a folder-browsing grid worth re-pointing at the import). That gate must only cover the
-  // folder-following block below, not the mouse-over/selection/view-switch block that follows
-  // it: those are what actually opens the newly imported image, and must run for every atelier,
-  // darkroom included -- otherwise importing a single image while already in darkroom never
-  // opens it, since dt_control_set_mouse_over_id() below (which darkroom's try_enter() reads to
-  // pick the target image) never runs.
-  if(!_collection_folder_ui_inactive(current_atelier))
+  // May the folder-browsing rules be re-pointed at the imported image's folder? That is the
+  // Collect module's persisted tab's business, and deliberately NOT the current atelier's: rule 0
+  // gets overwritten with the imported image's folder, which is legitimate on "Folders" and
+  // destructive on "Collections" and "Queries" where the rules belong to the user. The collection
+  // is global, so an import started from the darkroom (or the map, or print) must re-point it
+  // just the same, or the imported image is nowhere to be found when the user gets back to the
+  // grid. Studio Capture has no Collect module UI, hence no such rules to protect.
+  //
+  // This gates the folder-following block only, never the mouse-over/selection/view-switch block
+  // that follows it: those are what actually makes the newly imported image the one on screen.
+  const gboolean is_studio_capture = !IS_NULL_PTR(current_atelier)
+                                     && !g_strcmp0(current_atelier->module_name, "studio_capture");
+  const gboolean follow_import_folder = is_studio_capture
+                                        || dt_conf_get_int("plugins/lighttable/collect/tab") == 0;
+
+  if(follow_import_folder)
   {
     // Always the folder actually containing imgid (the first successfully imported image), for
     // every case -- copy or in-place, List or Tree view. This used to special-case in-place

--- a/src/common/collection.c
+++ b/src/common/collection.c
@@ -947,13 +947,21 @@ void dt_collection_hint_message(const dt_collection_t *collection)
   g_idle_add(dt_collection_hint_message_internal, message);
 }
 
-static inline void _dt_collection_change_view_after_import(const dt_view_t *current_view, gboolean open_single_image,
+static inline void _dt_collection_change_view_after_import(const dt_view_t *current_view,
+                                                           dt_collection_import_view_t view_policy,
                                                            const int32_t imgid)
 {
+  // An automatic import moves nobody. This is the caller's decision, taken from what the import
+  // IS (Studio Capture's folder survey imports on its own schedule, in whatever view the user
+  // happens to be), not from what is on screen when the job ends -- the survey keeps running
+  // after the user leaves the Studio Capture atelier, so gating on the current view would let a
+  // capture landing while the user edits in the darkroom throw them out of it.
+  if(view_policy == DT_COLLECTION_IMPORT_VIEW_KEEP) return;
+
   // Studio Capture already shows every newly-imported image itself (see
   // _studio_image_imported_callback() in views/studio_capture.c), without leaving the atelier:
-  // forcing a switch to darkroom/lighttable here on every auto-imported capture would fight that
-  // and kick the user out of a live shooting session.
+  // forcing a switch to darkroom/lighttable here on a manual import started from its own panel
+  // would fight that and kick the user out of a live shooting session.
   if(!g_strcmp0(current_view->module_name, "studio_capture")) return;
 
   // Name the image to open explicitly. This runs on the import job's thread, so the mouse-over
@@ -961,7 +969,7 @@ static inline void _dt_collection_change_view_after_import(const dt_view_t *curr
   // the GUI thread performs the switch -- the darkroom's own leave() rewrites the selection, and
   // any pointer motion rewrites the mouse-over id. dt_ctl_open_image_in_darkroom() publishes the
   // target and switches views in one GUI-thread callback instead.
-  if(open_single_image)
+  if(view_policy == DT_COLLECTION_IMPORT_VIEW_IMAGE)
     dt_ctl_open_image_in_darkroom(imgid);
   else if(g_strcmp0(current_view->module_name, "lighttable")) // if current view IS NOT "lighttable".
     dt_ctl_switch_mode_to("lighttable");
@@ -1079,8 +1087,8 @@ void dt_collection_notify_imported(const int32_t imgid, const gchar *known_image
                                 DT_COLLECTION_CHANGE_BACKGROUND_SYNC, DT_COLLECTION_PROP_UNDEF, NULL, -1);
 }
 
-void dt_collection_load_filmroll(dt_collection_t *collection, const int32_t imgid, gboolean open_single_image,
-                                 gboolean set_mouse_over)
+void dt_collection_load_filmroll(dt_collection_t *collection, const int32_t imgid,
+                                 dt_collection_import_view_t view_policy, gboolean set_mouse_over)
 {
   if(IS_NULL_PTR(collection)) return;
   const dt_view_t *current_atelier = dt_view_manager_get_current_view(dt_view_manager_get_global());
@@ -1089,20 +1097,28 @@ void dt_collection_load_filmroll(dt_collection_t *collection, const int32_t imgi
   if(imgid == UNKNOWN_IMAGE)
     return;
 
-  // May the folder-browsing rules be re-pointed at the imported image's folder? That is the
-  // Collect module's persisted tab's business, and deliberately NOT the current atelier's: rule 0
-  // gets overwritten with the imported image's folder, which is legitimate on "Folders" and
-  // destructive on "Collections" and "Queries" where the rules belong to the user. The collection
-  // is global, so an import started from the darkroom (or the map, or print) must re-point it
-  // just the same, or the imported image is nowhere to be found when the user gets back to the
-  // grid. Studio Capture has no Collect module UI, hence no such rules to protect.
+  // May the folder-browsing rules be re-pointed at the imported image's folder? Two questions,
+  // and they gate this block only -- what comes after it (the hovered image, the selection, the
+  // view switch) answers to the import's own policy, not to which atelier is on screen.
   //
-  // This gates the folder-following block only, never the mouse-over/selection/view-switch block
-  // that follows it: those are what actually makes the newly imported image the one on screen.
+  // Does the user expect the library to move at all? Only if they asked for this import. An
+  // AUTOMATIC one (Studio Capture's folder survey) re-points the collection in Studio Capture's
+  // own atelier, whose filmstrip is meant to follow the shooting session -- but nowhere else: the
+  // survey outlives that atelier, and a capture landing while the user browses or edits elsewhere
+  // must not drag the library onto the capture folder. Same reasoning as
+  // DT_COLLECTION_IMPORT_VIEW_KEEP, applied to the collection instead of the view.
+  //
+  // Then, may rule 0 be overwritten with a folder? That is the Collect module's persisted tab,
+  // and it is deliberately NOT a question about the current atelier: the collection is global, so
+  // an import started from the darkroom (or the map, or print) must re-point it just the same, or
+  // the imported image is nowhere to be found when the user gets back to the grid. On
+  // "Collections" (tags) and "Queries" the rules belong to the user and overwriting one would
+  // destroy the query they built. Studio Capture has no Collect module UI, hence no such rules.
   const gboolean is_studio_capture = !IS_NULL_PTR(current_atelier)
                                      && !g_strcmp0(current_atelier->module_name, "studio_capture");
   const gboolean follow_import_folder = is_studio_capture
-                                        || dt_conf_get_int("plugins/lighttable/collect/tab") == 0;
+                                        || (view_policy != DT_COLLECTION_IMPORT_VIEW_KEEP
+                                            && dt_conf_get_int("plugins/lighttable/collect/tab") == 0);
 
   if(follow_import_folder)
   {
@@ -1127,20 +1143,27 @@ void dt_collection_load_filmroll(dt_collection_t *collection, const int32_t imgi
     dt_collection_update_query(collection, DT_COLLECTION_CHANGE_NEW_QUERY, DT_COLLECTION_PROP_FILMROLL, NULL);
   }
 
-  // Necessary to directly open in darkroom if we want to. Skippable: a caller that already
-  // pointed mouse_over_id at imgid earlier (e.g. right when it was first known, before a long
-  // import job finishes) does not want it forced back here, possibly clobbering whatever the
-  // user is hovering by now.
-  if(set_mouse_over) dt_control_set_mouse_over_id(imgid);
+  // Hovered image and selection belong to the user as long as they did not ask for this import.
+  // Studio Capture points both at the capture it displays itself (_studio_set_image() in
+  // views/studio_capture.c); doing it here too would, anywhere else, add an image the user never
+  // asked for to their selection and hand it to the next darkroom entry -- try_enter() reads the
+  // mouse-over id first.
+  if(view_policy != DT_COLLECTION_IMPORT_VIEW_KEEP)
+  {
+    // Skippable: a caller that already pointed mouse_over_id at imgid earlier (e.g. right when it
+    // was first known, before a long import job finishes) does not want it forced back here,
+    // possibly clobbering whatever the user is hovering by now.
+    if(set_mouse_over) dt_control_set_mouse_over_id(imgid);
 
-  // To scroll the lighttable automatically to this image,
-  // it needs to be selected.
-  dt_selection_select(dt_selection_get_global(), imgid);
+    // To scroll the lighttable automatically to this image,
+    // it needs to be selected.
+    dt_selection_select(dt_selection_get_global(), imgid);
+  }
 
   // New images are untagged, that may need an update of the collection module for untagged count
   DT_DEBUG_CONTROL_SIGNAL_RAISE(dt_control_signal_get_global(), DT_SIGNAL_TAG_CHANGED);
 
-  if(!IS_NULL_PTR(current_atelier)) _dt_collection_change_view_after_import(current_atelier, open_single_image, imgid);
+  if(!IS_NULL_PTR(current_atelier)) _dt_collection_change_view_after_import(current_atelier, view_policy, imgid);
 }
 
 // clang-format off

--- a/src/common/collection.c
+++ b/src/common/collection.c
@@ -947,7 +947,8 @@ void dt_collection_hint_message(const dt_collection_t *collection)
   g_idle_add(dt_collection_hint_message_internal, message);
 }
 
-static inline void _dt_collection_change_view_after_import(const dt_view_t *current_view, gboolean open_single_image)
+static inline void _dt_collection_change_view_after_import(const dt_view_t *current_view, gboolean open_single_image,
+                                                           const int32_t imgid)
 {
   // Studio Capture already shows every newly-imported image itself (see
   // _studio_image_imported_callback() in views/studio_capture.c), without leaving the atelier:
@@ -955,13 +956,13 @@ static inline void _dt_collection_change_view_after_import(const dt_view_t *curr
   // and kick the user out of a live shooting session.
   if(!g_strcmp0(current_view->module_name, "studio_capture")) return;
 
+  // Name the image to open explicitly. This runs on the import job's thread, so the mouse-over
+  // id and the selection set just above cannot be relied on to still designate imgid by the time
+  // the GUI thread performs the switch -- the darkroom's own leave() rewrites the selection, and
+  // any pointer motion rewrites the mouse-over id. dt_ctl_open_image_in_darkroom() publishes the
+  // target and switches views in one GUI-thread callback instead.
   if(open_single_image)
-  {
-    if(!g_strcmp0(current_view->module_name, "darkroom")) // if current view IS "darkroom".
-      dt_ctl_reload_view("darkroom");
-    else
-      dt_ctl_switch_mode_to("darkroom");
-  }
+    dt_ctl_open_image_in_darkroom(imgid);
   else if(g_strcmp0(current_view->module_name, "lighttable")) // if current view IS NOT "lighttable".
     dt_ctl_switch_mode_to("lighttable");
 }
@@ -1131,7 +1132,7 @@ void dt_collection_load_filmroll(dt_collection_t *collection, const int32_t imgi
   // New images are untagged, that may need an update of the collection module for untagged count
   DT_DEBUG_CONTROL_SIGNAL_RAISE(dt_control_signal_get_global(), DT_SIGNAL_TAG_CHANGED);
 
-  if(current_atelier) _dt_collection_change_view_after_import(current_atelier, open_single_image);
+  if(!IS_NULL_PTR(current_atelier)) _dt_collection_change_view_after_import(current_atelier, open_single_image, imgid);
 }
 
 // clang-format off

--- a/src/common/collection.h
+++ b/src/common/collection.h
@@ -264,12 +264,35 @@ void dt_collection_set_text_filter(const dt_collection_t *collection, char *text
 /** set the tagid of collection */
 void dt_collection_set_tag_id(dt_collection_t *collection, const uint32_t tagid);
 
-/** load a filmroll-based collection from an imgid. set_mouse_over controls whether
- * dt_control_set_mouse_over_id(imgid) is (re-)applied here: pass FALSE when the caller already
- * pointed mouse_over_id at imgid earlier and does not want it forced back onto imgid here,
- * clobbering whatever the user may be hovering by the time this runs. */
-void dt_collection_load_filmroll(dt_collection_t *collection, const int32_t imgid, gboolean open_single_image,
-                                 gboolean set_mouse_over);
+/** What an import is allowed to do to the view the user is currently looking at. */
+typedef enum dt_collection_import_view_t
+{
+  /** Never move the user. The policy of every AUTOMATIC import (Studio Capture's folder
+   * survey): the images arrive on their own schedule, so switching views on their arrival
+   * interrupts whatever the user was doing, in the darkroom or anywhere else. */
+  DT_COLLECTION_IMPORT_VIEW_KEEP = 0,
+  /** Show the imported images in the lighttable grid. */
+  DT_COLLECTION_IMPORT_VIEW_GRID,
+  /** Exactly one image was imported on the user's request: open it in the darkroom. */
+  DT_COLLECTION_IMPORT_VIEW_IMAGE
+} dt_collection_import_view_t;
+
+/** load a filmroll-based collection from an imgid, and make that image visible to the user as
+ * far as @p view_policy allows.
+ *
+ * @param collection the collection to re-point and re-query.
+ * @param imgid the imported image the library should follow. Typically the FIRST image of an
+ *              import job: its folder is the one the Collect module's rule 0 is pointed at.
+ * @param view_policy what this import may do to what the user is currently looking at. It also
+ *                    governs the folder-following, the hovered image and the selection: under
+ *                    DT_COLLECTION_IMPORT_VIEW_KEEP none of them is touched outside Studio
+ *                    Capture's own atelier, which tracks its captures itself.
+ * @param set_mouse_over whether dt_control_set_mouse_over_id(imgid) is (re-)applied here: pass
+ *                       FALSE when the caller already pointed mouse_over_id at imgid earlier and
+ *                       does not want it forced back onto imgid here, clobbering whatever the
+ *                       user may be hovering by the time this runs. Ignored under KEEP. */
+void dt_collection_load_filmroll(dt_collection_t *collection, const int32_t imgid,
+                                 dt_collection_import_view_t view_policy, gboolean set_mouse_over);
 
 /** If lighttable/Studio Capture is currently browsing a single folder or film-roll (Collect
  * module on the "Folders" tab), copy its path into folder (up to len bytes), set *recursive to

--- a/src/control/control.c
+++ b/src/control/control.c
@@ -57,6 +57,7 @@
 #include "widgets/bauhaus.h"
 #include "darktable.h"
 #include "common/logging.h"
+#include "common/selection.h"
 #include "control/control.h"
 #include "develop/develop.h"
 
@@ -720,12 +721,34 @@ void dt_ctl_switch_mode_to_by_view(const dt_view_t *view)
   g_main_context_invoke(NULL, _dt_ctl_switch_mode_to_by_view, (gpointer)view);
 }
 
-void dt_ctl_reload_view(const char *mode)
+static gboolean _dt_ctl_open_image_in_darkroom(gpointer user_data)
 {
+  const int32_t imgid = GPOINTER_TO_INT(user_data);
+  _dt_ctl_switch_mode_prepare();
+
+  // Round-trip through the lighttable, the same way the darkroom changes image from the
+  // filmstrip (_dev_change_image() in views/darkroom.c): everything is torn down and re-inited
+  // through the regular enter()/leave() path instead of a partial in-place reload. Skipped when
+  // the lighttable is already the current view -- there is no darkroom state to tear down then,
+  // and re-entering it would needlessly rebuild the grid and the whole panel layout.
   const dt_view_t *current_view = dt_view_manager_get_current_view(darktable.view_manager);
-  if(current_view && g_strcmp0(current_view->module_name, "lighttable"))
-    dt_ctl_switch_mode_to("lighttable");
-  g_main_context_invoke(NULL, _dt_ctl_switch_mode_to, (gpointer)mode);
+  if(IS_NULL_PTR(current_view) || g_strcmp0(current_view->module_name, "lighttable"))
+    dt_view_manager_switch(darktable.view_manager, "lighttable");
+
+  // Publish the target AFTER leaving the darkroom, and from the GUI thread: the darkroom's
+  // leave() restores the selection to the image it was editing, and any pointer motion over the
+  // grid rewrites the mouse-over id. Both would silently overwrite a target published earlier
+  // from a worker thread, and the darkroom would re-open the previous image instead.
+  dt_control_set_mouse_over_id(imgid);
+  dt_selection_select_single(dt_selection_get_global(), imgid);
+
+  dt_view_manager_switch(darktable.view_manager, "darkroom");
+  return FALSE;
+}
+
+void dt_ctl_open_image_in_darkroom(const int32_t imgid)
+{
+  g_main_context_invoke(NULL, _dt_ctl_open_image_in_darkroom, GINT_TO_POINTER(imgid));
 }
 
 static gboolean _dt_ctl_log_message_timeout_callback(gpointer data)

--- a/src/control/control.h
+++ b/src/control/control.h
@@ -169,7 +169,19 @@ void dt_control_queue_redraw_widget(GtkWidget *widget);
 
 void dt_ctl_switch_mode_to(const char *mode);
 void dt_ctl_switch_mode_to_by_view(const dt_view_t *view);
-void dt_ctl_reload_view(const char *mode);
+
+/** \brief open one specific image in the darkroom, from any view and any thread.
+ *
+ * The darkroom picks the image it opens from the mouse-over id, falling back on the selection.
+ * Both are volatile: a pointer motion rewrites the mouse-over id, and leaving the darkroom
+ * restores the selection to the image it was editing. A caller that knows which image it wants
+ * -- an import job, a background task -- must therefore not publish the target and request the
+ * view switch separately: it has to happen in one go on the GUI thread, which is what this does.
+ *
+ * @param imgid the image to open. The caller owns this contract: an id that names no image only
+ *              gets the darkroom to refuse the switch and log "No image to open".
+ */
+void dt_ctl_open_image_in_darkroom(const int32_t imgid);
 
 struct dt_control_t;
 

--- a/src/control/jobs/film_jobs.c
+++ b/src/control/jobs/film_jobs.c
@@ -355,13 +355,12 @@ static void _film_import1(dt_job_t *job, dt_film_t *film, GList *images)
   dt_collection_load_filmroll(dt_collection_get_global(), first_imgid, g_list_length(all_imgs) == 1, FALSE);
 
   // dt_collection_load_filmroll() silently declines to switch/refresh the collection when it
-  // cannot switch folders -- e.g. the collect module is not on the "Folders" tab, or we are not
-  // in an atelier with a folder-browsing grid (see _collection_folder_ui_inactive() in
-  // common/collection.c). Without this, a recursive folder import (dt_film_import(), reached
-  // from CLI/D-Bus/macOS "open with" while Ansel is already running) never shows up in the
-  // lighttable grid or the Collect module until the user reloads the collection by hand -- the
-  // same issue #860 already fixed for control/jobs/import_jobs.c's import job, which this
-  // legacy, separate import path does not share code with.
+  // cannot switch folders -- e.g. the collect module is not on the "Folders" tab (see
+  // dt_collection_load_filmroll() in common/collection.c). Without this, a recursive folder
+  // import (dt_film_import(), reached from CLI/D-Bus/macOS "open with" while Ansel is already
+  // running) never shows up in the lighttable grid or the Collect module until the user reloads
+  // the collection by hand -- the same reason control/jobs/import_jobs.c's import job does it
+  // too, which this legacy, separate import path does not share code with.
   if(all_imgs)
     dt_collection_update_query(dt_collection_get_global(), DT_COLLECTION_CHANGE_NEW_QUERY, DT_COLLECTION_PROP_UNDEF, NULL);
 

--- a/src/control/jobs/film_jobs.c
+++ b/src/control/jobs/film_jobs.c
@@ -352,15 +352,18 @@ static void _film_import1(dt_job_t *job, dt_film_t *film, GList *images)
 
   // set_mouse_over = FALSE: already pointed at first_imgid as soon as it was known, above --
   // do not force it back here and clobber whatever the user may be hovering by now.
-  dt_collection_load_filmroll(dt_collection_get_global(), first_imgid, g_list_length(all_imgs) == 1, FALSE);
+  dt_collection_load_filmroll(dt_collection_get_global(), first_imgid,
+                              (g_list_length(all_imgs) == 1) ? DT_COLLECTION_IMPORT_VIEW_IMAGE
+                                                             : DT_COLLECTION_IMPORT_VIEW_GRID,
+                              FALSE);
 
   // dt_collection_load_filmroll() silently declines to switch/refresh the collection when it
   // cannot switch folders -- e.g. the collect module is not on the "Folders" tab (see
-  // dt_collection_load_filmroll() in common/collection.c). Without this, a recursive folder
-  // import (dt_film_import(), reached from CLI/D-Bus/macOS "open with" while Ansel is already
-  // running) never shows up in the lighttable grid or the Collect module until the user reloads
-  // the collection by hand -- the same reason control/jobs/import_jobs.c's import job does it
-  // too, which this legacy, separate import path does not share code with.
+  // dt_collection_load_filmroll() in common/collection.c). Without this, a recursive
+  // folder import (dt_film_import(), reached from CLI/D-Bus/macOS "open with" while Ansel is
+  // already running) never shows up in the lighttable grid or the Collect module until the user
+  // reloads the collection by hand -- the same reason control/jobs/import_jobs.c's import job
+  // does it too, which this legacy, separate import path does not share code with.
   if(all_imgs)
     dt_collection_update_query(dt_collection_get_global(), DT_COLLECTION_CHANGE_NEW_QUERY, DT_COLLECTION_PROP_UNDEF, NULL);
 

--- a/src/control/jobs/import_jobs.c
+++ b/src/control/jobs/import_jobs.c
@@ -534,6 +534,17 @@ static int32_t _control_import_job_run(dt_job_t *job)
   int32_t imgid = UNKNOWN_IMAGE;
   gint64 last_collection_refresh = 0;
 
+  // What this import may do to the view the user is in, decided once from what the import IS. An
+  // automatic (folder survey) one never moves them: Studio Capture displays the capture itself,
+  // from DT_SIGNAL_IMAGE_IMPORT, and the survey outlives its atelier. A requested one shows the
+  // grid as images arrive, and opens the darkroom instead if it turns out to have imported one.
+  const dt_collection_import_view_t first_image_policy = data->folder_survey
+                                                         ? DT_COLLECTION_IMPORT_VIEW_KEEP
+                                                         : DT_COLLECTION_IMPORT_VIEW_GRID;
+  const dt_collection_import_view_t single_image_policy = data->folder_survey
+                                                          ? DT_COLLECTION_IMPORT_VIEW_KEEP
+                                                          : DT_COLLECTION_IMPORT_VIEW_IMAGE;
+
   for(GList *img = g_list_first(data->imgs); img; img = g_list_next(img))
   {
     dt_print(DT_DEBUG_IMPORT, "[Import] starting import of image #%i...\n", index);
@@ -552,7 +563,7 @@ static int32_t _control_import_job_run(dt_job_t *job)
       // collection by hand (issue #860). So always run a collection update afterwards: it
       // re-runs the current query and makes newly-imported matching images appear.
       if(index == 0)
-        dt_collection_load_filmroll(dt_collection_get_global(), imgid, FALSE, TRUE);
+        dt_collection_load_filmroll(dt_collection_get_global(), imgid, first_image_policy, TRUE);
 
       // known_image_folder is NULL: in copy mode the image's final DB location can be a
       // completely different, pattern-generated folder from its original source path, which is
@@ -567,37 +578,34 @@ static int32_t _control_import_job_run(dt_job_t *job)
   if(index > 0)
     dt_collection_update_query(dt_collection_get_global(), DT_COLLECTION_CHANGE_NEW_QUERY, DT_COLLECTION_PROP_UNDEF, NULL);
 
+  dt_conf_set_int("ui_last/nb_imported", index);
+
   if(index == 0)
   {
-    if(data->folder_survey)
-      dt_control_log(_("Capture: No image imported!"));
-    else
-      dt_control_log(_("No image imported!"));
+    dt_control_log(data->folder_survey ? _("Capture: No image imported!") : _("No image imported!"));
     fprintf(stderr, "No image imported!\n\n");
+    return 1;
   }
+
   // Don't open the picture in darkroom if more than 1 xmp (= duplicates) has been imported: the
   // single file then stands for several images in the DB and none of them is the obvious one to
   // open. Zero xmp is the ordinary case of a file with no sidecar (and of a library configured
   // not to write any), still exactly one image: open it like any other single import.
-  else if(index == 1 && xmps <= 1)
+  if(index == 1 && xmps <= 1)
   {
-    if(data->folder_survey)
-      dt_control_log(_("Capture: imported 1 image."));
-    dt_collection_load_filmroll(dt_collection_get_global(), imgid, TRUE, TRUE);
-  }
-  else
-  {
-    if(data->folder_survey)
-      dt_control_log(ngettext("Capture: imported %d image.",
-                              "Capture: imported %d images.", index), index);
-    else
-      dt_control_log(ngettext("Imported %d image", "Imported %d images", index), index);
-    fprintf(stdout, "%d files imported in database.\n\n", index);
+    // A requested single image opens in the darkroom, which is announcement enough -- only the
+    // survey, which stays where it is, says anything.
+    if(data->folder_survey) dt_control_log(_("Capture: imported 1 image."));
+    dt_collection_load_filmroll(dt_collection_get_global(), imgid, single_image_policy, TRUE);
+    return 0;
   }
 
-  dt_conf_set_int("ui_last/nb_imported", index);
+  dt_control_log(data->folder_survey
+                 ? ngettext("Capture: imported %d image.", "Capture: imported %d images.", index)
+                 : ngettext("Imported %d image", "Imported %d images", index), index);
+  fprintf(stdout, "%d files imported in database.\n\n", index);
 
-  return index >= 1 ? 0 : 1;
+  return 0;
 }
 
 void dt_control_import_data_free(dt_control_import_t *data)

--- a/src/control/jobs/import_jobs.c
+++ b/src/control/jobs/import_jobs.c
@@ -575,8 +575,11 @@ static int32_t _control_import_job_run(dt_job_t *job)
       dt_control_log(_("No image imported!"));
     fprintf(stderr, "No image imported!\n\n");
   }
-  // don't open picture in darkroom if more than 1 xmps (= duplicates) have been imported.
-  else if(index == 1 && xmps == 1)
+  // Don't open the picture in darkroom if more than 1 xmp (= duplicates) has been imported: the
+  // single file then stands for several images in the DB and none of them is the obvious one to
+  // open. Zero xmp is the ordinary case of a file with no sidecar (and of a library configured
+  // not to write any), still exactly one image: open it like any other single import.
+  else if(index == 1 && xmps <= 1)
   {
     if(data->folder_survey)
       dt_control_log(_("Capture: imported 1 image."));


### PR DESCRIPTION
Importing a single image while already in the darkroom did not open it. Chasing that down surfaced four defects on the same path — how an import job tells the GUI what to show — one commit each. The fourth also covers the hovered image and the selection, which the same rule governs.

## What was wrong

**The darkroom target did not survive the view switch.** The import job published the target through `dt_control_set_mouse_over_id()` and the selection, from its own thread, then asked for the view switch separately. The switch round-trips through the lighttable, so the darkroom's `leave()` restores the selection to the image it was editing, and any pointer motion over the grid rewrites the mouse-over id. Which image re-opened depended on where the pointer happened to sit. Traced live:

```
change_view_after_import: current=darkroom open_single=1 mouse_over=51113
darkroom leave: restoring selection to active image 675   <- selection clobbered
darkroom try_enter: mouse_over=51113 num_selected=1 first_selected=675
darkroom try_enter: opening imgid=51113                   <- saved only by mouse_over_id
```

`dt_ctl_open_image_in_darkroom(imgid)` now names the image and marshals leave/publish/enter into one GUI-thread callback. `dt_ctl_reload_view()` had no other caller and goes away.

**A file with no sidecar never opened.** The single-image open was gated on `xmps == 1`, so an ordinary raw off a card — or any file in a library configured not to write XMP — fell through. Two or more sidecars is what actually means "several DB images"; zero means one, like one does.

**The imported folder was only followed from the lighttable.** Re-pointing the library at the import's folder was gated on the current atelier. Importing from the darkroom left the collection on the previously browsed folder, and the image was nowhere to be found on the way back to the grid. The collection is global; what must be respected is the Collect module's persisted tab (rule 0 belongs to the user on "Collections" and "Queries"), not which view is on screen.

**An automatic import moved the user.** Studio Capture's folder survey keeps running after the user leaves that atelier, and the only guard was a check on the current view. A capture landing while the user browsed or edited threw them into another view, re-pointed the library onto the capture folder, and dropped an image they never asked for into their selection — which the next darkroom entry would then open. What an import may do is now the caller's decision, carried as a `dt_collection_import_view_t` (`KEEP` / `GRID` / `IMAGE`) taken from what the import *is*, and it governs all three intrusions at once. Studio Capture still follows its own session.

## Verification

Each commit builds on its own. Every path was exercised in the running app, not only reasoned about:

- single manual import from the darkroom, pointer deliberately moved during the switch — the imported image opens, and the lighttable shows its folder;
- two automatic captures dropped into a live watched folder while editing in the darkroom — no view switch, no collection move, no selection change. Worth noting the log line `Found and imported 0 XMP`: a capture arrives without a sidecar, so it is exactly the case the `xmps <= 1` fix admits, and only the `KEEP` policy keeps it from opening.

`tools/include_graph.py --summary` still reports `cycles 0`, `pragma_once_to_guards.py --verify` passes, and `check_module_boundaries.sh` holds every baseline. `CLAUDE.md` and `doc/studio-capture.md` document the rules.
