### PR TITLE
masks: give the rasterisation family a typed result (P0 of the enclosure plan)

### DIFF
--- a/src/develop/blend.c
+++ b/src/develop/blend.c
@@ -576,7 +576,10 @@ static int _develop_blend_init_drawn_mask(const dt_develop_blend_params_t *const
 
   if(form && (!(self->flags() & IOP_FLAGS_NO_MASKS)) && (params->mask_mode & DEVELOP_MASK_SHAPE))
   {
-    if(dt_masks_group_render_roi(self, pipe, piece, form, roi_out, mask) != 0) return 1;
+    /* EMPTY is not a failure: the fold zeroes the buffer when no shape contributed, and a
+     * zero drawn mask is a legitimate state to blend with. Only ERROR leaves it undefined. */
+    if(dt_masks_group_render_roi(self, pipe, piece, form, roi_out, mask) == DT_MASKS_RASTER_ERROR)
+      return 1;
 
     if(params->mask_combine & DEVELOP_COMBINE_MASKS_POS)
       dt_iop_image_invert(mask, 1.0f, owidth, oheight, 1);

--- a/src/develop/blend_gui.c
+++ b/src/develop/blend_gui.c
@@ -1747,7 +1747,7 @@ static void _blendop_masks_apply_and_commit(dt_iop_module_t *module)
   if(IS_NULL_PTR(module)) return;
   if(IS_NULL_PTR(module->dev)) return;
 
-  dt_masks_iop_update(module);
+  dt_iop_gui_blend_masks_update(module);
   dt_dev_add_history_item(module->dev, module, TRUE, TRUE);
   dt_iop_gui_update_header(module);
   dt_control_queue_redraw_center();
@@ -2088,7 +2088,7 @@ static void _blendop_masks_group_operation_callback(GtkWidget *menu_item, gpoint
   const int parentid = GPOINTER_TO_INT(g_object_get_data(G_OBJECT(menu_item), "blend-parentid"));
   const dt_masks_state_t state = GPOINTER_TO_INT(g_object_get_data(G_OBJECT(menu_item), "blend-state"));
 
-  // apply_operation() below mutates the group_entry in place, memory owned by the parent
+  // dt_masks_group_entry_apply_operation() below mutates the group_entry in place, memory owned by the parent
   // group -- touch the parent before resolving the entry, or a shared parent's group_entry
   // gets mutated behind the back of a snapshot that still references it.
   dt_masks_form_t *parent_form = dt_masks_get_from_id(module->dev, parentid);
@@ -2108,7 +2108,7 @@ static void _blendop_masks_group_operation_callback(GtkWidget *menu_item, gpoint
   if(IS_NULL_PTR(group_entry)) return;
 
   const int old_state = group_entry->state;
-  apply_operation(group_entry, state);
+  dt_masks_group_entry_apply_operation(group_entry, state);
   if(group_entry->state == old_state) return;
 
   _blendop_masks_apply_and_commit(module);
@@ -3712,7 +3712,7 @@ void dt_iop_gui_init_contours(GtkBox *blendw, dt_iop_module_t *module)
   gtk_box_pack_start(blendw, bd->contrast_slider, FALSE, FALSE, 0);
 }
 
-void dt_masks_iop_update(dt_iop_module_t *module)
+void dt_iop_gui_blend_masks_update(dt_iop_module_t *module)
 {
   dt_iop_gui_blend_data_t *bd = module->gui ? (dt_iop_gui_blend_data_t *)module->gui->blend_data : NULL;
   dt_develop_blend_params_t *bp = module->blend_params;
@@ -4645,7 +4645,7 @@ void dt_iop_gui_update_blending(dt_iop_module_t *module)
       || _blendif_are_output_channels_used(module->blend_params, bd->csp);
 
   dt_iop_gui_update_blendif(module);
-  dt_masks_iop_update(module);
+  dt_iop_gui_blend_masks_update(module);
   dt_iop_gui_update_raster(module);
 
   /* sync page states from mask mode */

--- a/src/develop/blend_gui.h
+++ b/src/develop/blend_gui.h
@@ -190,6 +190,15 @@ void dt_iop_gui_cleanup_blending(dt_iop_module_t *module);
 void dt_iop_gui_blending_lose_focus(dt_iop_module_t *module);
 void dt_iop_gui_blending_reload_defaults(dt_iop_module_t *module);
 
+/** Refresh the blend GUI's mask widgets (shape combo, edit/polarity toggles, shape buttons and
+ * the mask list) from the module's current mask group.
+ *
+ * Declared here because this is where it lives and what it touches: dt_iop_gui_blend_data_t,
+ * which is the blend GUI's own. It spent years declared in develop/masks.h under a dt_masks_
+ * name while its body sat in blend_gui.c -- a masks symbol that the masks module did not
+ * implement and could not have, since every widget it drives is private to this one. */
+void dt_iop_gui_blend_masks_update(dt_iop_module_t *module);
+
 gboolean blend_color_picker_apply(dt_iop_module_t *module, GtkWidget *picker, dt_dev_pixelpipe_t *pipe,
                                   dt_dev_pixelpipe_iop_t *piece);
 

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -64,7 +64,6 @@
 */
 
 #include "develop/imageop_gui.h"
-#include "develop/masks_gui.h"
 #include "darktable.h"
 #include "widgets/widget_settings.h"
 #include "common/conf.h"

--- a/src/develop/masks.h
+++ b/src/develop/masks.h
@@ -397,10 +397,11 @@ dt_masks_raster_result_t dt_masks_get_points_border(struct dt_develop_t *dev, dt
                                float **points, int *points_count,
                                float **border, int *border_count, int source, dt_iop_module_t *module);
 /** get the rectangle which include the form and his border */
-int dt_masks_get_area(dt_iop_module_t *module, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece,
+dt_masks_raster_result_t dt_masks_get_area(dt_iop_module_t *module, dt_dev_pixelpipe_t *pipe,
+                      dt_dev_pixelpipe_iop_t *piece,
                       dt_masks_form_t *form,
                       int *width, int *height, int *posx, int *posy);
-int dt_masks_get_source_area(dt_iop_module_t *module, dt_dev_pixelpipe_t *pipe,
+dt_masks_raster_result_t dt_masks_get_source_area(dt_iop_module_t *module, dt_dev_pixelpipe_t *pipe,
                              dt_dev_pixelpipe_iop_t *piece, dt_masks_form_t *form,
                              int *width, int *height, int *posx, int *posy);
 
@@ -461,7 +462,7 @@ static inline void dt_masks_set_ctrl_points(float ctrl1[2], float ctrl2[2], cons
 
 
 /** get the transparency mask of the form and his border */
-int dt_masks_get_mask(const dt_iop_module_t *const module, dt_dev_pixelpipe_t *pipe,
+dt_masks_raster_result_t dt_masks_get_mask(const dt_iop_module_t *const module, dt_dev_pixelpipe_t *pipe,
                       const dt_dev_pixelpipe_iop_t *const piece,
                       dt_masks_form_t *const form,
                       float **buffer, int *width, int *height, int *posx, int *posy);

--- a/src/develop/masks.h
+++ b/src/develop/masks.h
@@ -426,6 +426,31 @@ static inline void dt_masks_set_ctrl_points(float ctrl1[2], float ctrl2[2], cons
 }
 
 
+/**
+ * @brief What a rasterisation attempt produced.
+ *
+ * @details The rasterisation family used to return a bare `int` on a "0 means success"
+ * convention that could not say the third thing that actually happens: a shape with nothing to
+ * draw. Callers therefore had to guess, and the shapes disagreed -- a NULL points list made a
+ * circle report failure (which aborted the whole group fold) and an ellipse report success
+ * (which rendered it as zeros). Same data, opposite outcomes, decided by which shape carried it.
+ *
+ * OK    -- the buffer was written; `touched`, where the callee takes one, describes what.
+ * EMPTY -- nothing to draw: degenerate geometry, or the shape lies entirely outside this ROI.
+ *          A legitimate outcome, NOT an error. The buffer is left as the caller supplied it.
+ * ERROR -- the shape could not be computed (allocation failure, a distortion transform that
+ *          did not converge). The buffer's contents are undefined and must not be published.
+ *
+ * OK is 0 so that a caller written against the old convention still reads a success as success;
+ * every other value is a non-success, which is the safe direction for anything not yet migrated.
+ */
+typedef enum dt_masks_raster_result_t
+{
+  DT_MASKS_RASTER_OK = 0,
+  DT_MASKS_RASTER_EMPTY,
+  DT_MASKS_RASTER_ERROR
+} dt_masks_raster_result_t;
+
 /** get the transparency mask of the form and his border */
 int dt_masks_get_mask(const dt_iop_module_t *const module, dt_dev_pixelpipe_t *pipe,
                       const dt_dev_pixelpipe_iop_t *const piece,
@@ -434,15 +459,15 @@ int dt_masks_get_mask(const dt_iop_module_t *const module, dt_dev_pixelpipe_t *p
 
 /** Rasterise `form` into the pre-zeroed ROI-sized `buffer`. `touched` (may be NULL) receives
  * the buffer-relative rectangle enclosing every pixel written; empty when nothing was. */
-int dt_masks_get_mask_roi(const dt_iop_module_t *const module, dt_dev_pixelpipe_t *pipe,
-                          const dt_dev_pixelpipe_iop_t *const piece,
-                          dt_masks_form_t *const form, const dt_iop_roi_t *roi, float *buffer,
-                          dt_iop_roi_t *touched);
+dt_masks_raster_result_t dt_masks_get_mask_roi(const dt_iop_module_t *const module, dt_dev_pixelpipe_t *pipe,
+                                               const dt_dev_pixelpipe_iop_t *const piece,
+                                               dt_masks_form_t *const form, const dt_iop_roi_t *roi,
+                                               float *buffer, dt_iop_roi_t *touched);
 
 
-int dt_masks_group_render_roi(dt_iop_module_t *module, dt_dev_pixelpipe_t *pipe,
-                              const dt_dev_pixelpipe_iop_t *piece, dt_masks_form_t *form,
-                              const dt_iop_roi_t *roi, float *buffer);
+dt_masks_raster_result_t dt_masks_group_render_roi(dt_iop_module_t *module, dt_dev_pixelpipe_t *pipe,
+                                                   const dt_dev_pixelpipe_iop_t *piece, dt_masks_form_t *form,
+                                                   const dt_iop_roi_t *roi, float *buffer);
 
 // returns current masks version
 int dt_masks_version(void);

--- a/src/develop/masks.h
+++ b/src/develop/masks.h
@@ -393,9 +393,7 @@ static inline dt_masks_raster_result_t dt_masks_raster_from_status(const int sta
   return (status == 0) ? DT_MASKS_RASTER_OK : DT_MASKS_RASTER_ERROR;
 }
 
-dt_masks_raster_result_t dt_masks_get_points_border(struct dt_develop_t *dev, dt_masks_form_t *form,
-                               float **points, int *points_count,
-                               float **border, int *border_count, int source, dt_iop_module_t *module);
+
 /** get the rectangle which include the form and his border */
 dt_masks_raster_result_t dt_masks_get_area(dt_iop_module_t *module, dt_dev_pixelpipe_t *pipe,
                       dt_dev_pixelpipe_iop_t *piece,
@@ -469,10 +467,7 @@ dt_masks_raster_result_t dt_masks_get_mask(const dt_iop_module_t *const module, 
 
 /** Rasterise `form` into the pre-zeroed ROI-sized `buffer`. `touched` (may be NULL) receives
  * the buffer-relative rectangle enclosing every pixel written; empty when nothing was. */
-dt_masks_raster_result_t dt_masks_get_mask_roi(const dt_iop_module_t *const module, dt_dev_pixelpipe_t *pipe,
-                                               const dt_dev_pixelpipe_iop_t *const piece,
-                                               dt_masks_form_t *const form, const dt_iop_roi_t *roi,
-                                               float *buffer, dt_iop_roi_t *touched);
+
 
 
 dt_masks_raster_result_t dt_masks_group_render_roi(dt_iop_module_t *module, dt_dev_pixelpipe_t *pipe,
@@ -554,7 +549,7 @@ void dt_masks_cleanup_unused(dt_develop_t *dev);
 
 dt_masks_edit_mode_t dt_masks_get_edit_mode(struct dt_iop_module_t *module);
 void dt_masks_set_edit_mode(struct dt_iop_module_t *module, dt_masks_edit_mode_t value);
-void dt_masks_iop_update(struct dt_iop_module_t *module);
+
 void dt_masks_iop_use_same_as(struct dt_iop_module_t *module, struct dt_iop_module_t *src);
 /** Hash a group's full content (recursing into members). Children are resolved from the given
  * forms list — pass the same list the group came from (live dev->forms or a snapshot), so the

--- a/src/develop/masks.h
+++ b/src/develop/masks.h
@@ -360,7 +360,41 @@ typedef struct dt_masks_form_t
 /* Rasterisation entry points: dispatch through the private table. */
 /** get points in real space with respect of distortion dx and dy are used to eventually move the center of
  * the circle */
-int dt_masks_get_points_border(struct dt_develop_t *dev, dt_masks_form_t *form, float **points, int *points_count,
+/**
+ * @brief What a rasterisation attempt produced.
+ *
+ * @details The rasterisation family used to return a bare `int` on a "0 means success"
+ * convention that could not say the third thing that actually happens: a shape with nothing to
+ * draw. Callers therefore had to guess, and the shapes disagreed -- a NULL points list made a
+ * circle report failure (which aborted the whole group fold) and an ellipse report success
+ * (which rendered it as zeros). Same data, opposite outcomes, decided by which shape carried it.
+ *
+ * OK    -- the buffer was written; `touched`, where the callee takes one, describes what.
+ * EMPTY -- nothing to draw: degenerate geometry, or the shape lies entirely outside this ROI.
+ *          A legitimate outcome, NOT an error. The buffer is left as the caller supplied it.
+ * ERROR -- the shape could not be computed (allocation failure, a distortion transform that
+ *          did not converge). The buffer's contents are undefined and must not be published.
+ *
+ * OK is 0 so that a caller written against the old convention still reads a success as success;
+ * every other value is a non-success, which is the safe direction for anything not yet migrated.
+ */
+typedef enum dt_masks_raster_result_t
+{
+  DT_MASKS_RASTER_OK = 0,
+  DT_MASKS_RASTER_EMPTY,
+  DT_MASKS_RASTER_ERROR
+} dt_masks_raster_result_t;
+
+/** Adapt an internal helper still on the plain "0 means success" convention. Such a helper has
+ * no way to report EMPTY, so everything non-zero becomes ERROR -- which is the conservative
+ * reading, and the one those helpers' callers already applied. */
+static inline dt_masks_raster_result_t dt_masks_raster_from_status(const int status)
+{
+  return (status == 0) ? DT_MASKS_RASTER_OK : DT_MASKS_RASTER_ERROR;
+}
+
+dt_masks_raster_result_t dt_masks_get_points_border(struct dt_develop_t *dev, dt_masks_form_t *form,
+                               float **points, int *points_count,
                                float **border, int *border_count, int source, dt_iop_module_t *module);
 /** get the rectangle which include the form and his border */
 int dt_masks_get_area(dt_iop_module_t *module, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece,
@@ -425,31 +459,6 @@ static inline void dt_masks_set_ctrl_points(float ctrl1[2], float ctrl2[2], cons
   ctrl2[1] = control_points[3];
 }
 
-
-/**
- * @brief What a rasterisation attempt produced.
- *
- * @details The rasterisation family used to return a bare `int` on a "0 means success"
- * convention that could not say the third thing that actually happens: a shape with nothing to
- * draw. Callers therefore had to guess, and the shapes disagreed -- a NULL points list made a
- * circle report failure (which aborted the whole group fold) and an ellipse report success
- * (which rendered it as zeros). Same data, opposite outcomes, decided by which shape carried it.
- *
- * OK    -- the buffer was written; `touched`, where the callee takes one, describes what.
- * EMPTY -- nothing to draw: degenerate geometry, or the shape lies entirely outside this ROI.
- *          A legitimate outcome, NOT an error. The buffer is left as the caller supplied it.
- * ERROR -- the shape could not be computed (allocation failure, a distortion transform that
- *          did not converge). The buffer's contents are undefined and must not be published.
- *
- * OK is 0 so that a caller written against the old convention still reads a success as success;
- * every other value is a non-success, which is the safe direction for anything not yet migrated.
- */
-typedef enum dt_masks_raster_result_t
-{
-  DT_MASKS_RASTER_OK = 0,
-  DT_MASKS_RASTER_EMPTY,
-  DT_MASKS_RASTER_ERROR
-} dt_masks_raster_result_t;
 
 /** get the transparency mask of the form and his border */
 int dt_masks_get_mask(const dt_iop_module_t *const module, dt_dev_pixelpipe_t *pipe,

--- a/src/develop/masks/brush.c
+++ b/src/develop/masks/brush.c
@@ -2987,13 +2987,13 @@ static inline void _brush_falloff_roi(float *buffer, const int *segment_start, c
  *
  * The buffer is assumed pre-zeroed. Points are scaled/shifted into ROI space before stamping.
  */
-static int _brush_get_mask_roi(const dt_iop_module_t *const module, dt_dev_pixelpipe_t *pipe,
+static dt_masks_raster_result_t _brush_get_mask_roi(const dt_iop_module_t *const module, dt_dev_pixelpipe_t *pipe,
                                const dt_dev_pixelpipe_iop_t *const piece,
                                dt_masks_form_t *const mask_form, const dt_iop_roi_t *roi, float *buffer,
                                dt_iop_roi_t *touched)
 {
   dt_masks_touched_none(touched);
-  if(IS_NULL_PTR(module)) return 1;
+  if(IS_NULL_PTR(module)) return DT_MASKS_RASTER_ERROR;
   double timer_start = 0.0;
   double timer_step_start = 0.0;
   if(dt_get_debug_flags() & DT_DEBUG_PERF) timer_start = timer_step_start = dt_get_wtime();
@@ -3018,7 +3018,7 @@ static int _brush_get_mask_roi(const dt_iop_module_t *const module, dt_dev_pixel
     dt_pixelpipe_cache_free_align(points);
     dt_pixelpipe_cache_free_align(border);
     dt_pixelpipe_cache_free_align(payload);
-    return 1;
+    return DT_MASKS_RASTER_ERROR;
   }
 
   if(dt_get_debug_flags() & DT_DEBUG_PERF)
@@ -3035,7 +3035,7 @@ static int _brush_get_mask_roi(const dt_iop_module_t *const module, dt_dev_pixel
     dt_pixelpipe_cache_free_align(points);
     dt_pixelpipe_cache_free_align(border);
     dt_pixelpipe_cache_free_align(payload);
-    return 0;
+    return DT_MASKS_RASTER_EMPTY;
   }
 
   // we shift and scale down brush and border
@@ -3074,7 +3074,7 @@ static int _brush_get_mask_roi(const dt_iop_module_t *const module, dt_dev_pixel
     dt_pixelpipe_cache_free_align(points);
     dt_pixelpipe_cache_free_align(border);
     dt_pixelpipe_cache_free_align(payload);
-    return 0;
+    return DT_MASKS_RASTER_EMPTY;
   }
 
   // now we fill the falloff
@@ -3163,7 +3163,7 @@ static int _brush_get_mask_roi(const dt_iop_module_t *const module, dt_dev_pixel
              dt_get_wtime() - timer_start);
   }
 
-  return 0;
+  return DT_MASKS_RASTER_OK;
 }
 
 static void _brush_sanitize_config(dt_masks_type_t type)

--- a/src/develop/masks/brush.c
+++ b/src/develop/masks/brush.c
@@ -1239,17 +1239,19 @@ static void _brush_get_distance(float point_x, float point_y, float radius,
   *distance = min_dist;
 }
 
-static int _brush_get_points_border(dt_develop_t *develop, dt_masks_form_t *mask_form,
+static dt_masks_raster_result_t _brush_get_points_border(dt_develop_t *develop, dt_masks_form_t *mask_form,
                                     float **point_buffer, int *point_count,
                                     float **border_buffer, int *border_count,
                                     int use_source, const dt_iop_module_t *module)
 {
-  if(use_source && IS_NULL_PTR(module)) return 1;
+  // Asking for the source outline without a module is a programming error, not an empty shape.
+  if(use_source && IS_NULL_PTR(module)) return DT_MASKS_RASTER_ERROR;
   const double ioporder = (module) ? module->iop_order : 0.0f;
   const dt_masks_distort_t gui_dist = dt_masks_distort_for_gui(develop);
-  return _brush_get_pts_border(develop, mask_form, ioporder, DT_DEV_TRANSFORM_DIR_ALL,
-                               &gui_dist, point_buffer, point_count, border_buffer,
-                               border_count, NULL, NULL, use_source);
+  return dt_masks_raster_from_status(
+      _brush_get_pts_border(develop, mask_form, ioporder, DT_DEV_TRANSFORM_DIR_ALL,
+                            &gui_dist, point_buffer, point_count, border_buffer,
+                            border_count, NULL, NULL, use_source));
 }
 
 /** find relative position within a brush segment that is closest to the point given by coordinates x and y;

--- a/src/develop/masks/brush.c
+++ b/src/develop/masks/brush.c
@@ -2749,7 +2749,10 @@ static int _get_area(const dt_iop_module_t *const module, dt_dev_pixelpipe_t *pi
   {
     dt_pixelpipe_cache_free_align(points);
     dt_pixelpipe_cache_free_align(border);
-    *width = *height = *offset_x = *offset_y = 0;
+    *width = 0;
+  *height = 0;
+  *offset_x = 0;
+  *offset_y = 0;
     return 0;
   }
   _brush_bounding_box(points, border, node_count, points_count, width, height, offset_x, offset_y);
@@ -2763,7 +2766,10 @@ static dt_masks_raster_result_t _brush_get_source_area(dt_iop_module_t *module, 
                                   dt_dev_pixelpipe_iop_t *piece,
                                   dt_masks_form_t *mask_form, int *width, int *height, int *offset_x, int *offset_y)
 {
-  *width = *height = *offset_x = *offset_y = 0;
+  *width = 0;
+  *height = 0;
+  *offset_x = 0;
+  *offset_y = 0;
   return dt_masks_raster_from_status(
       _get_area(module, pipe, piece, mask_form, width, height, offset_x, offset_y, 1));
 }
@@ -2773,7 +2779,10 @@ static dt_masks_raster_result_t _brush_get_area(const dt_iop_module_t *const mod
                            dt_masks_form_t *const mask_form, int *width, int *height, int *offset_x,
                            int *offset_y)
 {
-  *width = *height = *offset_x = *offset_y = 0;
+  *width = 0;
+  *height = 0;
+  *offset_x = 0;
+  *offset_y = 0;
   return dt_masks_raster_from_status(
       _get_area(module, pipe, piece, mask_form, width, height, offset_x, offset_y, 0));
 }
@@ -2820,7 +2829,10 @@ static dt_masks_raster_result_t _brush_get_mask(const dt_iop_module_t *const mod
                            float **buffer, int *width, int *height, int *offset_x, int *offset_y)
 {
   *buffer = NULL;
-  *width = *height = *offset_x = *offset_y = 0;
+  *width = 0;
+  *height = 0;
+  *offset_x = 0;
+  *offset_y = 0;
   if(IS_NULL_PTR(module)) return DT_MASKS_RASTER_ERROR;
   double timer_start = 0.0;
   double timer_step_start = 0.0;
@@ -2855,7 +2867,10 @@ static dt_masks_raster_result_t _brush_get_mask(const dt_iop_module_t *const mod
     dt_pixelpipe_cache_free_align(border);
     dt_pixelpipe_cache_free_align(payload);
     *buffer = NULL;
-    *width = *height = *offset_x = *offset_y = 0;
+    *width = 0;
+  *height = 0;
+  *offset_x = 0;
+  *offset_y = 0;
     return DT_MASKS_RASTER_EMPTY;
   }
   const gboolean use_sparse = (pipe->mask_rasterization_step > 1);

--- a/src/develop/masks/brush.c
+++ b/src/develop/masks/brush.c
@@ -2758,19 +2758,23 @@ static int _get_area(const dt_iop_module_t *const module, dt_dev_pixelpipe_t *pi
   return 0;
 }
 
-static int _brush_get_source_area(dt_iop_module_t *module, dt_dev_pixelpipe_t *pipe,
+static dt_masks_raster_result_t _brush_get_source_area(dt_iop_module_t *module, dt_dev_pixelpipe_t *pipe,
                                   dt_dev_pixelpipe_iop_t *piece,
                                   dt_masks_form_t *mask_form, int *width, int *height, int *offset_x, int *offset_y)
 {
-  return _get_area(module, pipe, piece, mask_form, width, height, offset_x, offset_y, 1);
+  *width = *height = *offset_x = *offset_y = 0;
+  return dt_masks_raster_from_status(
+      _get_area(module, pipe, piece, mask_form, width, height, offset_x, offset_y, 1));
 }
 
-static int _brush_get_area(const dt_iop_module_t *const module, dt_dev_pixelpipe_t *pipe,
+static dt_masks_raster_result_t _brush_get_area(const dt_iop_module_t *const module, dt_dev_pixelpipe_t *pipe,
                            const dt_dev_pixelpipe_iop_t *const piece,
                            dt_masks_form_t *const mask_form, int *width, int *height, int *offset_x,
                            int *offset_y)
 {
-  return _get_area(module, pipe, piece, mask_form, width, height, offset_x, offset_y, 0);
+  *width = *height = *offset_x = *offset_y = 0;
+  return dt_masks_raster_from_status(
+      _get_area(module, pipe, piece, mask_form, width, height, offset_x, offset_y, 0));
 }
 
 /** we write a falloff segment */
@@ -2809,12 +2813,14 @@ static void _brush_falloff(float *const restrict buffer, int segment_start[2], i
  *
  * The buffer is returned zero-initialized and filled only in the falloff region.
  */
-static int _brush_get_mask(const dt_iop_module_t *const module, dt_dev_pixelpipe_t *pipe,
+static dt_masks_raster_result_t _brush_get_mask(const dt_iop_module_t *const module, dt_dev_pixelpipe_t *pipe,
                            const dt_dev_pixelpipe_iop_t *const piece,
                            dt_masks_form_t *const mask_form,
                            float **buffer, int *width, int *height, int *offset_x, int *offset_y)
 {
-  if(IS_NULL_PTR(module)) return 1;
+  *buffer = NULL;
+  *width = *height = *offset_x = *offset_y = 0;
+  if(IS_NULL_PTR(module)) return DT_MASKS_RASTER_ERROR;
   double timer_start = 0.0;
   double timer_step_start = 0.0;
   if(dt_get_debug_flags() & DT_DEBUG_PERF) timer_start = timer_step_start = dt_get_wtime();
@@ -2830,7 +2836,7 @@ static int _brush_get_mask(const dt_iop_module_t *const module, dt_dev_pixelpipe
     dt_pixelpipe_cache_free_align(points);
     dt_pixelpipe_cache_free_align(border);
     dt_pixelpipe_cache_free_align(payload);
-    return 1;
+    return DT_MASKS_RASTER_ERROR;
   }
 
   if(dt_get_debug_flags() & DT_DEBUG_PERF)
@@ -2849,7 +2855,7 @@ static int _brush_get_mask(const dt_iop_module_t *const module, dt_dev_pixelpipe
     dt_pixelpipe_cache_free_align(payload);
     *buffer = NULL;
     *width = *height = *offset_x = *offset_y = 0;
-    return 0;
+    return DT_MASKS_RASTER_EMPTY;
   }
   const gboolean use_sparse = (pipe->mask_rasterization_step > 1);
   const int sparse_step = pipe->mask_rasterization_step;
@@ -2868,7 +2874,7 @@ static int _brush_get_mask(const dt_iop_module_t *const module, dt_dev_pixelpipe
     dt_pixelpipe_cache_free_align(points);
     dt_pixelpipe_cache_free_align(border);
     dt_pixelpipe_cache_free_align(payload);
-    return 1;
+    return DT_MASKS_RASTER_ERROR;
   }
   memset(*buffer, 0, sizeof(float) * buffer_size);
 
@@ -2925,7 +2931,7 @@ static int _brush_get_mask(const dt_iop_module_t *const module, dt_dev_pixelpipe
     dt_print(DT_DEBUG_MASKS, "[masks %s] brush fill buffer took %0.04f sec\n", mask_form->name,
              dt_get_wtime() - timer_start);
 
-  return 0;
+  return DT_MASKS_RASTER_OK;
 }
 
 /** we write a falloff segment respecting limits of buffer */

--- a/src/develop/masks/brush.c
+++ b/src/develop/masks/brush.c
@@ -47,6 +47,7 @@
 #include "develop/masks/masks_distort.h"
 #include "develop/masks.h"
 #include "develop/masks_gui.h"
+#include "develop/blend_gui.h"   // dt_iop_gui_blend_masks_update()
 #include "develop/masks/masks_functions.h"
 #include "develop/masks/masks_touched.h"
 #include "math/openmp_maths.h"
@@ -1975,7 +1976,7 @@ static int _brush_events_button_released(struct dt_iop_module_t *module, double 
       mask_gui->guipoints_count = 0;
 
       dt_masks_set_edit_mode(module, DT_MASKS_EDIT_FULL);
-      dt_masks_iop_update(module);
+      dt_iop_gui_blend_masks_update(module);
 
       dt_masks_change_form_gui(mask_gui->dev, NULL);
     }

--- a/src/develop/masks/circle.c
+++ b/src/develop/masks/circle.c
@@ -869,14 +869,14 @@ static int _circle_get_mask(const dt_iop_module_t *const restrict module, dt_dev
 }
 
 
-static int _circle_get_mask_roi(const dt_iop_module_t *const restrict module, dt_dev_pixelpipe_t *pipe,
+static dt_masks_raster_result_t _circle_get_mask_roi(const dt_iop_module_t *const restrict module, dt_dev_pixelpipe_t *pipe,
                                 const dt_dev_pixelpipe_iop_t *const restrict piece,
                                 dt_masks_form_t *const form, const dt_iop_roi_t *const roi,
                                 float *const restrict buffer, dt_iop_roi_t *touched)
 {
   dt_masks_touched_none(touched);
-  if(IS_NULL_PTR(form) || IS_NULL_PTR(form->points)) return 1;
-  if(IS_NULL_PTR(module)) return 1;
+  if(IS_NULL_PTR(form) || IS_NULL_PTR(form->points)) return DT_MASKS_RASTER_EMPTY;
+  if(IS_NULL_PTR(module)) return DT_MASKS_RASTER_ERROR;
   double start1 = 0.0;
   double start2 = start1;
   
@@ -884,7 +884,7 @@ static int _circle_get_mask_roi(const dt_iop_module_t *const restrict module, dt
 
   // we get the circle parameters
   dt_masks_node_circle_t *circle = (dt_masks_node_circle_t *)((form->points)->data);
-  if(IS_NULL_PTR(circle)) return 1;
+  if(IS_NULL_PTR(circle)) return DT_MASKS_RASTER_EMPTY;
   const int wi = pipe->iwidth, hi = pipe->iheight;
   const float centerx = circle->center[0] * wi;
   const float centery = circle->center[1] * hi;
@@ -920,7 +920,7 @@ static int _circle_get_mask_roi(const dt_iop_module_t *const restrict module, dt
   // we need many points as we do not know how the circle might get distorted in the pixelpipe
   const size_t circpts = dt_masks_roundup(MIN(360, 2 * M_PI * sqr_total), 8);
   float *const restrict circ = dt_pixelpipe_cache_alloc_align_float_cache(circpts * 2, 0);
-  if(IS_NULL_PTR(circ)) return 1;
+  if(IS_NULL_PTR(circ)) return DT_MASKS_RASTER_ERROR;
   __OMP_PARALLEL_FOR__(if(circpts/8 > 1000))
   for(int n = 0; n < circpts / 8; n++)
   {
@@ -955,7 +955,7 @@ static int _circle_get_mask_roi(const dt_iop_module_t *const restrict module, dt
                                         circpts))
   {
     dt_pixelpipe_cache_free_align(circ);
-    return 1;
+    return DT_MASKS_RASTER_ERROR;
   }
 
   if(dt_get_debug_flags() & DT_DEBUG_PERF)
@@ -1007,10 +1007,10 @@ static int _circle_get_mask_roi(const dt_iop_module_t *const restrict module, dt
   // check if there is anything to do at all;
   // only if width and height of bounding box is 2 or greater the shape lies inside of roi and requires action
   if(bbw <= 1 || bbh <= 1)
-    return 0;
+    return DT_MASKS_RASTER_EMPTY;
 
   float *const restrict points = dt_pixelpipe_cache_alloc_align_float_cache((size_t)bbw * bbh * 2, 0);
-  if(IS_NULL_PTR(points)) return 1;
+  if(IS_NULL_PTR(points)) return DT_MASKS_RASTER_ERROR;
 
   // we populate the grid points in module coordinates
   __OMP_PARALLEL_FOR__(collapse(2) if(bbw*bbh > 50000))
@@ -1033,7 +1033,7 @@ static int _circle_get_mask_roi(const dt_iop_module_t *const restrict module, dt
                                         (size_t)bbw * bbh))
   {
     dt_pixelpipe_cache_free_align(points);
-    return 1;
+    return DT_MASKS_RASTER_ERROR;
   }
 
   if(dt_get_debug_flags() & DT_DEBUG_PERF)
@@ -1117,7 +1117,7 @@ static int _circle_get_mask_roi(const dt_iop_module_t *const restrict module, dt
              dt_get_wtime() - start1);
   }
 
-  return 0;
+  return DT_MASKS_RASTER_OK;
 }
 
 static void _circle_sanitize_config(dt_masks_type_t type)

--- a/src/develop/masks/circle.c
+++ b/src/develop/masks/circle.c
@@ -715,14 +715,18 @@ static dt_masks_raster_result_t _circle_get_points_border(dt_develop_t *dev, str
   }
 }
 
-static int _circle_get_source_area(dt_iop_module_t *module, dt_dev_pixelpipe_t *pipe,
+static dt_masks_raster_result_t _circle_get_source_area(dt_iop_module_t *module, dt_dev_pixelpipe_t *pipe,
                                    dt_dev_pixelpipe_iop_t *piece,
                                    dt_masks_form_t *form, int *width, int *height, int *posx, int *posy)
 {
+  /* Every early exit below must leave the out-parameters defined: callers read them
+   * whenever this reports anything but ERROR, and three of them used to report success
+   * for a shape with no geometry while writing none of these. */
+  *width = *height = *posx = *posy = 0;
   // we get the circle values
-  if(IS_NULL_PTR(form) || IS_NULL_PTR(form->points)) return 0;
+  if(IS_NULL_PTR(form) || IS_NULL_PTR(form->points)) return DT_MASKS_RASTER_EMPTY;
   dt_masks_node_circle_t *circle = (dt_masks_node_circle_t *)((form->points)->data);
-  if(IS_NULL_PTR(circle)) return 0;
+  if(IS_NULL_PTR(circle)) return DT_MASKS_RASTER_EMPTY;
   float wd = pipe->iwidth, ht = pipe->iheight;
 
   // compute the points we need to transform (center and circumference of circle)
@@ -731,29 +735,30 @@ static int _circle_get_source_area(dt_iop_module_t *module, dt_dev_pixelpipe_t *
   float *const restrict points =
     _points_to_transform(pipe->dev, form->source[0], form->source[1], outer_radius, wd, ht, &num_points);
   if(IS_NULL_PTR(points))
-    return 1;
+    return DT_MASKS_RASTER_ERROR;
 
   // and transform them with all distorted modules
   if(!dt_dev_distort_transform_plus(pipe, module->iop_order, DT_DEV_TRANSFORM_DIR_BACK_INCL, points, num_points))
   {
     dt_pixelpipe_cache_free_align(points);
-    return 1;
+    return DT_MASKS_RASTER_ERROR;
   }
 
   _bounding_box(points, num_points, width, height, posx, posy);
   dt_pixelpipe_cache_free_align(points);
-  return 0;
+  return DT_MASKS_RASTER_OK;
 }
 
-static int _circle_get_area(const dt_iop_module_t *const restrict module, dt_dev_pixelpipe_t *pipe,
+static dt_masks_raster_result_t _circle_get_area(const dt_iop_module_t *const restrict module, dt_dev_pixelpipe_t *pipe,
                             const dt_dev_pixelpipe_iop_t *const restrict piece,
                             dt_masks_form_t *const restrict form,
                             int *width, int *height, int *posx, int *posy)
 {
-  if(IS_NULL_PTR(form) || IS_NULL_PTR(form->points)) return 0;
+  *width = *height = *posx = *posy = 0;
+  if(IS_NULL_PTR(form) || IS_NULL_PTR(form->points)) return DT_MASKS_RASTER_EMPTY;
   // we get the circle values
   dt_masks_node_circle_t *circle = (dt_masks_node_circle_t *)((form->points)->data);
-  if(IS_NULL_PTR(circle)) return 0;
+  if(IS_NULL_PTR(circle)) return DT_MASKS_RASTER_EMPTY;
   float wd = pipe->iwidth, ht = pipe->iheight;
 
   // compute the points we need to transform (center and circumference of circle)
@@ -762,30 +767,33 @@ static int _circle_get_area(const dt_iop_module_t *const restrict module, dt_dev
   float *const restrict points =
     _points_to_transform(pipe->dev, circle->center[0], circle->center[1], outer_radius, wd, ht, &num_points);
   if(IS_NULL_PTR(points))
-    return 1;
+    return DT_MASKS_RASTER_ERROR;
 
   // and transform them with all distorted modules
   if(!dt_dev_distort_transform_plus(pipe, module->iop_order, DT_DEV_TRANSFORM_DIR_BACK_INCL, points, num_points))
   {
     dt_pixelpipe_cache_free_align(points);
-    return 1;
+    return DT_MASKS_RASTER_ERROR;
   }
 
   _bounding_box(points, num_points, width, height, posx, posy);
   dt_pixelpipe_cache_free_align(points);
-  return 0;
+  return DT_MASKS_RASTER_OK;
 }
 
-static int _circle_get_mask(const dt_iop_module_t *const restrict module, dt_dev_pixelpipe_t *pipe,
+static dt_masks_raster_result_t _circle_get_mask(const dt_iop_module_t *const restrict module, dt_dev_pixelpipe_t *pipe,
                             const dt_dev_pixelpipe_iop_t *const restrict piece,
                             dt_masks_form_t *const restrict form,
                             float **buffer, int *width, int *height, int *posx, int *posy)
 {
+  *buffer = NULL;
+  *width = *height = *posx = *posy = 0;
   double start2 = 0.0;
   if(dt_get_debug_flags() & DT_DEBUG_PERF) start2 = dt_get_wtime();
 
   // we get the area
-  if(_circle_get_area(module, pipe, piece, form, width, height, posx, posy) != 0) return 1;
+  const dt_masks_raster_result_t area = _circle_get_area(module, pipe, piece, form, width, height, posx, posy);
+  if(area != DT_MASKS_RASTER_OK) return area;
 
   if(dt_get_debug_flags() & DT_DEBUG_PERF)
   {
@@ -800,7 +808,7 @@ static int _circle_get_mask(const dt_iop_module_t *const restrict module, dt_dev
   const int w = *width, h = *height;
   float *const restrict points = dt_pixelpipe_cache_alloc_align_float_cache((size_t)w * h * 2, 0);
   if(IS_NULL_PTR(points))
-    return 1;
+    return DT_MASKS_RASTER_ERROR;
 
   const float pos_x = *posx;
   const float pos_y = *posy;
@@ -826,7 +834,7 @@ static int _circle_get_mask(const dt_iop_module_t *const restrict module, dt_dev
   if(!dt_dev_distort_backtransform_plus(pipe, module->iop_order, DT_DEV_TRANSFORM_DIR_BACK_INCL, points, (size_t)w * h))
   {
     dt_pixelpipe_cache_free_align(points);
-    return 1;
+    return DT_MASKS_RASTER_ERROR;
   }
 
   if(dt_get_debug_flags() & DT_DEBUG_PERF)
@@ -841,7 +849,7 @@ static int _circle_get_mask(const dt_iop_module_t *const restrict module, dt_dev
   if(IS_NULL_PTR(*buffer))
   {
     dt_pixelpipe_cache_free_align(points);
-    return 1;
+    return DT_MASKS_RASTER_ERROR;
   }
 
   // we populate the buffer
@@ -870,7 +878,7 @@ static int _circle_get_mask(const dt_iop_module_t *const restrict module, dt_dev
   if(dt_get_debug_flags() & DT_DEBUG_PERF)
     dt_print(DT_DEBUG_MASKS, "[masks %s] circle fill took %0.04f sec\n", form->name, dt_get_wtime() - start2);
 
-  return 0;
+  return DT_MASKS_RASTER_OK;
 }
 
 

--- a/src/develop/masks/circle.c
+++ b/src/develop/masks/circle.c
@@ -681,33 +681,38 @@ static void _bounding_box(const float *const points, int num_points, int *width,
   *height = (ymax - ymin);
 }
 
-static int _circle_get_points_border(dt_develop_t *dev, struct dt_masks_form_t *form, float **points,
+static dt_masks_raster_result_t _circle_get_points_border(dt_develop_t *dev, struct dt_masks_form_t *form,
+                                     float **points,
                                      int *points_count, float **border, int *border_count, int source,
                                      const dt_iop_module_t *module)
 {
-  if(IS_NULL_PTR(form) || IS_NULL_PTR(form->points)) return 0;
+  /* No geometry to build an outline from: the outline is empty, which is a result, not a
+   * failure. Reporting success here (as this did) told the caller to cache a NULL outline as
+   * if it had been built. */
+  if(IS_NULL_PTR(form) || IS_NULL_PTR(form->points)) return DT_MASKS_RASTER_EMPTY;
   dt_masks_node_circle_t *circle = (dt_masks_node_circle_t *)((form->points)->data);
-  if(IS_NULL_PTR(circle)) return 0;
+  if(IS_NULL_PTR(circle)) return DT_MASKS_RASTER_EMPTY;
   float x = circle->center[0];
   float y = circle->center[1];
   if(source)
   {
     float xs = form->source[0];
     float ys = form->source[1];
-    return _circle_get_points_source(dev, x, y, xs, ys, circle->radius, circle->radius, 0.0f, points, points_count, module);
+    return dt_masks_raster_from_status(
+        _circle_get_points_source(dev, x, y, xs, ys, circle->radius, circle->radius, 0.0f, points, points_count, module));
   }
   else
   {
     if(form->functions->get_points(dev, x, y, circle->radius, circle->radius, 0, points, points_count) != 0)
-      return 1;
+      return DT_MASKS_RASTER_ERROR;
     if(!IS_NULL_PTR(border))
     {
       float outer_radius = circle->radius + circle->border;
-      return form->functions->get_points(dev, x, y, outer_radius, outer_radius, 0, border, border_count);
+      return dt_masks_raster_from_status(
+          form->functions->get_points(dev, x, y, outer_radius, outer_radius, 0, border, border_count));
     }
-    return 0;
+    return DT_MASKS_RASTER_OK;
   }
-  return 1;
 }
 
 static int _circle_get_source_area(dt_iop_module_t *module, dt_dev_pixelpipe_t *pipe,

--- a/src/develop/masks/circle.c
+++ b/src/develop/masks/circle.c
@@ -722,7 +722,10 @@ static dt_masks_raster_result_t _circle_get_source_area(dt_iop_module_t *module,
   /* Every early exit below must leave the out-parameters defined: callers read them
    * whenever this reports anything but ERROR, and three of them used to report success
    * for a shape with no geometry while writing none of these. */
-  *width = *height = *posx = *posy = 0;
+  *width = 0;
+  *height = 0;
+  *posx = 0;
+  *posy = 0;
   // we get the circle values
   if(IS_NULL_PTR(form) || IS_NULL_PTR(form->points)) return DT_MASKS_RASTER_EMPTY;
   dt_masks_node_circle_t *circle = (dt_masks_node_circle_t *)((form->points)->data);
@@ -754,7 +757,10 @@ static dt_masks_raster_result_t _circle_get_area(const dt_iop_module_t *const re
                             dt_masks_form_t *const restrict form,
                             int *width, int *height, int *posx, int *posy)
 {
-  *width = *height = *posx = *posy = 0;
+  *width = 0;
+  *height = 0;
+  *posx = 0;
+  *posy = 0;
   if(IS_NULL_PTR(form) || IS_NULL_PTR(form->points)) return DT_MASKS_RASTER_EMPTY;
   // we get the circle values
   dt_masks_node_circle_t *circle = (dt_masks_node_circle_t *)((form->points)->data);
@@ -787,7 +793,10 @@ static dt_masks_raster_result_t _circle_get_mask(const dt_iop_module_t *const re
                             float **buffer, int *width, int *height, int *posx, int *posy)
 {
   *buffer = NULL;
-  *width = *height = *posx = *posy = 0;
+  *width = 0;
+  *height = 0;
+  *posx = 0;
+  *posy = 0;
   double start2 = 0.0;
   if(dt_get_debug_flags() & DT_DEBUG_PERF) start2 = dt_get_wtime();
 

--- a/src/develop/masks/ellipse.c
+++ b/src/develop/masks/ellipse.c
@@ -464,13 +464,15 @@ static int _ellipse_get_points(dt_develop_t *dev, float xx, float yy, float radi
   return 0;
 }
 
-static int _ellipse_get_points_border(dt_develop_t *dev, struct dt_masks_form_t *form, float **points,
+static dt_masks_raster_result_t _ellipse_get_points_border(dt_develop_t *dev, struct dt_masks_form_t *form,
+                                      float **points,
                                       int *points_count, float **border, int *border_count, int source,
                                       const dt_iop_module_t *module)
 {
-  if(IS_NULL_PTR(form) || IS_NULL_PTR(form->points)) return 0;
+  // No geometry: an empty outline is the correct result here, not a failure. See the circle.
+  if(IS_NULL_PTR(form) || IS_NULL_PTR(form->points)) return DT_MASKS_RASTER_EMPTY;
   dt_masks_node_ellipse_t *ellipse = (dt_masks_node_ellipse_t *)((form->points)->data);
-  if(IS_NULL_PTR(ellipse)) return 0;
+  if(IS_NULL_PTR(ellipse)) return DT_MASKS_RASTER_EMPTY;
   float x = 0.0f, y = 0.0f, a = 0.0f, b = 0.0f;
   x = ellipse->center[0], y = ellipse->center[1];
   a = ellipse->radius[0], b = ellipse->radius[1];
@@ -478,22 +480,23 @@ static int _ellipse_get_points_border(dt_develop_t *dev, struct dt_masks_form_t 
   if(source)
   {
     float xs = form->source[0], ys = form->source[1];
-    return _ellipse_get_points_source(dev, x, y, xs, ys, a, b, ellipse->rotation, points, points_count, module);
+    return dt_masks_raster_from_status(
+        _ellipse_get_points_source(dev, x, y, xs, ys, a, b, ellipse->rotation, points, points_count, module));
   }
   else
   {
     if(_ellipse_get_points(dev, x, y, a, b, ellipse->rotation, points, points_count) != 0)
-      return 1;
+      return DT_MASKS_RASTER_ERROR;
     if(!IS_NULL_PTR(border))
     {
       const int prop = ellipse->flags & DT_MASKS_ELLIPSE_PROPORTIONAL;
-      return _ellipse_get_points(dev, x, y, (prop ? a * (1.0f + ellipse->border) : a + ellipse->border),
-                                 (prop ? b * (1.0f + ellipse->border) : b + ellipse->border), ellipse->rotation,
-                                 border, border_count);
+      return dt_masks_raster_from_status(
+          _ellipse_get_points(dev, x, y, (prop ? a * (1.0f + ellipse->border) : a + ellipse->border),
+                              (prop ? b * (1.0f + ellipse->border) : b + ellipse->border), ellipse->rotation,
+                              border, border_count));
     }
-    return 0;
+    return DT_MASKS_RASTER_OK;
   }
-  return 1;
 }
 
 /**

--- a/src/develop/masks/ellipse.c
+++ b/src/develop/masks/ellipse.c
@@ -1246,14 +1246,18 @@ static float *const _ellipse_points_to_transform(dt_develop_t *dev, const float 
   return points;
 }
 
-static int _ellipse_get_source_area(dt_iop_module_t *module, dt_dev_pixelpipe_t *pipe,
+static dt_masks_raster_result_t _ellipse_get_source_area(dt_iop_module_t *module, dt_dev_pixelpipe_t *pipe,
                                     dt_dev_pixelpipe_iop_t *piece,
                                     dt_masks_form_t *form, int *width, int *height, int *posx, int *posy)
 {
-  if(IS_NULL_PTR(form) || IS_NULL_PTR(form->points)) return 0;
+  /* Every early exit below must leave the out-parameters defined: callers read them
+   * whenever this reports anything but ERROR, and three of them used to report success
+   * for a shape with no geometry while writing none of these. */
+  *width = *height = *posx = *posy = 0;
+  if(IS_NULL_PTR(form) || IS_NULL_PTR(form->points)) return DT_MASKS_RASTER_EMPTY;
   // we get the ellipse values
   dt_masks_node_ellipse_t *ellipse = (dt_masks_node_ellipse_t *)((form->points)->data);
-  if(IS_NULL_PTR(ellipse)) return 0;
+  if(IS_NULL_PTR(ellipse)) return DT_MASKS_RASTER_EMPTY;
   const float wd = pipe->iwidth, ht = pipe->iheight;
   const int prop = ellipse->flags & DT_MASKS_ELLIPSE_PROPORTIONAL;
   const float total[2] = { (prop ? ellipse->radius[0] * (1.0f + ellipse->border) : ellipse->radius[0] + ellipse->border) * MIN(wd, ht),
@@ -1264,30 +1268,31 @@ static int _ellipse_get_source_area(dt_iop_module_t *module, dt_dev_pixelpipe_t 
   float *const restrict points
     = _ellipse_points_to_transform(module->dev, form->source[0], form->source[1], total[0], total[1], ellipse->rotation, wd, ht, &point_count);
   if (IS_NULL_PTR(points))
-    return 1;
+    return DT_MASKS_RASTER_ERROR;
 
   // and we transform them with all distorted modules
   if(!dt_dev_distort_transform_plus(pipe, module->iop_order, DT_DEV_TRANSFORM_DIR_BACK_INCL, points, point_count))
   {
     dt_pixelpipe_cache_free_align(points);
-    return 1;
+    return DT_MASKS_RASTER_ERROR;
   }
 
   // finally, find the extreme left/right and top/bottom points
   _bounding_box(points, point_count, width, height, posx, posy);
   dt_pixelpipe_cache_free_align(points);
-  return 0;
+  return DT_MASKS_RASTER_OK;
 }
 
-static int _ellipse_get_area(const dt_iop_module_t *const module, dt_dev_pixelpipe_t *pipe,
+static dt_masks_raster_result_t _ellipse_get_area(const dt_iop_module_t *const module, dt_dev_pixelpipe_t *pipe,
                              const dt_dev_pixelpipe_iop_t *const piece,
                              dt_masks_form_t *const form,
                              int *width, int *height, int *posx, int *posy)
 {
-  if(IS_NULL_PTR(form) || IS_NULL_PTR(form->points)) return 0;
+  *width = *height = *posx = *posy = 0;
+  if(IS_NULL_PTR(form) || IS_NULL_PTR(form->points)) return DT_MASKS_RASTER_EMPTY;
   // we get the ellipse values
   dt_masks_node_ellipse_t *ellipse = (dt_masks_node_ellipse_t *)((form->points)->data);
-  if(IS_NULL_PTR(ellipse)) return 0;
+  if(IS_NULL_PTR(ellipse)) return DT_MASKS_RASTER_EMPTY;
   const float wd = pipe->iwidth, ht = pipe->iheight;
   const int prop = ellipse->flags & DT_MASKS_ELLIPSE_PROPORTIONAL;
   const float total[2] = { (prop ? ellipse->radius[0] * (1.0f + ellipse->border) : ellipse->radius[0] + ellipse->border) * MIN(wd, ht),
@@ -1298,32 +1303,35 @@ static int _ellipse_get_area(const dt_iop_module_t *const module, dt_dev_pixelpi
   float *const restrict points
     = _ellipse_points_to_transform(module->dev, ellipse->center[0], ellipse->center[1], total[0], total[1], ellipse->rotation, wd, ht, &point_count);
   if (IS_NULL_PTR(points))
-    return 1;
+    return DT_MASKS_RASTER_ERROR;
 
   // and we transform them with all distorted modules
   if(!dt_dev_distort_transform_plus(pipe, module->iop_order, DT_DEV_TRANSFORM_DIR_BACK_INCL, points, point_count))
   {
     dt_pixelpipe_cache_free_align(points);
-    return 1;
+    return DT_MASKS_RASTER_ERROR;
   }
 
   // finally, find the extreme left/right and top/bottom points
   _bounding_box(points, point_count, width, height, posx, posy);
   dt_pixelpipe_cache_free_align(points);
-  return 0;
+  return DT_MASKS_RASTER_OK;
 }
 
-static int _ellipse_get_mask(const dt_iop_module_t *const module, dt_dev_pixelpipe_t *pipe,
+static dt_masks_raster_result_t _ellipse_get_mask(const dt_iop_module_t *const module, dt_dev_pixelpipe_t *pipe,
                              const dt_dev_pixelpipe_iop_t *const piece,
                              dt_masks_form_t *const form,
                              float **buffer, int *width, int *height, int *posx, int *posy)
 {
-  if(IS_NULL_PTR(form) || IS_NULL_PTR(form->points)) return 0;
+  *buffer = NULL;
+  *width = *height = *posx = *posy = 0;
+  if(IS_NULL_PTR(form) || IS_NULL_PTR(form->points)) return DT_MASKS_RASTER_EMPTY;
   double start2 = 0.0;
   if(dt_get_debug_flags() & DT_DEBUG_PERF) start2 = dt_get_wtime();
 
   // we get the area
-  if(_ellipse_get_area(module, pipe, piece, form, width, height, posx, posy) != 0) return 1;
+  const dt_masks_raster_result_t area = _ellipse_get_area(module, pipe, piece, form, width, height, posx, posy);
+  if(area != DT_MASKS_RASTER_OK) return area;
 
   if(dt_get_debug_flags() & DT_DEBUG_PERF)
   {
@@ -1333,14 +1341,14 @@ static int _ellipse_get_mask(const dt_iop_module_t *const module, dt_dev_pixelpi
 
   // we get the ellipse values
   dt_masks_node_ellipse_t *ellipse = (dt_masks_node_ellipse_t *)((form->points)->data);
-  if(IS_NULL_PTR(ellipse)) return 0;
+  if(IS_NULL_PTR(ellipse)) return DT_MASKS_RASTER_EMPTY;
   // we create a buffer of points with all points in the area
   int w = *width, h = *height;
   const int posx_ = *posx;
   const int posy_ = *posy;
   float *points = dt_pixelpipe_cache_alloc_align_float_cache((size_t)2 * w * h, 0);
   if(IS_NULL_PTR(points))
-    return 1;
+    return DT_MASKS_RASTER_ERROR;
   __OMP_PARALLEL_FOR__(collapse(2) if((size_t)w * h > 50000))
   for(int i = 0; i < h; i++)
     for(int j = 0; j < w; j++)
@@ -1359,7 +1367,7 @@ static int _ellipse_get_mask(const dt_iop_module_t *const module, dt_dev_pixelpi
   if(!dt_dev_distort_backtransform_plus(pipe, module->iop_order, DT_DEV_TRANSFORM_DIR_BACK_INCL, points, (size_t)w * h))
   {
     dt_pixelpipe_cache_free_align(points);
-    return 1;
+    return DT_MASKS_RASTER_ERROR;
   }
 
   if(dt_get_debug_flags() & DT_DEBUG_PERF)
@@ -1374,7 +1382,7 @@ static int _ellipse_get_mask(const dt_iop_module_t *const module, dt_dev_pixelpi
   if(IS_NULL_PTR(*buffer))
   {
     dt_pixelpipe_cache_free_align(points);
-    return 1;
+    return DT_MASKS_RASTER_ERROR;
   }
 
   // we populate the buffer
@@ -1412,7 +1420,7 @@ static int _ellipse_get_mask(const dt_iop_module_t *const module, dt_dev_pixelpi
   if(dt_get_debug_flags() & DT_DEBUG_PERF)
     dt_print(DT_DEBUG_MASKS, "[masks %s] ellipse fill took %0.04f sec\n", form->name, dt_get_wtime() - start2);
 
-  return 0;
+  return DT_MASKS_RASTER_OK;
 }
 
 static dt_masks_raster_result_t _ellipse_get_mask_roi(const dt_iop_module_t *const module, dt_dev_pixelpipe_t *pipe,

--- a/src/develop/masks/ellipse.c
+++ b/src/develop/masks/ellipse.c
@@ -1253,7 +1253,10 @@ static dt_masks_raster_result_t _ellipse_get_source_area(dt_iop_module_t *module
   /* Every early exit below must leave the out-parameters defined: callers read them
    * whenever this reports anything but ERROR, and three of them used to report success
    * for a shape with no geometry while writing none of these. */
-  *width = *height = *posx = *posy = 0;
+  *width = 0;
+  *height = 0;
+  *posx = 0;
+  *posy = 0;
   if(IS_NULL_PTR(form) || IS_NULL_PTR(form->points)) return DT_MASKS_RASTER_EMPTY;
   // we get the ellipse values
   dt_masks_node_ellipse_t *ellipse = (dt_masks_node_ellipse_t *)((form->points)->data);
@@ -1288,7 +1291,10 @@ static dt_masks_raster_result_t _ellipse_get_area(const dt_iop_module_t *const m
                              dt_masks_form_t *const form,
                              int *width, int *height, int *posx, int *posy)
 {
-  *width = *height = *posx = *posy = 0;
+  *width = 0;
+  *height = 0;
+  *posx = 0;
+  *posy = 0;
   if(IS_NULL_PTR(form) || IS_NULL_PTR(form->points)) return DT_MASKS_RASTER_EMPTY;
   // we get the ellipse values
   dt_masks_node_ellipse_t *ellipse = (dt_masks_node_ellipse_t *)((form->points)->data);
@@ -1324,7 +1330,10 @@ static dt_masks_raster_result_t _ellipse_get_mask(const dt_iop_module_t *const m
                              float **buffer, int *width, int *height, int *posx, int *posy)
 {
   *buffer = NULL;
-  *width = *height = *posx = *posy = 0;
+  *width = 0;
+  *height = 0;
+  *posx = 0;
+  *posy = 0;
   if(IS_NULL_PTR(form) || IS_NULL_PTR(form->points)) return DT_MASKS_RASTER_EMPTY;
   double start2 = 0.0;
   if(dt_get_debug_flags() & DT_DEBUG_PERF) start2 = dt_get_wtime();

--- a/src/develop/masks/ellipse.c
+++ b/src/develop/masks/ellipse.c
@@ -1412,13 +1412,13 @@ static int _ellipse_get_mask(const dt_iop_module_t *const module, dt_dev_pixelpi
   return 0;
 }
 
-static int _ellipse_get_mask_roi(const dt_iop_module_t *const module, dt_dev_pixelpipe_t *pipe,
+static dt_masks_raster_result_t _ellipse_get_mask_roi(const dt_iop_module_t *const module, dt_dev_pixelpipe_t *pipe,
                                  const dt_dev_pixelpipe_iop_t *const piece,
                                  dt_masks_form_t *const form, const dt_iop_roi_t *roi, float *buffer,
                                dt_iop_roi_t *touched)
 {
   dt_masks_touched_none(touched);
-  if(IS_NULL_PTR(form) || IS_NULL_PTR(form->points)) return 0;
+  if(IS_NULL_PTR(form) || IS_NULL_PTR(form->points)) return DT_MASKS_RASTER_EMPTY;
 
   double start1 = 0.0;
   double start2 = start1;
@@ -1426,7 +1426,7 @@ static int _ellipse_get_mask_roi(const dt_iop_module_t *const module, dt_dev_pix
 
   // we get the ellipse parameters
   dt_masks_node_ellipse_t *ellipse = (dt_masks_node_ellipse_t *)((form->points)->data);
-  if(IS_NULL_PTR(ellipse)) return 0;
+  if(IS_NULL_PTR(ellipse)) return DT_MASKS_RASTER_EMPTY;
   const int wi = pipe->iwidth, hi = pipe->iheight;
   const float center[2] = { ellipse->center[0] * wi, ellipse->center[1] * hi };
   const float radius[2] = { ellipse->radius[0] * MIN(wi, hi), ellipse->radius[1] * MIN(wi, hi) };
@@ -1466,7 +1466,7 @@ static int _ellipse_get_mask_roi(const dt_iop_module_t *const module, dt_dev_pix
   const int l = (int)(M_PI * (ta + tb) * (1.0f + (3.0f * lambda * lambda) / (10.0f + sqrtf(4.0f - 3.0f * lambda * lambda))));
   const size_t ellpts = MIN(360, l);
   float *ell = dt_pixelpipe_cache_alloc_align_float_cache(ellpts * 2, 0);
-  if(IS_NULL_PTR(ell)) return 1;
+  if(IS_NULL_PTR(ell)) return DT_MASKS_RASTER_ERROR;
   __OMP_PARALLEL_FOR__(if(ellpts > 100))
   for(int n = 0; n < ellpts; n++)
   {
@@ -1488,7 +1488,7 @@ static int _ellipse_get_mask_roi(const dt_iop_module_t *const module, dt_dev_pix
                                     ellpts))
   {
     dt_pixelpipe_cache_free_align(ell);
-    return 1;
+    return DT_MASKS_RASTER_ERROR;
   }
 
   if(dt_get_debug_flags() & DT_DEBUG_PERF)
@@ -1540,10 +1540,10 @@ static int _ellipse_get_mask_roi(const dt_iop_module_t *const module, dt_dev_pix
   // check if there is anything to do at all;
   // only if width and height of bounding box is 2 or greater the shape lies inside of roi and requires action
   if(bbw <= 1 || bbh <= 1)
-    return 0;
+    return DT_MASKS_RASTER_EMPTY;
 
   float *points = dt_pixelpipe_cache_alloc_align_float_cache((size_t)2 * bbw * bbh, 0);
-  if(IS_NULL_PTR(points)) return 1;
+  if(IS_NULL_PTR(points)) return DT_MASKS_RASTER_ERROR;
 
   // we populate the grid points in module coordinates
   __OMP_PARALLEL_FOR__(collapse(2) if((size_t)bbw * bbh > 50000))
@@ -1566,7 +1566,7 @@ static int _ellipse_get_mask_roi(const dt_iop_module_t *const module, dt_dev_pix
                                         (size_t)bbw * bbh))
   {
     dt_pixelpipe_cache_free_align(points);
-    return 1;
+    return DT_MASKS_RASTER_ERROR;
   }
 
   if(dt_get_debug_flags() & DT_DEBUG_PERF)
@@ -1637,7 +1637,7 @@ static int _ellipse_get_mask_roi(const dt_iop_module_t *const module, dt_dev_pix
     dt_print(DT_DEBUG_MASKS, "[masks %s] ellipse total render took %0.04f sec\n", form->name,
              dt_get_wtime() - start1);
   }
-  return 0;
+  return DT_MASKS_RASTER_OK;
 }
 
 static void _ellipse_set_form_name(struct dt_masks_form_t *const form, const size_t nb)

--- a/src/develop/masks/gradient.c
+++ b/src/develop/masks/gradient.c
@@ -1164,7 +1164,10 @@ static dt_masks_raster_result_t _gradient_get_area(const dt_iop_module_t *const 
                               dt_masks_form_t *const form,
                               int *width, int *height, int *posx, int *posy)
 {
-  *width = *height = *posx = *posy = 0;
+  *width = 0;
+  *height = 0;
+  *posx = 0;
+  *posy = 0;
   const float wd = pipe->iwidth, ht = pipe->iheight;
 
   float points[8] = { 0.0f, 0.0f, wd, 0.0f, wd, ht, 0.0f, ht };
@@ -1208,7 +1211,10 @@ static dt_masks_raster_result_t _gradient_get_mask(const dt_iop_module_t *const 
                               float **buffer, int *width, int *height, int *posx, int *posy)
 {
   *buffer = NULL;
-  *width = *height = *posx = *posy = 0;
+  *width = 0;
+  *height = 0;
+  *posx = 0;
+  *posy = 0;
   if(IS_NULL_PTR(form) || IS_NULL_PTR(form->points)) return DT_MASKS_RASTER_EMPTY;
   double start2 = 0.0;
   if(dt_get_debug_flags() & DT_DEBUG_PERF) start2 = dt_get_wtime();

--- a/src/develop/masks/gradient.c
+++ b/src/develop/masks/gradient.c
@@ -1370,18 +1370,18 @@ static int _gradient_get_mask(const dt_iop_module_t *const module, dt_dev_pixelp
 }
 
 
-static int _gradient_get_mask_roi(const dt_iop_module_t *const module, dt_dev_pixelpipe_t *pipe,
+static dt_masks_raster_result_t _gradient_get_mask_roi(const dt_iop_module_t *const module, dt_dev_pixelpipe_t *pipe,
                                   const dt_dev_pixelpipe_iop_t *const piece,
                                   dt_masks_form_t *const form, const dt_iop_roi_t *roi, float *buffer,
                                   dt_iop_roi_t *touched)
 {
   dt_masks_touched_none(touched);
-  if(IS_NULL_PTR(form) || IS_NULL_PTR(form->points)) return 0;
+  if(IS_NULL_PTR(form) || IS_NULL_PTR(form->points)) return DT_MASKS_RASTER_EMPTY;
   double start2 = 0.0;
   if(dt_get_debug_flags() & DT_DEBUG_PERF) start2 = dt_get_wtime();
   // we get the gradient values
   const dt_masks_anchor_gradient_t *gradient = (dt_masks_anchor_gradient_t *)(form->points->data);
-  if(IS_NULL_PTR(gradient)) return 0;
+  if(IS_NULL_PTR(gradient)) return DT_MASKS_RASTER_EMPTY;
 
   // we create a buffer of grid points for later interpolation. mainly in order to reduce memory footprint
   const int w = roi->width;
@@ -1394,7 +1394,7 @@ static int _gradient_get_mask_roi(const dt_iop_module_t *const module, dt_dev_pi
   const int gh = (h + grid - 1) / grid + 1;
 
   float *points = dt_pixelpipe_cache_alloc_align_float_cache((size_t)2 * gw * gh, 0);
-  if(IS_NULL_PTR(points)) return 1;
+  if(IS_NULL_PTR(points)) return DT_MASKS_RASTER_ERROR;
   __OMP_PARALLEL_FOR__(collapse(2) if((size_t)gw * gh > 50000))
   for(int j = 0; j < gh; j++)
     for(int i = 0; i < gw; i++)
@@ -1417,7 +1417,7 @@ static int _gradient_get_mask_roi(const dt_iop_module_t *const module, dt_dev_pi
                                         (size_t)gw * gh))
   {
     dt_pixelpipe_cache_free_align(points);
-    return 1;
+    return DT_MASKS_RASTER_ERROR;
   }
 
   if(dt_get_debug_flags() & DT_DEBUG_PERF)
@@ -1448,7 +1448,7 @@ static int _gradient_get_mask_roi(const dt_iop_module_t *const module, dt_dev_pi
   if(IS_NULL_PTR(lut))
   {
     dt_pixelpipe_cache_free_align(points);
-    return 1;
+    return DT_MASKS_RASTER_ERROR;
   }
   __OMP_PARALLEL_FOR_SIMD__(if(lutsize > 1000) aligned(lut : 64))
   for(int n = 0; n < lutsize; n++)
@@ -1528,7 +1528,7 @@ static int _gradient_get_mask_roi(const dt_iop_module_t *const module, dt_dev_pi
     dt_print(DT_DEBUG_MASKS, "[masks %s] gradient fill took %0.04f sec\n", form->name,
              dt_get_wtime() - start2);
 
-  return 0;
+  return DT_MASKS_RASTER_OK;
 }
 
 static void _gradient_sanitize_config(dt_masks_type_t type)

--- a/src/develop/masks/gradient.c
+++ b/src/develop/masks/gradient.c
@@ -1159,18 +1159,19 @@ static dt_masks_raster_result_t _gradient_get_points_border(dt_develop_t *dev, d
   return DT_MASKS_RASTER_OK;
 }
 
-static int _gradient_get_area(const dt_iop_module_t *const module, dt_dev_pixelpipe_t *pipe,
+static dt_masks_raster_result_t _gradient_get_area(const dt_iop_module_t *const module, dt_dev_pixelpipe_t *pipe,
                               const dt_dev_pixelpipe_iop_t *const piece,
                               dt_masks_form_t *const form,
                               int *width, int *height, int *posx, int *posy)
 {
+  *width = *height = *posx = *posy = 0;
   const float wd = pipe->iwidth, ht = pipe->iheight;
 
   float points[8] = { 0.0f, 0.0f, wd, 0.0f, wd, ht, 0.0f, ht };
 
   // and we transform them with all distorted modules
   if(!dt_dev_distort_transform_plus(pipe, module->iop_order, DT_DEV_TRANSFORM_DIR_BACK_INCL, points, 4))
-    return 1;
+    return DT_MASKS_RASTER_ERROR;
 
   // now we search min and max
   float xmin = 0.0f, xmax = 0.0f, ymin = 0.0f, ymax = 0.0f;
@@ -1189,7 +1190,7 @@ static int _gradient_get_area(const dt_iop_module_t *const module, dt_dev_pixelp
   *posy = ymin;
   *width = (xmax - xmin);
   *height = (ymax - ymin);
-  return 0;
+  return DT_MASKS_RASTER_OK;
 }
 
 // caller needs to make sure that input remains within bounds
@@ -1201,16 +1202,19 @@ static inline float dt_gradient_lookup(const float *lut, const float i)
   return lut[bin1] * f + lut[bin0] * (1.0f - f);
 }
 
-static int _gradient_get_mask(const dt_iop_module_t *const module, dt_dev_pixelpipe_t *pipe,
+static dt_masks_raster_result_t _gradient_get_mask(const dt_iop_module_t *const module, dt_dev_pixelpipe_t *pipe,
                               const dt_dev_pixelpipe_iop_t *const piece,
                               dt_masks_form_t *const form,
                               float **buffer, int *width, int *height, int *posx, int *posy)
 {
-  if(IS_NULL_PTR(form) || IS_NULL_PTR(form->points)) return 0;
+  *buffer = NULL;
+  *width = *height = *posx = *posy = 0;
+  if(IS_NULL_PTR(form) || IS_NULL_PTR(form->points)) return DT_MASKS_RASTER_EMPTY;
   double start2 = 0.0;
   if(dt_get_debug_flags() & DT_DEBUG_PERF) start2 = dt_get_wtime();
   // we get the area
-  if(_gradient_get_area(module, pipe, piece, form, width, height, posx, posy) != 0) return 1;
+  const dt_masks_raster_result_t area = _gradient_get_area(module, pipe, piece, form, width, height, posx, posy);
+  if(area != DT_MASKS_RASTER_OK) return area;
 
   if(dt_get_debug_flags() & DT_DEBUG_PERF)
   {
@@ -1221,7 +1225,7 @@ static int _gradient_get_mask(const dt_iop_module_t *const module, dt_dev_pixelp
 
   // we get the gradient values
   dt_masks_anchor_gradient_t *gradient = (dt_masks_anchor_gradient_t *)((form->points)->data);
-  if(IS_NULL_PTR(gradient)) return 0;
+  if(IS_NULL_PTR(gradient)) return DT_MASKS_RASTER_EMPTY;
   // we create a buffer of grid points for later interpolation. mainly in order to reduce memory footprint
   const int w = *width;
   const int h = *height;
@@ -1232,7 +1236,7 @@ static int _gradient_get_mask(const dt_iop_module_t *const module, dt_dev_pixelp
   const int gh = (h + grid - 1) / grid + 1;
 
   float *points = dt_pixelpipe_cache_alloc_align_float_cache((size_t)2 * gw * gh, 0);
-  if(IS_NULL_PTR(points)) return 1;
+  if(IS_NULL_PTR(points)) return DT_MASKS_RASTER_ERROR;
   __OMP_PARALLEL_FOR__(collapse(2) if((size_t)gw * gh > 50000))
   for(int j = 0; j < gh; j++)
     for(int i = 0; i < gw; i++)
@@ -1252,7 +1256,7 @@ static int _gradient_get_mask(const dt_iop_module_t *const module, dt_dev_pixelp
   if(!dt_dev_distort_backtransform_plus(pipe, module->iop_order, DT_DEV_TRANSFORM_DIR_BACK_INCL, points, (size_t)gw * gh))
   {
     dt_pixelpipe_cache_free_align(points);
-    return 1;
+    return DT_MASKS_RASTER_ERROR;
   }
 
   if(dt_get_debug_flags() & DT_DEBUG_PERF)
@@ -1283,7 +1287,7 @@ static int _gradient_get_mask(const dt_iop_module_t *const module, dt_dev_pixelp
   if(IS_NULL_PTR(lut))
   {
     dt_pixelpipe_cache_free_align(points);
-    return 1;
+    return DT_MASKS_RASTER_ERROR;
   }
   __OMP_PARALLEL_FOR_SIMD__(if(lutsize > 1000) aligned(lut : 64))
   for(int n = 0; n < lutsize; n++)
@@ -1322,7 +1326,7 @@ static int _gradient_get_mask(const dt_iop_module_t *const module, dt_dev_pixelp
   if(IS_NULL_PTR(*buffer))
   {
     dt_pixelpipe_cache_free_align(points);
-    return 1;
+    return DT_MASKS_RASTER_ERROR;
   }
 
   const float inv_grid2 = 1.0f / (grid * grid);
@@ -1369,7 +1373,7 @@ static int _gradient_get_mask(const dt_iop_module_t *const module, dt_dev_pixelp
     dt_print(DT_DEBUG_MASKS, "[masks %s] gradient fill took %0.04f sec\n", form->name,
              dt_get_wtime() - start2);
 
-  return 0;
+  return DT_MASKS_RASTER_OK;
 }
 
 

--- a/src/develop/masks/gradient.c
+++ b/src/develop/masks/gradient.c
@@ -1138,22 +1138,25 @@ static void _gradient_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks
                          gui->form_rotating, zoom_scale, gpt->points, gpt->points_count);
 }
 
-static int _gradient_get_points_border(dt_develop_t *dev, dt_masks_form_t *form, float **points, int *points_count,
+static dt_masks_raster_result_t _gradient_get_points_border(dt_develop_t *dev, dt_masks_form_t *form,
+                                       float **points, int *points_count,
                                        float **border, int *border_count, int source,
                                        const dt_iop_module_t *module)
 {
     // unused arg, keep compiler from complaining
-  if(IS_NULL_PTR(form) || IS_NULL_PTR(form->points)) return 0;
+  // No geometry: an empty outline is the correct result here, not a failure. See the circle.
+  if(IS_NULL_PTR(form) || IS_NULL_PTR(form->points)) return DT_MASKS_RASTER_EMPTY;
   dt_masks_anchor_gradient_t *gradient = (dt_masks_anchor_gradient_t *)form->points->data;
-  if(IS_NULL_PTR(gradient)) return 0;
+  if(IS_NULL_PTR(gradient)) return DT_MASKS_RASTER_EMPTY;
   if(_gradient_get_points(dev, gradient->center[0], gradient->center[1], gradient->rotation, gradient->curvature,
                           points, points_count) != 0)
-    return 1;
+    return DT_MASKS_RASTER_ERROR;
   if(border)
-    return _gradient_get_pts_border(dev, gradient->center[0], gradient->center[1],
-                                    gradient->rotation, gradient->extent, gradient->curvature,
-                                    border, border_count);
-  return 0;
+    return dt_masks_raster_from_status(
+        _gradient_get_pts_border(dev, gradient->center[0], gradient->center[1],
+                                 gradient->rotation, gradient->extent, gradient->curvature,
+                                 border, border_count));
+  return DT_MASKS_RASTER_OK;
 }
 
 static int _gradient_get_area(const dt_iop_module_t *const module, dt_dev_pixelpipe_t *pipe,

--- a/src/develop/masks/group.c
+++ b/src/develop/masks/group.c
@@ -238,7 +238,10 @@ static dt_masks_raster_result_t _group_get_mask(const dt_iop_module_t *const mod
                            float **buffer, int *width, int *height, int *posx, int *posy)
 {
   *buffer = NULL;
-  *width = *height = *posx = *posy = 0;
+  *width = 0;
+  *height = 0;
+  *posx = 0;
+  *posy = 0;
 
   // we allocate buffers and values
   const guint nb = g_list_length(form->points);
@@ -306,7 +309,10 @@ static dt_masks_raster_result_t _group_get_mask(const dt_iop_module_t *const mod
   if(nb_ok == 0)
   {
     *buffer = NULL;
-    *width = *height = *posx = *posy = 0;
+    *width = 0;
+  *height = 0;
+  *posx = 0;
+  *posy = 0;
     goto cleanup;
   }
 

--- a/src/develop/masks/group.c
+++ b/src/develop/masks/group.c
@@ -232,19 +232,17 @@ static int _inverse_mask(const dt_iop_module_t *const module, const dt_dev_pixel
   return 0;
 }
 
-static int _group_get_mask(const dt_iop_module_t *const module, dt_dev_pixelpipe_t *pipe,
+static dt_masks_raster_result_t _group_get_mask(const dt_iop_module_t *const module, dt_dev_pixelpipe_t *pipe,
                            const dt_dev_pixelpipe_iop_t *const piece,
                            dt_masks_form_t *const form,
                            float **buffer, int *width, int *height, int *posx, int *posy)
 {
+  *buffer = NULL;
+  *width = *height = *posx = *posy = 0;
+
   // we allocate buffers and values
   const guint nb = g_list_length(form->points);
-  if(nb == 0)
-  {
-    *buffer = NULL;
-    *width = *height = *posx = *posy = 0;
-    return 0;
-  }
+  if(nb == 0) return DT_MASKS_RASTER_EMPTY;
   float **bufs = calloc(nb, sizeof(float *));
   int *w = malloc(sizeof(int) * nb);
   int *h = malloc(sizeof(int) * nb);
@@ -261,22 +259,30 @@ static int _group_get_mask(const dt_iop_module_t *const module, dt_dev_pixelpipe
     dt_free(h);
     dt_free(w);
     dt_free(bufs);
-    return 1;
+    return DT_MASKS_RASTER_ERROR;
   }
 
   // and we get all masks
   int pos = 0;
   int nb_ok = 0;
-  int err = 0;
+  dt_masks_raster_result_t err = DT_MASKS_RASTER_OK;
   for(GList *fpts = form->points; fpts; fpts = g_list_next(fpts))
   {
     dt_masks_form_group_t *fpt = (dt_masks_form_group_t *)fpts->data;
     dt_masks_form_t *sel = dt_masks_get_from_id(module->dev, fpt->formid);
     if(sel)
     {
-      if(dt_masks_get_mask(module, pipe, piece, sel, &bufs[pos], &w[pos], &h[pos], &px[pos], &py[pos]) != 0)
+      /* EMPTY is folded in as a failure here, unlike in the ROI rasteriser: this legacy path
+       * keeps one slot per child in parallel malloc'd arrays, and skipping a slot would leave
+       * its `states'/`op' entries uninitialised for the combine below. Erroring out is still
+       * strictly better than what this did before -- a child reporting success with no buffer
+       * (which is what a degenerate circle or ellipse used to do) walked on into the combine
+       * with bufs[pos] NULL and w/h/px/py never written. Making the slots skippable belongs
+       * with the rest of this path's bookkeeping. */
+      if(dt_masks_get_mask(module, pipe, piece, sel, &bufs[pos], &w[pos], &h[pos], &px[pos], &py[pos])
+         != DT_MASKS_RASTER_OK)
       {
-        err = 1;
+        err = DT_MASKS_RASTER_ERROR;
         break;
       }
       if(fpt->state & DT_MASKS_STATE_INVERSE)
@@ -284,7 +290,7 @@ static int _group_get_mask(const dt_iop_module_t *const module, dt_dev_pixelpipe
         const double start = dt_get_wtime();
         if(_inverse_mask(module, piece, sel, &bufs[pos], &w[pos], &h[pos], &px[pos], &py[pos]) != 0)
         {
-          err = 1;
+          err = DT_MASKS_RASTER_ERROR;
           break;
         }
         if(dt_get_debug_flags() & DT_DEBUG_PERF)
@@ -322,7 +328,7 @@ static int _group_get_mask(const dt_iop_module_t *const module, dt_dev_pixelpipe
   *buffer = dt_pixelpipe_cache_alloc_align_float_cache((size_t)(r - l) * (b - t), 0);
   if(IS_NULL_PTR(*buffer))
   {
-    err = 1;
+    err = DT_MASKS_RASTER_ERROR;
     goto cleanup;
   }
 

--- a/src/develop/masks/group.c
+++ b/src/develop/masks/group.c
@@ -661,14 +661,14 @@ static uint64_t _group_prefix_hash(const dt_masks_form_t *const form, GList *mas
   return hash ? hash : 1;
 }
 
-static int _group_get_mask_roi(const dt_iop_module_t *const restrict module, dt_dev_pixelpipe_t *pipe,
+static dt_masks_raster_result_t _group_get_mask_roi(const dt_iop_module_t *const restrict module, dt_dev_pixelpipe_t *pipe,
                                const dt_dev_pixelpipe_iop_t *const restrict piece,
                                dt_masks_form_t *const form, const dt_iop_roi_t *const roi,
                                float *const restrict buffer, dt_iop_roi_t *touched)
 {
   double start = dt_get_wtime();
   dt_masks_touched_none(touched);
-  if(IS_NULL_PTR(form->points)) return 0;
+  if(IS_NULL_PTR(form->points)) return DT_MASKS_RASTER_EMPTY;
   int nb_ok = 0;
 
   const int width = roi->width;
@@ -715,8 +715,8 @@ static int _group_get_mask_roi(const dt_iop_module_t *const restrict module, dt_
 
   // we need to allocate a zeroed temporary buffer for intermediate creation of individual shapes
   float *const restrict bufs = dt_pixelpipe_cache_alloc_align_float_cache(npixels, 0);
-  if(IS_NULL_PTR(bufs)) return 1;
-  int err = 0;
+  if(IS_NULL_PTR(bufs)) return DT_MASKS_RASTER_ERROR;
+  dt_masks_raster_result_t err = DT_MASKS_RASTER_OK;
 
   /* Somewhere to hold the fold minus its last shape. Only needed when there is something new to
    * publish; a failure to allocate simply means this render publishes nothing. */
@@ -762,17 +762,31 @@ static int _group_get_mask_roi(const dt_iop_module_t *const restrict module, dt_
       }
       else
         dt_masks_touched_clear(bufs, width, &child_touched);
-      const int err_child = dt_masks_get_mask_roi(module, pipe, piece, sel, roi, bufs, &child_touched);
+      const dt_masks_raster_result_t child_result
+          = dt_masks_get_mask_roi(module, pipe, piece, sel, roi, bufs, &child_touched);
       const float op = fpt->opacity;
       // Add a foolproof to ensure that the first shape is no-op
       const int no_op_state = fpt->state & ~(DT_MASKS_STATE_IS_COMBINE_OP) ;
       const int state = (i == 0) ? no_op_state : fpt->state;
-      if(err_child != 0)
+      if(child_result == DT_MASKS_RASTER_ERROR)
       {
-        err = 1;
+        /* Undefined buffer: what this child left in `bufs' cannot be folded in, and the fold as
+         * a whole must not be published. */
+        err = DT_MASKS_RASTER_ERROR;
         break;
       }
-      if(err_child == 0)
+      /* EMPTY combines exactly like OK, because `bufs' is fully zeroed before every child (the
+       * first child memsets it, each later one clears the previous child's reported box), so a
+       * shape that drew nothing IS an all-zero child. That distinction matters: an EMPTY child
+       * must still be intersected with -- a brush lying outside this ROI genuinely has no
+       * coverage here, and skipping the combine would leave the previous fold standing where
+       * the mask should have gone to zero.
+       *
+       * What EMPTY changes is only that it is no longer an ERROR. A NULL points list used to
+       * abort the entire group for a circle and fold as zeros for an ellipse: the same
+       * degenerate data killed or spared the whole mask depending only on which shape carried
+       * it. Both now fold as zeros. */
+      else
       {
         // first see if we need to invert this shape
         const int inverted = (state & DT_MASKS_STATE_INVERSE);
@@ -865,7 +879,7 @@ static int _group_get_mask_roi(const dt_iop_module_t *const restrict module, dt_
    *
    * Only on a complete, error-free fold: a prefix that describes fewer shapes than its key claims
    * is not a wrong-looking mask, it is a mask. */
-  if(!err && shape_count > 1 && nb_ok == shape_count && resume_from < shape_count - 1
+  if(err == DT_MASKS_RASTER_OK && shape_count > 1 && nb_ok == shape_count && resume_from < shape_count - 1
      && !IS_NULL_PTR(publishable))
   {
     const uint64_t prefix = _group_prefix_hash(form, masks, piece, roi, shape_count - 1);
@@ -892,14 +906,14 @@ static int _group_get_mask_roi(const dt_iop_module_t *const restrict module, dt_
   return err;
 }
 
-int dt_masks_group_render_roi(dt_iop_module_t *module, dt_dev_pixelpipe_t *pipe,
-                              const dt_dev_pixelpipe_iop_t *piece, dt_masks_form_t *form,
-                              const dt_iop_roi_t *roi, float *buffer)
+dt_masks_raster_result_t dt_masks_group_render_roi(dt_iop_module_t *module, dt_dev_pixelpipe_t *pipe,
+                                                   const dt_dev_pixelpipe_iop_t *piece, dt_masks_form_t *form,
+                                                   const dt_iop_roi_t *roi, float *buffer)
 {
   const double start = dt_get_wtime();
-  if(IS_NULL_PTR(form)) return 0;
+  if(IS_NULL_PTR(form)) return DT_MASKS_RASTER_EMPTY;
 
-  const int err = dt_masks_get_mask_roi(module, pipe, piece, form, roi, buffer, NULL);
+  const dt_masks_raster_result_t err = dt_masks_get_mask_roi(module, pipe, piece, form, roi, buffer, NULL);
 
   if(dt_get_debug_flags() & DT_DEBUG_PERF)
     dt_print(DT_DEBUG_MASKS, "[masks] render all masks took %0.04f sec\n", dt_get_wtime() - start);

--- a/src/develop/masks/masks.c
+++ b/src/develop/masks/masks.c
@@ -52,6 +52,7 @@
 #include "caches/pixelpipe_cache_alloc.h"
 #include "develop/masks.h"
 #include "history/notify.h"
+#include "develop/blend_gui.h"   // dt_iop_gui_blend_masks_update()
 #include "develop/masks/masks_functions.h"
 #include "develop/masks/masks_touched.h"
 #include "develop/develop.h"
@@ -989,7 +990,7 @@ void dt_masks_form_delete(dt_develop_t *dev, struct dt_iop_module_t *module, dt_
     if(removed)
     if(removed && !IS_NULL_PTR(module))
     {
-      dt_masks_iop_update(module);
+      dt_iop_gui_blend_masks_update(module);
 
     }
     if(removed) dt_masks_form_update_gravity_center(dev, group_form);
@@ -1025,7 +1026,7 @@ void dt_masks_form_delete(dt_develop_t *dev, struct dt_iop_module_t *module, dt_
       if(form_id == iop_module->blend_params->mask_id)
       {
         iop_module->blend_params->mask_id = 0;
-        dt_masks_iop_update(iop_module);
+        dt_iop_gui_blend_masks_update(iop_module);
       }
       else
       {
@@ -1051,7 +1052,7 @@ void dt_masks_form_delete(dt_develop_t *dev, struct dt_iop_module_t *module, dt_
           }
           if(removed)
           {
-            dt_masks_iop_update(iop_module);
+            dt_iop_gui_blend_masks_update(iop_module);
 
             if(IS_NULL_PTR(iop_group->points)) dt_masks_form_delete(dev, iop_module, NULL, iop_group);
           }

--- a/src/develop/masks/masks.c
+++ b/src/develop/masks/masks.c
@@ -1394,15 +1394,17 @@ int dt_masks_get_mask(const dt_iop_module_t *const module, dt_dev_pixelpipe_t *p
     : 1;
 }
 
-int dt_masks_get_mask_roi(const dt_iop_module_t *const module, dt_dev_pixelpipe_t *pipe,
-                          const dt_dev_pixelpipe_iop_t *const piece,
-                          dt_masks_form_t *const form, const dt_iop_roi_t *roi, float *buffer,
-                          dt_iop_roi_t *touched)
+dt_masks_raster_result_t dt_masks_get_mask_roi(const dt_iop_module_t *const module, dt_dev_pixelpipe_t *pipe,
+                                               const dt_dev_pixelpipe_iop_t *const piece,
+                                               dt_masks_form_t *const form, const dt_iop_roi_t *roi,
+                                               float *buffer, dt_iop_roi_t *touched)
 {
   dt_masks_touched_none(touched);
+  /* A shape type with no rasteriser is a programming error, not an empty shape: report ERROR so
+   * the fold refuses to publish a buffer nobody wrote. */
   return (form->functions && form->functions->get_mask_roi)
     ? form->functions->get_mask_roi(module, pipe, piece, form, roi, buffer, touched)
-    : 1;
+    : DT_MASKS_RASTER_ERROR;
 }
 
 // clang-format off

--- a/src/develop/masks/masks.c
+++ b/src/develop/masks/masks.c
@@ -228,7 +228,10 @@ dt_masks_raster_result_t dt_masks_get_area(dt_iop_module_t *module, dt_dev_pixel
                       dt_dev_pixelpipe_iop_t *piece, dt_masks_form_t *mask_form,
                       int *area_width, int *area_height, int *area_pos_x, int *area_pos_y)
 {
-  *area_width = *area_height = *area_pos_x = *area_pos_y = 0;
+  *area_width = 0;
+  *area_height = 0;
+  *area_pos_x = 0;
+  *area_pos_y = 0;
   if(mask_form->functions && mask_form->functions->get_area)
     return mask_form->functions->get_area(module, pipe, piece, mask_form, area_width, area_height,
                                           area_pos_x, area_pos_y);
@@ -240,7 +243,10 @@ dt_masks_raster_result_t dt_masks_get_source_area(dt_iop_module_t *module, dt_de
                              int *area_width, int *area_height,
                              int *area_pos_x, int *area_pos_y)
 {
-  *area_width = *area_height = *area_pos_x = *area_pos_y = 0;
+  *area_width = 0;
+  *area_height = 0;
+  *area_pos_x = 0;
+  *area_pos_y = 0;
 
   // must be a clone form
   if(mask_form->type & DT_MASKS_CLONE)
@@ -1395,7 +1401,10 @@ dt_masks_raster_result_t dt_masks_get_mask(const dt_iop_module_t *const module, 
                       float **buffer, int *width, int *height, int *posx, int *posy)
 {
   *buffer = NULL;
-  *width = *height = *posx = *posy = 0;
+  *width = 0;
+  *height = 0;
+  *posx = 0;
+  *posy = 0;
   /* A shape type with no rasteriser is a programming error, not an empty shape. */
   return (form->functions && form->functions->get_mask)
     ? form->functions->get_mask(module, pipe, piece, form, buffer, width, height, posx, posy)

--- a/src/develop/masks/masks.c
+++ b/src/develop/masks/masks.c
@@ -223,17 +223,18 @@ dt_masks_raster_result_t dt_masks_get_points_border(dt_develop_t *develop, dt_ma
   return DT_MASKS_RASTER_ERROR;
 }
 
-int dt_masks_get_area(dt_iop_module_t *module, dt_dev_pixelpipe_t *pipe,
+dt_masks_raster_result_t dt_masks_get_area(dt_iop_module_t *module, dt_dev_pixelpipe_t *pipe,
                       dt_dev_pixelpipe_iop_t *piece, dt_masks_form_t *mask_form,
                       int *area_width, int *area_height, int *area_pos_x, int *area_pos_y)
 {
+  *area_width = *area_height = *area_pos_x = *area_pos_y = 0;
   if(mask_form->functions && mask_form->functions->get_area)
     return mask_form->functions->get_area(module, pipe, piece, mask_form, area_width, area_height,
                                           area_pos_x, area_pos_y);
-  return 1;
+  return DT_MASKS_RASTER_ERROR;
 }
 
-int dt_masks_get_source_area(dt_iop_module_t *module, dt_dev_pixelpipe_t *pipe,
+dt_masks_raster_result_t dt_masks_get_source_area(dt_iop_module_t *module, dt_dev_pixelpipe_t *pipe,
                              dt_dev_pixelpipe_iop_t *piece, dt_masks_form_t *mask_form,
                              int *area_width, int *area_height,
                              int *area_pos_x, int *area_pos_y)
@@ -247,7 +248,9 @@ int dt_masks_get_source_area(dt_iop_module_t *module, dt_dev_pixelpipe_t *pipe,
       return mask_form->functions->get_source_area(module, pipe, piece, mask_form, area_width, area_height,
                                                    area_pos_x, area_pos_y);
   }
-  return 1;
+
+  /* A form that is not a clone has no source area. That is an absence, not a failure. */
+  return DT_MASKS_RASTER_EMPTY;
 }
 
 int dt_masks_version(void)
@@ -1385,14 +1388,17 @@ void dt_masks_cleanup_unused(dt_develop_t *develop)
 /* The two rasterisation dispatchers. They were inline in masks.h, which forced the
  * per-shape function table to be public; a per-buffer call is not a per-pixel cost,
  * so the inline bought nothing and the table is private now. */
-int dt_masks_get_mask(const dt_iop_module_t *const module, dt_dev_pixelpipe_t *pipe,
+dt_masks_raster_result_t dt_masks_get_mask(const dt_iop_module_t *const module, dt_dev_pixelpipe_t *pipe,
                       const dt_dev_pixelpipe_iop_t *const piece,
                       dt_masks_form_t *const form,
                       float **buffer, int *width, int *height, int *posx, int *posy)
 {
+  *buffer = NULL;
+  *width = *height = *posx = *posy = 0;
+  /* A shape type with no rasteriser is a programming error, not an empty shape. */
   return (form->functions && form->functions->get_mask)
     ? form->functions->get_mask(module, pipe, piece, form, buffer, width, height, posx, posy)
-    : 1;
+    : DT_MASKS_RASTER_ERROR;
 }
 
 dt_masks_raster_result_t dt_masks_get_mask_roi(const dt_iop_module_t *const module, dt_dev_pixelpipe_t *pipe,

--- a/src/develop/masks/masks.c
+++ b/src/develop/masks/masks.c
@@ -211,15 +211,16 @@ int dt_masks_form_duplicate_in_group(dt_develop_t *develop, int group_id, int fo
   return nid;
 }
 
-int dt_masks_get_points_border(dt_develop_t *develop, dt_masks_form_t *mask_form,
+dt_masks_raster_result_t dt_masks_get_points_border(dt_develop_t *develop, dt_masks_form_t *mask_form,
                                float **point_buffer, int *point_count,
                                float **border_buffer, int *border_count,
                                int source, dt_iop_module_t *module)
 {
+  /* A shape type with no outline builder is a programming error, not an empty outline. */
   if(mask_form->functions && mask_form->functions->get_points_border)
     return mask_form->functions->get_points_border(develop, mask_form, point_buffer, point_count,
                                                    border_buffer, border_count, source, module);
-  return 1;
+  return DT_MASKS_RASTER_ERROR;
 }
 
 int dt_masks_get_area(dt_iop_module_t *module, dt_dev_pixelpipe_t *pipe,

--- a/src/develop/masks/masks_functions.h
+++ b/src/develop/masks/masks_functions.h
@@ -145,6 +145,18 @@ typedef struct dt_masks_functions_t
   int (*populate_context_menu)(GtkWidget *menu, struct dt_masks_form_t *form, struct dt_masks_form_gui_t *gui, const float pzx, const float pzy);
 } dt_masks_functions_t;
 
+/* Rasterisation entry points, dispatched only from inside the masks module: the group fold
+ * calls get_mask_roi on its children, and the GUI outline builder calls get_points_border.
+ * They were declared in the public header with no caller outside this directory. */
+dt_masks_raster_result_t dt_masks_get_mask_roi(const dt_iop_module_t *const module, dt_dev_pixelpipe_t *pipe,
+                                               const dt_dev_pixelpipe_iop_t *const piece,
+                                               dt_masks_form_t *const form, const dt_iop_roi_t *roi,
+                                               float *buffer, dt_iop_roi_t *touched);
+
+dt_masks_raster_result_t dt_masks_get_points_border(struct dt_develop_t *dev, dt_masks_form_t *form,
+                               float **points, int *points_count,
+                               float **border, int *border_count, int source, dt_iop_module_t *module);
+
 /** the shape-specific function tables */
 extern const dt_masks_functions_t dt_masks_functions_circle;
 extern const dt_masks_functions_t dt_masks_functions_ellipse;

--- a/src/develop/masks/masks_functions.h
+++ b/src/develop/masks/masks_functions.h
@@ -71,7 +71,17 @@ typedef struct dt_masks_functions_t
                        int *inside, int *inside_border, int *near_handle, int *inside_source, float *dist);
   int (*get_points)(struct dt_develop_t *dev, float x, float y, float radius_a, float radius_b, float rotation,
                     float **points, int *points_count);
-  int (*get_points_border)(struct dt_develop_t *dev, struct dt_masks_form_t *form, float **points, int *points_count,
+  /** Build the shape's outline (and, when `border' is given, its border outline).
+   *
+   * Returns OK when the outline was built, EMPTY when the shape has no geometry to build one
+   * from -- an outline that is legitimately empty, which the caller may cache like any other
+   * result -- and ERROR when the build itself failed and produced nothing cacheable. The
+   * distinction is load-bearing: the outline cache key covers the whole group, so caching a
+   * FAILURE hides the shape until the geometry next moves, while refusing to cache an
+   * legitimately EMPTY one rebuilds every shape of the group on every expose, forever.
+   */
+  dt_masks_raster_result_t (*get_points_border)(struct dt_develop_t *dev, struct dt_masks_form_t *form,
+                           float **points, int *points_count,
                            float **border, int *border_count, int source, const dt_iop_module_t *const module);
   int (*get_mask)(const dt_iop_module_t *const module, struct dt_dev_pixelpipe_t *pipe,
                   const dt_dev_pixelpipe_iop_t *const piece,

--- a/src/develop/masks/masks_functions.h
+++ b/src/develop/masks/masks_functions.h
@@ -83,7 +83,10 @@ typedef struct dt_masks_functions_t
   dt_masks_raster_result_t (*get_points_border)(struct dt_develop_t *dev, struct dt_masks_form_t *form,
                            float **points, int *points_count,
                            float **border, int *border_count, int source, const dt_iop_module_t *const module);
-  int (*get_mask)(const dt_iop_module_t *const module, struct dt_dev_pixelpipe_t *pipe,
+  /** Rasterise into a freshly allocated buffer covering the shape's own bounding box.
+   * Same three outcomes as get_mask_roi. On anything but OK the out-parameters are still
+   * written (NULL buffer, zero geometry): callers read them unconditionally. */
+  dt_masks_raster_result_t (*get_mask)(const dt_iop_module_t *const module, struct dt_dev_pixelpipe_t *pipe,
                   const dt_dev_pixelpipe_iop_t *const piece,
                   struct dt_masks_form_t *const form,
                   float **buffer, int *width, int *height, int *posx, int *posy);
@@ -102,11 +105,13 @@ typedef struct dt_masks_functions_t
                       const dt_dev_pixelpipe_iop_t *const piece,
                       struct dt_masks_form_t *const form,
                       const dt_iop_roi_t *roi, float *buffer, dt_iop_roi_t *touched);
-  int (*get_area)(const dt_iop_module_t *const module, struct dt_dev_pixelpipe_t *pipe,
+  /** The shape's bounding box. Same three outcomes; the out-parameters are always written. */
+  dt_masks_raster_result_t (*get_area)(const dt_iop_module_t *const module, struct dt_dev_pixelpipe_t *pipe,
                   const dt_dev_pixelpipe_iop_t *const piece,
                   struct dt_masks_form_t *const form,
                   int *width, int *height, int *posx, int *posy);
-  int (*get_source_area)(dt_iop_module_t *module, struct dt_dev_pixelpipe_t *pipe,
+  /** The clone source's bounding box. Same three outcomes; out-parameters always written. */
+  dt_masks_raster_result_t (*get_source_area)(dt_iop_module_t *module, struct dt_dev_pixelpipe_t *pipe,
                          dt_dev_pixelpipe_iop_t *piece, struct dt_masks_form_t *form,
                          int *width, int *height, int *posx, int *posy);
   gboolean (*get_gravity_center)(struct dt_develop_t *dev, const struct dt_masks_form_t *form, float center[2], float *area);

--- a/src/develop/masks/masks_functions.h
+++ b/src/develop/masks/masks_functions.h
@@ -77,9 +77,18 @@ typedef struct dt_masks_functions_t
                   const dt_dev_pixelpipe_iop_t *const piece,
                   struct dt_masks_form_t *const form,
                   float **buffer, int *width, int *height, int *posx, int *posy);
-  /** Rasterise into a pre-zeroed ROI-sized buffer. `touched` (may be NULL) receives the
-   * buffer-relative rectangle enclosing every pixel written -- see masks_touched.h. */
-  int (*get_mask_roi)(const dt_iop_module_t *const fmodule, struct dt_dev_pixelpipe_t *pipe,
+  /** Rasterise into a pre-zeroed ROI-sized buffer.
+   *
+   * `touched` (may be NULL) receives the buffer-relative rectangle enclosing every pixel
+   * written -- see masks_touched.h.
+   *
+   * Returns OK when the buffer was written, EMPTY when the shape has nothing to draw here
+   * (degenerate geometry, or wholly outside `roi`) and the buffer was left untouched, ERROR
+   * when the shape could not be computed and the buffer's contents are undefined. EMPTY is
+   * NOT a failure: the group fold skips such a shape and keeps folding. Every implementation
+   * must agree on which is which -- see dt_masks_raster_result_t.
+   */
+  dt_masks_raster_result_t (*get_mask_roi)(const dt_iop_module_t *const fmodule, struct dt_dev_pixelpipe_t *pipe,
                       const dt_dev_pixelpipe_iop_t *const piece,
                       struct dt_masks_form_t *const form,
                       const dt_iop_roi_t *roi, float *buffer, dt_iop_roi_t *touched);

--- a/src/develop/masks/masks_gui.c
+++ b/src/develop/masks/masks_gui.c
@@ -655,7 +655,7 @@ static void _masks_operation_callback(GtkWidget *menu, gpointer user_data)
   dt_masks_form_group_t *form_op = (dt_masks_form_group_t *)g_object_get_data(G_OBJECT(menu), "op_form");
   if(IS_NULL_PTR(form_op)) return;
 
-  apply_operation(form_op, state_op);
+  dt_masks_group_entry_apply_operation(form_op, state_op);
 
   DT_DEBUG_CONTROL_SIGNAL_RAISE(dt_control_signal_get_global(), DT_SIGNAL_MASK_CHANGED, form_op->formid, form_op->parentid, DT_MASKS_EVENT_UPDATE);
 }
@@ -2206,7 +2206,7 @@ gboolean dt_masks_form_exit_creation(dt_iop_module_t *module, dt_masks_form_gui_
         dt_dev_masks_selection_change(dev, creation_module, last_formid, FALSE);
       }
 
-      dt_masks_iop_update(creation_module);
+      dt_iop_gui_blend_masks_update(creation_module);
       dt_iop_gui_blend_data_t *blend_data
           = creation_module->gui ? (dt_iop_gui_blend_data_t *)creation_module->gui->blend_data : NULL;
       if(!IS_NULL_PTR(dev) && !IS_NULL_PTR(dev->form_gui))
@@ -2459,7 +2459,7 @@ void dt_masks_gui_form_save_creation(dt_develop_t *develop, dt_iop_module_t *mod
     
     // we update module gui
 
-    if(IS_NULL_PTR(mask_gui)) dt_masks_iop_update(module);
+    if(IS_NULL_PTR(mask_gui)) dt_iop_gui_blend_masks_update(module);
     dt_dev_add_history_item(develop, module, TRUE, TRUE);
   }
 
@@ -2501,7 +2501,7 @@ void dt_masks_gui_form_save_creation(dt_develop_t *develop, dt_iop_module_t *mod
     mask_gui->creation_closing_form = FALSE;
     dt_masks_soft_reset_form_gui(mask_gui);
     dt_masks_set_visible_form(develop, next_form);
-    if(!IS_NULL_PTR(module)) dt_masks_iop_update(module);
+    if(!IS_NULL_PTR(module)) dt_iop_gui_blend_masks_update(module);
   }
 }
 
@@ -4099,7 +4099,7 @@ static void _menu_no_masks(struct dt_iop_module_t *module)
 
   // and we update the iop
   dt_masks_set_edit_mode(module, DT_MASKS_EDIT_OFF);
-  dt_masks_iop_update(module);
+  dt_iop_gui_blend_masks_update(module);
 }
 
 static void _menu_add_shape(struct dt_iop_module_t *module, dt_masks_type_t type)
@@ -4125,7 +4125,7 @@ static void _menu_add_exist(dt_iop_module_t *module, int form_id)
   // we save the group
   // and we ensure that we are in edit mode
 
-  dt_masks_iop_update(module);
+  dt_iop_gui_blend_masks_update(module);
   dt_masks_set_edit_mode(module, DT_MASKS_EDIT_FULL);
 }
 
@@ -4138,7 +4138,7 @@ void dt_masks_group_update_name(dt_iop_module_t *module)
 
   _set_group_name_from_module(module, group_form);
 
-  dt_masks_iop_update(module);
+  dt_iop_gui_blend_masks_update(module);
 }
 
 void dt_masks_iop_combo_populate(GtkWidget *widget, void *data)
@@ -4291,7 +4291,7 @@ void dt_masks_iop_value_changed_callback(GtkWidget *widget, struct dt_iop_module
       return;
   }
   // we update the combo line
-  dt_masks_iop_update(module);
+  dt_iop_gui_blend_masks_update(module);
   dt_dev_add_history_item(module->dev, module, TRUE, TRUE);
 }
 
@@ -4872,7 +4872,7 @@ gboolean dt_masks_creation_mode_enter(dt_develop_t *dev, dt_iop_module_t *module
  *
  * Inverse toggles its flag, combine operations replace the combine bits.
  */
-void apply_operation(struct dt_masks_form_group_t *group_entry, const dt_masks_state_t apply_state)
+void dt_masks_group_entry_apply_operation(struct dt_masks_form_group_t *group_entry, const dt_masks_state_t apply_state)
 {
   if(IS_NULL_PTR(group_entry)) return;
 

--- a/src/develop/masks/masks_gui.c
+++ b/src/develop/masks/masks_gui.c
@@ -1848,26 +1848,33 @@ void dt_masks_gui_form_create(dt_masks_form_t *mask_form, dt_masks_form_gui_t *m
 
   dt_masks_form_gui_points_t *gui_points
       = (dt_masks_form_gui_points_t *)g_list_nth_data(mask_gui->points, form_index);
-  const int border_status
+  const dt_masks_raster_result_t border_status
       = dt_masks_get_points_border(mask_gui->dev, mask_form, &gui_points->points, &gui_points->points_count,
                                    &gui_points->border, &gui_points->border_count, 0, NULL);
 
-  /* A shape that fails here leaves the cache key UNSET, so the next expose rebuilds the whole
-   * group again -- and the one after that, forever. An empty shape mid-creation is the obvious
-   * candidate and it is invisible in a log otherwise: say so. */
-  if(border_status != 0 && (dt_get_debug_flags() & DT_DEBUG_MASKS))
+  /* Only a genuine FAILURE may leave the cache key unset, and it must: the key covers the whole
+   * group, so one unstamped shape rebuilds every shape of the group on every later expose --
+   * forever, until the geometry moves.
+   *
+   * That is precisely why "this shape has no outline" and "building the outline broke" had to
+   * stop sharing one return value. A shape with no geometry HAS an outline -- the empty one --
+   * and caching it is correct; the drawing code already skips a NULL outline. A build that
+   * failed produced nothing to cache and must be retried. Three of the five shapes used to
+   * report the first case as success, so the cache was stamped over a NULL outline and the
+   * shape stayed invisible until the geometry next moved. */
+  if(border_status == DT_MASKS_RASTER_ERROR && (dt_get_debug_flags() & DT_DEBUG_MASKS))
     dt_print(DT_DEBUG_MASKS,
              "[masks] outline build FAILED for %s (index %d, %d nodes): the cache key stays unset,"
              " so every later expose rebuilds this whole group\n",
              mask_form->name, form_index, g_list_length(mask_form->points));
 
-  if(border_status == 0)
+  if(border_status != DT_MASKS_RASTER_ERROR)
   {
-    if(mask_form->type & DT_MASKS_CLONE)
+    if(border_status == DT_MASKS_RASTER_OK && (mask_form->type & DT_MASKS_CLONE))
     {
       if(dt_masks_get_points_border(mask_gui->dev, mask_form, &gui_points->source, &gui_points->source_count,
                                     NULL, NULL, TRUE, module)
-         != 0)
+         != DT_MASKS_RASTER_OK)
         return;
     }
     mask_gui->geometry_generation = dt_geometry_chain_generation(mask_gui->dev->geometry_chain);

--- a/src/develop/masks/polygon.c
+++ b/src/develop/masks/polygon.c
@@ -1232,17 +1232,19 @@ static void _polygon_translate_all_nodes(dt_masks_form_t *mask_form, const float
     _polygon_translate_node((dt_masks_node_polygon_t *)node_entry->data, delta_x, delta_y);
 }
 
-static int _polygon_get_points_border(dt_develop_t *develop, dt_masks_form_t *mask_form,
+static dt_masks_raster_result_t _polygon_get_points_border(dt_develop_t *develop, dt_masks_form_t *mask_form,
                                       float **point_buffer, int *point_count,
                                       float **border_buffer, int *border_count,
                                       int source, const dt_iop_module_t *module)
 {
-  if(source && IS_NULL_PTR(module)) return 1;
+  // Asking for the source outline without a module is a programming error, not an empty shape.
+  if(source && IS_NULL_PTR(module)) return DT_MASKS_RASTER_ERROR;
   const double ioporder = (module) ? module->iop_order : 0.0f;
   const dt_masks_distort_t gui_dist = dt_masks_distort_for_gui(develop);
-  return _polygon_get_pts_border(develop, mask_form, ioporder, DT_DEV_TRANSFORM_DIR_ALL,
-                                 &gui_dist, point_buffer, point_count,
-                                 border_buffer, border_count, source);
+  return dt_masks_raster_from_status(
+      _polygon_get_pts_border(develop, mask_form, ioporder, DT_DEV_TRANSFORM_DIR_ALL,
+                              &gui_dist, point_buffer, point_count,
+                              border_buffer, border_count, source));
 }
 
 static void _polygon_get_sizes(struct dt_iop_module_t *module, dt_masks_form_t *mask_form,

--- a/src/develop/masks/polygon.c
+++ b/src/develop/masks/polygon.c
@@ -2524,19 +2524,23 @@ static int _get_area(const dt_iop_module_t *const module, dt_dev_pixelpipe_t *pi
   return 0;
 }
 
-static int _polygon_get_source_area(dt_iop_module_t *module, dt_dev_pixelpipe_t *pipe,
+static dt_masks_raster_result_t _polygon_get_source_area(dt_iop_module_t *module, dt_dev_pixelpipe_t *pipe,
                                    dt_dev_pixelpipe_iop_t *piece,
                                    dt_masks_form_t *mask_form, int *width, int *height, int *posx, int *posy)
 {
-  return _get_area(module, pipe, piece, mask_form, width, height, posx, posy, TRUE);
+  *width = *height = *posx = *posy = 0;
+  return dt_masks_raster_from_status(
+      _get_area(module, pipe, piece, mask_form, width, height, posx, posy, TRUE));
 }
 
-static int _polygon_get_area(const dt_iop_module_t *const module, dt_dev_pixelpipe_t *pipe,
+static dt_masks_raster_result_t _polygon_get_area(const dt_iop_module_t *const module, dt_dev_pixelpipe_t *pipe,
                              const dt_dev_pixelpipe_iop_t *const piece,
                              dt_masks_form_t *const mask_form,
                              int *width, int *height, int *posx, int *posy)
 {
-  return _get_area(module, pipe, piece, mask_form, width, height, posx, posy, FALSE);
+  *width = *height = *posx = *posy = 0;
+  return dt_masks_raster_from_status(
+      _get_area(module, pipe, piece, mask_form, width, height, posx, posy, FALSE));
 }
 
 /**
@@ -2567,12 +2571,14 @@ static int _polygon_get_area(const dt_iop_module_t *const module, dt_dev_pixelpi
   }
 }
 
-static int _polygon_get_mask(const dt_iop_module_t *const module, dt_dev_pixelpipe_t *pipe,
+static dt_masks_raster_result_t _polygon_get_mask(const dt_iop_module_t *const module, dt_dev_pixelpipe_t *pipe,
                              const dt_dev_pixelpipe_iop_t *const piece,
                              dt_masks_form_t *const mask_form,
                              float **buffer, int *width, int *height, int *posx, int *posy)
 {
-  if(IS_NULL_PTR(module)) return 1;
+  *buffer = NULL;
+  *width = *height = *posx = *posy = 0;
+  if(IS_NULL_PTR(module)) return DT_MASKS_RASTER_ERROR;
   double start = 0.0;
   double start2 = 0.0;
 
@@ -2590,7 +2596,7 @@ static int _polygon_get_mask(const dt_iop_module_t *const module, dt_dev_pixelpi
   {
     dt_pixelpipe_cache_free_align(point_buffer);
     dt_pixelpipe_cache_free_align(border_buffer);
-    return 1;
+    return DT_MASKS_RASTER_ERROR;
   }
 
   if(dt_get_debug_flags() & DT_DEBUG_PERF)
@@ -2631,7 +2637,7 @@ static int _polygon_get_mask(const dt_iop_module_t *const module, dt_dev_pixelpi
   {
     dt_pixelpipe_cache_free_align(point_buffer);
     dt_pixelpipe_cache_free_align(border_buffer);
-    return 1;
+    return DT_MASKS_RASTER_ERROR;
   }
 
   // we write all the point around the polygon into the buffer
@@ -2841,7 +2847,7 @@ static int _polygon_get_mask(const dt_iop_module_t *const module, dt_dev_pixelpi
     dt_print(DT_DEBUG_MASKS, "[masks %s] polygon fill buffer took %0.04f sec\n", mask_form->name,
              dt_get_wtime() - start);
 
-  return 0;
+  return DT_MASKS_RASTER_OK;
 }
 
 

--- a/src/develop/masks/polygon.c
+++ b/src/develop/masks/polygon.c
@@ -2528,7 +2528,10 @@ static dt_masks_raster_result_t _polygon_get_source_area(dt_iop_module_t *module
                                    dt_dev_pixelpipe_iop_t *piece,
                                    dt_masks_form_t *mask_form, int *width, int *height, int *posx, int *posy)
 {
-  *width = *height = *posx = *posy = 0;
+  *width = 0;
+  *height = 0;
+  *posx = 0;
+  *posy = 0;
   return dt_masks_raster_from_status(
       _get_area(module, pipe, piece, mask_form, width, height, posx, posy, TRUE));
 }
@@ -2538,7 +2541,10 @@ static dt_masks_raster_result_t _polygon_get_area(const dt_iop_module_t *const m
                              dt_masks_form_t *const mask_form,
                              int *width, int *height, int *posx, int *posy)
 {
-  *width = *height = *posx = *posy = 0;
+  *width = 0;
+  *height = 0;
+  *posx = 0;
+  *posy = 0;
   return dt_masks_raster_from_status(
       _get_area(module, pipe, piece, mask_form, width, height, posx, posy, FALSE));
 }
@@ -2577,7 +2583,10 @@ static dt_masks_raster_result_t _polygon_get_mask(const dt_iop_module_t *const m
                              float **buffer, int *width, int *height, int *posx, int *posy)
 {
   *buffer = NULL;
-  *width = *height = *posx = *posy = 0;
+  *width = 0;
+  *height = 0;
+  *posx = 0;
+  *posy = 0;
   if(IS_NULL_PTR(module)) return DT_MASKS_RASTER_ERROR;
   double start = 0.0;
   double start2 = 0.0;

--- a/src/develop/masks/polygon.c
+++ b/src/develop/masks/polygon.c
@@ -3179,14 +3179,14 @@ static inline void _polygon_falloff_roi(float *buffer, int *p0, int *p1, int bw,
 
 // build a stamp which can be combined with other shapes in the same group
 // prerequisite: 'buffer' is all zeros
-static int _polygon_get_mask_roi(const dt_iop_module_t *const module, dt_dev_pixelpipe_t *pipe,
+static dt_masks_raster_result_t _polygon_get_mask_roi(const dt_iop_module_t *const module, dt_dev_pixelpipe_t *pipe,
                                  const dt_dev_pixelpipe_iop_t *const piece,
                                  dt_masks_form_t *const mask_form,
                                  const dt_iop_roi_t *roi, float *buffer,
                                  dt_iop_roi_t *touched)
 {
   dt_masks_touched_none(touched);
-  if(IS_NULL_PTR(module)) return 1;
+  if(IS_NULL_PTR(module)) return DT_MASKS_RASTER_ERROR;
   double start = 0.0;
   double start2 = 0.0;
   if(dt_get_debug_flags() & DT_DEBUG_PERF) start = dt_get_wtime();
@@ -3223,13 +3223,13 @@ static int _polygon_get_mask_roi(const dt_iop_module_t *const module, dt_dev_pix
   {
     dt_pixelpipe_cache_free_align(points);
     dt_pixelpipe_cache_free_align(border);
-    return 1;
+    return DT_MASKS_RASTER_ERROR;
   }
   if(points_count <= 2)
   {
     dt_pixelpipe_cache_free_align(points);
     dt_pixelpipe_cache_free_align(border);
-    return 0;
+    return DT_MASKS_RASTER_EMPTY;
   }
 
   if(dt_get_debug_flags() & DT_DEBUG_PERF)
@@ -3324,7 +3324,7 @@ static int _polygon_get_mask_roi(const dt_iop_module_t *const module, dt_dev_pix
   {
     dt_pixelpipe_cache_free_align(points);
     dt_pixelpipe_cache_free_align(border);
-    return 0;
+    return DT_MASKS_RASTER_EMPTY;
   }
 
   // now get min/max values
@@ -3355,7 +3355,7 @@ static int _polygon_get_mask_roi(const dt_iop_module_t *const module, dt_dev_pix
     {
       dt_pixelpipe_cache_free_align(points);
       dt_pixelpipe_cache_free_align(border);
-      return 1;
+      return DT_MASKS_RASTER_ERROR;
     }
     memcpy(cpoints, points, sizeof(float) * 2 * points_count);
 
@@ -3468,7 +3468,7 @@ static int _polygon_get_mask_roi(const dt_iop_module_t *const module, dt_dev_pix
     {
       dt_pixelpipe_cache_free_align(points);
       dt_pixelpipe_cache_free_align(border);
-      return 1;
+      return DT_MASKS_RASTER_ERROR;
     }
 
     int dindex = 0;
@@ -3587,7 +3587,7 @@ static int _polygon_get_mask_roi(const dt_iop_module_t *const module, dt_dev_pix
              mask_form->name,
              dt_get_wtime() - start);
 
-  return 0;
+  return DT_MASKS_RASTER_OK;
 }
 
 static void _polygon_sanitize_config(dt_masks_type_t type)

--- a/src/develop/masks_gui.h
+++ b/src/develop/masks_gui.h
@@ -837,7 +837,8 @@ int dt_masks_find_closest_handle_common(dt_masks_form_t *mask_form, dt_masks_for
 
 void dt_masks_creation_mode_quit(dt_masks_form_gui_t *gui);
 gboolean dt_masks_creation_mode_enter(dt_develop_t *dev, dt_iop_module_t *module, const dt_masks_type_t type);
-void apply_operation(struct dt_masks_form_group_t *pt, const dt_masks_state_t apply_state);
+void dt_masks_group_entry_apply_operation(struct dt_masks_form_group_t *pt,
+                                          const dt_masks_state_t apply_state);
 
 /** Contextual menu */
 

--- a/src/gui/actions/menu.c
+++ b/src/gui/actions/menu.c
@@ -32,8 +32,6 @@
 #ifdef GDK_WINDOWING_QUARTZ
 #endif
 
-typedef struct dt_masks_form_gui_t dt_masks_form_gui_t;
-
 /** How to use:
  *  1. write callback functions returning a gboolean that will check the context to decide if
  *  the menu item should be insensitive, checked, active. These should only use the content of

--- a/src/iop/retouch.c
+++ b/src/iop/retouch.c
@@ -824,7 +824,9 @@ static gboolean rt_masks_form_is_in_roi(dt_iop_module_t *self, const dt_dev_pixe
   int fl, ft, fw, fh;
   dt_dev_pixelpipe_iop_t piece_copy = *piece;
 
-  if(dt_masks_get_area(self, (dt_dev_pixelpipe_t *)pipe, &piece_copy, form, &fw, &fh, &fl, &ft) != 0) return FALSE;
+  if(dt_masks_get_area(self, (dt_dev_pixelpipe_t *)pipe, &piece_copy, form, &fw, &fh, &fl, &ft)
+     != DT_MASKS_RASTER_OK)
+    return FALSE;
 
   // is the form outside of the roi?
   fw *= roi_in->scale, fh *= roi_in->scale, fl *= roi_in->scale, ft *= roi_in->scale;
@@ -2593,7 +2595,7 @@ static void rt_compute_roi_in(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *
       // if the form is outside the roi, we just skip it
       // we get the area for the form
       int fl, ft, fw, fh;
-      if(dt_masks_get_area(self, pipe, piece, form, &fw, &fh, &fl, &ft) != 0)
+      if(dt_masks_get_area(self, pipe, piece, form, &fw, &fh, &fl, &ft) != DT_MASKS_RASTER_OK)
       {
         continue;
       }
@@ -2692,7 +2694,7 @@ static void rt_extend_roi_in_from_source_clones(struct dt_iop_module_t *self, dt
       
       // we get the source area
       int fl, ft, fw, fh;
-      if(dt_masks_get_source_area(self, pipe, piece, form, &fw, &fh, &fl, &ft) != 0)
+      if(dt_masks_get_source_area(self, pipe, piece, form, &fw, &fh, &fl, &ft) != DT_MASKS_RASTER_OK)
       {
         continue;
       }
@@ -2777,7 +2779,8 @@ static void rt_extend_roi_in_for_clone(struct dt_iop_module_t *self, dt_dev_pixe
 
       // get the source area
       int fl_src, ft_src, fw_src, fh_src;
-      if(dt_masks_get_source_area(self, pipe, piece, form, &fw_src, &fh_src, &fl_src, &ft_src) != 0)
+      if(dt_masks_get_source_area(self, pipe, piece, form, &fw_src, &fh_src, &fl_src, &ft_src)
+         != DT_MASKS_RASTER_OK)
       {
         continue;
       }

--- a/src/iop/spots.c
+++ b/src/iop/spots.c
@@ -402,7 +402,9 @@ static inline __attribute__((always_inline)) gboolean masks_form_is_in_roi(dt_io
   int fl, ft, fw, fh;
   dt_dev_pixelpipe_iop_t piece_copy = *piece;
 
-  if(dt_masks_get_area(self, (dt_dev_pixelpipe_t *)pipe, &piece_copy, form, &fw, &fh, &fl, &ft) != 0) return FALSE;
+  if(dt_masks_get_area(self, (dt_dev_pixelpipe_t *)pipe, &piece_copy, form, &fw, &fh, &fl, &ft)
+     != DT_MASKS_RASTER_OK)
+    return FALSE;
 
   // is the form outside of the roi?
   fw *= roi_in->scale, fh *= roi_in->scale, fl *= roi_in->scale, ft *= roi_in->scale;
@@ -455,7 +457,8 @@ void modify_roi_in(struct dt_iop_module_t *self, const struct dt_dev_pixelpipe_t
         // we get the area for the source
         int fl, ft, fw, fh;
 
-        if(dt_masks_get_source_area(self, processing_pipe, piece, form, &fw, &fh, &fl, &ft) != 0)
+        if(dt_masks_get_source_area(self, processing_pipe, piece, form, &fw, &fh, &fl, &ft)
+           != DT_MASKS_RASTER_OK)
         {
           continue;
         }
@@ -647,7 +650,9 @@ static int _process(struct dt_iop_module_t *self, const dt_dev_pixelpipe_t *pipe
         // we get the mask
         float *mask = NULL;
         int posx, posy, width, height;
-        if(dt_masks_get_mask(self, (dt_dev_pixelpipe_t *)pipe, piece, form, &mask, &width, &height, &posx, &posy) != 0)
+        if(dt_masks_get_mask(self, (dt_dev_pixelpipe_t *)pipe, piece, form, &mask, &width, &height, &posx,
+                             &posy)
+           != DT_MASKS_RASTER_OK)
         {
           return 1;
         }

--- a/src/libs/masks.c
+++ b/src/libs/masks.c
@@ -333,7 +333,7 @@ static void _tree_add_exist(GtkButton *button, dt_masks_form_t *grp)
 
     // and we apply the change
 
-    dt_masks_iop_update(module);
+    dt_iop_gui_blend_masks_update(module);
     dt_dev_masks_selection_change(dev, NULL, grp->formid, TRUE);
   }
 }
@@ -500,7 +500,7 @@ static void _tree_inverse(GtkButton *button, dt_lib_module_t *self)
           if(pt->formid == id)
           {
             const int old_state = pt->state;
-            apply_operation(pt, DT_MASKS_STATE_INVERSE);
+            dt_masks_group_entry_apply_operation(pt, DT_MASKS_STATE_INVERSE);
             if(pt->state != old_state)
             {
               _set_iter_name(lm, dt_masks_get_from_id(dt_dev_get_global(), id), pt->state, pt->opacity, model,
@@ -555,7 +555,7 @@ static void _tree_intersection(GtkButton *button, dt_lib_module_t *self)
           if(pt->formid == id)
           {
             const int old_state = pt->state;
-            apply_operation(pt, DT_MASKS_STATE_INTERSECTION);
+            dt_masks_group_entry_apply_operation(pt, DT_MASKS_STATE_INTERSECTION);
             if(pt->state != old_state)
             {
               _set_iter_name(lm, dt_masks_get_from_id(dt_dev_get_global(), id), pt->state, pt->opacity, model,
@@ -610,7 +610,7 @@ static void _tree_difference(GtkButton *button, dt_lib_module_t *self)
           if(pt->formid == id)
           {
             const int old_state = pt->state;
-            apply_operation(pt, DT_MASKS_STATE_DIFFERENCE);
+            dt_masks_group_entry_apply_operation(pt, DT_MASKS_STATE_DIFFERENCE);
             if(pt->state != old_state)
             {
               _set_iter_name(lm, dt_masks_get_from_id(dt_dev_get_global(), id), pt->state, pt->opacity, model,
@@ -665,7 +665,7 @@ static void _tree_exclusion(GtkButton *button, dt_lib_module_t *self)
           if(pt->formid == id)
           {
             const int old_state = pt->state;
-            apply_operation(pt, DT_MASKS_STATE_EXCLUSION);
+            dt_masks_group_entry_apply_operation(pt, DT_MASKS_STATE_EXCLUSION);
             if(pt->state != old_state)
             {
               _set_iter_name(lm, dt_masks_get_from_id(dt_dev_get_global(), id), pt->state, pt->opacity, model,
@@ -720,7 +720,7 @@ static void _tree_union(GtkButton *button, dt_lib_module_t *self)
           if(pt->formid == id)
           {
             const int old_state = pt->state;
-            apply_operation(pt, DT_MASKS_STATE_UNION);
+            dt_masks_group_entry_apply_operation(pt, DT_MASKS_STATE_UNION);
             if(pt->state != old_state)
             {
               _set_iter_name(lm, dt_masks_get_from_id(dt_dev_get_global(), id), pt->state, pt->opacity, model,
@@ -885,7 +885,7 @@ static void _tree_duplicate_shape(GtkButton *button, dt_lib_module_t *self)
     const int nid = dt_masks_form_duplicate_in_group(dt_dev_get_global(), grid, id);
     if(nid > 0)
     {
-      if(module) dt_masks_iop_update(module);
+      if(module) dt_iop_gui_blend_masks_update(module);
 
       dt_dev_masks_selection_change(dt_dev_get_global(), NULL, nid, TRUE);
 

--- a/src/tests/unittests/CMakeLists.txt
+++ b/src/tests/unittests/CMakeLists.txt
@@ -19,6 +19,7 @@ set(DATABASE_UNIT_TESTS
   test_conf_value_lifetime
   test_dtpthread_recursive
   test_history_snapshot
+  test_masks_raster_contract
 )
 
 foreach(test ${DATABASE_UNIT_TESTS})

--- a/src/tests/unittests/test_masks_raster_contract.c
+++ b/src/tests/unittests/test_masks_raster_contract.c
@@ -1,0 +1,217 @@
+/*
+    This file is part of Ansel,
+    Copyright (C) 2026 Aurélien PIERRE.
+
+    Ansel is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Ansel is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Ansel.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+/** The rasterisation family answers the same question the same way for every shape.
+ *
+ * It did not use to. The family returned a bare int on a "0 means success" convention that
+ * could not express the third outcome that actually occurs -- a shape with nothing to draw --
+ * so each shape picked its own answer and they disagreed. A form with no points made a circle
+ * report failure, which aborted the whole group fold and blanked the mask, and made an ellipse
+ * report success, which folded it as zeros. Three shapes reported success from the outline
+ * builder while writing no outline at all, which stamped the outline cache over a NULL and hid
+ * the shape until the geometry next moved. Two more reported success from get_area/get_mask
+ * without writing a single out-parameter, which callers then read.
+ *
+ * Every one of those was a disagreement between shapes about a contract nobody had written
+ * down, so these tests pin the contract rather than any one shape's behaviour: the degenerate
+ * input goes to every implementation, and they must all answer alike.
+ *
+ * The forms are built on the stack instead of through dt_masks_create(), which reaches for
+ * conf and the supervisor. A shape struct plus its function table is the whole input the
+ * contract is about.
+ */
+
+#include "develop/masks.h"
+#include "develop/masks/masks_functions.h"
+#include "develop/masks/masks_touched.h"
+
+#include <stdarg.h>
+#include <stddef.h>
+// cmocka.h declares `extern jmp_buf global_expect_assert_env' at file scope without including
+// <setjmp.h> itself. Same suppression as the other tests here, and for the same reason.
+#include <setjmp.h>  // NOLINT(misc-include-cleaner)
+#include <stdint.h>
+#include <cmocka.h>
+
+/** Every shape whose rasteriser can be reached with a degenerate form and no pipeline.
+ *
+ * Brush and polygon are deliberately absent: both check their module argument before they look
+ * at the geometry, so reaching their "no geometry" branch needs a live module and pipe. Their
+ * module-less branch is covered by the ERROR case below instead. */
+typedef struct
+{
+  const char *name;
+  dt_masks_type_t type;
+  const dt_masks_functions_t *functions;
+  /* Whether this shape's bounding box is a function of its geometry at all. A gradient's is
+   * not: it covers the whole frame by construction, so it reads the pipe's dimensions without
+   * ever looking at its points, and "no points" is not a degenerate area for it. Every other
+   * shape derives its box from its geometry and must report the absence of one. */
+  gboolean area_depends_on_geometry;
+} _shape_t;
+
+static const _shape_t _shapes[] = {
+  { "circle",   DT_MASKS_CIRCLE,   &dt_masks_functions_circle,   TRUE },
+  { "ellipse",  DT_MASKS_ELLIPSE,  &dt_masks_functions_ellipse,  TRUE },
+  { "gradient", DT_MASKS_GRADIENT, &dt_masks_functions_gradient, FALSE },
+  { "group",    DT_MASKS_GROUP,    &dt_masks_functions_group,    TRUE },
+};
+static const size_t _shape_count = sizeof(_shapes) / sizeof(_shapes[0]);
+
+/** A form of the given kind carrying no geometry at all -- the degenerate case every shape
+ * used to answer differently. */
+static dt_masks_form_t _empty_form(const _shape_t *shape)
+{
+  dt_masks_form_t form = { 0 };
+  form.type = shape->type;
+  form.functions = shape->functions;
+  form.points = NULL;
+  return form;
+}
+
+static void _from_status_maps_zero_to_ok_and_everything_else_to_error(void **state)
+{
+  (void)state;
+  // The adapter for helpers still on the old convention: they cannot report EMPTY, so
+  // anything non-zero has to read as the conservative outcome.
+  assert_int_equal(dt_masks_raster_from_status(0), DT_MASKS_RASTER_OK);
+  assert_int_equal(dt_masks_raster_from_status(1), DT_MASKS_RASTER_ERROR);
+  assert_int_equal(dt_masks_raster_from_status(-1), DT_MASKS_RASTER_ERROR);
+}
+
+static void _a_shape_with_no_geometry_rasterises_empty(void **state)
+{
+  (void)state;
+  const dt_iop_roi_t roi = { 0, 0, 4, 4, 1.0f };
+  float buffer[16] = { 0.0f };
+
+  for(size_t i = 0; i < _shape_count; i++)
+  {
+    dt_masks_form_t form = _empty_form(&_shapes[i]);
+    dt_iop_roi_t touched;
+    const dt_masks_raster_result_t result
+        = dt_masks_get_mask_roi(NULL, NULL, NULL, &form, &roi, buffer, &touched);
+
+    // Not ERROR (which aborts the group fold and blanks the whole mask) and not OK (which
+    // would claim the buffer was written). This is the disagreement that used to exist
+    // between the circle and the ellipse, on identical input.
+    assert_int_equal(result, DT_MASKS_RASTER_EMPTY);
+
+    // EMPTY promises the caller an empty touched box, which is what lets the group fold clear
+    // and combine only what a child actually wrote.
+    assert_true(dt_masks_touched_is_empty(&touched));
+  }
+}
+
+static void _a_shape_with_no_rasteriser_is_an_error(void **state)
+{
+  (void)state;
+  const dt_iop_roi_t roi = { 0, 0, 4, 4, 1.0f };
+  float buffer[16] = { 0.0f };
+  dt_iop_roi_t touched;
+
+  // No function table at all: a shape type nobody implemented is a programming error, never an
+  // empty shape -- the fold must refuse to publish a buffer nobody wrote.
+  dt_masks_form_t form = { 0 };
+  form.type = DT_MASKS_NONE;
+  form.functions = NULL;
+
+  assert_int_equal(dt_masks_get_mask_roi(NULL, NULL, NULL, &form, &roi, buffer, &touched),
+                   DT_MASKS_RASTER_ERROR);
+}
+
+static void _an_unbuildable_outline_is_never_reported_as_built(void **state)
+{
+  (void)state;
+
+  for(size_t i = 0; i < _shape_count; i++)
+  {
+    if(IS_NULL_PTR(_shapes[i].functions->get_points_border)) continue; // group has none
+
+    dt_masks_form_t form = _empty_form(&_shapes[i]);
+    float *points = NULL, *border = NULL;
+    int points_count = -1, border_count = -1;
+
+    // The caller stamps the group-wide outline cache key on success. Reporting success here
+    // with *points still NULL is what marked the cache current over an outline that had never
+    // been built, hiding the shape until the geometry generation next changed.
+    assert_int_not_equal(dt_masks_get_points_border(NULL, &form, &points, &points_count, &border,
+                                                    &border_count, 0, NULL),
+                         DT_MASKS_RASTER_OK);
+    assert_null(points);
+  }
+}
+
+static void _area_and_mask_always_write_their_out_parameters(void **state)
+{
+  (void)state;
+
+  for(size_t i = 0; i < _shape_count; i++)
+  {
+    dt_masks_form_t form = _empty_form(&_shapes[i]);
+
+    /* Poisoned on purpose: these are the callers' uninitialised stack. iop/spots.c reads
+     * width/height straight after the call and iop/retouch.c sizes an allocation from them,
+     * so "reported not-OK" is not enough -- the values have to be defined too. */
+    int width = -12345, height = -12345, posx = -12345, posy = -12345;
+    float *buffer = (float *)(intptr_t)-1;
+
+    if(_shapes[i].area_depends_on_geometry && !IS_NULL_PTR(form.functions->get_area))
+    {
+      const dt_masks_raster_result_t area = dt_masks_get_area(NULL, NULL, NULL, &form, &width, &height,
+                                                              &posx, &posy);
+      assert_int_not_equal(area, DT_MASKS_RASTER_OK);
+      assert_int_equal(width, 0);
+      assert_int_equal(height, 0);
+      assert_int_equal(posx, 0);
+      assert_int_equal(posy, 0);
+    }
+
+    width = height = posx = posy = -12345;
+    if(!IS_NULL_PTR(form.functions->get_mask))
+    {
+      const dt_masks_raster_result_t mask
+          = dt_masks_get_mask(NULL, NULL, NULL, &form, &buffer, &width, &height, &posx, &posy);
+      assert_int_not_equal(mask, DT_MASKS_RASTER_OK);
+      assert_null(buffer);
+      assert_int_equal(width, 0);
+      assert_int_equal(height, 0);
+      assert_int_equal(posx, 0);
+      assert_int_equal(posy, 0);
+    }
+  }
+}
+
+int main(void)
+{
+  const struct CMUnitTest tests[] = {
+    cmocka_unit_test(_from_status_maps_zero_to_ok_and_everything_else_to_error),
+    cmocka_unit_test(_a_shape_with_no_geometry_rasterises_empty),
+    cmocka_unit_test(_a_shape_with_no_rasteriser_is_an_error),
+    cmocka_unit_test(_an_unbuildable_outline_is_never_reported_as_built),
+    cmocka_unit_test(_area_and_mask_always_write_their_out_parameters),
+  };
+
+  return cmocka_run_group_tests(tests, NULL, NULL);
+}
+
+// clang-format off
+// modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py
+// vim: shiftwidth=2 expandtab tabstop=2 cindent
+// kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;
+// clang-format on

--- a/src/tests/unittests/test_masks_raster_contract.c
+++ b/src/tests/unittests/test_masks_raster_contract.c
@@ -144,8 +144,10 @@ static void _an_unbuildable_outline_is_never_reported_as_built(void **state)
     if(IS_NULL_PTR(_shapes[i].functions->get_points_border)) continue; // group has none
 
     dt_masks_form_t form = _empty_form(&_shapes[i]);
-    float *points = NULL, *border = NULL;
-    int points_count = -1, border_count = -1;
+    float *points = NULL;
+    float *border = NULL;
+    int points_count = -1;
+    int border_count = -1;
 
     // The caller stamps the group-wide outline cache key on success. Reporting success here
     // with *points still NULL is what marked the cache current over an outline that had never
@@ -168,7 +170,10 @@ static void _area_and_mask_always_write_their_out_parameters(void **state)
     /* Poisoned on purpose: these are the callers' uninitialised stack. iop/spots.c reads
      * width/height straight after the call and iop/retouch.c sizes an allocation from them,
      * so "reported not-OK" is not enough -- the values have to be defined too. */
-    int width = -12345, height = -12345, posx = -12345, posy = -12345;
+    int width = -12345;
+    int height = -12345;
+    int posx = -12345;
+    int posy = -12345;
     float *buffer = (float *)(intptr_t)-1;
 
     if(_shapes[i].area_depends_on_geometry && !IS_NULL_PTR(form.functions->get_area))
@@ -182,7 +187,10 @@ static void _area_and_mask_always_write_their_out_parameters(void **state)
       assert_int_equal(posy, 0);
     }
 
-    width = height = posx = posy = -12345;
+    width = -12345;
+    height = -12345;
+    posx = -12345;
+    posy = -12345;
     if(!IS_NULL_PTR(form.functions->get_mask))
     {
       const dt_masks_raster_result_t mask


### PR DESCRIPTION
First phase of the masks enclosure plan from #1299. It closes three shipped defects that all have the same cause: the rasterisation family returned a bare `int` on an undocumented "0 means success" convention, so each shape picked its own answer and they disagreed — and it removes the ambiguity that let them.

> **Based on #1300**, which changed `get_mask_roi`'s signature; GitHub shows that PR's two commits here until it merges, after which I rebase and this drops to its own five. Same handling as #1294/#1295 had.

## The three defects

**1. A degenerate shape killed or spared the whole group depending on which shape it was.** A NULL points list made a circle return 1, which aborted the entire group fold and blanked the mask; the identical data made an ellipse return 0, which folded it as zeros and carried on. Neither behaviour was written down.

**2. A failed outline build was cached as if it were an outline.** `dt_masks_gui_form_create()` stamps the outline cache key on success. Circle, ellipse and gradient reported success for a shape with no geometry while leaving `*points` NULL, so the cache was marked current over an outline that had never been built and the shape stayed invisible until the geometry generation next changed.

**3. `get_mask`/`get_area` reported success with their out-parameters unwritten.** `iop/spots.c` then tests `if(width < 1 || height < 1)` on uninitialised stack, and garbage that happens to be ≥1 walks into the resample with a NULL mask pointer. `_circle_get_mask()` sizes an allocation from uninitialised width/height. `iop/retouch.c` escapes only because it ignores the return value and NULL-checks the buffer instead.

## The fix

`dt_masks_raster_result_t` makes the three outcomes distinct — **OK** (buffer written), **EMPTY** (nothing to draw: degenerate geometry or wholly outside the ROI — a legitimate outcome, not a failure), **ERROR** (could not compute; buffer undefined). `OK` is 0, so any caller still written against the old convention reads success as success and everything else as non-success: the safe direction.

Every return site in every implementation was classified against what it actually detects — allocation and distort-transform failures are ERROR, degenerate and out-of-ROI geometry is EMPTY — and every function in the family now writes its out-parameters *before it can return*, so no exit path can leave them undefined whatever is added later.

One subtlety worth flagging for review: **EMPTY still combines**, it is not skipped. `bufs` is fully zeroed before every child, so a shape that drew nothing is an all-zero child — and it must still be intersected with, since a brush lying outside this ROI genuinely has no coverage here and skipping the combine would leave the previous fold standing where the mask should go to zero.

## Behaviour changes, both deliberate and confined to degenerate data

- A shape with no geometry now folds as zeros instead of blanking the whole group (what three of the five shapes already did).
- `_group_get_mask()` (the legacy non-ROI path) treats EMPTY as an error, because that path keeps one slot per child in parallel `malloc`'d arrays and skipping a slot would leave its `states`/`op` entries uninitialised for the combine. Still strictly better than walking on with a NULL buffer, which is what it did.

## Also in here

Four misplaced symbols put back (commit 4), none behavioural: `dt_masks_iop_update()` was declared in `masks.h` under a `dt_masks_` name while its body sat in `blend_gui.c` driving widgets private to `dt_iop_gui_blend_data_t` — now `dt_iop_gui_blend_masks_update()` in `blend_gui.h`, body unmoved; `apply_operation()` was an un-namespaced exported global; `dt_masks_get_mask_roi`/`get_points_border` were public with no caller outside the module and move to the private header; `imageop.c` included `masks_gui.h` and used nothing from it; `gui/actions/menu.c` carried a private forward typedef of a masks type it never uses.

## Verification

- **Bit-identical exports** vs the branch base, both resolutions, image *and* `--export_masks` page: 0 differing of 18M and 72M.
- **New CMocka suite** `test_masks_raster_contract` (5 cases, all pass) pinning the contract across every shape rather than any one shape's behaviour, including the out-parameter guarantee checked against deliberately poisoned locals.
- Full build clean; `ctest` 15/15 of the tests that run (the 4 "Not Run" are LensSerious's own executables, which the default `ninja` never builds — pre-existing).

## Not in here

The event family (`mouse_moved` and friends, ~40 functions on a uniform `1 = handled`) is a separate mechanical pass: its convention is at least self-consistent, so it carries no hazard, and folding it in would bury these fixes in several hundred lines of rename. `get_points` stays on the legacy convention behind `dt_masks_raster_from_status()` for the same reason.

Part of #1299.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
