### PR TITLE
masks: fix the clang build break on master (tautological unsigned-enum comparison)

### DIFF
--- a/src/develop/masks/masks_gui.c
+++ b/src/develop/masks/masks_gui.c
@@ -2943,9 +2943,14 @@ static const char *const _scroll_conf_keys[DT_MASKS_SCROLL_MODIFIER_LAST]
 static const char *const _interaction_conf_values[DT_MASKS_INTERACTION_LAST]
     = { "none", "size", "hardness", "opacity", "rotation" };
 
+/* Both enums declare only non-negative enumerators, so a compiler is free to give them an
+ * unsigned underlying type -- clang does, and then `x < 0' is a tautology it rejects under
+ * -Weverything -Werror. Casting to unsigned instead of dropping the lower bound keeps the
+ * check honest either way: a negative value converts to a huge unsigned one and is caught by
+ * the upper bound, whatever signedness the compiler picked. */
 dt_masks_interaction_t dt_masks_scroll_mapping_get(dt_masks_scroll_modifier_t modifier)
 {
-  if(modifier < 0 || modifier >= DT_MASKS_SCROLL_MODIFIER_LAST) return DT_MASKS_INTERACTION_UNDEF;
+  if((unsigned int)modifier >= DT_MASKS_SCROLL_MODIFIER_LAST) return DT_MASKS_INTERACTION_UNDEF;
 
   const char *value = dt_conf_get_string_const(_scroll_conf_keys[modifier]);
   if(IS_NULL_PTR(value)) return DT_MASKS_INTERACTION_UNDEF;
@@ -2958,8 +2963,8 @@ dt_masks_interaction_t dt_masks_scroll_mapping_get(dt_masks_scroll_modifier_t mo
 
 void dt_masks_scroll_mapping_set(dt_masks_scroll_modifier_t modifier, dt_masks_interaction_t interaction)
 {
-  if(modifier < 0 || modifier >= DT_MASKS_SCROLL_MODIFIER_LAST) return;
-  if(interaction < 0 || interaction >= DT_MASKS_INTERACTION_LAST)
+  if((unsigned int)modifier >= DT_MASKS_SCROLL_MODIFIER_LAST) return;
+  if((unsigned int)interaction >= DT_MASKS_INTERACTION_LAST)
     interaction = DT_MASKS_INTERACTION_UNDEF;
 
   dt_conf_set_string(_scroll_conf_keys[modifier], _interaction_conf_values[interaction]);


### PR DESCRIPTION
**Master's CI is red and has been since 0175dac0f2, so no PR can go green until this lands.**

`dt_masks_scroll_modifier_t` and `dt_masks_interaction_t` declare only non-negative enumerators, so a compiler may give them an unsigned underlying type. Clang does, and then `modifier < 0` is a tautology it rejects under `-Weverything -Werror`:

```
src/develop/masks/masks_gui.c:2948:15: error: result of comparison of unsigned enum
expression < 0 is always false [-Werror,-Wtautological-unsigned-enum-zero-compare]
src/develop/masks/masks_gui.c:2961:15: error: …
src/develop/masks/masks_gui.c:2962:18: error: …
```

Three sites, in `dt_masks_scroll_mapping_get()` and `dt_masks_scroll_mapping_set()`.

## Blast radius

It takes down every clang and macOS job, and fail-fast cancels the rest of the matrix, so a run reports far more damage than it has:

| | |
|---|---|
| master run 33177685614 | `Linux.noble.LLVM20.nofeatures` + `macOS.XCode.26.3.nofeatures` failed, 8 more cancelled |
| PR #1303 | `Linux.noble.LLVM20.skiptest`, `macOS.XCode.26.3.nofeatures` — same error, nothing to do with that PR |
| PR #1304 | same two, plus an unrelated Win64 `file DOWNLOAD` SSL flake |

## Why a cast and not just deleting `< 0`

Dropping the lower bound is correct for the underlying type clang picks today and silently wrong if a compiler ever picked a signed one: a negative value would then pass `>= …_LAST` and index `_scroll_conf_keys[]` out of bounds. `(unsigned int)` is right under both — a negative value converts to a huge unsigned one and the single upper-bound test catches it — and it is warning-free either way.

## Verification

Full clang Debug build with `-Weverything -Werror`: **0 errors** (the break reproduces on clang 19 locally, not only on CI's clang 20). The same translation unit under GCC Release, since the cast must not upset that either: clean.

Once this is in, #1303 and #1304 need only a CI re-run — their own content already builds.