### PR TITLE
darkroom: render drawn-mask drags from the transient slot, commit history on release (#1098)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -346,9 +346,39 @@ pins that contract; `-d history` shows the hold times.
 
 The named-rwlock diagnostic lives in `system/dtpthread.h` (`dt_pthread_rwlock_set_name()`,
 opt-in per lock, combine with `-d history`); `dev->history_mutex` is named in `dt_dev_init()`.
-Drawn-mask geometry editing still commits history through the throttle on every drag motion
-rather than through the transient-params channel the drawlayer brush uses — that is the remaining
-follow-up for #1098, and it is a GUI-side routing change, not a locking one.
+
+### Drawn-mask drags render from the transient slot; history is written once, on release
+
+The other half of #1098. `views/darkroom.c` used to make a mask drag visible by committing
+history on the GUI throttle — about once per pipe render, mid-drag: a history rewrite, a DB write
+job and a full `synch_top` per tick, with the shape's owner re-hashed against `dev->forms` only as
+a side effect. It now takes the drawlayer brush's route (`_publish_mask_edit_transient()`,
+mirroring `_publish_backend_progress()` in `iop/drawlayer/worker.c`): on every drag motion and
+every scroll step, publish the owner module's *own, unchanged* params through
+`dt_dev_transient_params_set()` and flag the main pipe `TOP_CHANGED`. That is only a ticket onto
+`_sync_focused_in_place()`, which re-commits the one focused piece against the **live**
+`dev->forms` — `dt_iop_compute_blendop_hash()` folds the group's geometry in, and
+`dt_dev_pixelpipe_process()` re-snapshots `pipe->forms` on every recompute — so the piece re-keys
+from the moved shape and only it and its downstream recompute. Nothing about the shape lives in
+params; the geometry is in `dev->forms`, which is why publishing unchanged params works.
+
+Three things a reviewer would otherwise "simplify" away:
+
+- **The throttled commit defers itself while `dt_masks_gui_is_dragging()`** by re-queueing, and
+  runs after the button comes up. It must not be suppressed outright: the release path only
+  *queues* the commit, it does not commit, so a suppressed callback would never write history.
+- **Flag with `dt_dev_pixelpipe_or_changed()`, not `_change_pipe()`.** The latter also raises the
+  killswitch; per-motion killswitches abort every in-flight render and a fast drag never gets a
+  frame. The drawlayer heartbeat makes the same choice for the same reason.
+- **Clear the transient slot before the commit, and even when nothing changed.** The commit's
+  resync must come from history, and a no-op drag must not leave the slot occupied. When the slot
+  was active but `forms_changed` is false, flag the main pipe once so it re-syncs from history
+  rather than keeping a render keyed to a slot that no longer exists.
+
+Scrolling (size / feather / opacity) has no release, so there the throttle marks the end of the
+burst: each step renders live, one commit lands after the last. The mask-manager path
+(`libs/masks.c`, no focused module) is unchanged and still commits directly; the focused-piece
+path needs `dev->gui_module` to be the shape's owner.
 
 ### `_insert_default_modules` must check `dev->history` in memory, not the DB row for `dev->image_storage.id`
 

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -101,6 +101,8 @@
 #include "control/control.h"
 #include "control/jobs.h"
 #include "develop/dev_pixelpipe.h"
+#include "develop/dev_history.h"
+#include "develop/pixelpipe_hb.h"
 #include "develop/develop.h"
 #include "develop/dev_history_gui.h"
 #include "develop/imageop.h"
@@ -2249,9 +2251,49 @@ void mouse_enter(dt_view_t *self)
 // cacheline (issue #1060 family: "the mask does nothing until you nudge a slider").
 static dt_iop_module_t *_pending_mask_commit_module = NULL;
 
+/* Re-render the mask's owner from the LIVE geometry, without writing history.
+ *
+ * A drawn shape's geometry lives in dev->forms, not in any module's params, and the pipe reads
+ * it fresh on every recompute (dt_dev_pixelpipe_process() re-snapshots pipe->forms). What the
+ * pipe does NOT do on its own is notice that the geometry moved: a piece is re-keyed only when
+ * its history item changes, so a drag used to be made visible by committing history on a
+ * throttle, mid-drag -- one history rewrite, one DB write job and one full synch_top per
+ * throttle tick, with the mask's owner re-hashed against the forms as a side effect.
+ *
+ * This is the drawlayer brush's route instead (see _publish_backend_progress() in
+ * iop/drawlayer/worker.c): publish the owner's params through the transient channel and flag
+ * the main pipe TOP_CHANGED. That routes the resync through _sync_focused_in_place(), which
+ * re-commits the ONE focused piece against the live dev->forms -- dt_iop_compute_blendop_hash()
+ * folds the group's geometry in -- so the piece re-keys from the moved shape and only it and
+ * its downstream recompute. The params published are the module's own, unchanged: it is the
+ * forms that moved, and the transient slot is only the ticket onto the focused-piece path.
+ *
+ * Flagged without the killswitch (dt_dev_pixelpipe_or_changed, not _change_pipe), as the
+ * drawlayer heartbeat does: a fast drag must not abort every in-flight render or none would
+ * ever finish. History is written once, when the interaction ends -- see the commit below,
+ * which clears this slot so the pipe goes back to rendering the committed state. */
+static void _publish_mask_edit_transient(dt_develop_t *dev)
+{
+  dt_iop_module_t *module = dev->gui_module;
+  if(IS_NULL_PTR(module) || IS_NULL_PTR(module->params) || module->params_size <= 0) return;
+  dt_dev_transient_params_set(module, module->params, (size_t)module->params_size, NULL, 0);
+  dt_dev_pixelpipe_or_changed(dev->pipe, DT_DEV_PIPE_TOP_CHANGED);
+}
+
 static void _delayed_history_commit(gpointer data)
 {
   dt_develop_t *dev = (dt_develop_t *)data;
+
+  /* Not while a shape is still being dragged. The throttle fires about once per pipe render,
+   * which used to land a history commit -- and the resync it triggers -- in the middle of the
+   * drag; the transient publish above is what feeds the pipe meanwhile, so the commit can wait
+   * for the button to come up. Re-queueing re-arms the throttle; the pending module is left in
+   * place so the eventual commit still lands on the owner of the interaction. */
+  if(!IS_NULL_PTR(dev->form_gui) && dt_masks_gui_is_dragging(dev->form_gui))
+  {
+    dt_gui_throttle_queue(dev, _delayed_history_commit, dev);
+    return;
+  }
 
   dt_iop_module_t *module = _pending_mask_commit_module;
   _pending_mask_commit_module = NULL;
@@ -2259,6 +2301,12 @@ static void _delayed_history_commit(gpointer data)
   // it is still a live member of dev->iop, else fall back to the current focus.
   if(IS_NULL_PTR(module) || IS_NULL_PTR(g_list_find(dev->iop, module)))
     module = dev->gui_module;
+
+  // The interaction is over: drop the transient ticket so the pipe renders the committed
+  // history state again. Cleared BEFORE the commit, whose resync must come from history --
+  // and cleared even when nothing changed, so a no-op drag does not leave the slot occupied.
+  const gboolean was_transient = !IS_NULL_PTR(module) && dt_dev_transient_params_active(dev, module);
+  if(was_transient) dt_dev_transient_params_clear(module);
 
   // Figure out if an history item needs to be added
   // aka drawn masks have changed somehow. This is more expensive
@@ -2269,6 +2317,10 @@ static void _delayed_history_commit(gpointer data)
 
   if(dev->forms_changed)
     dt_dev_add_history_item(dev, module, FALSE, TRUE);
+  else if(was_transient)
+    // Nothing to commit, but the pipe was rendering from the transient slot: re-sync it from
+    // history so it does not keep a render keyed to a slot that no longer exists.
+    dt_dev_pixelpipe_update_history_main(dev);
 }
 
 // Queue the throttled mask-edit history commit, capturing its target module NOW. Every mask
@@ -2561,8 +2613,15 @@ void mouse_moved(dt_view_t *self, double x, double y, double pressure, int which
   {
     // There is no shape dragging in creation mode, so no need to commit history.
     if(!dev->form_gui->creation)
+    {
+      // A shape being dragged is re-rendered live from the transient slot on every motion;
+      // hover motion changes no geometry and gets nothing. The history commit queued below
+      // defers itself until the drag ends (see _delayed_history_commit).
+      if(dt_masks_gui_is_dragging(dev->form_gui))
+        _publish_mask_edit_transient(dev);
       _queue_delayed_history_commit(dev);
-      
+    }
+
     handled = TRUE;
   }
 
@@ -2984,7 +3043,14 @@ int scrolled(dt_view_t *self, double x, double y, int up, int state, int delta_y
   {
     dt_control_queue_redraw_center();
     if(!dev->form_gui->creation)
+    {
+      // Every scroll step changes the shape (size, feather or opacity) and is rendered live
+      // from the transient slot at once; a burst of steps then lands ONE history commit when
+      // the throttle fires after the last one, which also clears the slot. Scrolling has no
+      // "release" the way a drag does, so the throttle is what marks the end of the burst.
+      _publish_mask_edit_transient(dev);
       _queue_delayed_history_commit(dev);
+    }
 
     return TRUE;
   }


### PR DESCRIPTION
## Summary

The other half of #1098, built on top of #1293. **Targets master, not the #1293 branch** (a PR against a feature-branch base gets no CI matrix and can merge into a dead base). Until #1293 merges, this diff shows both commits; once it does, only `333410773f` remains and this branch should be rebased onto master before merging.

A drawn shape's geometry lives in `dev->forms`, not in any module's params, and the pipe already re-reads it on every recompute (`dt_dev_pixelpipe_process()` re-snapshots `pipe->forms`). What the pipe could not do was *notice* a move — a piece re-keys only when its history item changes — so `views/darkroom.c` used to make a drag visible by committing history on the GUI throttle, mid-drag: one history rewrite, one DB write job and one full `synch_top` per tick, for a shape that had not finished moving.

This takes the drawlayer brush's route (`_publish_backend_progress()` in `iop/drawlayer/worker.c`): on every drag motion and every scroll step, publish the owner module's **own, unchanged** params through the transient channel and flag the main pipe `TOP_CHANGED`. That is only a ticket onto `_sync_focused_in_place()`, which re-commits the one focused piece against the live `dev->forms` — `dt_iop_compute_blendop_hash()` folds the group's geometry in — so the piece re-keys from the moved shape and only it and its downstream recompute. No history, no undo churn, no DB write per motion. History is written once, on release.

## Three deliberate choices (documented in CLAUDE.md)

- The throttled commit **defers itself** while `dt_masks_gui_is_dragging()` by re-queueing, and runs after the button comes up. It is not suppressed: the release path only *queues* the commit, so a suppressed callback would never write history.
- Flagged with `dt_dev_pixelpipe_or_changed()`, **not** `_change_pipe()`: the latter raises the killswitch, and per-motion killswitches abort every in-flight render so a fast drag never gets a frame. The drawlayer heartbeat makes the same choice.
- The transient slot is cleared **before** the commit (the resync must come from history) and even on a no-op drag, re-flagging the pipe in that case so it does not keep a render keyed to a slot that no longer exists.

Scrolling (size / feather / opacity) has no release, so there the throttle marks the end of the burst: each step renders live, one commit lands after the last. The mask-manager path (`libs/masks.c`, no focused module) is unchanged.

## Verification

Builds clean; smoke-tested by opening the 47-item mask-heavy raw (`-d history`): 9 lock-free resyncs, no crash markers. **The drag itself is interactive and has not been exercised by me** — please drag a shape in the darkroom with `-d history -d perf` before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
