### PR TITLE
tools: ratchet the masks module's remaining leaks so they can only shrink (P1)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1162,6 +1162,33 @@ prematurely).
 
 ---
 
+### The masks module is being enclosed, and the ratchet counts the way out
+
+`src/develop/masks` is not a closed module yet: five files outside it (`develop/blend_gui.c`,
+`libs/masks.c`, `iop/retouch.c`, `iop/spots.c`, `develop/supervisor.c`) reach directly into
+`dt_masks_form_t` and friends, four places `malloc` a masks type by hand, and `->forms` is walked
+as a plain `GList` all over `develop/`. The audit behind that is issue #1299; the plan is to drain
+it phase by phase rather than in one break.
+
+**`tools/check_module_boundaries.sh` section 9 counts the remaining leaks, and the counts may only
+FALL.** Adding a new external struct access, a new includer of `masks.h`, a new hand-rolled
+allocation or a new raw `->forms` walk fails CI. So does *removing* one without lowering the
+baseline in the same commit — that is deliberate: it is what stops a phase from half-landing and
+the ground being quietly given back later.
+
+Two things about those counters a future editor should not "improve":
+
+- **The member list is curated to names no other struct in the tree uses** (`formid`,
+  `form_dragging`, `creation_formids`, …) and deliberately omits the ambiguous ones a masks form
+  shares with everything else (`points`, `type`, `name`, `state`, `opacity`). It therefore
+  undercounts — the full census found ~385 accesses by reading declarations, the gate reports 102
+  — and that is the right error for a gate. Widening it buys a bigger number and loses the
+  property that every match is real.
+- **One write match is a known false positive and stays counted**: `supervisor.c`'s own event
+  struct also has a `formid`, so `e->formid = form->formid` matches on the left while genuinely
+  reading a masks form on the right. It is stable, so it costs nothing; chasing it would mean
+  excluding the file, which would hide real writes appearing there later.
+
 ## IOP modules
 
 ### ashift: preview buffer and crop geometry

--- a/tools/check_module_boundaries.sh
+++ b/tools/check_module_boundaries.sh
@@ -349,6 +349,121 @@ if [ "${history_upcalls_now}" -gt "${history_upcalls_baseline}" ]; then
 fi
 
 # ---------------------------------------------------------------------------------------
+# 9. src/develop/masks is NOT closed. This is the ratchet that closes it.
+#
+# Unlike colorprofiles, opencl, caches and database above, this one starts far from zero and
+# is expected to stay non-zero for several releases. It is here because the masks audit
+# (issue #1299) found the leak is CONCENTRATED rather than diffuse -- five files account for
+# every direct struct access outside the module -- which is what makes draining it tractable,
+# and because the same defect kept coming back while nothing counted it: the rule that the
+# pipeline must resolve shapes through pipe->forms and never the live dev->forms was violated
+# and re-fixed four separate times, once three lines below the comment stating it.
+#
+# The counts here are what the enclosure plan's later phases drain. Every accessor added to
+# the module and every caller moved onto it takes one off a number, and the number may then
+# only be lowered, never raised -- so a phase that half-lands cannot silently un-land.
+#
+# What is counted, and why each is counted THIS way rather than more ambitiously:
+#
+#   includes       Files outside src/develop/masks/ that include the module's two public
+#                  headers. develop/blend.h is one of them, which is how the whole masks
+#                  surface reaches every IOP in the tree; that single edge is worth more than
+#                  the other twenty put together and it is the one P2 removes.
+#
+#   members        Direct reads of a masks-owned struct member from outside the module. The
+#                  member list is CURATED on purpose: it holds only names that no other struct
+#                  in this tree uses (formid, form_dragging, creation_formids, ...) and leaves
+#                  out the ambiguous ones a masks form shares with half the codebase (points,
+#                  type, name, state, opacity). That undercounts -- the audit's full census
+#                  found ~385 by reading declarations, this finds 102 -- and undercounting is
+#                  the right error for a gate. A ratchet that moves when somebody renames an
+#                  unrelated `->state` is a ratchet that gets switched off. Every match this
+#                  does report is real: they land in exactly five files, and no other.
+#
+#   writes         The same members, assigned to. A write from outside is the sharper half:
+#                  it is a caller mutating a refcounted, copy-on-write object without going
+#                  through dt_masks_cow_touch(), which is how a snapshot ends up observing a
+#                  half-rewritten form. One of the 27 is a false positive and stays counted
+#                  because it is stable: supervisor.c's own event struct also has a `formid`
+#                  field, so `e->formid = form->formid` matches on the left as well as reading
+#                  a real one on the right.
+#
+#   allocations    malloc/calloc of a masks type outside the module: four places build a
+#                  group-membership entry or a circle node by hand and rely on the module's
+#                  free path to release it. An allocator/deallocator pact held together by
+#                  convention.
+#
+#   forms          Direct touches of ->forms / ->allforms outside the module: the live GUI
+#                  list, the pipe's refcounted snapshot and the per-history-item snapshot, all
+#                  reached as plain GLists. This is the count behind the bug that came back
+#                  four times, and it only reaches zero when resolving a shape is something
+#                  callers ask the module to do.
+masks_include_baseline=24
+masks_gui_include_baseline=11
+masks_member_baseline=102
+masks_write_baseline=27
+masks_alloc_baseline=4
+masks_forms_baseline=88
+
+# Members no other struct in the tree uses. Keep it that way: adding an ambiguous name here
+# buys a bigger number and loses the gate.
+masks_members='formid|parentid|form_dragging|source_dragging|form_selected|border_selected'
+masks_members="${masks_members}|source_selected|pivot_selected|group_selected|form_visible"
+masks_members="${masks_members}|creation_formids|creation_module|creation_type|guipoints"
+masks_members="${masks_members}|guipoints_count|uses_bezier_points_layout|gravity_center_valid"
+masks_members="${masks_members}|node_dragging|handle_dragging|seg_dragging|node_selected_idx"
+masks_members="${masks_members}|handle_border_selected|handle_border_hovered"
+
+# Drop whole-line comments so a count cannot move because somebody described the code.
+masks_strip() { grep -vE ':[0-9]+:[[:space:]]*(\*|//)'; }
+
+masks_include_now=$(grep -rn '^[ \t]*#[ \t]*include[ \t]*"develop/masks\.h"' \
+                    src/ --include='*.c' --include='*.h' --include='*.cc' 2>/dev/null \
+                    | grep -cv '^src/develop/masks/')
+masks_gui_include_now=$(grep -rn '^[ \t]*#[ \t]*include[ \t]*"develop/masks_gui\.h"' \
+                        src/ --include='*.c' --include='*.h' --include='*.cc' 2>/dev/null \
+                        | grep -cv '^src/develop/masks/')
+masks_member_now=$(grep -rnE "\->(${masks_members})\b" src/ --include='*.c' --include='*.cc' 2>/dev/null \
+                   | grep -v '^src/develop/masks/' | masks_strip | wc -l)
+masks_write_now=$(grep -rnE "\->(${masks_members})[[:space:]]*(=[^=]|\|=|&=|\+=|-=)" \
+                  src/ --include='*.c' --include='*.cc' 2>/dev/null \
+                  | grep -v '^src/develop/masks/' | masks_strip | wc -l)
+masks_alloc_now=$(grep -rnE '\b(malloc|calloc|g_malloc[0-9n]*|g_new[0-9]*)[[:space:]]*\(' \
+                  src/ --include='*.c' --include='*.cc' 2>/dev/null \
+                  | grep -v '^src/develop/masks/' \
+                  | grep -cE 'dt_masks_(form_t|form_gui_t|form_group_t|node_|anchor_|point_)')
+masks_forms_now=$(grep -rnE '\->(forms|allforms)\b' src/ --include='*.c' --include='*.cc' 2>/dev/null \
+                  | grep -v '^src/develop/masks/' | masks_strip | wc -l)
+
+echo "masks:         ${masks_include_now} include masks.h, ${masks_gui_include_now} include masks_gui.h" \
+     "(baselines ${masks_include_baseline}, ${masks_gui_include_baseline}),"
+echo "               ${masks_member_now} external struct-member reads, ${masks_write_now} of them writes" \
+     "(baselines ${masks_member_baseline}, ${masks_write_baseline}),"
+echo "               ${masks_alloc_now} external allocations, ${masks_forms_now} direct ->forms touches" \
+     "(baselines ${masks_alloc_baseline}, ${masks_forms_baseline})."
+
+masks_findings=0
+masks_check() { # name now baseline
+  if [ "$2" -gt "$3" ]; then
+    echo "masks: $1 ROSE ($3 -> $2). The module is being enclosed, not extended: ask it for what"
+    echo "       you need instead of reaching into a dt_masks_form_t. See issue #1299."
+    masks_findings=$((masks_findings + 1))
+  elif [ "$2" -lt "$3" ]; then
+    echo "masks: $1 fell ($3 -> $2). Lower the baseline in this script, in the same commit, so"
+    echo "       the ground you took cannot be given back."
+    masks_findings=$((masks_findings + 1))
+  fi
+}
+masks_check "masks.h includers"    "${masks_include_now}"     "${masks_include_baseline}"
+masks_check "masks_gui.h includers" "${masks_gui_include_now}" "${masks_gui_include_baseline}"
+masks_check "struct-member reads"  "${masks_member_now}"      "${masks_member_baseline}"
+masks_check "struct-member writes" "${masks_write_now}"       "${masks_write_baseline}"
+masks_check "external allocations" "${masks_alloc_now}"       "${masks_alloc_baseline}"
+masks_check "direct ->forms"       "${masks_forms_now}"       "${masks_forms_baseline}"
+findings=$((findings + masks_findings))
+
+
+# ---------------------------------------------------------------------------------------
 # 4. How much of the pixel engine still names a toolkit -- the GTK->Qt door.
 #
 # This measures a DIFFERENT property from tools/check_layering.sh, and the difference is the
@@ -438,5 +553,5 @@ if [ "${findings}" -gt 0 ]; then
   exit 1
 fi
 
-echo "OK: src/system is closed, src/widgets does not reach into gui/; colorprofiles, opencl, caches, database, metadata and history held; the pixel engine's toolkit surface did not grow."
+echo "OK: src/system is closed, src/widgets does not reach into gui/; colorprofiles, opencl, caches, database, metadata and history held; masks did not leak further; the pixel engine's toolkit surface did not grow."
 exit 0


### PR DESCRIPTION
P1 of the masks enclosure plan from #1299: the counts that P2 and later drain, made mechanical so they can only fall.

> **Based on #1310 (P0)**, which removes `develop/imageop.c`'s unused `masks_gui.h` include — one of the numbers baselined here. GitHub shows P0's six commits until it merges, after which I rebase and this drops to its own one. Same handling as #1294/#1295/#1310 had.

## Why a ratchet, and why now

`src/develop/masks` is not a closed module, and unlike colorprofiles, opencl, caches and database — all sitting at zero above it in this script — it will not be for several releases. That is the argument *for* counting it now rather than at the end: the plan drains it in phases, and without a number a phase that half-lands is indistinguishable from one that landed.

There is precedent for needing it in this exact module. The rule that the pipeline resolves shapes through `pipe->forms` and never the live `dev->forms` was violated and re-fixed **four separate times** — once three lines below the comment stating it — while nothing counted the pattern.

## The six counts

| count | now | what it is |
|---|---|---|
| `masks.h` includers | 24 | one of them is `develop/blend.h`, which is how the whole masks surface reaches **every IOP in the tree**; that single edge is worth more than the other twenty |
| `masks_gui.h` includers | 11 | |
| external struct-member reads | 102 | direct reads of a masks-owned member from outside the module |
| …of which writes | 27 | a caller mutating a refcounted copy-on-write object without going through `dt_masks_cow_touch()` |
| external allocations | 4 | hand-rolled `malloc()` of a masks type, freed by the module's own path — an allocator/deallocator pact held together by convention |
| direct `->forms` touches | 88 | the live GUI list, the pipe's snapshot and the per-history-item snapshot, all walked as plain `GList`s |

A count that **rises** fails. A count that **falls** also fails, until the baseline is lowered in the same commit — that half is the point: it stops ground being quietly given back.

## On deliberately undercounting

The member list is **curated to names no other struct in this tree uses** (`formid`, `form_dragging`, `creation_formids`, …) and omits the ambiguous ones a masks form shares with half the codebase (`points`, `type`, `name`, `state`, `opacity`). So it reports 102 where the audit's full census — done by reading declarations — found ~385.

That is the right error for a gate. A ratchet that moves when somebody renames an unrelated `->state` is a ratchet that gets switched off, and this script already says so about a static-analysis rule it removed for the same reason. Every match this *does* report is real: they land in exactly five files (`blend_gui.c`, `libs/masks.c`, `retouch.c`, `spots.c`, `supervisor.c`) and no others — which is also the audit's central finding, that the leak is concentrated rather than diffuse, and therefore drainable.

One write match is a **stable false positive and stays counted**, with the reason written next to it: `supervisor.c`'s own event struct also has a `formid`, so `e->formid = form->formid` matches on the left while genuinely reading a masks form on the right. Excluding the file would hide real writes appearing there later.

## Verification

- Passes on the tree as it stands.
- **Fails on a rise**: adding one external `f->formid` read reports `struct-member reads ROSE (102 -> 103)`, exit 1.
- **Fails on a fall**: removing one reports `fell (102 -> 101). Lower the baseline in this script, in the same commit`, exit 1.
- All pre-existing sections unaffected.

`CLAUDE.md` gains a short section pointing at the gate, including the two things about the counters a future editor should not "improve".

Part of #1299.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
