### PR TITLE
locallaplacian: fix a crash on tiny inputs, and a swapped coordinate in the padding test

### DIFF
--- a/src/pixel/locallaplacian.c
+++ b/src/pixel/locallaplacian.c
@@ -231,7 +231,14 @@ static inline float *ll_pad_input(
 #define LL_FILL(fallback) do {\
     float isx = ((i - max_supp) + b->roi->x)/b->roi->scale;\
     float isy = ((j - max_supp) + b->roi->y)/b->roi->scale;\
-    if(isx < 0 || isy >= b->buf->width\
+    /* isx against the WIDTH, isy against the HEIGHT. This read `isy >= b->buf->width`,
+       which never bounds-checked isx at all and tested isy twice. The comment above says
+       what the test is for -- "if not out of buf" -- so the intent is unambiguous. It is
+       not a memory-safety bug, because both coordinates are CLAMPed in the else branch,
+       but it picks the wrong branch: a pixel past the right edge sampled the preview with
+       px clamped to the last column instead of taking the hi-res fallback, and on a
+       portrait image every row below `width` took the fallback instead of the preview. */\
+    if(isx < 0 || isx >= b->buf->width\
     || isy < 0 || isy >= b->buf->height)\
       out[*wd2*j+i] = (fallback);\
     else\

--- a/src/pixel/locallaplacian.c
+++ b/src/pixel/locallaplacian.c
@@ -367,6 +367,25 @@ int local_laplacian_internal(
 
   // don't divide by 2 more often than we can:
   const int num_levels = MIN(max_levels, 31-__builtin_clz(MIN(wd,ht)));
+
+  /* Two levels are the minimum this can work with, and the guard above does not give that.
+   *
+   * 31-clz(x) is 1 for x of 2 or 3, so an input only 2 or 3 pixels on its short side yields
+   * num_levels == 1 and last_level == 0. The coarsest-level reduction below then reads
+   * padded[last_level-1], i.e. padded[-1] -- off the front of a stack array -- and hands
+   * whatever pointer lives there to gauss_reduce() as its input buffer.
+   *
+   * That is Sentry 137433784, and every number in its backtrace agrees: gauss_reduce was
+   * called with wd=5, ht=227, which is dl(w,-1) returning w unchanged (its loop body never
+   * runs for a negative level) with w = 2*max_supp + 3 = 5 and h = 2*max_supp + 225 = 227 for
+   * max_supp = 1<<0. So the image was three pixels wide, and the fault was the stencil
+   * dereferencing that garbage pointer -- not the index arithmetic, which is in bounds for
+   * those dimensions.
+   *
+   * Nothing is lost by declining: a 3-pixel-wide strip has no local contrast to enhance, and
+   * the caller already handles this returning 0 the same way it does for a 1-pixel input. */
+  if(num_levels < 2) return 0;
+
   int last_level = num_levels-1;
   if(b && b->mode == 2) // higher number here makes it less prone to aliasing and slower.
     last_level = num_levels > 4 ? 4 : num_levels-1;


### PR DESCRIPTION
Two defects in `src/pixel/locallaplacian.c`, one a crash, one a latent typo in the same file.

## 1. Sentry 137433784 — a 3-pixel-wide input read `padded[-1]`

SIGSEGV inside `gauss_reduce`'s 5×5 stencil, on an OpenMP worker, from bilat's "local contrast"
mode.

```c
const int num_levels = MIN(max_levels, 31-__builtin_clz(MIN(wd,ht)));
int last_level = num_levels-1;
...
gauss_reduce(padded[last_level-1], output[last_level], dl(w,last_level-1), dl(h,last_level-1));
```

`31-clz(x)` is **1** for `x` of 2 or 3, so an input only 2 or 3 pixels on its short side gives
`num_levels == 1` and `last_level == 0`. That call then reads **`padded[-1]`** — off the front of a
stack array — and hands whatever pointer lives there to `gauss_reduce` as its input buffer. The
guard above it is `wd <= 1 || ht <= 1`, which lets 2 and 3 straight through.

| Short side | `num_levels` | `last_level` | |
| ---: | ---: | ---: | --- |
| 1 | 0 | −1 | caught by the existing guard |
| **2** | **1** | **0** | **`padded[-1]`** |
| **3** | **1** | **0** | **`padded[-1]`** |
| 4 | 2 | 1 | fine |

**Every number in the backtrace agrees.** `gauss_reduce` was called with `wd=5, ht=227`: `dl(w,-1)`
returns `w` unchanged — its loop body never runs for a negative level — and
`w = 2·max_supp + wd_orig = 2·1 + 3 = 5`, `h = 2·1 + 225 = 227` at `max_supp = 1<<0`. The image was
three pixels wide.

Worth recording, because it cost a wrong conclusion first time round: the **index arithmetic in
that stencil is correct** for those dimensions — max input index 1134 of 1135, max coarse index 337
of 342. Verifying it twice proved nothing, because the fault was the *pointer*, not the subscript.
"Do the subscripts fit the buffer" and "where did this buffer come from" are different questions.

Fixed by declining below two levels rather than special-casing the coarsest reduction: the
algorithm needs at least one reduction to mean anything, and a 3-pixel strip has no local contrast
to enhance. Returns 0 like the existing tiny-input guard, which `iop/bilat.c` already treats as
success.

## 2. The preview-padding test compared `isy` against the width

```c
if(isx < 0 || isy >= b->buf->width      // <- isy, should be isx
|| isy < 0 || isy >= b->buf->height)
```

`isx` was never bounds-checked at all; `isy` was tested twice. The comment directly above states
the intent — *"if not out of buf"* — so this is a typo, not a subtlety.

**Not a memory-safety bug**: both coordinates are `CLAMP`ed in the `else` branch, so nothing was
read out of bounds. It picked the wrong *branch* — a pixel past the right edge sampled the preview
with `px` clamped to the last column instead of taking the hi-res sample-and-hold fallback, and on
a portrait image every row below `width` took the fallback instead of the preview, potentially most
of the frame.

**Changes no output today.** The `b->mode == 2` path is unreachable in the current tree: nothing
constructs a `local_laplacian_boundary_t` or sets its `mode`, and the only caller of
`local_laplacian()` passes `0`. This removes a trap for whoever revives preview-based padding
rather than fixing a live defect.

## Verification

GCC Release, clang Debug and nofeatures: 0 errors. Local gates pass (conditional includes, unused
includes, layering at baseline, Windows syntax). `tools/check_it_runs.sh` passes; a 3×3 export runs
clean.
