### PR TITLE
develop: resync the pipe against a history snapshot, not under history_mutex (#1098)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -296,21 +296,59 @@ teardown. Any other GUI-thread code that tears down darkroom pipe state must wai
 same way — `dev->exit`/`pipe->shutdown` alone do not guarantee the worker has stopped touching a
 pipe.
 
-### History items are refcounted; `history_mutex` resync contention is a known issue
+### History items are refcounted; the pipe resyncs against a snapshot, not under `history_mutex`
 
-`dt_dev_history_item_t` now carries a `refcount` and must be constructed exclusively through
+`dt_dev_history_item_t` carries a `refcount` and must be constructed exclusively through
 `dt_dev_history_item_create()` — never a bare `calloc` (mirrors the masks-forms rule below;
 `dt_dev_history_cow_touch()` clones a shared item before an in-place mutation, mirroring
 `dt_masks_cow_touch()`).
 
-`dt_dev_pixelpipe_change()` (worker thread, called from `dt_dev_darkroom_pipeline()`) holds
-`dev->history_mutex` as **reader** for the entire O(nodes × history) pipe resync — measured over
-200ms under mask-heavy history during active editing — which starves the GUI-thread writer
-(`dt_dev_add_history_item_ext()`) for the same duration on every edit (a scroll on exposure, a
-mask drag). Still open. See `doc/reorganisation.md` ("History item refcounting and the
-`history_mutex` contention") for the full diagnosis and status, and the named-rwlock diagnostic
-in `common/dtpthread.h` (`dt_pthread_rwlock_set_name()`, opt-in per lock, combine with
-`-d history`) to reproduce the measurement.
+That refcount exists for one consumer: `dt_dev_pixelpipe_change()` (worker thread, called from
+`dt_dev_darkroom_pipeline()`) used to hold `dev->history_mutex` as **reader** for the entire
+O(nodes × history) pipe resync — every module's `commit_params()` — measured at **204–227 ms**
+on the load-time resync of a 47-item mask-heavy history, with no user input at all. The GUI
+thread needs the *writer* side of that lock on every commit (each slider tick, and each
+throttled mask-drag commit that `views/darkroom.c`'s `_queue_delayed_history_commit()` fires
+mid-drag), and glibc's writer-preferring rwlock policy then blocks every **new reader** behind
+the queued writer too — so one slow resync stalled the whole application until it finished.
+That is discussion #1098's "the shape moves in steps": each step is one lock acquisition.
+
+Fixed by resyncing against a **snapshot**. `dt_dev_history_snapshot_take()` (`dev_history.h`)
+copies the list cells and takes one reference per item under the read lock — microseconds —
+and `change()` releases the lock before any `commit_params()` runs. The same load-time resync
+now logs `resynced from snapshot in 174 ms, lock-free` with **no lock hold above the 1 ms print
+threshold**; the compute cost is unchanged, only the lock is gone. The three other sync entry
+points (`dt_dev_pixelpipe_synch_all`/`synch_top`, used by export, snapshots and the focus
+overlay on throwaway devs) take their own brief snapshot the same way. The writer's COW gate is
+the other half of the contract: a snapshotted item has refcount > 1, so `cow_touch` clones it
+and the snapshot never sees a half-rewritten item. `src/tests/unittests/test_history_snapshot.c`
+pins that contract; `-d history` shows the hold times.
+
+**Three things about this design that are not obvious from the code:**
+
+- **Capture `history_end` and the hash inside the same brief lock as the list.**
+  `dt_dev_set_history_end_ext()` writes both together under the write lock. Reading the atomic
+  hash *after* releasing lets a commit land in between and mark the pipe as synced to history it
+  never resynced against — a missed recompute, silently. The snapshot struct carries all three.
+- **`pipe->last_history_item` must hold a reference and be exchanged atomically.** It is the
+  identity marker `synch_top` uses to bound an in-place top-entry rewrite to one node instead of
+  a full resync. `cow_touch` re-points it at the clone from the GUI thread while the worker
+  writes it outside the lock, so it is a genuine cross-thread slot: `dt_atomic_exch_ptr` keeps
+  every interleaving refcount-honest (each side releases exactly what it displaced), and the
+  held reference means a compare against a possibly-departed item can never hit a **recycled
+  address** — a hazard the old under-the-lock raw pointer already had in principle. Do not
+  "simplify" it back to a plain assignment; the worst case of a lost exchange race is one full
+  resync, never a leak or a double free.
+- **The async DB write job (`_dt_dev_write_history_job_run`) is the *second* long reader** of
+  this lock — it holds it across the whole history+masks rewrite and is instrumented the same
+  way. It has the same disease and would take the same cure; it was left as is because it does
+  not sit on the interactive path the way the pipe resync did.
+
+The named-rwlock diagnostic lives in `system/dtpthread.h` (`dt_pthread_rwlock_set_name()`,
+opt-in per lock, combine with `-d history`); `dev->history_mutex` is named in `dt_dev_init()`.
+Drawn-mask geometry editing still commits history through the throttle on every drag motion
+rather than through the transient-params channel the drawlayer brush uses — that is the remaining
+follow-up for #1098, and it is a GUI-side routing change, not a locking one.
 
 ### `_insert_default_modules` must check `dev->history` in memory, not the DB row for `dev->image_storage.id`
 

--- a/doc/reorganisation.md
+++ b/doc/reorganisation.md
@@ -403,9 +403,31 @@ This is directly observable with the named-rwlock diagnostic added to `dt_pthrea
 (`common/dtpthread.h`: `dt_pthread_rwlock_set_name()` + wait-time logging, opt-in per lock —
 `dev->history_mutex` is named in `dt_dev_init()`) combined with `-d history`.
 
-**Status: open.** The refcounting/COW infrastructure above is a prerequisite for resyncing a
-pipe against a snapshot of `dev->history` instead of holding `history_mutex` for the whole
-resync, which is the direction to pursue to remove this stall.
+**Status: fixed.** `dt_dev_pixelpipe_change()` now resyncs against a
+`dt_dev_history_snapshot_t` (`dt_dev_history_snapshot_take()` / `_release()`, `dev_history.h`):
+the read lock is held only to copy the list cells, take one reference per item and capture
+`history_end` and the history hash — the three fields `dt_dev_set_history_end_ext()` writes
+together — and is released before any `commit_params()` runs. The writer's copy-on-write gate
+above is what makes that sound: an item a snapshot holds has refcount > 1, so
+`dt_dev_history_cow_touch()` clones it rather than mutating it under the reader.
+
+Measured on the load-time resync of `_DSC9410.NEF` (47 history items, mask group with a 57-node
+brush), `-d history`, same machine, same scratch config, before and after:
+
+| | lock held (preview pipe) | lock held (full pipe) | resync work |
+|---|---|---|---|
+| before | 204.66 ms | 226.75 ms | (inside the hold) |
+| after | < 1 ms (below the print threshold) | < 1 ms | 174.63 ms / 158.52 ms, lock-free |
+
+The compute cost is unchanged — the resync is as expensive as it was — but nothing waits on it
+any more. `pipe->last_history_item` became an atomic pointer the pipe holds a reference on,
+exchanged with `dt_atomic_exch_ptr()` (added to `system/atomic.h`), so the marker that
+`synch_top` bounds its work with stays valid across a copy-on-write clone landing from the GUI
+thread while the worker writes the slot outside the lock. `src/tests/unittests/test_history_snapshot.c`
+pins the snapshot/COW/refcount contract. See CLAUDE.md, "History items are refcounted; the pipe
+resyncs against a snapshot, not under `history_mutex`", for the three design constraints that are
+not obvious from the code, and for the second long reader of this lock (the async DB write job)
+that was deliberately left alone.
 
 ### Where the pipeline architecture could go
 

--- a/src/develop/dev_history.c
+++ b/src/develop/dev_history.c
@@ -77,6 +77,7 @@
 #include "develop/masks.h"
 #include "develop/supervisor.h"
 #include "develop/gui_throttle.h"
+#include "system/atomic.h"
 
 
 #include <inttypes.h>
@@ -1208,14 +1209,28 @@ dt_dev_history_item_t *dt_dev_history_cow_touch(dt_develop_t *dev, dt_dev_histor
   dt_dev_history_item_t *clone = _dt_dev_history_item_duplicate_one(hist);
   node->data = clone;
 
-  // Raw pointer cache outside dev->history: each pipe's own last-synced-item marker (used by
-  // dt_dev_pixelpipe_synch_top to bound the resync range). dt_dev_pixelpipe_change() holds
-  // history_mutex for its whole resync, same as this splice, so a plain compare-and-assign is
-  // enough -- no concurrent access is possible.
+  // Each pipe's own last-synced-item marker (used by the synch_top path to bound the resync
+  // range) may name the item being cloned; re-point it at the clone so an in-place top-entry
+  // rewrite keeps its bounded resync instead of degrading to a full one.
+  //
+  // The pipe HOLDS A REFERENCE on that marker and the resync writes it OUTSIDE history_mutex
+  // (it runs against a snapshot), so this is a genuine cross-thread exchange, not a
+  // compare-and-assign under a shared lock. The atomic exchange keeps the refcount honest in
+  // every interleaving: this side takes a reference on the clone before publishing it, and
+  // releases exactly the reference it displaced. If the worker publishes its own item between
+  // the compare and the exchange, the slot ends up naming the clone, the worker's item is
+  // released here, and the worst case is one full resync next frame -- never a leak or a
+  // double release.
   dt_dev_pixelpipe_t *const pipes[] = { dev->pipe, dev->preview_pipe };
   for(size_t i = 0; i < G_N_ELEMENTS(pipes); i++)
-    if(pipes[i] && pipes[i]->last_history_item == hist)
-      pipes[i]->last_history_item = clone;
+  {
+    if(IS_NULL_PTR(pipes[i])) continue;
+    if(dt_atomic_get_ptr(&pipes[i]->last_history_item) != hist) continue;
+    dt_dev_history_item_ref(clone);
+    dt_dev_history_item_t *displaced
+        = (dt_dev_history_item_t *)dt_atomic_exch_ptr(&pipes[i]->last_history_item, clone);
+    dt_dev_free_history_item(displaced);
+  }
 
   dt_pthread_rwlock_unlock(&dev->history_mutex);
 
@@ -1224,9 +1239,33 @@ dt_dev_history_item_t *dt_dev_history_cow_touch(dt_develop_t *dev, dt_dev_histor
   return clone;
 }
 
-void dt_dev_history_release_snapshot(GList *snapshot)
+void dt_dev_history_snapshot_take(dt_develop_t *dev, dt_dev_history_snapshot_t *snapshot)
+    REQUIRES_SHARED(dev->history_mutex)
 {
-  g_list_free_full(snapshot, dt_dev_free_history_item);
+  if(IS_NULL_PTR(snapshot)) return;
+  snapshot->items = NULL;
+  snapshot->history_end = 0;
+  snapshot->history_hash = DT_PIXELPIPE_CACHE_HASH_INVALID;
+  if(IS_NULL_PTR(dev)) return;
+
+  // One reference per element, taken while the list cannot change under us. The copy is of
+  // the list cells only: the items are shared, and the writer's copy-on-write gate is what
+  // keeps them immutable for as long as this snapshot holds them.
+  snapshot->items = g_list_copy(dev->history);
+  for(GList *node = snapshot->items; node; node = g_list_next(node))
+    dt_dev_history_item_ref((dt_dev_history_item_t *)node->data);
+
+  snapshot->history_end = dt_dev_get_history_end_ext(dev);
+  snapshot->history_hash = dt_dev_get_history_hash(dev);
+}
+
+void dt_dev_history_snapshot_release(dt_dev_history_snapshot_t *snapshot)
+{
+  if(IS_NULL_PTR(snapshot)) return;
+  g_list_free_full(snapshot->items, dt_dev_free_history_item);
+  snapshot->items = NULL;
+  snapshot->history_end = 0;
+  snapshot->history_hash = DT_PIXELPIPE_CACHE_HASH_INVALID;
 }
 
 void dt_dev_history_free_history(dt_develop_t *dev) REQUIRES(dev->history_mutex)

--- a/src/develop/dev_history.h
+++ b/src/develop/dev_history.h
@@ -120,6 +120,43 @@ dt_dev_history_item_t *dt_dev_history_item_ref(dt_dev_history_item_t *item);
 dt_dev_history_item_t *dt_dev_history_cow_touch(struct dt_develop_t *dev, dt_dev_history_item_t *hist);
 
 /**
+ * @brief A reference-sharing snapshot of dev->history, for readers that outlive a lock.
+ *
+ * The pipe resync is O(nodes x history) and runs every module's commit_params(): tens of ms
+ * routinely, over 200 ms under mask-heavy history. Holding history_mutex as reader for all of
+ * it starves the GUI thread's writer for the same duration on every edit, and glibc's
+ * writer-preferring policy then blocks every NEW reader too, so one slow resync stalls the
+ * whole application on the next commit. A snapshot ends that: take the read lock, copy the
+ * list and reference each item, capture history_end and the hash that were written together
+ * with it, release the lock -- microseconds -- and resync against the snapshot instead.
+ *
+ * Nothing is deep-copied. dt_dev_history_cow_touch() is the writer's side of this contract:
+ * an item whose refcount is above 1 is cloned before it is mutated in place, so a snapshot
+ * never observes a half-rewritten item, and dt_history_duplicate() is not needed here.
+ *
+ * `history_end` and `history_hash` are captured under the same lock as the list because
+ * dt_dev_set_history_end_ext() writes them together: the three describe one committed state.
+ * Reading the hash after releasing the lock would let a commit land in between and mark the
+ * pipe as synced to history it never resynced against.
+ */
+typedef struct dt_dev_history_snapshot_t
+{
+  GList *items;          // dt_dev_history_item_t*, one reference each, same order as dev->history
+  int32_t history_end;   // dt_dev_get_history_end_ext() at snapshot time
+  uint64_t history_hash; // dt_dev_get_history_hash() at snapshot time
+} dt_dev_history_snapshot_t;
+
+/**
+ * @brief Take a snapshot of dev->history. Caller holds history_mutex (reader suffices).
+ */
+void dt_dev_history_snapshot_take(struct dt_develop_t *dev, dt_dev_history_snapshot_t *snapshot);
+
+/**
+ * @brief Release every reference a snapshot holds and reset it. Needs no lock.
+ */
+void dt_dev_history_snapshot_release(dt_dev_history_snapshot_t *snapshot);
+
+/**
  * @brief Fill/refresh a history item from explicit params and apply them to the module.
  *
  * This helper exists to share code between regular history edits and history merge logic.

--- a/src/develop/dev_pixelpipe.c
+++ b/src/develop/dev_pixelpipe.c
@@ -28,6 +28,8 @@
 #include "common/paths.h"
 #include "gui/application.h"
 #include "system/dtpthread.h"
+#include "system/atomic.h"
+#include "develop/dev_history.h"
 #include "develop/geometry/geometry.h"
 #include "develop/imageop.h"
 #include "develop/pixelpipe.h"
@@ -39,7 +41,7 @@
 #include <stdint.h>
 #include <stdlib.h>
 
-static void _sync_pipe_nodes_from_history_from_node(dt_dev_pixelpipe_t *pipe,
+static void _sync_pipe_nodes_from_history_from_node(dt_dev_pixelpipe_t *pipe, GList *history_list,
                                                     const uint32_t history_end, GList *start_node,
                                                     const char *debug_label);
 // dt_dev_pixelpipe_propagate_formats() is the authoritative forward buffer-format pass; it is
@@ -229,7 +231,26 @@ static void _change_pipe(dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_change_t fla
  * This helper only replaces the history-tail replay. The rest of `dt_dev_pixelpipe_change()` still runs
  * afterwards so cache policy and ROI contracts remain sealed for the next processing pass.
  */
-static gboolean _sync_focused_in_place(dt_dev_pixelpipe_t *pipe)
+/* Record the history item a resync last synchronized to, holding a reference on it.
+ *
+ * The resync runs against a snapshot outside history_mutex, so by the time it writes this the
+ * item may already have been cloned out of dev->history by the GUI thread's copy-on-write.
+ * Two things follow. The reference keeps the item alive for as long as the pipe names it, so an
+ * identity compare on the pointer can never hit a recycled address. The atomic exchange is
+ * what makes the write safe against dt_dev_history_cow_touch() re-pointing the same slot at the
+ * clone from the GUI thread: whichever side loses the race still ends up releasing exactly the
+ * reference it took, never the other side's. */
+static void _pipe_set_last_history_item(dt_dev_pixelpipe_t *pipe, dt_dev_history_item_t *hist)
+{
+  if(!IS_NULL_PTR(hist)) dt_dev_history_item_ref(hist);
+  dt_dev_history_item_t *previous
+      = (dt_dev_history_item_t *)dt_atomic_exch_ptr(&pipe->last_history_item, hist);
+  dt_dev_free_history_item(previous);
+}
+
+/* `snap` is the caller's history snapshot (dt_dev_history_snapshot_take): this runs outside
+ * history_mutex and must not touch dev->history or dev->history_end directly. */
+static gboolean _sync_focused_in_place(dt_dev_pixelpipe_t *pipe, const dt_dev_history_snapshot_t *snap)
 {
   if(IS_NULL_PTR(pipe) || IS_NULL_PTR(pipe->dev) || IS_NULL_PTR(pipe->dev->gui_module)) return FALSE;
   dt_develop_t *dev = pipe->dev;
@@ -239,11 +260,11 @@ static gboolean _sync_focused_in_place(dt_dev_pixelpipe_t *pipe)
   const gboolean realtime = dt_dev_pixelpipe_get_realtime(pipe);
   if(!transient && !realtime) return FALSE;
 
-  const uint32_t history_end = dt_dev_get_history_end_ext(dev);
+  const uint32_t history_end = (uint32_t)snap->history_end;
   if(history_end == 0) return FALSE;
 
   // Enable/blend state comes from the focused module's history item (transient edits are params-only).
-  dt_dev_history_item_t *hist = dt_dev_history_get_last_item_by_module(dev->history, focus, history_end);
+  dt_dev_history_item_t *hist = dt_dev_history_get_last_item_by_module(snap->items, focus, history_end);
   if(IS_NULL_PTR(hist) || IS_NULL_PTR(hist->module) || IS_NULL_PTR(hist->params)) return FALSE;
 
   dt_dev_pixelpipe_iop_t *piece = (dt_dev_pixelpipe_iop_t *)dt_dev_pixelpipe_get_module_piece(pipe, focus);
@@ -279,11 +300,11 @@ static gboolean _sync_focused_in_place(dt_dev_pixelpipe_t *pipe)
   // Only advance the synch_top fence when the focused module is the newest history item (the realtime
   // drawlayer case, where each heartbeat appended a top item). For a transient edit of a non-top module
   // no history item changed, so the fence must stay where the last real history sync left it.
-  GList *last_item = g_list_nth(dev->history, history_end - 1);
+  GList *last_item = g_list_nth(snap->items, history_end - 1);
   if(last_item && (dt_dev_history_item_t *)last_item->data == hist)
   {
     pipe->last_history_hash = hist->hash;
-    pipe->last_history_item = hist;
+    _pipe_set_last_history_item(pipe, hist);
   }
   return TRUE;
 }
@@ -1231,8 +1252,11 @@ void dt_dev_pixelpipe_propagate_formats(dt_dev_pixelpipe_t *pipe)
   dt_free(pipe_name);
 }
 
-static void _sync_pipe_nodes_from_history(dt_dev_pixelpipe_t *pipe, dt_develop_t *dev, const uint32_t history_end,
-                                          const char *debug_label)
+/* `history_list` is the snapshot's list (dt_dev_history_snapshot_t::items), never dev->history:
+ * this runs OUTSIDE history_mutex, and the snapshot's references are what keep every item it
+ * walks alive and unmodified (see dt_dev_history_snapshot_take). */
+static void _sync_pipe_nodes_from_history(dt_dev_pixelpipe_t *pipe, GList *history_list,
+                                          const uint32_t history_end, const char *debug_label)
 {
   dt_iop_buffer_dsc_t upstream_dsc = pipe->dev->image_storage.dsc;
   const gboolean previous_want_detail_mask = (pipe->want_detail_mask != DT_DEV_DETAIL_MASK_NONE);
@@ -1254,7 +1278,7 @@ static void _sync_pipe_nodes_from_history(dt_dev_pixelpipe_t *pipe, dt_develop_t
     uint64_t history_param_hash = DT_PIXELPIPE_CACHE_HASH_INVALID;
     gboolean found_history = FALSE;
 
-    for(GList *history = g_list_nth(dev->history, history_end - 1);
+    for(GList *history = g_list_nth(history_list, history_end - 1);
         history;
         history = g_list_previous(history))
     {
@@ -1295,11 +1319,11 @@ static void _sync_pipe_nodes_from_history(dt_dev_pixelpipe_t *pipe, dt_develop_t
   {
     GList *detailmask_node = _find_detailmask_node(pipe);
     if(detailmask_node)
-      _sync_pipe_nodes_from_history_from_node(pipe, history_end, detailmask_node, debug_label);
+      _sync_pipe_nodes_from_history_from_node(pipe, history_list, history_end, detailmask_node, debug_label);
   }
 }
 
-static void _sync_pipe_nodes_from_history_from_node(dt_dev_pixelpipe_t *pipe,
+static void _sync_pipe_nodes_from_history_from_node(dt_dev_pixelpipe_t *pipe, GList *history_list,
                                                     const uint32_t history_end, GList *start_node,
                                                     const char *debug_label)
 {
@@ -1333,7 +1357,7 @@ static void _sync_pipe_nodes_from_history_from_node(dt_dev_pixelpipe_t *pipe,
     uint64_t history_param_hash = DT_PIXELPIPE_CACHE_HASH_INVALID;
     gboolean found_history = FALSE;
 
-    for(GList *history = g_list_nth(pipe->dev->history, history_end - 1);
+    for(GList *history = g_list_nth(history_list, history_end - 1);
         history;
         history = g_list_previous(history))
     {
@@ -1374,7 +1398,7 @@ static void _sync_pipe_nodes_from_history_from_node(dt_dev_pixelpipe_t *pipe,
   {
     GList *detailmask_node = _find_detailmask_node(pipe);
     if(detailmask_node && detailmask_node != start_node)
-      _sync_pipe_nodes_from_history_from_node(pipe, history_end, detailmask_node, debug_label);
+      _sync_pipe_nodes_from_history_from_node(pipe, history_list, history_end, detailmask_node, debug_label);
   }
 }
 
@@ -1573,52 +1597,81 @@ void dt_pixelpipe_get_global_hash(dt_dev_pixelpipe_t *pipe)
  * @param dev
  * @param caller_func
  */
-void dt_dev_pixelpipe_synch_all_real(dt_dev_pixelpipe_t *pipe, const char *caller_func)
+/* Resync every node against a history snapshot. Runs outside history_mutex: everything it reads
+ * is owned by `snap`, whose references keep the items alive and, through the writer's
+ * copy-on-write gate, unmodified. */
+static void _synch_all_snapshot(dt_dev_pixelpipe_t *pipe, const dt_dev_history_snapshot_t *snap,
+                                const char *caller_func)
 {
   gchar *type = _get_debug_pipe_name(pipe, pipe->dev);
   dt_print(DT_DEBUG_DEV, "[pixelpipe] synch all modules with history for pipe %s called from %s\n", type, caller_func);
 
-  const uint32_t history_end = dt_dev_get_history_end_ext(pipe->dev);
-  _sync_pipe_nodes_from_history(pipe, pipe->dev, history_end, type);
+  const uint32_t history_end = (uint32_t)snap->history_end;
+  _sync_pipe_nodes_from_history(pipe, snap->items, history_end, type);
 
   // Keep track of the last history item to have been synced
-  GList *last_item = g_list_nth(pipe->dev->history, history_end - 1);
+  GList *last_item = g_list_nth(snap->items, history_end - 1);
   if(last_item)
   {
     dt_dev_history_item_t *last_hist = (dt_dev_history_item_t *)last_item->data;
     pipe->last_history_hash = last_hist->hash;
-    pipe->last_history_item = last_hist;
+    _pipe_set_last_history_item(pipe, last_hist);
   }
   else
   {
     pipe->last_history_hash = DT_PIXELPIPE_CACHE_HASH_INVALID;
-    pipe->last_history_item = NULL;
+    _pipe_set_last_history_item(pipe, NULL);
   }
 
   dt_free(type);
 }
 
-void dt_dev_pixelpipe_synch_top(dt_dev_pixelpipe_t *pipe)
+/* Public entry: export, snapshots and the focus overlay drive a throwaway pipe through this
+ * without going through dt_dev_pixelpipe_change(), and none of them holds history_mutex. Take
+ * the snapshot here, under a read lock held only for the copy. A caller that DOES already hold
+ * the lock (as reader or writer) re-enters it on the same thread, which dt_pthread_rwlock_t
+ * permits (see dtpthread.h). */
+void dt_dev_pixelpipe_synch_all_real(dt_dev_pixelpipe_t *pipe, const char *caller_func)
+{
+  dt_dev_history_snapshot_t snap;
+  dt_pthread_rwlock_rdlock(&pipe->dev->history_mutex);
+  dt_dev_history_snapshot_take(pipe->dev, &snap);
+  dt_pthread_rwlock_unlock(&pipe->dev->history_mutex);
+
+  _synch_all_snapshot(pipe, &snap, caller_func);
+
+  dt_dev_history_snapshot_release(&snap);
+}
+
+/* Resync only the nodes touched since the last sync, against a history snapshot. Runs outside
+ * history_mutex, same contract as _synch_all_snapshot(). */
+static void _synch_top_snapshot(dt_dev_pixelpipe_t *pipe, const dt_dev_history_snapshot_t *snap)
 {
   gchar *type = _get_debug_pipe_name(pipe, pipe->dev);
 
   dt_print(DT_DEBUG_DEV, "[pixelpipe] synch top modules with history for pipe %s\n", type);
 
-  const uint32_t history_end = dt_dev_get_history_end_ext(pipe->dev);
-  GList *last_item = g_list_nth(pipe->dev->history, history_end - 1);
+  const uint32_t history_end = (uint32_t)snap->history_end;
+  GList *last_item = g_list_nth(snap->items, history_end - 1);
   if(last_item)
   {
+    // The identity marker is read once: the GUI thread may re-point it at a clone (see
+    // dt_dev_history_cow_touch) while this walk runs, and the reference the pipe holds on it
+    // is what makes comparing against a possibly-departed item safe.
+    const dt_dev_history_item_t *last_synced
+        = (const dt_dev_history_item_t *)dt_atomic_get_ptr(&pipe->last_history_item);
+
     GList *first_item = NULL;
     for(GList *history = last_item; history; history = g_list_previous(history))
     {
       dt_dev_history_item_t *hist = (dt_dev_history_item_t *)history->data;
       first_item = history;
 
-      if(hist->hash == pipe->last_history_hash || hist == pipe->last_history_item)
+      if(hist->hash == pipe->last_history_hash || hist == last_synced)
         break;
     }
 
-    GList *fence_item = g_list_nth(pipe->dev->history, history_end);
+    GList *fence_item = g_list_nth(snap->items, history_end);
     for(GList *history = first_item; history && history != fence_item; history = g_list_next(history))
     {
       dt_dev_history_item_t *hist = (dt_dev_history_item_t *)history->data;
@@ -1630,23 +1683,35 @@ void dt_dev_pixelpipe_synch_top(dt_dev_pixelpipe_t *pipe)
         dt_dev_pixelpipe_iop_t *piece = (dt_dev_pixelpipe_iop_t *)nodes->data;
         if(IS_NULL_PTR(piece) || piece->module != hist->module) continue;
 
-        _sync_pipe_nodes_from_history_from_node(pipe, history_end, nodes, type);
+        _sync_pipe_nodes_from_history_from_node(pipe, snap->items, history_end, nodes, type);
         break;
       }
     }
 
     dt_dev_history_item_t *last_hist = (dt_dev_history_item_t *)last_item->data;
     pipe->last_history_hash = last_hist->hash;
-    pipe->last_history_item = last_hist;
+    _pipe_set_last_history_item(pipe, last_hist);
   }
   else
   {
     dt_print(DT_DEBUG_DEV, "[pixelpipe] synch top history module missing error for pipe %s\n", type);
     pipe->last_history_hash = DT_PIXELPIPE_CACHE_HASH_INVALID;
-    pipe->last_history_item = NULL;
+    _pipe_set_last_history_item(pipe, NULL);
   }
 
   dt_free(type);
+}
+
+void dt_dev_pixelpipe_synch_top(dt_dev_pixelpipe_t *pipe)
+{
+  dt_dev_history_snapshot_t snap;
+  dt_pthread_rwlock_rdlock(&pipe->dev->history_mutex);
+  dt_dev_history_snapshot_take(pipe->dev, &snap);
+  dt_pthread_rwlock_unlock(&pipe->dev->history_mutex);
+
+  _synch_top_snapshot(pipe, &snap);
+
+  dt_dev_history_snapshot_release(&snap);
 }
 
 // Modules without history need to be resynced unconditionnally with their internal params
@@ -1707,11 +1772,29 @@ void dt_dev_pixelpipe_change(dt_dev_pixelpipe_t *pipe)
   else
     _refresh_pipe_detail_mask_state(pipe);
 
+  // Snapshot history under the read lock, then resync against the snapshot with the lock
+  // RELEASED. The resync is O(nodes x history) and runs every module's commit_params() --
+  // tens of ms routinely, over 200 ms under mask-heavy history -- and it used to hold this
+  // lock for all of it. The GUI thread needs the writer side of the same lock on every
+  // commit (each slider tick, each throttled mask-drag commit), and glibc's writer-preferring
+  // policy then also blocks every NEW reader behind the queued writer: one slow resync stalled
+  // the whole application until it finished. The snapshot holds a reference on each item, and
+  // the writer's copy-on-write gate (dt_dev_history_cow_touch) clones a shared item before
+  // touching it, so what this resync reads can neither move nor change under it.
+  //
   // A call chain that already holds history_mutex as writer on this same thread can re-enter
-  // here (e.g. history-commit paths that resync a pipe while still holding the write lock). dt_pthread_rwlock_rdlock is same-thread-recursive for this exact case (see
-  // dtpthread.h), so this proceeds immediately instead of deadlocking or deferring the sync.
+  // here (e.g. history-commit paths that resync a pipe while still holding the write lock);
+  // dt_pthread_rwlock_rdlock is same-thread-recursive for exactly that (see dtpthread.h).
   const double _history_mutex_hold_start = dt_get_wtime();
+  dt_dev_history_snapshot_t snap;
   dt_pthread_rwlock_rdlock(&pipe->dev->history_mutex);
+  dt_dev_history_snapshot_take(pipe->dev, &snap);
+  dt_pthread_rwlock_unlock(&pipe->dev->history_mutex);
+  const double _history_mutex_hold_ms = (dt_get_wtime() - _history_mutex_hold_start) * 1000.0;
+  if(_history_mutex_hold_ms > 1.0)
+    dt_print(DT_DEBUG_HISTORY,
+             "[dt_dev_pixelpipe_change] tid %lu pipe %s held history_mutex for %.2f ms (status 0x%x)\n",
+             (unsigned long)pthread_self(), type, _history_mutex_hold_ms, (unsigned)status);
 
   // The realtime in-place path settles the format contract and the global hash itself (it must,
   // since that hash is cumulative over enabled nodes); the other paths defer it to the
@@ -1725,25 +1808,25 @@ void dt_dev_pixelpipe_change(dt_dev_pixelpipe_t *pipe)
     if(pipe->nodes) dt_dev_pixelpipe_cleanup_nodes(pipe);
     dt_dev_pixelpipe_create_nodes(pipe);
     dt_dev_pixelpipe_sync_no_history(pipe);
-    dt_dev_pixelpipe_synch_all(pipe);
+    _synch_all_snapshot(pipe, &snap, __FUNCTION__);
   }
   else if(status & DT_DEV_PIPE_SYNCH)
   {
     // pipeline topology remains intact, only change all params.
     dt_dev_pixelpipe_sync_no_history(pipe);
-    dt_dev_pixelpipe_synch_all(pipe);
+    _synch_all_snapshot(pipe, &snap, __FUNCTION__);
   }
   else if(status & DT_DEV_PIPE_TOP_CHANGED)
   {
     // only top history item(s) changed, or a focused module published transient/realtime params
-    if(_sync_focused_in_place(pipe))
+    if(_sync_focused_in_place(pipe, &snap))
     {
       formats_propagated = TRUE;
     }
     else
     {
       dt_dev_pixelpipe_sync_no_history(pipe);
-      dt_dev_pixelpipe_synch_top(pipe);
+      _synch_top_snapshot(pipe, &snap);
     }
   }
   else // DT_DEV_PIPE_ZOOMED DT_DEV_PIPE_CACHE_REQUEST DT_DEV_PIPE_REENTRY
@@ -1751,13 +1834,16 @@ void dt_dev_pixelpipe_change(dt_dev_pixelpipe_t *pipe)
     // Finalscale will need to self-enable/disable depending on zoom level
     dt_dev_pixelpipe_sync_no_history(pipe);
   }
-  dt_dev_pixelpipe_set_history_hash(pipe, dt_dev_get_history_hash(pipe->dev));
-  const double _history_mutex_hold_ms = (dt_get_wtime() - _history_mutex_hold_start) * 1000.0;
-  if(_history_mutex_hold_ms > 1.0)
+  // The hash the SNAPSHOT carried, not the live one: a commit may have landed since the lock
+  // was released, and this pipe is synced to what it just resynced against, nothing newer. The
+  // worker loop compares this against the live hash and re-flags the pipe if they differ.
+  dt_dev_pixelpipe_set_history_hash(pipe, snap.history_hash);
+  dt_dev_history_snapshot_release(&snap);
+  const double _resync_ms = (dt_get_wtime() - _history_mutex_hold_start) * 1000.0;
+  if(_resync_ms > 1.0)
     dt_print(DT_DEBUG_HISTORY,
-             "[dt_dev_pixelpipe_change] tid %lu pipe %s held history_mutex for %.2f ms (status 0x%x)\n",
-             (unsigned long)pthread_self(), type, _history_mutex_hold_ms, (unsigned)status);
-  dt_pthread_rwlock_unlock(&pipe->dev->history_mutex);
+             "[dt_dev_pixelpipe_change] tid %lu pipe %s resynced from snapshot in %.2f ms, lock-free (status 0x%x)\n",
+             (unsigned long)pthread_self(), type, _resync_ms, (unsigned)status);
 
   // Re-establish the buffer-format contract of the whole chain once, after whichever sync path
   // (full, top-only or realtime-in-place) committed params. This is the single authoritative,

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -65,6 +65,7 @@
 #include "control/signal.h"
 #include "develop/blend.h"
 #include "develop/dev_pixelpipe.h"
+#include "develop/dev_history.h"
 #include "pixel/format.h"
 #include "develop/imageop_math.h"
 #include "common/sentry.h"
@@ -547,6 +548,10 @@ void dt_dev_pixelpipe_cleanup(dt_dev_pixelpipe_t *pipe)
 
   // blocks while busy and sets shutdown bit:
   dt_dev_pixelpipe_cleanup_nodes(pipe);
+  // The pipe held a reference on the history item it last synced to (see the field's comment
+  // in pixelpipe_hb.h); drop it now that no resync can run on this pipe any more. Exchanged,
+  // not read-then-cleared, for the same reason every other write to that slot is.
+  dt_dev_free_history_item(dt_atomic_exch_ptr(&pipe->last_history_item, NULL));
   // so now it's safe to clean up cache:
   const uint64_t old_backbuf_hash = dt_dev_backbuf_get_hash(&pipe->backbuf);
   if(old_backbuf_hash != DT_PIXELPIPE_CACHE_HASH_INVALID)

--- a/src/develop/pixelpipe_hb.h
+++ b/src/develop/pixelpipe_hb.h
@@ -480,7 +480,15 @@ typedef struct dt_dev_pixelpipe_t
   // pointer identity of the last synchronized history item.
   // This complements `last_history_hash` for in-place top-entry updates where
   // the same history node is reused and its hash changes.
-  gpointer last_history_item;
+  //
+  // The pipe HOLDS A REFERENCE on whatever this points at (dt_dev_history_item_ref), and
+  // it is exchanged atomically (_pipe_set_last_history_item / dt_dev_history_cow_touch).
+  // The resync runs against a snapshot outside history_mutex, so the item it last synced
+  // may since have left dev->history; the reference keeps it alive, which is what makes an
+  // identity compare on it safe -- a freed address could be reused by a NEW item and match.
+  // The exchange is what lets the worker (writing its last-synced item) and the GUI thread
+  // (cow_touch re-pointing it at a clone) race on the slot without leaking or double-freeing.
+  dt_atomic_ptr last_history_item;
 
   // hash of the whole history stack at the time of synchonization
   // between pipe and history. This is a local copy of 

--- a/src/system/atomic.h
+++ b/src/system/atomic.h
@@ -52,6 +52,7 @@ static inline void *dt_atomic_get_ptr(const dt_atomic_ptr *var) { return __atomi
 static inline int dt_atomic_add_int(dt_atomic_int *var, int incr) { return __atomic_fetch_add(var, incr, __ATOMIC_SEQ_CST); }
 static inline int dt_atomic_sub_int(dt_atomic_int *var, int decr) { return __atomic_fetch_sub(var, decr, __ATOMIC_SEQ_CST); }
 static inline int dt_atomic_exch_int(dt_atomic_int *var, int value) { return __atomic_exchange_n(var, value, __ATOMIC_SEQ_CST); }
+static inline void *dt_atomic_exch_ptr(dt_atomic_ptr *var, void *value) { return __atomic_exchange_n(var, value, __ATOMIC_SEQ_CST); }
 static inline int dt_atomic_CAS_int(dt_atomic_int *var, int *expected, int value)
 {
   return __atomic_compare_exchange_n(var, expected, value, 0, __ATOMIC_SEQ_CST, __ATOMIC_SEQ_CST);
@@ -76,6 +77,7 @@ static inline void *dt_atomic_get_ptr(const dt_atomic_ptr *var) { return atomic_
 static inline int dt_atomic_add_int(dt_atomic_int *var, int incr) { return atomic_fetch_add(var,incr); }
 static inline int dt_atomic_sub_int(dt_atomic_int *var, int decr) { return atomic_fetch_sub(var,decr); }
 static inline int dt_atomic_exch_int(dt_atomic_int *var, int value) { return atomic_exchange(var,value); }
+static inline void *dt_atomic_exch_ptr(dt_atomic_ptr *var, void *value) { return atomic_exchange(var,value); }
 static inline int dt_atomic_CAS_int(dt_atomic_int *var, int *expected, int value)
 { return atomic_compare_exchange_strong(var,expected,value); }
 
@@ -103,6 +105,8 @@ static inline int dt_atomic_add_int(dt_atomic_int *var, int incr) { return __ato
 static inline int dt_atomic_sub_int(dt_atomic_int *var, int decr) { return __atomic_fetch_sub(var,decr,__ATOMIC_SEQ_CST); }
 static inline int dt_atomic_exch_int(dt_atomic_int *var, int value)
 { int orig;  __atomic_exchange(var,&value,&orig,__ATOMIC_SEQ_CST); return orig; }
+static inline void *dt_atomic_exch_ptr(dt_atomic_ptr *var, void *value)
+{ void *orig;  __atomic_exchange(var,&value,&orig,__ATOMIC_SEQ_CST); return orig; }
 static inline int dt_atomic_CAS_int(dt_atomic_int *var, int *expected, int value)
 { return __atomic_compare_exchange(var,expected,&value,0,__ATOMIC_SEQ_CST,__ATOMIC_SEQ_CST); }
 
@@ -186,6 +190,15 @@ static inline int dt_atomic_exch_int(dt_atomic_int *var, int value)
 {
   pthread_mutex_lock(&dt_atom_mutex);
   int origvalue = *var;
+  *var = value;
+  pthread_mutex_unlock(&dt_atom_mutex);
+  return origvalue;
+}
+
+static inline void *dt_atomic_exch_ptr(dt_atomic_ptr *var, void *value)
+{
+  pthread_mutex_lock(&dt_atom_mutex);
+  void *origvalue = *var;
   *var = value;
   pthread_mutex_unlock(&dt_atom_mutex);
   return origvalue;

--- a/src/tests/unittests/CMakeLists.txt
+++ b/src/tests/unittests/CMakeLists.txt
@@ -18,6 +18,7 @@ set(DATABASE_UNIT_TESTS
   test_backbuf_publish
   test_conf_value_lifetime
   test_dtpthread_recursive
+  test_history_snapshot
 )
 
 foreach(test ${DATABASE_UNIT_TESTS})

--- a/src/tests/unittests/test_history_snapshot.c
+++ b/src/tests/unittests/test_history_snapshot.c
@@ -1,0 +1,274 @@
+/*
+    This file is part of Ansel,
+    Copyright (C) 2026 Aurélien PIERRE.
+
+    Ansel is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Ansel is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Ansel.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+/* The contract between a history snapshot and the writer's copy-on-write gate.
+ *
+ * dt_dev_pixelpipe_change() resyncs a pipe against a dt_dev_history_snapshot_t with
+ * history_mutex RELEASED. That is only sound if two things hold, and this file pins both:
+ *
+ *   1. the snapshot holds one reference per item, so nothing it walks can be freed under it;
+ *   2. dt_dev_history_cow_touch() clones a shared item instead of mutating it in place, so
+ *      nothing the snapshot walks can CHANGE under it either -- and the pipe's last-synced
+ *      marker, which the GUI thread re-points at the clone, keeps every refcount balanced.
+ *
+ * A dt_develop_t is built by hand here: the functions under test touch dev->history,
+ * dev->history_mutex, dev->pipe and dev->preview_pipe and nothing else, and dt_dev_init()
+ * would drag the whole application in for no gain. */
+
+#include "develop/develop.h"
+#include "develop/dev_history.h"
+#include "develop/pixelpipe_hb.h"
+#include "system/atomic.h"
+#include "system/dtpthread.h"
+
+#include <glib.h>
+#include <stdarg.h>
+#include <stddef.h>
+#include <stdlib.h>
+// cmocka.h declares `extern jmp_buf global_expect_assert_env' at file scope without including
+// <setjmp.h> itself. Same suppression as the other tests here, and for the same reason.
+#include <setjmp.h>  // NOLINT(misc-include-cleaner)
+#include <stdint.h>
+#include <cmocka.h>
+
+typedef struct _fixture_t
+{
+  dt_develop_t dev;
+  dt_dev_pixelpipe_t pipe;
+} _fixture_t;
+
+static int _setup(void **state)
+{
+  _fixture_t *f = calloc(1, sizeof(_fixture_t));
+  if(!f) return -1;
+  dt_pthread_rwlock_init(&f->dev.history_mutex, NULL);
+  f->dev.pipe = &f->pipe;
+  f->dev.preview_pipe = NULL;
+  *state = f;
+  return 0;
+}
+
+static int _teardown(void **state)
+{
+  _fixture_t *f = *state;
+  // Whatever a test left in the pipe's marker and in history is released here, so a test
+  // that asserts on refcounts mid-way does not have to also be its own janitor.
+  dt_dev_free_history_item(dt_atomic_exch_ptr(&f->pipe.last_history_item, NULL));
+  g_list_free_full(f->dev.history, dt_dev_free_history_item);
+  f->dev.history = NULL;
+  dt_pthread_rwlock_destroy(&f->dev.history_mutex);
+  free(f);
+  return 0;
+}
+
+static int _refs(const dt_dev_history_item_t *item)
+{
+  return dt_atomic_get_int(&((dt_dev_history_item_t *)item)->refcount);
+}
+
+static dt_dev_history_item_t *_append(dt_develop_t *dev, const uint64_t hash)
+{
+  dt_dev_history_item_t *item = dt_dev_history_item_create();
+  assert_non_null(item);
+  item->hash = hash;
+  dev->history = g_list_append(dev->history, item);
+  item->num = g_list_index(dev->history, item);
+  return item;
+}
+
+static void _a_snapshot_references_every_item_and_releases_them(void **state)
+{
+  _fixture_t *f = *state;
+  dt_dev_history_item_t *a = _append(&f->dev, 0xA);
+  dt_dev_history_item_t *b = _append(&f->dev, 0xB);
+  dt_dev_history_item_t *c = _append(&f->dev, 0xC);
+  f->dev.history_end = 3;
+  dt_dev_set_history_hash(&f->dev, 0xABC);
+
+  dt_dev_history_snapshot_t snap;
+  dt_pthread_rwlock_rdlock(&f->dev.history_mutex);
+  dt_dev_history_snapshot_take(&f->dev, &snap);
+  dt_pthread_rwlock_unlock(&f->dev.history_mutex);
+
+  // Same items, same order, one extra reference each. No copy: the pointers are identical.
+  assert_int_equal(g_list_length(snap.items), 3);
+  assert_ptr_equal(g_list_nth_data(snap.items, 0), a);
+  assert_ptr_equal(g_list_nth_data(snap.items, 1), b);
+  assert_ptr_equal(g_list_nth_data(snap.items, 2), c);
+  assert_int_equal(_refs(a), 2);
+  assert_int_equal(_refs(b), 2);
+  assert_int_equal(_refs(c), 2);
+
+  // end and hash travel with the list.
+  assert_int_equal(snap.history_end, 3);
+  assert_int_equal(snap.history_hash, 0xABC);
+
+  dt_dev_history_snapshot_release(&snap);
+  assert_null(snap.items);
+  assert_int_equal(_refs(a), 1);
+  assert_int_equal(_refs(b), 1);
+  assert_int_equal(_refs(c), 1);
+}
+
+static void _history_end_is_clamped_to_the_list_at_snapshot_time(void **state)
+{
+  _fixture_t *f = *state;
+  _append(&f->dev, 0x1);
+  _append(&f->dev, 0x2);
+  f->dev.history_end = 99; // stale, larger than the list
+
+  dt_dev_history_snapshot_t snap;
+  dt_pthread_rwlock_rdlock(&f->dev.history_mutex);
+  dt_dev_history_snapshot_take(&f->dev, &snap);
+  dt_pthread_rwlock_unlock(&f->dev.history_mutex);
+
+  assert_int_equal(snap.history_end, 2);
+  dt_dev_history_snapshot_release(&snap);
+}
+
+static void _cow_touch_leaves_an_exclusively_owned_item_alone(void **state)
+{
+  _fixture_t *f = *state;
+  dt_dev_history_item_t *item = _append(&f->dev, 0x1);
+  assert_int_equal(_refs(item), 1);
+
+  dt_dev_history_item_t *touched = dt_dev_history_cow_touch(&f->dev, item);
+
+  // Nobody else can see it: mutate in place, no clone, no churn.
+  assert_ptr_equal(touched, item);
+  assert_int_equal(_refs(item), 1);
+  assert_ptr_equal(g_list_nth_data(f->dev.history, 0), item);
+}
+
+static void _cow_touch_clones_an_item_a_snapshot_is_holding(void **state)
+{
+  _fixture_t *f = *state;
+  dt_dev_history_item_t *original = _append(&f->dev, 0x1);
+  original->enabled = TRUE;
+  f->dev.history_end = 1;
+
+  dt_dev_history_snapshot_t snap;
+  dt_pthread_rwlock_rdlock(&f->dev.history_mutex);
+  dt_dev_history_snapshot_take(&f->dev, &snap);
+  dt_pthread_rwlock_unlock(&f->dev.history_mutex);
+  assert_int_equal(_refs(original), 2);
+
+  dt_dev_history_item_t *clone = dt_dev_history_cow_touch(&f->dev, original);
+
+  // The writer got a fresh object and dev->history now names it ...
+  assert_non_null(clone);
+  assert_ptr_not_equal(clone, original);
+  assert_ptr_equal(g_list_nth_data(f->dev.history, 0), clone);
+  assert_int_equal(_refs(clone), 1);
+  assert_int_equal(clone->hash, original->hash);
+  assert_true(clone->enabled);
+
+  // ... while the snapshot still names the original, which it alone now keeps alive.
+  assert_ptr_equal(g_list_nth_data(snap.items, 0), original);
+  assert_int_equal(_refs(original), 1);
+
+  // A mutation of the clone is invisible through the snapshot -- the whole point.
+  clone->enabled = FALSE;
+  clone->hash = 0x2;
+  assert_true(((dt_dev_history_item_t *)g_list_nth_data(snap.items, 0))->enabled);
+  assert_int_equal(((dt_dev_history_item_t *)g_list_nth_data(snap.items, 0))->hash, 0x1);
+
+  dt_dev_history_snapshot_release(&snap); // drops the original's last reference
+}
+
+static void _cow_touch_repoints_the_pipe_marker_and_balances_every_reference(void **state)
+{
+  _fixture_t *f = *state;
+  dt_dev_history_item_t *original = _append(&f->dev, 0x1);
+  f->dev.history_end = 1;
+
+  // The pipe recorded this item as its last-synced marker, holding a reference on it, the
+  // way _pipe_set_last_history_item() does at the end of a resync.
+  dt_dev_history_item_ref(original);
+  dt_atomic_set_ptr(&f->pipe.last_history_item, original);
+  assert_int_equal(_refs(original), 2); // history + pipe
+
+  dt_dev_history_snapshot_t snap;
+  dt_pthread_rwlock_rdlock(&f->dev.history_mutex);
+  dt_dev_history_snapshot_take(&f->dev, &snap);
+  dt_pthread_rwlock_unlock(&f->dev.history_mutex);
+  assert_int_equal(_refs(original), 3); // history + pipe + snapshot
+
+  dt_dev_history_item_t *clone = dt_dev_history_cow_touch(&f->dev, original);
+  assert_ptr_not_equal(clone, original);
+
+  // The marker followed the clone, so an in-place top-entry rewrite keeps its bounded resync;
+  // the reference the marker held on the original moved with it.
+  assert_ptr_equal(dt_atomic_get_ptr(&f->pipe.last_history_item), clone);
+  assert_int_equal(_refs(clone), 2);    // history + pipe
+  assert_int_equal(_refs(original), 1); // snapshot only
+
+  dt_dev_history_snapshot_release(&snap);
+
+  // Dropping the pipe's marker the way dt_dev_pixelpipe_cleanup() does leaves the clone
+  // owned by history alone: nothing leaked, nothing double-released.
+  dt_dev_free_history_item(dt_atomic_exch_ptr(&f->pipe.last_history_item, NULL));
+  assert_int_equal(_refs(clone), 1);
+}
+
+static void _cow_touch_ignores_a_marker_naming_a_different_item(void **state)
+{
+  _fixture_t *f = *state;
+  dt_dev_history_item_t *first = _append(&f->dev, 0x1);
+  dt_dev_history_item_t *second = _append(&f->dev, 0x2);
+  f->dev.history_end = 2;
+
+  dt_dev_history_item_ref(first);
+  dt_atomic_set_ptr(&f->pipe.last_history_item, first);
+
+  dt_dev_history_snapshot_t snap;
+  dt_pthread_rwlock_rdlock(&f->dev.history_mutex);
+  dt_dev_history_snapshot_take(&f->dev, &snap);
+  dt_pthread_rwlock_unlock(&f->dev.history_mutex);
+
+  dt_dev_history_item_t *clone = dt_dev_history_cow_touch(&f->dev, second);
+  assert_ptr_not_equal(clone, second);
+
+  // The marker named `first', not the item being cloned: it must not move.
+  assert_ptr_equal(dt_atomic_get_ptr(&f->pipe.last_history_item), first);
+  assert_int_equal(_refs(first), 3);  // history + pipe + snapshot
+  assert_int_equal(_refs(clone), 1);  // history
+  assert_int_equal(_refs(second), 1); // snapshot
+
+  dt_dev_history_snapshot_release(&snap);
+}
+
+int main(void)
+{
+  const struct CMUnitTest tests[] = {
+    cmocka_unit_test_setup_teardown(_a_snapshot_references_every_item_and_releases_them, _setup, _teardown),
+    cmocka_unit_test_setup_teardown(_history_end_is_clamped_to_the_list_at_snapshot_time, _setup, _teardown),
+    cmocka_unit_test_setup_teardown(_cow_touch_leaves_an_exclusively_owned_item_alone, _setup, _teardown),
+    cmocka_unit_test_setup_teardown(_cow_touch_clones_an_item_a_snapshot_is_holding, _setup, _teardown),
+    cmocka_unit_test_setup_teardown(_cow_touch_repoints_the_pipe_marker_and_balances_every_reference, _setup, _teardown),
+    cmocka_unit_test_setup_teardown(_cow_touch_ignores_a_marker_naming_a_different_item, _setup, _teardown),
+  };
+
+  return cmocka_run_group_tests(tests, NULL, NULL);
+}
+
+// clang-format off
+// modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py
+// vim: shiftwidth=2 expandtab tabstop=2 cindent
+// kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;
+// clang-format on


### PR DESCRIPTION
## Summary

`dt_dev_pixelpipe_change()` held `dev->history_mutex` as **reader** for the entire O(nodes × history) pipe resync — every module's `commit_params()` — while the GUI thread needed the writer side of the same lock on every commit. glibc's writer-preferring rwlock then blocked every *new* reader behind the queued writer as well, so one slow resync stalled the whole application until it finished.

This is the mechanism behind #1098 ("the shape moves in steps"): `views/darkroom.c` queues a throttled history commit on every mask-drag motion, the throttle fires about once per pipe render, and each firing waited out whatever resync the worker was mid-flight on. Each step was one lock acquisition.

The resync now runs against a `dt_dev_history_snapshot_t`: the read lock is held only to copy the list cells, take one reference per item, and capture `history_end` and the hash — the three fields `dt_dev_set_history_end_ext()` writes together — and is released before any `commit_params()` runs. The writer's existing copy-on-write gate (`dt_dev_history_cow_touch`) is the other half of the contract.

## Measured

Load-time resync of a 47-item mask-heavy history (`_DSC9410.NEF`, 57-node brush), `-d history`, same machine, same scratch config:

| | lock held (preview / full pipe) | resync work |
|---|---|---|
| before | **204.66 ms / 226.75 ms** | inside the hold |
| after | below the 1 ms print threshold | 174.63 / 158.52 ms, lock-free |

The compute cost is unchanged; only the waiting is gone.

## Design notes (also in CLAUDE.md and `doc/reorganisation.md`)

- `history_end` and the hash are captured **inside** the brief lock. Reading the atomic hash after release would let a commit land in between and mark the pipe synced to history it never resynced against.
- `pipe->last_history_item` — the identity marker `synch_top` uses to bound an in-place top-entry rewrite — becomes an atomic pointer the pipe holds a **reference** on, exchanged with `dt_atomic_exch_ptr()` (added to `system/atomic.h`, all four backends). `cow_touch` re-points it at the clone from the GUI thread while the worker writes it outside the lock, so it is a genuine cross-thread slot; the held reference also closes a recycled-address hazard the raw pointer had.
- The async DB write job is the *second* long reader of this lock; left alone here since it is not on the interactive path (follow-up).

## Tests

- `src/tests/unittests/test_history_snapshot.c` — six cases pinning the snapshot/COW/refcount contract, all pass.
- `test_dtpthread_recursive` still passes (same-thread rwlock recursion is preserved).
- Full build clean; ctest 14/14 of the tests that run (the five "Not Run" are LensSerious's own executables, which the default `ninja` never builds — pre-existing).

## Follow-ups

- #1294 routes mask drags through the transient-params channel (no history committed mid-drag at all); based on this branch, targets master, merge after this one.
- #1295 gives the async DB write job (the second long reader of this lock) the same snapshot treatment; also based on this branch, targets master, merge after this one.

Fixes #1196.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
