### PR TITLE
opencl: clear the driver-crash streak before conf is torn down, per vendor

### DIFF
--- a/src/common/opencl.c
+++ b/src/common/opencl.c
@@ -1526,15 +1526,34 @@ static void dt_opencl_cleanup_device(dt_opencl_t *cl, int i)
   dt_free(cl->dev[i].options_md5);
 }
 
+void dt_opencl_clear_driver_crash_streak(void)
+{
+  /* Clear the driver-crash streak only if OpenCL actually RAN and we still reached a clean
+   * shutdown: that is the one thing showing the driver behaving. Surviving with OpenCL
+   * switched off proves nothing about it, and clearing on that would re-enable it next launch
+   * and crash again -- halving the crash rate instead of stopping it.
+   *
+   * This touches conf, so it must run while conf is still alive -- i.e. BEFORE
+   * dt_conf_cleanup(), which is why it is not part of dt_opencl_cleanup(): that one runs after
+   * conf has been saved and freed, where a conf access is both a use-after-free and a write
+   * that can never be persisted. */
+  dt_opencl_t *cl = _opencl;
+  if(IS_NULL_PTR(cl) || !cl->inited || !cl->enabled || IS_NULL_PTR(cl->dev)) return;
+
+  /* The counters are per vendor (the same keys _gpu_vendor_crash_streak() gates a device on),
+   * and only a vendor whose device RAN is cleared: a device this session skipped because of
+   * its own streak has not shown anything. */
+  for(int i = 0; i < cl->num_devs; i++)
+  {
+    if(cl->dev[i].disabled) continue;
+    const unsigned int vendor_id = cl->dev[i].vendor_id;
+    if(_gpu_vendor_crash_streak(vendor_id) != 0)
+      _gpu_vendor_set_crash_streak(vendor_id, 0);
+  }
+}
+
 void dt_opencl_cleanup(void)
 {
-  /* Clear the driver-crash streak only if OpenCL actually RAN and we still reached cleanup:
-   * that is the one thing showing the driver behaving. Surviving with OpenCL switched off
-   * proves nothing about it, and clearing on that would re-enable it next launch and crash
-   * again -- halving the crash rate instead of stopping it. */
-  if(_opencl && _opencl->enabled && dt_conf_get_int("opencl_driver_crash_streak") != 0)
-    dt_conf_set_int("opencl_driver_crash_streak", 0);
-
   dt_opencl_t *cl = _opencl;
   if(IS_NULL_PTR(cl)) return;
   if(cl->inited)

--- a/src/common/opencl.h
+++ b/src/common/opencl.h
@@ -355,7 +355,12 @@ void dt_opencl_note_crash_backtrace(const char *backtrace, size_t backtrace_len)
 
 void dt_opencl_init(const gboolean exclude_opencl, const gboolean print_statistics);
 
-/** cleans up the opencl subsystem. */
+/** Clears the persisted driver-crash streak after a session in which OpenCL ran to a clean
+ * shutdown. Reads and writes conf: call it from the shutdown sequence BEFORE dt_conf_cleanup(),
+ * and before dt_opencl_cleanup(). */
+void dt_opencl_clear_driver_crash_streak(void);
+
+/** cleans up the opencl subsystem. Touches no conf: conf may already be gone. */
 void dt_opencl_cleanup(void);
 
 /** cleans up the i-th device in the cl->dev list */
@@ -708,6 +713,9 @@ static inline void dt_opencl_init(const gboolean exclude_opencl, const gboolean 
   /* There is no state to initialise in this build: the queries below are constants. */
   dt_conf_set_bool("opencl", FALSE);
   dt_print(DT_DEBUG_OPENCL, "[opencl_init] this version of darktable was built without opencl support\n");
+}
+static inline void dt_opencl_clear_driver_crash_streak(void)
+{
 }
 static inline void dt_opencl_cleanup(void)
 {

--- a/src/darktable.c
+++ b/src/darktable.c
@@ -1959,6 +1959,8 @@ void dt_cleanup()
   dt_colorprofiles_cleanup();
   dt_conf_set_int("processing/gui_throttle_runtime_us", dt_gui_throttle_get_runtime_us());
   dt_gui_throttle_cleanup();
+  // Needs conf alive: a clean exit with OpenCL running is what clears the driver-crash streak.
+  dt_opencl_clear_driver_crash_streak();
   dt_conf_cleanup(darktable.conf);
   dt_free(darktable.conf);
   dt_points_cleanup(darktable.points);


### PR DESCRIPTION
## Summary

Every clean exit with OpenCL enabled currently segfaults (exit 139) — found while profiling on a branch based on `c87d95acad`, reproduced from the base commit itself.

`dt_opencl_cleanup()` read and wrote conf to clear the driver-crash streak, but `dt_cleanup()` runs it **after** `dt_conf_cleanup()` has saved and freed the conf (`darktable.c:1962` vs `:1983`). Three defects in that one block:

- a use-after-free on every clean exit: `dt_conf_get_int("opencl_driver_crash_streak")` reads `darktable.conf->x_confgen` after `dt_free(darktable.conf)` → SIGSEGV at `conf.c:681`;
- even ordered right, the write could never be persisted (conf already saved), so the streak never reset once it tripped and OpenCL stayed off on every later launch — the opposite of what the counter is for;
- it cleared a bare `opencl_driver_crash_streak` key that nothing reads: the gate in `dt_opencl_init()` is on the **per-vendor** keys (`opencl_driver_crash_streak_<vendor>`) that the crash-marker path increments.

## Fix

The clear is now `dt_opencl_clear_driver_crash_streak()`, called from `dt_cleanup()` right before `dt_conf_cleanup()`. It resets the per-vendor counter of each device that actually ran this session (inited, enabled, not disabled) — a device skipped because of its own streak has shown nothing and stays counted. `dt_opencl_cleanup()` no longer touches conf. The no-OpenCL build gets an empty inline stub, same as `dt_opencl_cleanup()`.

Backtrace of the crash this fixes:

```
dt_cleanup() darktable.c:1983 → dt_opencl_cleanup() opencl.c:1535 → dt_conf_get_int() conf.c:681  SIGSEGV
```

Introduced by c87d95acad.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
