### PR TITLE
githooks: stop regenerating AUTHORS on every commit

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -50,26 +50,30 @@ if [ ${#errors[@]} -ne 0 ]; then
   exit 1
 fi
 
-# Regenerate AUTHORS in repo root before committing
+# AUTHORS is NOT regenerated here. The build already does it: CMakeLists.txt runs
+# tools/generate-authors.cmake at install time, which calls
+# tools/release/generate-authors.sh against live git history and writes
+# ${CMAKE_BINARY_DIR}/AUTHORS. The file checked in at the repo root is only the
+# fallback used when a build has no git or no shell (source tarballs), so it needs
+# refreshing when a release is cut -- create_release.sh prints the command -- and
+# not on every commit.
+#
+# Doing it per commit was wrong in four ways, all of them silent:
+#
+#   - it wrote its temporary file into $repo_root/.git, which is a FILE and not a
+#     directory in a linked worktree, so mktemp failed and every commit made from
+#     a `git worktree add` checkout was rejected outright;
+#   - it generated from release-3.9.0..HEAD, and at pre-commit time HEAD is the
+#     PREVIOUS commit, so the AUTHORS it staged never described the commit being
+#     made -- a new contributor's own first commit could not list them;
+#   - it `git add`ed a file the author had not staged, widening every commit with
+#     an unrelated change and making single-topic commits impossible to keep;
+#   - generate-authors.sh reads each submodule's contributors by cd-ing into the
+#     working tree, so a dirty or moved submodule silently changed the AUTHORS
+#     content -- two people committing the same change produced different files,
+#     which is how a contributor came to be dropped and re-added across commits.
 repo_root=$(git rev-parse --show-toplevel 2>/dev/null)
 if [ -n "$repo_root" ]; then
-  gen_script="$repo_root/tools/release/generate-authors.sh"
-  if [ -x "$gen_script" ]; then
-    tmp_file=$(mktemp "${repo_root}/.git/authors.XXXXXX") || exit 1
-    if "$gen_script" release-3.9.0 HEAD > "$tmp_file"; then
-      if [ ! -f "$repo_root/AUTHORS" ] || ! cmp -s "$tmp_file" "$repo_root/AUTHORS"; then
-        mv "$tmp_file" "$repo_root/AUTHORS"
-        git add "$repo_root/AUTHORS"
-        echo "Updated AUTHORS"
-      else
-        rm -f "$tmp_file"
-      fi
-    else
-      echo "Warning: failed to regenerate AUTHORS" >&2
-      rm -f "$tmp_file"
-    fi
-  fi
-
   # Quick image test smoke test (tests/image_test.sh): local only, uses the shared
   # team bank (a gitignored clone at tests/image_test/samples) if it's present, a
   # personal bank (tests/image_test.sh configure <dir> / $ANSEL_IMAGE_TEST) otherwise.

--- a/build.sh
+++ b/build.sh
@@ -37,8 +37,9 @@
 
 set -e
 
-# setup local hooks
-[ -d .git ] && git config core.hooksPath .githooks
+# setup local hooks. -e, not -d: in a linked worktree (git worktree add) .git is a
+# FILE pointing at the real gitdir, so -d silently skipped the setup there.
+[ -e .git ] && git config core.hooksPath .githooks
 
 DT_SRC_DIR=$(dirname "$0")
 DT_SRC_DIR=$(cd "$DT_SRC_DIR" && pwd -P)

--- a/tools/release/create_release.sh
+++ b/tools/release/create_release.sh
@@ -38,7 +38,7 @@ cd "$DT_SRC_DIR" || exit
 git shortlog -sne release-3.9.0..HEAD
 
 echo "are you sure these guys received proper credit in the about dialog?"
-echo "HINT: $ tools/generate-authors.sh release-3.1.0 HEAD > AUTHORS"
+echo "HINT: $ tools/release/generate-authors.sh release-3.9.0 HEAD > AUTHORS"
 read -r answer
 
 # prefix rc with ~, so debian thinks its less than


### PR DESCRIPTION
The pre-commit hook regenerated `AUTHORS` and `git add`ed it into whatever commit you were making. **The build already does this**, so the hook was duplicating it — and doing it wrong.

`CMakeLists.txt` runs `tools/generate-authors.cmake` at install time, which calls `tools/release/generate-authors.sh` against live git history and writes `${CMAKE_BINARY_DIR}/AUTHORS`. The copy checked in at the repo root is only the fallback for a build with no git or no shell (source tarballs).

## Four ways it was wrong, all silent

**It could not commit from a worktree at all.** The temp file went to `$repo_root/.git/authors.XXXXXX`, and in a `git worktree add` checkout `.git` is a *file*, not a directory:

```
mktemp: impossible de créer le fichier à partir du modèle
« …/ansel-runtime-streak/.git/authors.XXXXXX »: N'est pas un dossier
```

`mktemp` fails, the hook `exit 1`s, and the commit is rejected with no other explanation.

**It generated from `HEAD`, which at pre-commit time is the previous commit.** `generate-authors.sh release-3.9.0 HEAD` cannot see the commit being made, so the `AUTHORS` it staged was always one commit stale — a new contributor's own first commit could never list them; it took a later commit by somebody else.

**It staged a file the author had not.** `git add "$repo_root/AUTHORS"` widens every commit with an unrelated change, which makes a single-topic commit impossible to keep.

**Its output depended on the local submodule checkout.** `generate-authors.sh`'s `forsubmodule()` `cd`s into the submodule working tree to read its shortlog, so a dirty or moved submodule changed the generated content. Two people committing the same change produced different `AUTHORS` files — that is the mechanism behind a contributor being dropped and re-added across commits.

## What changes

- The AUTHORS block is gone. The hook keeps its other two jobs: the guarded-path patterns (rawspeed, OpenCL, whereami, tests/integration) and the `image_test` smoke test.
- `create_release.sh` prints the command for refreshing the checked-in fallback when a release is cut. It named `tools/generate-authors.sh`, a path that has not existed since the script moved under `tools/release/`, against `release-3.1.0`, three releases older than the `release-3.9.0` the build itself uses. Both corrected.
- `build.sh` installed the hooks behind `[ -d .git ]` — the same assumption that `.git` is a directory, so a worktree never got `core.hooksPath` set. Now `-e`.

## Verification

This commit was made **with the hook active and without `--no-verify`, from a linked worktree** — the case that could not commit before. It succeeded, and touched 3 files with `AUTHORS` not among them.