### PR TITLE
masks: cut drawn-mask fold and overlay-draw cost

### DIFF
--- a/src/develop/blend.c
+++ b/src/develop/blend.c
@@ -567,7 +567,12 @@ static int _develop_blend_init_drawn_mask(const dt_develop_blend_params_t *const
                                           const size_t owidth,
                                           const size_t oheight)
 {
-  dt_masks_form_t *form = dt_masks_get_from_id(self->dev, params->mask_id);
+  /* Resolve through the pipe's refcounted forms snapshot, never the live dev->forms: this runs
+   * on the worker while the GUI thread moves the very shape being rendered (see the retouch
+   * rule in CLAUDE.md). The live list is only a fallback for a pipe that took no snapshot. */
+  dt_masks_form_t *form = (!IS_NULL_PTR(pipe) && !IS_NULL_PTR(pipe->forms))
+                              ? dt_masks_get_from_id_ext(pipe->forms, params->mask_id)
+                              : dt_masks_get_from_id(self->dev, params->mask_id);
 
   if(form && (!(self->flags() & IOP_FLAGS_NO_MASKS)) && (params->mask_mode & DEVELOP_MASK_SHAPE))
   {
@@ -1249,6 +1254,7 @@ int dt_develop_blend_process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_t
   float parameters[DEVELOP_BLENDIF_PARAMETER_ITEMS * DEVELOP_BLENDIF_SIZE] DT_ALIGNED_ARRAY;
   dt_develop_blendif_process_parameters(parameters, d);
 
+
   // copy blend parameters to constant device memory
   dev_blendif_params = dt_opencl_copy_host_to_device_constant(devid, sizeof(parameters), parameters);
   if(IS_NULL_PTR(dev_blendif_params)) goto error;
@@ -1354,7 +1360,7 @@ int dt_develop_blend_process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_t
       goto error;
     }
 
-    // the mask is now located in dev_mask_2, put it in dev_mask_1
+      // the mask is now located in dev_mask_2, put it in dev_mask_1
     _blend_process_cl_exchange(&dev_mask_1, &dev_mask_2);
 
     // post processing the mask (it will always be stored in dev_mask_1)

--- a/src/develop/masks.h
+++ b/src/develop/masks.h
@@ -432,9 +432,12 @@ int dt_masks_get_mask(const dt_iop_module_t *const module, dt_dev_pixelpipe_t *p
                       dt_masks_form_t *const form,
                       float **buffer, int *width, int *height, int *posx, int *posy);
 
+/** Rasterise `form` into the pre-zeroed ROI-sized `buffer`. `touched` (may be NULL) receives
+ * the buffer-relative rectangle enclosing every pixel written; empty when nothing was. */
 int dt_masks_get_mask_roi(const dt_iop_module_t *const module, dt_dev_pixelpipe_t *pipe,
                           const dt_dev_pixelpipe_iop_t *const piece,
-                          dt_masks_form_t *const form, const dt_iop_roi_t *roi, float *buffer);
+                          dt_masks_form_t *const form, const dt_iop_roi_t *roi, float *buffer,
+                          dt_iop_roi_t *touched);
 
 
 int dt_masks_group_render_roi(dt_iop_module_t *module, dt_dev_pixelpipe_t *pipe,

--- a/src/develop/masks/brush.c
+++ b/src/develop/masks/brush.c
@@ -48,6 +48,7 @@
 #include "develop/masks.h"
 #include "develop/masks_gui.h"
 #include "develop/masks/masks_functions.h"
+#include "develop/masks/masks_touched.h"
 #include "math/openmp_maths.h"
 #include "gui/actions/menu.h"
 #include "widgets/accelerators.h"
@@ -2970,8 +2971,10 @@ static inline void _brush_falloff_roi(float *buffer, const int *segment_start, c
  */
 static int _brush_get_mask_roi(const dt_iop_module_t *const module, dt_dev_pixelpipe_t *pipe,
                                const dt_dev_pixelpipe_iop_t *const piece,
-                               dt_masks_form_t *const mask_form, const dt_iop_roi_t *roi, float *buffer)
+                               dt_masks_form_t *const mask_form, const dt_iop_roi_t *roi, float *buffer,
+                               dt_iop_roi_t *touched)
 {
+  dt_masks_touched_none(touched);
   if(IS_NULL_PTR(module)) return 1;
   double timer_start = 0.0;
   double timer_step_start = 0.0;
@@ -3128,6 +3131,11 @@ static int _brush_get_mask_roi(const dt_iop_module_t *const module, dt_dev_pixel
   dt_pixelpipe_cache_free_align(points);
   dt_pixelpipe_cache_free_align(border);
   dt_pixelpipe_cache_free_align(payload);
+
+  /* Every stamp lies between a centreline sample and its border sample, and writes one extra
+   * neighbour pixel in each direction to close rounding gaps -- hence the margin. */
+  dt_masks_touched_set(touched, (int)floorf(min_x) - 2, (int)floorf(min_y) - 2, (int)ceilf(max_x) + 2,
+                       (int)ceilf(max_y) + 2, roi_width, roi_height);
 
   if(dt_get_debug_flags() & DT_DEBUG_PERF)
   {

--- a/src/develop/masks/circle.c
+++ b/src/develop/masks/circle.c
@@ -43,6 +43,7 @@
 #include "develop/masks.h"
 #include "develop/masks_gui.h"
 #include "develop/masks/masks_functions.h"
+#include "develop/masks/masks_touched.h"
 #include "math/openmp_maths.h"
 #include "widgets/accelerators.h"
 
@@ -847,8 +848,9 @@ static int _circle_get_mask(const dt_iop_module_t *const restrict module, dt_dev
 static int _circle_get_mask_roi(const dt_iop_module_t *const restrict module, dt_dev_pixelpipe_t *pipe,
                                 const dt_dev_pixelpipe_iop_t *const restrict piece,
                                 dt_masks_form_t *const form, const dt_iop_roi_t *const roi,
-                                float *const restrict buffer)
+                                float *const restrict buffer, dt_iop_roi_t *touched)
 {
+  dt_masks_touched_none(touched);
   if(IS_NULL_PTR(form) || IS_NULL_PTR(form->points)) return 1;
   if(IS_NULL_PTR(module)) return 1;
   double start1 = 0.0;
@@ -1081,6 +1083,8 @@ static int _circle_get_mask_roi(const dt_iop_module_t *const restrict module, dt
   }
 
   dt_pixelpipe_cache_free_align(points);
+
+  dt_masks_touched_set(touched, bbxm * grid, bbym * grid, endx - 1, endy - 1, width, height);
 
   if(dt_get_debug_flags() & DT_DEBUG_PERF)
   {

--- a/src/develop/masks/circle.c
+++ b/src/develop/masks/circle.c
@@ -466,9 +466,20 @@ static int _circle_events_mouse_moved(struct dt_iop_module_t *module, double x, 
 static void _circle_draw_shape(dt_develop_t *dev, cairo_t *cr, const float *points, const int points_count, const int coord_nb, const gboolean border, const gboolean source)
 {
    // unused arg, keep compiler from complaining
-  cairo_move_to(cr, points[coord_nb * 2 + 2], points[coord_nb * 2 + 3]);
+  /* One line_to per point sampled at RAW resolution is several per device pixel; emit at the
+   * resolution the context can actually show. See dt_draw_min_emit_step() (mirrors the brush). */
+  const double min_step = dt_draw_min_emit_step(cr);
+  const double min_step2 = min_step * min_step;
+  double last_x = points[coord_nb * 2 + 2], last_y = points[coord_nb * 2 + 3];
+  cairo_move_to(cr, last_x, last_y);
   for(int i = 2; i < points_count; i++)
-    cairo_line_to(cr, points[i * 2], points[i * 2 + 1]);
+  {
+    const double x = points[i * 2], y = points[i * 2 + 1];
+    const double dx = x - last_x, dy = y - last_y;
+    if((dx * dx + dy * dy) < min_step2) continue;
+    cairo_line_to(cr, x, y);
+    last_x = x; last_y = y;
+  }
   cairo_close_path(cr);
 }
 

--- a/src/develop/masks/ellipse.c
+++ b/src/develop/masks/ellipse.c
@@ -1002,13 +1002,19 @@ static int _ellipse_events_mouse_moved(struct dt_iop_module_t *module, double x,
 static void _ellipse_draw_shape(dt_develop_t *dev, cairo_t *cr, const float *points, const int points_count, const int nb, const gboolean border, const gboolean source)
 {
   // dev unused, kept for shape_draw_function_t signature
-  cairo_move_to(cr, points[10], points[11]);
+  /* Decimate to the device resolution, as the brush does; see dt_draw_min_emit_step(). */
+  const double min_step = dt_draw_min_emit_step(cr);
+  const double min_step2 = min_step * min_step;
+  double last_x = points[10], last_y = points[11];
+  cairo_move_to(cr, last_x, last_y);
   for(int t = 6; t < points_count; t++)
   {
-    const float x = points[t * 2];
-    const float y = points[t * 2 + 1];
-
+    const double x = points[t * 2];
+    const double y = points[t * 2 + 1];
+    const double dx = x - last_x, dy = y - last_y;
+    if((dx * dx + dy * dy) < min_step2) continue;
     cairo_line_to(cr, x, y);
+    last_x = x; last_y = y;
   }
   cairo_close_path(cr);
 }

--- a/src/develop/masks/ellipse.c
+++ b/src/develop/masks/ellipse.c
@@ -44,6 +44,7 @@
 #include "develop/masks.h"
 #include "develop/masks_gui.h"
 #include "develop/masks/masks_functions.h"
+#include "develop/masks/masks_touched.h"
 #include "math/openmp_maths.h"
 #include "widgets/accelerators.h"
 
@@ -1395,8 +1396,10 @@ static int _ellipse_get_mask(const dt_iop_module_t *const module, dt_dev_pixelpi
 
 static int _ellipse_get_mask_roi(const dt_iop_module_t *const module, dt_dev_pixelpipe_t *pipe,
                                  const dt_dev_pixelpipe_iop_t *const piece,
-                                 dt_masks_form_t *const form, const dt_iop_roi_t *roi, float *buffer)
+                                 dt_masks_form_t *const form, const dt_iop_roi_t *roi, float *buffer,
+                               dt_iop_roi_t *touched)
 {
+  dt_masks_touched_none(touched);
   if(IS_NULL_PTR(form) || IS_NULL_PTR(form->points)) return 0;
 
   double start1 = 0.0;
@@ -1607,6 +1610,8 @@ static int _ellipse_get_mask_roi(const dt_iop_module_t *const module, dt_dev_pix
   }
 
   dt_pixelpipe_cache_free_align(points);
+
+  dt_masks_touched_set(touched, bbxm * grid, bbym * grid, endx - 1, endy - 1, w, h);
 
   if(dt_get_debug_flags() & DT_DEBUG_PERF)
   {

--- a/src/develop/masks/gradient.c
+++ b/src/develop/masks/gradient.c
@@ -40,6 +40,7 @@
 #include "develop/masks.h"
 #include "develop/masks_gui.h"
 #include "develop/masks/masks_functions.h"
+#include "develop/masks/masks_touched.h"
 #include "math/openmp_maths.h"
 #include "widgets/accelerators.h"
 
@@ -1347,8 +1348,10 @@ static int _gradient_get_mask(const dt_iop_module_t *const module, dt_dev_pixelp
 
 static int _gradient_get_mask_roi(const dt_iop_module_t *const module, dt_dev_pixelpipe_t *pipe,
                                   const dt_dev_pixelpipe_iop_t *const piece,
-                                  dt_masks_form_t *const form, const dt_iop_roi_t *roi, float *buffer)
+                                  dt_masks_form_t *const form, const dt_iop_roi_t *roi, float *buffer,
+                                  dt_iop_roi_t *touched)
 {
+  dt_masks_touched_none(touched);
   if(IS_NULL_PTR(form) || IS_NULL_PTR(form->points)) return 0;
   double start2 = 0.0;
   if(dt_get_debug_flags() & DT_DEBUG_PERF) start2 = dt_get_wtime();
@@ -1493,6 +1496,9 @@ static int _gradient_get_mask_roi(const dt_iop_module_t *const module, dt_dev_pi
   }
 
   dt_pixelpipe_cache_free_align(points);
+
+  // A gradient is non-zero over the whole ROI: there is no box smaller than the buffer.
+  dt_masks_touched_full(touched, w, h);
 
   if(dt_get_debug_flags() & DT_DEBUG_PERF)
     dt_print(DT_DEBUG_MASKS, "[masks %s] gradient fill took %0.04f sec\n", form->name,

--- a/src/develop/masks/gradient.c
+++ b/src/develop/masks/gradient.c
@@ -971,6 +971,10 @@ static void _gradient_draw_shape(struct dt_develop_t *dev, cairo_t *cr, const fl
   const float wd = geometry.raw_width;
   const float ht = geometry.raw_height;
 
+  /* Decimate each segment to device resolution, as the brush does; see dt_draw_min_emit_step().
+   * The last point of a segment is always emitted so an open guide line keeps its true end. */
+  const double min_step = dt_draw_min_emit_step(cr);
+  const double min_step2 = min_step * min_step;
   int i = 0;
   while(i < points_count)
   {
@@ -984,15 +988,21 @@ static void _gradient_draw_shape(struct dt_develop_t *dev, cairo_t *cr, const fl
     }
 
     cairo_move_to(cr, px, py);
+    double last_x = px, last_y = py;
     i++;
 
     // continue the current segment until a non-normal or out-of-range point
     while(i < points_count)
     {
-      const float qx = points[i * 2];
-      const float qy = points[i * 2 + 1];
-      if(!isnormal(qx) || !_gradient_is_canonical(qx, qy, wd, ht)) break;
+      const double qx = points[i * 2];
+      const double qy = points[i * 2 + 1];
+      if(!isnormal((float)qx) || !_gradient_is_canonical((float)qx, (float)qy, wd, ht)) break;
+      const double dx = qx - last_x, dy = qy - last_y;
+      const gboolean is_last = (i + 1 >= points_count) || !isnormal(points[(i + 1) * 2])
+                               || !_gradient_is_canonical(points[(i + 1) * 2], points[(i + 1) * 2 + 1], wd, ht);
+      if(!is_last && (dx * dx + dy * dy) < min_step2) { i++; continue; }
       cairo_line_to(cr, qx, qy);
+      last_x = qx; last_y = qy;
       i++;
     }
   }

--- a/src/develop/masks/group.c
+++ b/src/develop/masks/group.c
@@ -43,6 +43,7 @@
 #include "develop/masks.h"
 #include "develop/masks_gui.h"
 #include "develop/masks/masks_functions.h"
+#include "develop/masks/masks_touched.h"
 
 /* Shape handlers receive widget-space coordinates, while normalized output-image
  * coordinates come from `gui->rel_pos` and absolute output-image
@@ -514,6 +515,22 @@ static void _combine_masks_union(float *const restrict dest, float *const restri
   }
 }
 
+/** Union bounded to `box' (buffer-relative): outside it the child is zero and max(dest, 0) is dest. */
+static void _combine_masks_union_box(float *const restrict dest, const float *const restrict newmask,
+                                     const int width, const dt_iop_roi_t *const box, const float opacity)
+{
+  for(int y = box->y; y < box->y + box->height; y++)
+  {
+    float *const restrict dest_row = dest + (size_t)y * width + box->x;
+    const float *const restrict src_row = newmask + (size_t)y * width + box->x;
+    for(int x = 0; x < box->width; x++)
+    {
+      const float mask = opacity * src_row[x];
+      dest_row[x] = MAX(dest_row[x], mask);
+    }
+  }
+}
+
 static void _combine_masks_intersect(float *const restrict dest, float *const restrict newmask, const size_t npixels,
                                      const float opacity, const int inverted)
 {
@@ -647,9 +664,10 @@ static uint64_t _group_prefix_hash(const dt_masks_form_t *const form, GList *mas
 static int _group_get_mask_roi(const dt_iop_module_t *const restrict module, dt_dev_pixelpipe_t *pipe,
                                const dt_dev_pixelpipe_iop_t *const restrict piece,
                                dt_masks_form_t *const form, const dt_iop_roi_t *const roi,
-                               float *const restrict buffer)
+                               float *const restrict buffer, dt_iop_roi_t *touched)
 {
   double start = dt_get_wtime();
+  dt_masks_touched_none(touched);
   if(IS_NULL_PTR(form->points)) return 0;
   int nb_ok = 0;
 
@@ -706,12 +724,20 @@ static int _group_get_mask_roi(const dt_iop_module_t *const restrict module, dt_
   if(shape_count > 1 && resume_from < shape_count - 1)
     publishable = dt_pixelpipe_cache_alloc_align_float_cache(npixels, 0);
 
+  if(resume_from == 0) memset(buffer, 0, npixels * sizeof(float));
+  gboolean bufs_zeroed = FALSE;
+  dt_iop_roi_t child_touched;
+  dt_masks_touched_none(&child_touched);
+  dt_iop_roi_t group_touched;
+  dt_masks_touched_none(&group_touched);
+  if(resume_from > 0) dt_masks_touched_full(&group_touched, width, height); // the prefix is opaque to us
+
   int i = 0;
   // and we get all masks
   for(GList *fpts = form->points; fpts; fpts = g_list_next(fpts))
   {
     dt_masks_form_group_t *fpt = (dt_masks_form_group_t *)fpts->data;
-    dt_masks_form_t *sel = dt_masks_get_from_id(module->dev, fpt->formid);
+    dt_masks_form_t *sel = dt_masks_get_from_id_ext(masks, fpt->formid);
 
     if(sel && i < resume_from)
     {
@@ -727,9 +753,16 @@ static int _group_get_mask_roi(const dt_iop_module_t *const restrict module, dt_
       if(i == shape_count - 1 && !IS_NULL_PTR(publishable))
         memcpy(publishable, buffer, npixels * sizeof(float));
 
-      // ensure that we start with a zeroed buffer regardless of what was previously written into 'bufs'
-      memset(bufs, 0, npixels*sizeof(float));
-      const int err_child = dt_masks_get_mask_roi(module, pipe, piece, sel, roi, bufs);
+      /* `bufs' must be zero wherever the child will not write. Clearing only the PREVIOUS child's
+       * reported box keeps that invariant at the cost of that box, not of the whole ROI per shape. */
+      if(!bufs_zeroed)
+      {
+        memset(bufs, 0, npixels * sizeof(float));
+        bufs_zeroed = TRUE;
+      }
+      else
+        dt_masks_touched_clear(bufs, width, &child_touched);
+      const int err_child = dt_masks_get_mask_roi(module, pipe, piece, sel, roi, bufs, &child_touched);
       const float op = fpt->opacity;
       // Add a foolproof to ensure that the first shape is no-op
       const int no_op_state = fpt->state & ~(DT_MASKS_STATE_IS_COMBINE_OP) ;
@@ -744,9 +777,21 @@ static int _group_get_mask_roi(const dt_iop_module_t *const restrict module, dt_
         // first see if we need to invert this shape
         const int inverted = (state & DT_MASKS_STATE_INVERSE);
 
+        /* Union and plain copy leave `buffer' untouched outside the child's box: max(dest,0) is
+         * dest, and the copy writes op * 0 = 0 over an already-zero buffer. Those two run over the
+         * box alone. Intersection/difference/exclusion rewrite the outside too, and an inverted
+         * child is non-zero outside its box, so those keep the full-ROI pass. */
+        const gboolean box_only = !inverted && !dt_masks_touched_is_empty(&child_touched)
+                                  && ((state & DT_MASKS_STATE_UNION)
+                                      || !(state & (DT_MASKS_STATE_INTERSECTION | DT_MASKS_STATE_DIFFERENCE
+                                                    | DT_MASKS_STATE_EXCLUSION)));
+
         if(state & DT_MASKS_STATE_UNION)
         {
-          _combine_masks_union(buffer, bufs, npixels, op, inverted);
+          if(box_only)
+            _combine_masks_union_box(buffer, bufs, width, &child_touched, op);
+          else
+            _combine_masks_union(buffer, bufs, npixels, op, inverted);
         }
         else if(state & DT_MASKS_STATE_INTERSECTION)
         {
@@ -760,7 +805,17 @@ static int _group_get_mask_roi(const dt_iop_module_t *const restrict module, dt_
         {
           _combine_masks_exclusion(buffer, bufs, npixels, op, inverted);
         }
-        else // if we are here, this mean that we just have to copy the shape and null other parts
+        else if(box_only) // plain copy: op * child inside the box, zero everywhere else
+        {
+          if(i != 0) memset(buffer, 0, npixels * sizeof(float)); // a later copy discards the fold so far
+          for(int y = child_touched.y; y < child_touched.y + child_touched.height; y++)
+          {
+            float *const restrict dest_row = buffer + (size_t)y * width + child_touched.x;
+            const float *const restrict src_row = bufs + (size_t)y * width + child_touched.x;
+            for(int x = 0; x < child_touched.width; x++) dest_row[x] = op * src_row[x];
+          }
+        }
+        else
         {
           __OMP_PARALLEL_FOR_SIMD__(aligned(buffer, bufs : 64) if(npixels > 10000))
           for(int index = 0; index < npixels; index++)
@@ -768,6 +823,13 @@ static int _group_get_mask_roi(const dt_iop_module_t *const restrict module, dt_
             buffer[index] = op * (inverted ? (1.0f - bufs[index]) : bufs[index]);
           }
         }
+
+        if(box_only && (state & DT_MASKS_STATE_UNION))
+          dt_masks_touched_union(&group_touched, &child_touched);
+        else if(box_only)
+          group_touched = child_touched; // the copy discarded everything outside this box
+        else
+          dt_masks_touched_full(&group_touched, width, height);
 
         if(dt_get_debug_flags() & DT_DEBUG_PERF)
           dt_print(DT_DEBUG_MASKS, "[masks %d] combine took %0.04f sec\n", nb_ok, dt_get_wtime() - start);
@@ -784,6 +846,8 @@ static int _group_get_mask_roi(const dt_iop_module_t *const restrict module, dt_
 
   if(nb_ok == 0)
     memset(buffer, 0, npixels * sizeof(float));
+  else if(!IS_NULL_PTR(touched))
+    *touched = group_touched;
 
   /* Publish the fold WITHOUT the last shape, never the complete one.
    *
@@ -835,7 +899,7 @@ int dt_masks_group_render_roi(dt_iop_module_t *module, dt_dev_pixelpipe_t *pipe,
   const double start = dt_get_wtime();
   if(IS_NULL_PTR(form)) return 0;
 
-  const int err = dt_masks_get_mask_roi(module, pipe, piece, form, roi, buffer);
+  const int err = dt_masks_get_mask_roi(module, pipe, piece, form, roi, buffer, NULL);
 
   if(dt_get_debug_flags() & DT_DEBUG_PERF)
     dt_print(DT_DEBUG_MASKS, "[masks] render all masks took %0.04f sec\n", dt_get_wtime() - start);

--- a/src/develop/masks/masks.c
+++ b/src/develop/masks/masks.c
@@ -53,6 +53,7 @@
 #include "develop/masks.h"
 #include "history/notify.h"
 #include "develop/masks/masks_functions.h"
+#include "develop/masks/masks_touched.h"
 #include "develop/develop.h"
 #include "develop/supervisor.h"
 #include "math/math.h"
@@ -1395,10 +1396,12 @@ int dt_masks_get_mask(const dt_iop_module_t *const module, dt_dev_pixelpipe_t *p
 
 int dt_masks_get_mask_roi(const dt_iop_module_t *const module, dt_dev_pixelpipe_t *pipe,
                           const dt_dev_pixelpipe_iop_t *const piece,
-                          dt_masks_form_t *const form, const dt_iop_roi_t *roi, float *buffer)
+                          dt_masks_form_t *const form, const dt_iop_roi_t *roi, float *buffer,
+                          dt_iop_roi_t *touched)
 {
+  dt_masks_touched_none(touched);
   return (form->functions && form->functions->get_mask_roi)
-    ? form->functions->get_mask_roi(module, pipe, piece, form, roi, buffer)
+    ? form->functions->get_mask_roi(module, pipe, piece, form, roi, buffer, touched)
     : 1;
 }
 

--- a/src/develop/masks/masks_functions.h
+++ b/src/develop/masks/masks_functions.h
@@ -77,10 +77,12 @@ typedef struct dt_masks_functions_t
                   const dt_dev_pixelpipe_iop_t *const piece,
                   struct dt_masks_form_t *const form,
                   float **buffer, int *width, int *height, int *posx, int *posy);
+  /** Rasterise into a pre-zeroed ROI-sized buffer. `touched` (may be NULL) receives the
+   * buffer-relative rectangle enclosing every pixel written -- see masks_touched.h. */
   int (*get_mask_roi)(const dt_iop_module_t *const fmodule, struct dt_dev_pixelpipe_t *pipe,
                       const dt_dev_pixelpipe_iop_t *const piece,
                       struct dt_masks_form_t *const form,
-                      const dt_iop_roi_t *roi, float *buffer);
+                      const dt_iop_roi_t *roi, float *buffer, dt_iop_roi_t *touched);
   int (*get_area)(const dt_iop_module_t *const module, struct dt_dev_pixelpipe_t *pipe,
                   const dt_dev_pixelpipe_iop_t *const piece,
                   struct dt_masks_form_t *const form,

--- a/src/develop/masks/masks_touched.h
+++ b/src/develop/masks/masks_touched.h
@@ -1,0 +1,117 @@
+/*
+    This file is part of Ansel.
+    Copyright (C) 2026 Aurélien PIERRE.
+
+    Ansel is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Ansel is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Ansel.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef DT_DEVELOP_MASKS_MASKS_TOUCHED_H
+#define DT_DEVELOP_MASKS_MASKS_TOUCHED_H
+
+#include <string.h>
+
+#include "pixel/format.h"
+
+/**
+ * The rectangle a shape rasteriser actually wrote, in BUFFER-RELATIVE pixels.
+ *
+ * Every `get_mask_roi` implementation reports it through its `touched` out-parameter (a
+ * `dt_iop_roi_t`, `scale` unused) so the group fold can zero and combine only what the shape
+ * covers instead of the whole ROI once per shape. `width == 0 || height == 0` means the shape
+ * wrote nothing. A rasteriser that cannot bound its writes reports the full buffer, which is
+ * always correct and merely costs what it cost before.
+ *
+ * The contract is "encloses every pixel written": a box larger than the writes is fine, a box
+ * smaller is a wrong mask, since the fold will not look outside it.
+ */
+
+static inline void dt_masks_touched_none(dt_iop_roi_t *touched)
+{
+  if(touched == NULL) return;
+  touched->x = 0;
+  touched->y = 0;
+  touched->width = 0;
+  touched->height = 0;
+  touched->scale = 1.0f;
+}
+
+static inline void dt_masks_touched_full(dt_iop_roi_t *touched, const int width, const int height)
+{
+  if(touched == NULL) return;
+  touched->x = 0;
+  touched->y = 0;
+  touched->width = width;
+  touched->height = height;
+  touched->scale = 1.0f;
+}
+
+/** Set from an inclusive pixel span [x0, x1] x [y0, y1], clamped to the buffer. Empty if it
+ * falls entirely outside. */
+static inline void dt_masks_touched_set(dt_iop_roi_t *touched, int x0, int y0, int x1, int y1,
+                                        const int width, const int height)
+{
+  if(touched == NULL) return;
+  if(x0 < 0) x0 = 0;
+  if(y0 < 0) y0 = 0;
+  if(x1 > width - 1) x1 = width - 1;
+  if(y1 > height - 1) y1 = height - 1;
+  if(x1 < x0 || y1 < y0)
+  {
+    dt_masks_touched_none(touched);
+    return;
+  }
+  touched->x = x0;
+  touched->y = y0;
+  touched->width = x1 - x0 + 1;
+  touched->height = y1 - y0 + 1;
+  touched->scale = 1.0f;
+}
+
+static inline int dt_masks_touched_is_empty(const dt_iop_roi_t *touched)
+{
+  return touched == NULL || touched->width <= 0 || touched->height <= 0;
+}
+
+/** Grow `into` so it also encloses `other`. */
+static inline void dt_masks_touched_union(dt_iop_roi_t *into, const dt_iop_roi_t *other)
+{
+  if(into == NULL || dt_masks_touched_is_empty(other)) return;
+  if(dt_masks_touched_is_empty(into))
+  {
+    *into = *other;
+    return;
+  }
+  const int x0 = into->x < other->x ? into->x : other->x;
+  const int y0 = into->y < other->y ? into->y : other->y;
+  const int ix1 = into->x + into->width - 1;
+  const int ox1 = other->x + other->width - 1;
+  const int iy1 = into->y + into->height - 1;
+  const int oy1 = other->y + other->height - 1;
+  const int x1 = ix1 > ox1 ? ix1 : ox1;
+  const int y1 = iy1 > oy1 ? iy1 : oy1;
+  into->x = x0;
+  into->y = y0;
+  into->width = x1 - x0 + 1;
+  into->height = y1 - y0 + 1;
+}
+
+/** Zero a rectangle of a `width`-strided float buffer. */
+static inline void dt_masks_touched_clear(float *const buffer, const int width, const dt_iop_roi_t *touched)
+{
+  if(buffer == NULL || dt_masks_touched_is_empty(touched)) return;
+  for(int y = touched->y; y < touched->y + touched->height; y++)
+    memset(buffer + (size_t)y * width + touched->x, 0, sizeof(float) * (size_t)touched->width);
+}
+
+#endif // DT_DEVELOP_MASKS_MASKS_TOUCHED_H

--- a/src/develop/masks/polygon.c
+++ b/src/develop/masks/polygon.c
@@ -2255,11 +2255,19 @@ static void _polygon_draw_shape(struct dt_develop_t *dev, cairo_t *cr, const flo
   // Only draw if we have at least one valid point
   if(start_idx >= 0)
   {
-    cairo_move_to(cr, point_buffer[start_idx * 2], point_buffer[start_idx * 2 + 1]);
+    /* Decimate to device resolution, as the brush does; see dt_draw_min_emit_step(). */
+    const double min_step = dt_draw_min_emit_step(cr);
+    const double min_step2 = min_step * min_step;
+    double last_x = point_buffer[start_idx * 2], last_y = point_buffer[start_idx * 2 + 1];
+    cairo_move_to(cr, last_x, last_y);
     for(int point_index = start_idx + 1; point_index < point_count; point_index++)
     {
-      if(!isnan(point_buffer[point_index * 2]) && !isnan(point_buffer[point_index * 2 + 1]))
-        cairo_line_to(cr, point_buffer[point_index * 2], point_buffer[point_index * 2 + 1]);
+      const double x = point_buffer[point_index * 2], y = point_buffer[point_index * 2 + 1];
+      if(isnan(x) || isnan(y)) continue;
+      const double dx = x - last_x, dy = y - last_y;
+      if((dx * dx + dy * dy) < min_step2) continue;
+      cairo_line_to(cr, x, y);
+      last_x = x; last_y = y;
     }
   }
 }

--- a/src/develop/masks/polygon.c
+++ b/src/develop/masks/polygon.c
@@ -55,6 +55,7 @@
 #include "develop/masks.h"
 #include "develop/masks_gui.h"
 #include "develop/masks/masks_functions.h"
+#include "develop/masks/masks_touched.h"
 #include "math/openmp_maths.h"
 #include "gui/actions/menu.h"
 #include <assert.h>
@@ -3162,8 +3163,10 @@ static inline void _polygon_falloff_roi(float *buffer, int *p0, int *p1, int bw,
 static int _polygon_get_mask_roi(const dt_iop_module_t *const module, dt_dev_pixelpipe_t *pipe,
                                  const dt_dev_pixelpipe_iop_t *const piece,
                                  dt_masks_form_t *const mask_form,
-                                 const dt_iop_roi_t *roi, float *buffer)
+                                 const dt_iop_roi_t *roi, float *buffer,
+                                 dt_iop_roi_t *touched)
 {
+  dt_masks_touched_none(touched);
   if(IS_NULL_PTR(module)) return 1;
   double start = 0.0;
   double start2 = 0.0;
@@ -3356,6 +3359,7 @@ static int _polygon_get_mask_roi(const dt_iop_module_t *const module, dt_dev_pix
     {
       // roi lies completely within polygon
       for(size_t k = 0; k < (size_t)width * height; k++) buffer[k] = 1.0f;
+      dt_masks_touched_full(touched, width, height);
     }
     else
     {
@@ -3551,6 +3555,13 @@ static int _polygon_get_mask_roi(const dt_iop_module_t *const module, dt_dev_pix
 
   dt_pixelpipe_cache_free_align(points);
   dt_pixelpipe_cache_free_align(border);
+
+  /* The raw bounding box already spans the border samples, so the feather falloff lies inside
+   * it too; the margin covers the one-pixel neighbour writes of the falloff stamps. The
+   * encircling case reported the full buffer above. */
+  if(!polygon_encircles_roi)
+    dt_masks_touched_set(touched, (int)floorf(xmin) - 2, (int)floorf(ymin) - 2, (int)ceilf(xmax) + 2,
+                         (int)ceilf(ymax) + 2, width, height);
 
   if(dt_get_debug_flags() & DT_DEBUG_PERF)
     dt_print(DT_DEBUG_MASKS, "[masks %s] polygon fill buffer took %0.04f sec\n",


### PR DESCRIPTION
Two independent drawn-mask performance fixes, one per commit, both part of #1299 ("drawn mask handling is choppy"). Same files, distinct threads: the first is the pipeline mask raster (worker), the second is the darkroom overlay draw (GUI thread).

## 1. Fold a group per shape-box instead of per full ROI (worker/CPU)

The group mask fold zeroed and combined a full ROI-sized buffer once per shape, so a group of N shapes cost N full-buffer `memset`s and N full-buffer combines regardless of how little of the frame each shape covers. On a 26-shape exposure mask that is **~0.85 s** of a CPU/export render, almost independent of resolution.

Each rasteriser now reports, through a new `touched` out-parameter, the buffer-relative box it actually wrote (helpers in `develop/masks/masks_touched.h`). The fold clears the scratch buffer and runs the **union** and **plain-copy** combines over that box alone — exact, since `max(dest,0)==dest` and the copy writes `op*0==0` over an already-zero buffer — and keeps the full-ROI pass for **intersection/difference/exclusion and inverted** shapes.

CPU export of the 26-shape group: `Exposure` **1.26 → 0.86 s**, the fold itself 0.85 → 0.54 s. On OpenCL the fold overlaps GPU compute and was never on the critical path, so this is a CPU/export win — the weak-hardware case in #1299. **Bit-identical** to the previous fold, verified by CLI export pixel-diff incl. the `--export_masks` page at fit and full res: 0 differing of 18M and 72M, image and mask pages.

Also fixes two pipe-thread reads of the live GUI-owned `dev->forms` in this path (group child lookup, `blend.c` drawn-mask resolution) — both now use the refcounted `pipe->forms` snapshot, per the retouch rule in `CLAUDE.md`.

## 2. Decimate the circle/ellipse/gradient/polygon overlays (GUI)

The brush outline was already decimated to display resolution; the other four were not — they emitted a `cairo line_to` per raw-resolution sample (several per device pixel) and stroked it twice. Measured in the darkroom: **7–10 ms per circle/ellipse/gradient/polygon per frame** vs 1–4 ms for the decimated brushes. Each now skips points within half a device pixel of the last emitted, via the existing `dt_draw_min_emit_step()`, tracking HiDPI/zoom through the cairo matrix. Overlay-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
