### PR TITLE
masks: the group-membership API, and the first two consumers converted (P2)

### DIFF
--- a/doc/masks-enclosure-p2.md
+++ b/doc/masks-enclosure-p2.md
@@ -1,0 +1,312 @@
+# Masks enclosure, phase P2: the group-membership API {#masks_enclosure_p2}
+
+[TOC]
+
+## Status
+
+**Design only — no API code has been written yet.** This document exists so the design survives
+between sessions and contributors, in the same spirit as `doc/masks_history_dedup.md`. Phases P0
+and P1 of the plan have shipped (typed rasterisation result; the section-9 ratchet in
+`tools/check_module_boundaries.sh`); P2 is what drains the counts that ratchet holds.
+
+It was produced by surveying every one of the ~385 external accesses in the five consumer files,
+grouping them by *intent* rather than by struct mechanics, then designing three independent APIs
+(minimal-orthogonal, CRUD-shaped, opaque-handle-and-iterator) and judging them against the survey.
+Everything below marked **verified** was checked against the code, and several of those checks
+overturned what the proposals assumed.
+
+## The convention: the first parameter names the world
+
+Three suffix schemes were proposed (`_in`, `_frozen`, `_ext`). All three are unnecessary, because
+the tree already distinguishes the cases positionally:
+
+- **`GList *forms` first** → resolve against a borrowed refcounted snapshot (`pipe->forms`,
+  `hist->forms`). No lock, no copy-on-write, read-only.
+- **`const dt_masks_form_t *` first** → an already-resolved handle. Thread-neutral: it reads only
+  that object's own memory. No lock, no COW, and no `_in` twin is needed.
+- **`dt_develop_t *dev` first** → touches the live list. Returns `dt_masks_result_t` ⟹ it writes,
+  locks and COW-touches internally; returns a value ⟹ it reads under the read lock.
+
+Only the *resolvers* come in pairs. That removes about six functions relative to the CRUD proposal,
+and it makes `iop/spots.c:441/561` — which resolves `self->dev->forms` from the pipeline thread, the
+retouch bug that never got migrated — visibly wrong at the call site.
+
+Handles are non-negotiable for reads. **Verified:** `dt_masks_get_visible_form()` can return a
+`formid == 0` transient display group that is in neither `dev->forms` nor `dev->allforms`
+(`masks_gui.c:4009-4051`), so no id-keyed reader can reach it — yet `retouch.c:986`, `spots.c:289`
+and `blend_gui.c:2159` all read it.
+
+## Headers
+
+Neither `masks.h` nor `masks_functions.h` can host the new API.
+
+- **Not `develop/masks.h`.** Its 886 lines drag in `develop/develop.h`, `develop/pixelpipe.h`,
+  `caches/pixelpipe_cache_alloc.h`, `common/logging.h`, `system/atomic.h`, `system/simd.h` and
+  `common/times.h`. Declaring the API there means no consumer can ever drop the include, which is
+  the entire objective.
+- **Not `develop/masks/masks_functions.h`.** It is the private per-shape vtable header and it
+  includes both `masks.h` and `masks_gui.h` (lines 51-52), so anything declared there is
+  unreachable from outside `src/develop/masks/`.
+
+Two new headers, modelled exactly on the `colorprofiles/profile_types.h` cut and on
+`masks/masks_history.h` (which already compiles against an opaque `dt_masks_form_t` using tag
+declarations and `<glib.h>` alone):
+
+- **`src/develop/masks_types.h`** — `<glib.h>` only, guard `DT_DEVELOP_MASKS_TYPES_H`. *Moves*
+  `dt_masks_type_t`, `dt_masks_state_t`, `dt_masks_increment_t`, `dt_masks_edit_mode_t`,
+  `dt_masks_interaction_t` and `dt_masks_form_group_t` out of `masks.h`; adds
+  `DT_MASKS_FORM_NAME_LEN`, `dt_masks_result_t`, `dt_masks_member_t`, `dt_masks_form_info_t`.
+  `masks.h` includes it first, so all 24 current includers keep compiling unchanged — that is the
+  safety property that makes the move reviewable on its own.
+- **`src/develop/masks_group.h`** — includes `masks_types.h` and nothing else; tag-declares
+  `struct dt_develop_t`, `struct dt_masks_form_t`, `struct dt_iop_module_t`. **No GTK.**
+  (`masks_gui.h` really does pull `widgets/draw.h` and `<gtk/gtk.h>` — verified at :50-53 — for six
+  IOPs that want one call.) GUI-state accessors stay in `masks_gui.h`.
+
+Implementation goes in `src/develop/masks/masks.c`, the data-model translation unit. No CMake change
+is needed.
+
+### Value types crossing the boundary
+
+```c
+#define DT_MASKS_FORM_NAME_LEN 128
+
+typedef enum dt_masks_result_t
+{
+  DT_MASKS_OK = 0,     /* the model changed */
+  DT_MASKS_UNCHANGED,  /* legal request, nothing to do -- caller skips the history commit */
+  DT_MASKS_NOT_FOUND,  /* no such group, or no such member in it */
+  DT_MASKS_INVALID     /* refused: not a group, self-inclusion, bad argument */
+} dt_masks_result_t;
+
+typedef struct dt_masks_member_t
+{
+  int              formid;
+  int              parentid;   /* the row's AUTHORED origin; != holder inside a display group */
+  guint            index;      /* position == compositing order == GTK row identity */
+  dt_masks_state_t state;      /* tightened from the struct's plain `int` */
+  float            opacity;
+} dt_masks_member_t;
+
+typedef struct dt_masks_form_info_t
+{
+  int             formid;
+  dt_masks_type_t type;
+  int             version;
+  gboolean        is_group;
+  gboolean        is_retouch;   /* (type & DT_MASKS_IS_RETOUCHE) != 0 */
+  guint           member_count; /* 0 unless is_group; NOT recursive */
+  char            name[DT_MASKS_FORM_NAME_LEN];
+} dt_masks_form_info_t;
+```
+
+**Why `dt_masks_form_group_t` moves rather than going opaque.** `common/xmp_sidecar.cc:1203-1204`
+casts an XMP binary blob straight to `dt_masks_form_group_t *` and validates
+`entry->mask_nb * sizeof(dt_masks_form_group_t) == entry->mask_points_len`. **The struct's size and
+field order are the on-disk format in every user's sidecars and database.** It can never be made
+opaque and its layout can never change — which is exactly why the value-typed `dt_masks_member_t`
+must be what everyone else consumes.
+
+## The API
+
+### Resolvers — the only `dev` / snapshot pair
+
+```c
+dt_masks_form_t *dt_masks_get_group_from_id   (struct dt_develop_t *dev, int group_id);
+dt_masks_form_t *dt_masks_get_group_from_id_in(GList *forms, int group_id);   /* pipe->forms */
+```
+
+NULL unless it resolves *and* is a group. Collapses ~30 sites that write `dt_masks_get_from_id(...)`
+followed by `(x->type & DT_MASKS_GROUP)`. **Do not collapse the pair** — that reintroduces the
+`spots.c` cross-thread bug as the path of least resistance.
+
+### Reads — handle-taking, thread-neutral, no lock, no COW
+
+```c
+gboolean dt_masks_form_get_info(const dt_masks_form_t *form, dt_masks_form_info_t *out);
+
+guint    dt_masks_group_copy_members (const dt_masks_form_t *group,
+                                      dt_masks_member_t *out, guint out_max);
+gboolean dt_masks_group_get_member   (const dt_masks_form_t *group, int formid,
+                                      dt_masks_member_t *out);
+gboolean dt_masks_group_get_member_at(const dt_masks_form_t *group, guint index,
+                                      dt_masks_member_t *out);
+
+gboolean dt_masks_form_get_anchor(const dt_masks_form_t *form, float anchor[2], float source[2]);
+
+const char *dt_masks_type_name(dt_masks_type_t type);   /* untranslated token; takes a VALUE */
+```
+
+- `get_info` retires ~40 `->formid`, ~30 `->type`, 24 `->name` and supervisor's `->version` reads,
+  plus every hand-written `type & (DT_MASKS_CLONE|DT_MASKS_NON_CLONE)` (8 copies; `masks.h:422`
+  already names that predicate). `name` is **copied**: the borrowed `const char *` is exactly the
+  hazard `blend_gui.c:1701` already trips, caching `parent_form->name` and using it down to :1712.
+- `copy_members` returns the total always and fills `min(total, out_max)`; `out == NULL` makes it a
+  count. **Order is the contract**, and it must be stated at the declaration: stored order ==
+  compositing order == GTK row order == `retouch.c:725`'s `p->rt_forms[]` index ==
+  `spots.c:565`'s `d->clone_algo[pos]` index, *which is persisted in every user's database*. A
+  member that fails to resolve **still consumes its index** — verified: `spots.c:569` `continue`s
+  but `pos++` sits in the for-increment. Never filter, never recurse, never reorder.
+- All four assert the group type internally and return 0/FALSE otherwise — that is what makes the
+  polymorphic `->points` unreachable — and leave `*out` **completely untouched** on FALSE
+  (the `dt_colorspaces_profile_at()` convention).
+- `get_anchor` is the only reason `dt_masks_node_*` is public today. It dispatches through the
+  already-private `form->functions` vtable and replaces `retouch.c:893-930` and its byte-for-byte
+  copy at `spots.c:513-538`.
+
+### Reads that must resolve children — take `dev`, read lock internally
+
+```c
+gboolean dt_masks_group_has_leaf_shape         (struct dt_develop_t *dev, int group_id);
+gboolean dt_masks_group_is_single_group_wrapper(struct dt_develop_t *dev, int group_id);
+int      dt_masks_form_owner_group             (struct dt_develop_t *dev, int formid); /* 0 = none */
+guint    dt_masks_forms_list_ids               (struct dt_develop_t *dev, int **out_ids);
+gchar   *dt_masks_group_member_label           (struct dt_develop_t *dev, int group_id, int formid);
+```
+
+The first two delete `blend_gui.c:1482-1521` outright — pure masks-graph queries with zero GUI
+content in a GUI file. **Depth-cap both at 32**, as `_masks_find_any_parent_group()` already does
+and neither copy does. `owner_group` replaces `dt_masks_form_group_find_any()` and **drops its COW
+side effect** — verified: that function copy-on-write-touches inside a *lookup*.
+
+### Writes — all id-keyed, all COW internal, all returning `dt_masks_result_t`
+
+```c
+dt_masks_result_t dt_masks_group_set_member_operation(struct dt_develop_t *dev, int group_id,
+                                                      int formid, dt_masks_state_t operation);
+dt_masks_result_t dt_masks_group_set_member_opacity  (struct dt_develop_t *dev, int group_id,
+                                                      int formid, float opacity);
+dt_masks_result_t dt_masks_group_nudge_member_opacity(struct dt_develop_t *dev, int group_id,
+                                                      int formid, float amount,
+                                                      dt_masks_increment_t increment, int flow);
+float             dt_masks_group_set_member_property (struct dt_develop_t *dev, int group_id,
+                                                      int formid, dt_masks_interaction_t property,
+                                                      float value, dt_masks_increment_t increment,
+                                                      int flow);  /* NAN = not applicable */
+dt_masks_result_t dt_masks_group_move_member  (struct dt_develop_t *dev, int group_id,
+                                               int formid, int delta); /* -1 up, +1 down */
+dt_masks_result_t dt_masks_group_add_member   (struct dt_develop_t *dev, int group_id, int formid,
+                                               dt_masks_state_t state, float opacity);
+dt_masks_result_t dt_masks_group_remove_member(struct dt_develop_t *dev,
+                                               struct dt_iop_module_t *module /* nullable */,
+                                               int group_id, int formid);
+dt_masks_result_t dt_masks_form_set_name        (struct dt_develop_t *dev, int formid, const char *name);
+dt_masks_result_t dt_masks_form_set_retouch_mode(struct dt_develop_t *dev, int formid, gboolean is_clone);
+int               dt_masks_group_create_for_module(struct dt_iop_module_t *module, const char *name);
+```
+
+Every one: resolve → `dt_masks_cow_touch()` → **re-resolve the row from the touched group** →
+mutate → compare. An id-keyed signature is the only shape that *can* be written this way, which is
+the whole point: cloning a parent also clones its `dt_masks_form_group_t` blocks, so any entry
+pointer taken before the touch belongs to the abandoned copy.
+
+- `set_member_operation` closes **six verified COW holes** (`libs/masks.c` 502/557/612/667/722 and
+  `blend_gui.c:2091`) and collapses five ~50-line handlers into one. Do it in a single commit —
+  fixing it in five places separately is how one gets missed.
+- `add_member` becomes the **sole constructor** for `dt_masks_form_group_t`, retiring the three
+  hand-rolled `malloc`s (`libs/masks.c` 365-369 / 970-974, `retouch.c` 685-690). It keeps the
+  self-inclusion guard and the `dt_masks_form_update_gravity_center()` all three skip, and
+  `parentid` is never a parameter — always stamped `group_id`.
+- `move_member` is **keyed on formid, not index**: the GTK model already carries
+  `BLENDOP_MASKS_GROUP_COL_FORMID`, so the stale-index hazard disappears.
+
+## Corrections the survey overturned
+
+These are the findings that contradict what the proposals — and in one case this project's own
+assumptions — took for granted. They are the reason to read this document before implementing.
+
+1. **`dt_masks_form_set_interaction_value()` does *not* copy-on-write for opacity.** All three
+   proposals claimed it does and wanted to route opacity writes through it. Verified false:
+   `masks_gui.c:4361-4365` dispatches to `_change_opacity()` (:4920-4928), a bare in-place write
+   plus a toast; the touch lives in the *caller* `dt_masks_form_change_opacity()` (:4939-4941).
+   Only the geometry branch touches, and it touches the *shape*. Reusing the existing setter as-is
+   would ship the `retouch.c:598` bug into the new API.
+2. **The locking rationale is misdiagnosed.** The framing "~21 unlocked external walks of
+   `dev->forms`" is wrong about which end is dangerous: every *writer* of `dev->forms` is on the GUI
+   thread, and the only cross-thread reader is `pixelpipe_hb.c:1629`'s snapshot on the worker.
+   Single writer ⟹ the unlocked GUI reads are benign today. The genuinely racy site is the unlocked
+   **write** at `libs/masks.c:377`. Read-side locking in the new enumerators is cheap insurance, not
+   a bug fix — and it is still a behaviour change that needs approval.
+3. **P2 does not make `dt_masks_form_t` opaque, and no phase of P2 will.** Three blockers survive:
+   the rasterisers take *non-const* `dt_masks_form_t *` because they lazily fill cached geometry (12
+   external sites); `spots.c:583-595` reads `circle->center`/`->radius` for a fast path and
+   `:149-158` mallocs a node for the v1 migration; and `dt_masks_get_form_size_from_nodes()` casts
+   each `points` element to `const float *` assuming `float node[2]` is the first member — a node
+   layout hard-coded in a public header. Budget a **P2b per-shape geometry axis** and freeze it
+   against retouch *and* spots together.
+4. **The type-token set feeds persisted conf keys.** `_get_mask_type()` feeds
+   `dt_masks_get_set_conf_value()`, which builds `plugins/darkroom/<plugin>/<type>/<feature>` — keys
+   declared in `data/anselconfig.xml.in` as `.../polygon/hardness` etc. So the token is **polygon**,
+   never supervisor's "path": adopting supervisor's spelling in a unified function would silently
+   repoint every polygon shape at a non-confgen key defaulting to 0.
+5. **Two ratchet mechanics decide how the API is *consumed*.** Section 9 counts `->` only, so a
+   converted site that reads `m[i].formid` by value is invisible to the gate while one that takes
+   `dt_masks_member_t *p = &m[i]` puts the count straight back — this is why value structs, not
+   accessor-per-field, are what actually drain the number. And `masks_strip()` drops lines starting
+   with `*` or `//` but **not** `/*` (verified: `blend.c:570` is counted), so do not reflow comments
+   in a commit that moves a baseline.
+
+## The first pull request
+
+**Convert `develop/supervisor.c` and `views/studio_capture.c`.** Not the biggest consumers — the
+two that can reach *zero* direct accesses. `supervisor.c` is the only pure consumer in the tree: 8
+member reads, no `->forms` touches, no allocations, no COW requirement, no lock, all inside three
+functions, behind a `dt_supervisor_active()` gate. It exercises all three read functions and both
+value structs, including the ordered members walk, on real code with a debug-only blast radius.
+
+Three commits, because each moves a different set of baselines and must stay bisectable:
+
+1. **Headers and the three read functions** (moves no count): create `masks_types.h` and
+   `masks_group.h`, move the enums, implement `get_info` / `copy_members` / `type_name`, fold
+   `_get_mask_type()` into the last of these, extend `test_masks_raster_contract.c` with read-API
+   cases reusing its stack-built fixtures.
+2. **`dt_masks_release_all_forms()`** in `masks_history.h` (moves 2 baselines): replaces the
+   four-line free-both-lists block copy-pasted verbatim into `develop.c`, `darkroom.c` and
+   `studio_capture.c`; `studio_capture.c` then drops `masks.h`. Baselines → includers 23,
+   `->forms` 76.
+3. **Convert `supervisor.c`** (moves 3 baselines): the three functions, plus renaming its own
+   `dt_sv_entry_t.formid` → `form_id` so the gate's documented false positive genuinely disappears
+   — and **delete that paragraph from section 9 in the same commit**. Baselines → includers 22,
+   member reads 94, writes 26.
+
+Expected ratchet movement: `24 → 22` includers, `11 → 11` masks_gui.h (unchanged), `102 → 94`
+reads, `27 → 26` writes, `4 → 4` allocations, `88 → 76` `->forms`.
+
+**Honesty the PR description must carry**, because the numbers overstate the result: neither file
+becomes `masks.h`-free — `supervisor.c` still reaches it through `blend.h:43` and
+`studio_capture.c` through `masks_gui.h:50`. The literal count falls; the edge does not die until
+the `blend.h` supply line is cut in its own PR.
+
+### Verification
+
+`tools/check_module_boundaries.sh` after **each** commit (a "ROSE"/"fell" line means the baseline
+edit is in the wrong commit and bisect will fail); three build configurations sequentially — Release,
+Debug and **build-nofeatures**, which is the one that caught the last include-supply-line break;
+`tools/check_unused_includes.sh`; `pragma_once_to_guards.py --verify` and `include_graph.py
+--summary` (cycles 0); `ctest`; `tools/check_it_runs.sh` — the gate that caught the colorprofiles
+double-free after every static check had passed; and a pixel comparison with
+`tools/check_export_pixels.sh` on a raw carrying **both** a drawn mask group and a retouch clone,
+`--disable-opencl`. Nothing in PR 1 is on the pixel path, but the claim has to be measured.
+
+The biggest silent risk is the **ordering contract**: supervisor only emits ids, so a `copy_members`
+that filtered or reordered would pass PR 1 unnoticed and silently re-pair every shape with the wrong
+clone algorithm the moment `spots.c` converts.
+
+## Later tranches
+
+The rule that keeps this honest: **a function lands in the same commit as its first caller**, and
+every commit that moves a count moves its baseline. (The survey found
+`dt_masks_form_get/set_interaction_value` already do what five external sites hand-roll, and have
+zero callers, because they shipped ahead of their consumers.)
+
+- **PR 2 — the detail-mask math is not the forms model.** Split `dt_masks_extend_border`,
+  `dt_masks_blur_9x9`, `dt_masks_calc_rawdetail_mask`, `dt_masks_calc_detail_mask` into
+  `masks_detail.h`: pure pixel math, no form involvement. `iop/detailmask.c` and `iop/demosaic.c`
+  name nothing else from `masks.h` and both drop it. Includers 22 → 20.
+- **PR 3 — `blend.h` stops being the masks module's delivery van.** Remove `masks.h` from
+  `blend.h:43`, the edge the gate's own comment calls worth more than the other twenty put together.
+  `blend.h` names zero masks symbols; the work is entirely a fan-out of explicit includes across its
+  33 includers, each confirmed against the symbols the file actually names, verified in
+  build-nofeatures.
+- **Then** the write API against `libs/masks.c` and `blend_gui.c` (the six COW holes), and finally
+  the P2b per-shape geometry axis for `retouch.c` and `spots.c`.

--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -308,15 +308,7 @@ void dt_dev_cleanup(dt_develop_t *dev)
     dev->color_picker.primary_sample = NULL;
   }
 
-  dt_pthread_rwlock_wrlock(&dev->masks_mutex);
-  // dev->forms and dev->allforms are independent claims on possibly-shared objects
-  // (dt_masks_append_form/dt_masks_create_ext each take their own reference): release both,
-  // do not unconditionally free -- a form referenced by both only reaches refcount 0 once.
-  g_list_free_full(dev->forms, (void (*)(void *))dt_masks_form_unref);
-  dev->forms = NULL;
-  g_list_free_full(dev->allforms, (void (*)(void *))dt_masks_form_unref);
-  dev->allforms = NULL;
-  dt_pthread_rwlock_unlock(&dev->masks_mutex);
+  dt_masks_release_all_forms(dev);
 
   dt_pthread_rwlock_destroy(&dev->masks_mutex);
 

--- a/src/develop/masks.h
+++ b/src/develop/masks.h
@@ -109,6 +109,7 @@ GList dev->forms
 #ifndef DT_DEVELOP_MASKS_H
 #define DT_DEVELOP_MASKS_H
 
+#include "develop/masks_types.h"   // the vocabulary: shape kinds, states, and the value types
 #include "system/atomic.h"
 #include "common/logging.h"
 #include "system/macros.h"
@@ -134,31 +135,7 @@ extern "C" {
 
 #define DEVELOP_MASKS_VERSION (6)
 
-/**forms types */
-typedef enum dt_masks_type_t
-{
-  DT_MASKS_NONE = 0, // keep first
-  DT_MASKS_CIRCLE = 1 << 0,
-  DT_MASKS_POLYGON = 1 << 1,
-  DT_MASKS_GROUP = 1 << 2,
-  DT_MASKS_CLONE = 1 << 3,
-  DT_MASKS_GRADIENT = 1 << 4,
-  DT_MASKS_ELLIPSE = 1 << 5,
-  DT_MASKS_BRUSH = 1 << 6,
-  DT_MASKS_NON_CLONE = 1 << 7,
 
-  DT_MASKS_ALL = DT_MASKS_CIRCLE | DT_MASKS_POLYGON | DT_MASKS_GROUP |
-                 DT_MASKS_GRADIENT | DT_MASKS_ELLIPSE | DT_MASKS_BRUSH,
-
-  DT_MASKS_IS_CLOSED_SHAPE = DT_MASKS_CIRCLE | DT_MASKS_ELLIPSE | DT_MASKS_POLYGON,
-  DT_MASKS_IS_OPEN_SHAPE   = DT_MASKS_ALL & ~DT_MASKS_IS_CLOSED_SHAPE,
-  
-  DT_MASKS_IS_RETOUCHE = DT_MASKS_CLONE | DT_MASKS_NON_CLONE,
-
-  DT_MASKS_IS_PATH_SHAPE   = DT_MASKS_POLYGON | DT_MASKS_BRUSH,
-  DT_MASKS_IS_PRIMITIVE_SHAPE = DT_MASKS_CIRCLE | DT_MASKS_ELLIPSE | DT_MASKS_GRADIENT
-
-} dt_masks_type_t;
 
 /**masts states */
 
@@ -172,20 +149,7 @@ typedef enum dt_masks_event_t
   DT_MASKS_EVENT_CHANGE = 5,
   DT_MASKS_EVENT_RESET  = 6
 } dt_masks_event_t;
-typedef enum dt_masks_state_t
-{
-  DT_MASKS_STATE_NONE = 0,
-  DT_MASKS_STATE_USE = 1 << 0,
-  DT_MASKS_STATE_SHOW = 1 << 1,
-  DT_MASKS_STATE_INVERSE = 1 << 2,
-  DT_MASKS_STATE_UNION = 1 << 3,
-  DT_MASKS_STATE_INTERSECTION = 1 << 4,
-  DT_MASKS_STATE_DIFFERENCE = 1 << 5,
-  DT_MASKS_STATE_EXCLUSION = 1 << 6,
-  DT_MASKS_STATE_NOOP = 1 << 7,
 
-  DT_MASKS_STATE_IS_COMBINE_OP = DT_MASKS_STATE_UNION | DT_MASKS_STATE_INTERSECTION | DT_MASKS_STATE_DIFFERENCE | DT_MASKS_STATE_EXCLUSION
-} dt_masks_state_t;
 
 typedef enum dt_masks_points_states_t
 {
@@ -199,19 +163,9 @@ typedef enum dt_masks_gradient_states_t
   DT_MASKS_GRADIENT_STATE_SIGMOIDAL = 2
 } dt_masks_gradient_states_t;
 
-typedef enum dt_masks_increment_t
-{
-  DT_MASKS_INCREMENT_ABSOLUTE = 0,
-  DT_MASKS_INCREMENT_SCALE = 1,
-  DT_MASKS_INCREMENT_OFFSET = 2
-} dt_masks_increment_t;
 
-typedef enum dt_masks_edit_mode_t
-{
-  DT_MASKS_EDIT_OFF = 0,
-  DT_MASKS_EDIT_FULL = 1,
-  DT_MASKS_EDIT_RESTRICTED = 2
-} dt_masks_edit_mode_t;
+
+
 
 typedef enum dt_masks_pressure_sensitivity_t
 {
@@ -287,34 +241,11 @@ typedef struct dt_masks_anchor_gradient_t
   dt_masks_gradient_states_t state;
 } dt_masks_anchor_gradient_t;
 
-/** structure used to store all forms's id for a group */
-typedef struct dt_masks_form_group_t
-{
-  int formid;
-  int parentid;
-  int state;
-  float opacity;
-} dt_masks_form_group_t;
 
 
 
-/*
-* Type of user interaction to map with internal properties of masks.
-* Those used to be deduced implicitly by each shape from Shift/Ctrl/Shift+Ctrl + mouse
-* scroll, which is a shitty design when using Wacom tablets. No shape reads key modifiers
-* any more: the wheel is resolved once, against the user's mapping, by
-* dt_masks_scroll_get_interaction() -- see masks_gui.h -- and every entry point
-* (mouse_scroll callback, context-menu sliders) names the property it acts on.
-*/
-typedef enum dt_masks_interaction_t
-{
-  DT_MASKS_INTERACTION_UNDEF = 0,    // no property: an unmapped wheel combination does nothing
-  DT_MASKS_INTERACTION_SIZE = 1,     // property of the form (shape), explicit
-  DT_MASKS_INTERACTION_HARDNESS = 2, // property of the form (shape), explicit
-  DT_MASKS_INTERACTION_OPACITY = 3,  // property of the group in which the form is included, explicit
-  DT_MASKS_INTERACTION_ROTATION = 4, // property of the form (shape), explicit
-  DT_MASKS_INTERACTION_LAST
-} dt_masks_interaction_t;
+
+
 
 /** structure used to define a form */
 typedef struct dt_masks_form_t

--- a/src/develop/masks/group.c
+++ b/src/develop/masks/group.c
@@ -265,8 +265,12 @@ static dt_masks_raster_result_t _group_get_mask(const dt_iop_module_t *const mod
     return DT_MASKS_RASTER_ERROR;
   }
 
-  // and we get all masks
-  int pos = 0;
+  /* Slots are filled DENSELY: `nb_ok' is both the count of usable children and the index of the
+   * next one. A child that resolves to nothing -- an id that is gone, or a shape with no geometry
+   * -- simply does not take a slot. That matters because the bounding-box and copy loops below
+   * read every slot they iterate: indexing by list position instead left a hole whose px/py/w/h
+   * were never written (the arrays are malloc'd, not calloc'd), and one unresolved id was enough
+   * to drag the group's bounding box to garbage. */
   int nb_ok = 0;
   dt_masks_raster_result_t err = DT_MASKS_RASTER_OK;
   for(GList *fpts = form->points; fpts; fpts = g_list_next(fpts))
@@ -275,23 +279,22 @@ static dt_masks_raster_result_t _group_get_mask(const dt_iop_module_t *const mod
     dt_masks_form_t *sel = dt_masks_get_from_id(module->dev, fpt->formid);
     if(sel)
     {
-      /* EMPTY is folded in as a failure here, unlike in the ROI rasteriser: this legacy path
-       * keeps one slot per child in parallel malloc'd arrays, and skipping a slot would leave
-       * its `states'/`op' entries uninitialised for the combine below. Erroring out is still
-       * strictly better than what this did before -- a child reporting success with no buffer
-       * (which is what a degenerate circle or ellipse used to do) walked on into the combine
-       * with bufs[pos] NULL and w/h/px/py never written. Making the slots skippable belongs
-       * with the rest of this path's bookkeeping. */
-      if(dt_masks_get_mask(module, pipe, piece, sel, &bufs[pos], &w[pos], &h[pos], &px[pos], &py[pos])
-         != DT_MASKS_RASTER_OK)
+      const dt_masks_raster_result_t child
+          = dt_masks_get_mask(module, pipe, piece, sel, &bufs[nb_ok], &w[nb_ok], &h[nb_ok],
+                              &px[nb_ok], &py[nb_ok]);
+      if(child == DT_MASKS_RASTER_ERROR)
       {
         err = DT_MASKS_RASTER_ERROR;
         break;
       }
+      /* A shape with nothing to draw contributes nothing and must NOT stop the fold: the other
+       * members of the group are still theirs to render. It takes no slot, so the loops below
+       * never see it. (dt_masks_get_mask() has already zeroed this slot's out-parameters.) */
+      if(child == DT_MASKS_RASTER_EMPTY) continue;
       if(fpt->state & DT_MASKS_STATE_INVERSE)
       {
         const double start = dt_get_wtime();
-        if(_inverse_mask(module, piece, sel, &bufs[pos], &w[pos], &h[pos], &px[pos], &py[pos]) != 0)
+        if(_inverse_mask(module, piece, sel, &bufs[nb_ok], &w[nb_ok], &h[nb_ok], &px[nb_ok], &py[nb_ok]) != 0)
         {
           err = DT_MASKS_RASTER_ERROR;
           break;
@@ -299,11 +302,10 @@ static dt_masks_raster_result_t _group_get_mask(const dt_iop_module_t *const mod
         if(dt_get_debug_flags() & DT_DEBUG_PERF)
           dt_print(DT_DEBUG_MASKS, "[masks %s] inverse took %0.04f sec\n", sel->name, dt_get_wtime() - start);
       }
-      op[pos] = fpt->opacity;
-      states[pos] = fpt->state;
+      op[nb_ok] = fpt->opacity;
+      states[nb_ok] = fpt->state;
       nb_ok++;
     }
-    pos++;
   }
   if(err) goto cleanup;
   if(nb_ok == 0)
@@ -318,7 +320,7 @@ static dt_masks_raster_result_t _group_get_mask(const dt_iop_module_t *const mod
 
   // now we get the min, max, width, height of the final mask
   int l = INT_MAX, r = INT_MIN, t = INT_MAX, b = INT_MIN;
-  for(int i = 0; i < nb; i++)
+  for(int i = 0; i < nb_ok; i++)
   {
     l = MIN(l, px[i]);
     t = MIN(t, py[i]);
@@ -342,7 +344,7 @@ static dt_masks_raster_result_t _group_get_mask(const dt_iop_module_t *const mod
   const int dst_w = r - l;
   const int dst_h = b - t;
   float *const dst = *buffer;
-  for(int i = 0; i < nb; i++)
+  for(int i = 0; i < nb_ok; i++)
   {
     const double start = dt_get_wtime();
     const int wi = w[i];

--- a/src/develop/masks/masks.c
+++ b/src/develop/masks/masks.c
@@ -53,6 +53,7 @@
 #include "develop/masks.h"
 #include "history/notify.h"
 #include "develop/blend_gui.h"   // dt_iop_gui_blend_masks_update()
+#include "develop/masks_group.h"
 #include "develop/masks/masks_functions.h"
 #include "develop/masks/masks_touched.h"
 #include "develop/develop.h"
@@ -1422,6 +1423,90 @@ dt_masks_raster_result_t dt_masks_get_mask_roi(const dt_iop_module_t *const modu
   return (form->functions && form->functions->get_mask_roi)
     ? form->functions->get_mask_roi(module, pipe, piece, form, roi, buffer, touched)
     : DT_MASKS_RASTER_ERROR;
+}
+
+
+/* ==========================================================================================
+ * The read side of the group API (develop/masks_group.h).
+ *
+ * All three are thread-neutral by construction: they read only the object they are handed and
+ * take no lock. That is what lets the pipeline call them on a snapshot and the GUI call them on
+ * the live list with the same code.
+ * ========================================================================================== */
+
+gboolean dt_masks_form_get_info(const dt_masks_form_t *form, dt_masks_form_info_t *out)
+{
+  /* `out' is left untouched on FALSE so a caller may keep a default in it across a failed call --
+   * the dt_colorspaces_profile_at() convention. */
+  if(IS_NULL_PTR(form) || IS_NULL_PTR(out)) return FALSE;
+
+  out->formid = form->formid;
+  out->type = form->type;
+  out->version = form->version;
+  out->is_group = (form->type & DT_MASKS_GROUP) != 0;
+  out->is_retouch = (form->type & DT_MASKS_IS_RETOUCHE) != 0;
+  /* Not recursive: the group's own rows, which is what compositing order is defined over. */
+  out->member_count = out->is_group ? g_list_length(form->points) : 0;
+  g_strlcpy(out->name, form->name, sizeof(out->name));
+  return TRUE;
+}
+
+guint dt_masks_group_copy_members(const dt_masks_form_t *group, dt_masks_member_t *out,
+                                  const guint out_max)
+{
+  /* Refusing anything that is not a group is what keeps the polymorphic ->points unreachable from
+   * outside: for a group it holds membership rows, for every other form it holds geometry nodes,
+   * and the only thing telling them apart is this bit. */
+  if(IS_NULL_PTR(group) || !(group->type & DT_MASKS_GROUP)) return 0;
+
+  guint total = 0;
+  for(const GList *node = group->points; node; node = g_list_next(node), total++)
+  {
+    if(IS_NULL_PTR(out) || total >= out_max) continue;
+
+    dt_masks_member_t *const member = &out[total];
+    member->index = total;
+
+    /* A row that cannot be read STILL CONSUMES ITS INDEX. Position is the compositing order and
+     * the index into retouch's rt_forms[] and spots' clone_algo[], both persisted in the user's
+     * database, so dropping a row here would silently re-pair every later shape with the wrong
+     * algorithm. It comes back zeroed instead. */
+    const dt_masks_form_group_t *const entry = (const dt_masks_form_group_t *)node->data;
+    if(IS_NULL_PTR(entry))
+    {
+      member->formid = 0;
+      member->parentid = 0;
+      member->state = DT_MASKS_STATE_NONE;
+      member->opacity = 0.0f;
+      continue;
+    }
+
+    member->formid = entry->formid;
+    member->parentid = entry->parentid;
+    member->state = (dt_masks_state_t)entry->state;
+    member->opacity = entry->opacity;
+  }
+
+  /* The TOTAL, always -- a caller that passed a short buffer needs to know it was short, and a
+   * caller that passed NULL is asking for exactly this. */
+  return total;
+}
+
+const char *dt_masks_type_name(const dt_masks_type_t type)
+{
+  /* dt_masks_type_t is a bit field, not an enumeration of alternatives, so first match wins and
+   * this order is load-bearing. It is the order the conf-key builder has always used.
+   *
+   * These tokens are PERSISTED: they build plugins/darkroom/<plugin>/<type>/<feature>, declared in
+   * data/anselconfig.xml.in. "polygon" can never become "path" -- a key outside confgen reads 0,
+   * which would silently reset the user's hardness. */
+  if(type & DT_MASKS_CIRCLE) return "circle";
+  else if(type & DT_MASKS_POLYGON) return "polygon";
+  else if(type & DT_MASKS_ELLIPSE) return "ellipse";
+  else if(type & DT_MASKS_GRADIENT) return "gradient";
+  else if(type & DT_MASKS_BRUSH) return "brush";
+  else if(type & DT_MASKS_GROUP) return "group";
+  else return "unknown";
 }
 
 // clang-format off

--- a/src/develop/masks/masks_gui.c
+++ b/src/develop/masks/masks_gui.c
@@ -36,6 +36,7 @@
 #include "develop/geometry/geometry.h"   // dt_geometry_chain_generation()
 #include "develop/masks.h"
 #include "develop/masks_gui.h"
+#include "develop/masks_group.h"
 #include "develop/masks/masks_functions.h"
 #include "widgets/bauhaus.h"
 #include "common/conf.h"
@@ -4394,25 +4395,6 @@ const char * _get_mask_plugin(dt_masks_form_t *mask_form)
     return "masks";
 }
 
-const char * _get_mask_type(dt_masks_form_t *mask_form)
-{
-  // warning: mask types or not int enum but bit flags ?!?
-  // that's a shitty design that prevents us from doing a clean switch case over the enum.
-  // why would we overlap mask types ?!?
-  if(mask_form->type & DT_MASKS_CIRCLE)
-    return "circle";
-  else if(mask_form->type & DT_MASKS_POLYGON)
-    return "polygon";
-  else if(mask_form->type & DT_MASKS_ELLIPSE)
-    return "ellipse";
-  else if(mask_form->type & DT_MASKS_GRADIENT)
-    return "gradient";
-  else if(mask_form->type & DT_MASKS_BRUSH)
-    return "brush";
-  else
-    return "unknown";
-}
-
 float dt_masks_apply_increment(float current, float amount, dt_masks_increment_t increment, int flow)
 {
   switch(increment)
@@ -4451,7 +4433,7 @@ float dt_masks_get_set_conf_value(dt_masks_form_t *mask_form, char *feature, flo
     config_key = g_strdup_printf("plugins/darkroom/%s_opacity", _get_mask_plugin(mask_form));
   else
     config_key = g_strdup_printf("plugins/darkroom/%s/%s/%s",
-                                 _get_mask_plugin(mask_form), _get_mask_type(mask_form), feature);
+                                 _get_mask_plugin(mask_form), dt_masks_type_name(mask_form->type), feature);
 
   if(!g_strcmp0(feature, "rotation")) flow = (flow > 1) ? (flow - 1) * 5 : flow;
 

--- a/src/develop/masks/masks_history.c
+++ b/src/develop/masks/masks_history.c
@@ -113,3 +113,17 @@ GList *dt_masks_snapshot_current_forms(dt_develop_t *dev, gboolean reset_changed
   if(reset_changed) dev->forms_changed = FALSE;
   return forms_snapshot;
 }
+
+void dt_masks_release_all_forms(dt_develop_t *dev)
+{
+  if(IS_NULL_PTR(dev)) return;
+
+  dt_pthread_rwlock_wrlock(&dev->masks_mutex);
+  /* Release both claims, never free unconditionally: a form held by dev->forms AND dev->allforms
+   * only reaches refcount 0 on the second unref. */
+  g_list_free_full(dev->forms, (void (*)(void *))dt_masks_form_unref);
+  dev->forms = NULL;
+  g_list_free_full(dev->allforms, (void (*)(void *))dt_masks_form_unref);
+  dev->allforms = NULL;
+  dt_pthread_rwlock_unlock(&dev->masks_mutex);
+}

--- a/src/develop/masks/masks_history.h
+++ b/src/develop/masks/masks_history.h
@@ -69,6 +69,20 @@ void dt_masks_replace_current_forms(struct dt_develop_t *dev, GList *forms);
  *  Optionally reset dev->forms_changed. */
 GList *dt_masks_snapshot_current_forms(struct dt_develop_t *dev, gboolean reset_changed);
 
+/** Release every reference this dev holds on any form, and empty both lists.
+ *
+ *  dev->forms and dev->allforms are INDEPENDENT claims on possibly-shared objects
+ *  (dt_masks_append_form() and dt_masks_create_ext() each take their own reference), so both are
+ *  released and neither is unconditionally freed: a form referenced by both only reaches
+ *  refcount 0 once.
+ *
+ *  Takes dev->masks_mutex as writer itself -- do NOT wrap the call in one. That mistake is silent
+ *  rather than a deadlock, because dt_pthread_rwlock_t tracks same-thread recursive writers, so it
+ *  would leave a trap for the next reader rather than a failure.
+ *
+ *  Does not touch dev->form_gui: that is the GUI's object, torn down by dt_masks_gui_cleanup(). */
+void dt_masks_release_all_forms(struct dt_develop_t *dev);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/develop/masks_group.h
+++ b/src/develop/masks_group.h
@@ -1,0 +1,124 @@
+/*
+    This file is part of Ansel,
+    Copyright (C) 2026 Aurélien PIERRE.
+
+    Ansel is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Ansel is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Ansel.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+/** @file develop/masks_group.h
+ *
+ * @brief Ask the masks module about a shape or a group, instead of reading its structs.
+ *
+ * @details Part of the enclosure of src/develop/masks (issue #1299, phase P2). Eight files outside
+ * the module reach directly into dt_masks_form_t and dt_masks_form_group_t; this is where the
+ * questions they are really asking get names.
+ *
+ * WHAT THE FIRST PARAMETER MEANS -- the convention that replaces per-function threading notes:
+ *
+ *   GList *forms first            -- resolve against a borrowed refcounted snapshot (pipe->forms,
+ *                                    hist->forms). No lock, no copy-on-write, read-only.
+ *   const dt_masks_form_t * first -- an already-resolved handle. Thread-neutral: reads only that
+ *                                    object's own memory. No lock, no copy-on-write.
+ *   dt_develop_t *dev first       -- touches the live list. Returns dt_masks_result_t => it writes,
+ *                                    and owns the lock and the copy-on-write internally.
+ *
+ * Only the resolvers come in pairs, which is what makes a cross-thread resolve visible at the call
+ * site rather than invisible.
+ *
+ * Everything crosses this boundary BY VALUE (dt_masks_form_info_t, dt_masks_member_t). A caller
+ * never holds a pointer into a refcounted form: the next dt_masks_cow_touch() replaces the object
+ * wholesale, so such a pointer is a use-after-free waiting for a slow enough reader.
+ *
+ * This header includes develop/masks_types.h and nothing else -- in particular no GTK, unlike
+ * develop/masks_gui.h. Model: develop/masks/masks_history.h, which already compiles against an
+ * opaque dt_masks_form_t on tag declarations alone.
+ */
+
+#ifndef DT_DEVELOP_MASKS_MASKS_GROUP_H
+#define DT_DEVELOP_MASKS_MASKS_GROUP_H
+
+#include "develop/masks_types.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+struct dt_develop_t;
+struct dt_masks_form_t;
+struct dt_iop_module_t;
+
+/**
+ * @brief Describe a form: identity, kind, and -- for a group -- how many members it holds.
+ *
+ * Thread-neutral: reads only @p form's own memory. Takes no lock and does not copy-on-write.
+ *
+ * @param form the form to describe. NULL is not an error, it is simply not a form: returns FALSE.
+ * @param out filled on TRUE, and left COMPLETELY UNTOUCHED on FALSE, so a caller may keep a
+ *            default in it across a failed call.
+ * @return TRUE when @p out was filled.
+ */
+gboolean dt_masks_form_get_info(const struct dt_masks_form_t *form, dt_masks_form_info_t *out);
+
+/**
+ * @brief Copy a group's membership rows, in order, into caller storage.
+ *
+ * Thread-neutral: reads only @p group's own memory. Takes no lock and does not copy-on-write.
+ *
+ * ORDER IS THE CONTRACT, and it is not cosmetic. The stored order is the compositing order, the
+ * GTK row order, the index into iop/retouch.c's rt_forms[] and the index into iop/spots.c's
+ * clone_algo[] -- the last two persisted in every user's database. This function must never
+ * filter, never recurse into sub-groups, and never reorder. A row that cannot be read still
+ * consumes its index (it comes back zeroed), because dropping it would silently re-pair every
+ * later shape with the wrong algorithm.
+ *
+ * @param group a group form. Anything else -- including NULL, and including a shape whose
+ *              ->points holds geometry nodes rather than membership rows -- returns 0. That check
+ *              is what keeps the polymorphic ->points unreachable from outside the module.
+ * @param out caller storage, or NULL to query the count only.
+ * @param out_max capacity of @p out in elements.
+ * @return the TOTAL number of members, which may exceed @p out_max; exactly
+ *         MIN(total, out_max) elements are written.
+ */
+guint dt_masks_group_copy_members(const struct dt_masks_form_t *group,
+                                  dt_masks_member_t *out, guint out_max);
+
+/**
+ * @brief The stable, untranslated token for a shape kind: circle, ellipse, polygon, brush,
+ * gradient, group, or "unknown".
+ *
+ * Takes a VALUE, not a form, so a caller can name a kind it recorded earlier, after the form it
+ * came from may be gone.
+ *
+ * THESE TOKENS ARE PERSISTED. They build the conf keys plugins/darkroom/<plugin>/<type>/<feature>
+ * declared in data/anselconfig.xml.in (".../polygon/hardness" and friends), so the polygon token
+ * is "polygon" and can never become "path": a shape reading a key that is not in confgen gets 0,
+ * which would silently reset the user's setting. dt_masks_type_t is a bit field, so first match
+ * wins and the order below is load-bearing.
+ *
+ * @return a static string, never NULL, never translated. For display, use the translated label in
+ *         develop/masks_gui.h instead.
+ */
+const char *dt_masks_type_name(dt_masks_type_t type);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // DT_DEVELOP_MASKS_MASKS_GROUP_H
+
+// clang-format off
+// modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py
+// vim: shiftwidth=2 expandtab tabstop=2 cindent
+// kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;
+// clang-format on

--- a/src/develop/masks_types.h
+++ b/src/develop/masks_types.h
@@ -1,0 +1,199 @@
+/*
+    This file is part of Ansel,
+    Copyright (C) 2026 Aurélien PIERRE.
+
+    Ansel is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Ansel is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Ansel.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+/** @file develop/masks_types.h
+ *
+ * @brief The masks vocabulary: the enumerations a caller needs to NAME a shape or an operation,
+ * and the value types the module hands across its boundary.
+ *
+ * @details This exists for the same reason colorprofiles/profile_types.h does. develop/masks.h is
+ * 880 lines that drag develop/develop.h, develop/pixelpipe.h, caches/pixelpipe_cache_alloc.h,
+ * common/logging.h, system/atomic.h, system/simd.h and common/times.h behind them. A translation
+ * unit that only needs to say DT_MASKS_CIRCLE, or to receive a description of a shape, should not
+ * have to take the pixel pipeline with it -- and while it does, it can never drop the include,
+ * which is the whole objective of the enclosure (issue #1299).
+ *
+ * Nothing here may include anything but <glib.h>. develop/masks.h includes this file first, so
+ * every existing consumer keeps compiling unchanged.
+ */
+
+#ifndef DT_DEVELOP_MASKS_TYPES_H
+#define DT_DEVELOP_MASKS_TYPES_H
+
+#include <glib.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** Size of dt_masks_form_t.name. Named because a caller receiving a copy needs the bound, and
+ * because sizeof(form->name) stops being available once the struct is not in scope. */
+#define DT_MASKS_FORM_NAME_LEN 128
+
+/**forms types */
+typedef enum dt_masks_type_t
+{
+  DT_MASKS_NONE = 0, // keep first
+  DT_MASKS_CIRCLE = 1 << 0,
+  DT_MASKS_POLYGON = 1 << 1,
+  DT_MASKS_GROUP = 1 << 2,
+  DT_MASKS_CLONE = 1 << 3,
+  DT_MASKS_GRADIENT = 1 << 4,
+  DT_MASKS_ELLIPSE = 1 << 5,
+  DT_MASKS_BRUSH = 1 << 6,
+  DT_MASKS_NON_CLONE = 1 << 7,
+
+  DT_MASKS_ALL = DT_MASKS_CIRCLE | DT_MASKS_POLYGON | DT_MASKS_GROUP |
+                 DT_MASKS_GRADIENT | DT_MASKS_ELLIPSE | DT_MASKS_BRUSH,
+
+  DT_MASKS_IS_CLOSED_SHAPE = DT_MASKS_CIRCLE | DT_MASKS_ELLIPSE | DT_MASKS_POLYGON,
+  DT_MASKS_IS_OPEN_SHAPE   = DT_MASKS_ALL & ~DT_MASKS_IS_CLOSED_SHAPE,
+  
+  DT_MASKS_IS_RETOUCHE = DT_MASKS_CLONE | DT_MASKS_NON_CLONE,
+
+  DT_MASKS_IS_PATH_SHAPE   = DT_MASKS_POLYGON | DT_MASKS_BRUSH,
+  DT_MASKS_IS_PRIMITIVE_SHAPE = DT_MASKS_CIRCLE | DT_MASKS_ELLIPSE | DT_MASKS_GRADIENT
+
+} dt_masks_type_t;
+
+typedef enum dt_masks_state_t
+{
+  DT_MASKS_STATE_NONE = 0,
+  DT_MASKS_STATE_USE = 1 << 0,
+  DT_MASKS_STATE_SHOW = 1 << 1,
+  DT_MASKS_STATE_INVERSE = 1 << 2,
+  DT_MASKS_STATE_UNION = 1 << 3,
+  DT_MASKS_STATE_INTERSECTION = 1 << 4,
+  DT_MASKS_STATE_DIFFERENCE = 1 << 5,
+  DT_MASKS_STATE_EXCLUSION = 1 << 6,
+  DT_MASKS_STATE_NOOP = 1 << 7,
+
+  DT_MASKS_STATE_IS_COMBINE_OP = DT_MASKS_STATE_UNION | DT_MASKS_STATE_INTERSECTION | DT_MASKS_STATE_DIFFERENCE | DT_MASKS_STATE_EXCLUSION
+} dt_masks_state_t;
+
+typedef enum dt_masks_increment_t
+{
+  DT_MASKS_INCREMENT_ABSOLUTE = 0,
+  DT_MASKS_INCREMENT_SCALE = 1,
+  DT_MASKS_INCREMENT_OFFSET = 2
+} dt_masks_increment_t;
+
+typedef enum dt_masks_edit_mode_t
+{
+  DT_MASKS_EDIT_OFF = 0,
+  DT_MASKS_EDIT_FULL = 1,
+  DT_MASKS_EDIT_RESTRICTED = 2
+} dt_masks_edit_mode_t;
+
+/*
+* Type of user interaction to map with internal properties of masks.
+* Those used to be deduced implicitly by each shape from Shift/Ctrl/Shift+Ctrl + mouse
+* scroll, which is a shitty design when using Wacom tablets. No shape reads key modifiers
+* any more: the wheel is resolved once, against the user's mapping, by
+* dt_masks_scroll_get_interaction() -- see masks_gui.h -- and every entry point
+* (mouse_scroll callback, context-menu sliders) names the property it acts on.
+*/
+typedef enum dt_masks_interaction_t
+{
+  DT_MASKS_INTERACTION_UNDEF = 0,    // no property: an unmapped wheel combination does nothing
+  DT_MASKS_INTERACTION_SIZE = 1,     // property of the form (shape), explicit
+  DT_MASKS_INTERACTION_HARDNESS = 2, // property of the form (shape), explicit
+  DT_MASKS_INTERACTION_OPACITY = 3,  // property of the group in which the form is included, explicit
+  DT_MASKS_INTERACTION_ROTATION = 4, // property of the form (shape), explicit
+  DT_MASKS_INTERACTION_LAST
+} dt_masks_interaction_t;
+
+/** structure used to store all forms's id for a group */
+typedef struct dt_masks_form_group_t
+{
+  int formid;
+  int parentid;
+  int state;
+  float opacity;
+} dt_masks_form_group_t;
+
+/**
+ * @brief What a request that may change the masks model did.
+ *
+ * @details UNCHANGED is not a failure and is the reason this is not a gboolean: a caller that
+ * asked for the value a member already has must skip its history commit, or every no-op slider
+ * tick writes an undo step and a database row.
+ */
+typedef enum dt_masks_result_t
+{
+  DT_MASKS_OK = 0,     /* the model changed */
+  DT_MASKS_UNCHANGED,  /* legal request, nothing to do -- caller skips the history commit */
+  DT_MASKS_NOT_FOUND,  /* no such group, or no such member in it */
+  DT_MASKS_INVALID     /* refused: not a group, self-inclusion, bad argument */
+} dt_masks_result_t;
+
+/**
+ * @brief One shape's membership of one group, BY VALUE.
+ *
+ * @details The caller gets a copy, never a pointer into the group's own list. That is deliberate
+ * twice over: the entry it would otherwise point at belongs to a refcounted, copy-on-write object
+ * that the next dt_masks_cow_touch() replaces wholesale, and dt_masks_form_group_t itself can
+ * never be made opaque -- common/xmp_sidecar.cc casts an XMP blob straight to an array of them and
+ * validates the length against sizeof, so its size and field order ARE the on-disk format in every
+ * user's sidecars. A value type is what lets everyone else stop depending on that layout.
+ *
+ * `index` is the position in the group's list, and position is meaning: it is the compositing
+ * order, the GTK row identity, and the index into iop/retouch.c's rt_forms[] and iop/spots.c's
+ * clone_algo[] -- both persisted in the user's database.
+ */
+typedef struct dt_masks_member_t
+{
+  int              formid;
+  int              parentid;   /* the row's AUTHORED origin; not always the group holding it */
+  guint            index;      /* position == compositing order == GTK row identity */
+  dt_masks_state_t state;      /* tightened from the stored struct's plain int */
+  float            opacity;
+} dt_masks_member_t;
+
+/**
+ * @brief What a form IS, BY VALUE: identity, kind, and -- for a group -- how many members.
+ *
+ * @details `name` is COPIED rather than borrowed. A borrowed const char * into a refcounted form
+ * is exactly the hazard develop/blend_gui.c already trips, caching the pointer across a call that
+ * can clone the form underneath it.
+ *
+ * `member_count` is NOT recursive: it counts the group's own rows, which is what every caller
+ * that asks means, and what the compositing order is defined over.
+ */
+typedef struct dt_masks_form_info_t
+{
+  int             formid;
+  dt_masks_type_t type;
+  int             version;
+  gboolean        is_group;
+  gboolean        is_retouch;   /* (type & DT_MASKS_IS_RETOUCHE) != 0 */
+  guint           member_count; /* 0 unless is_group */
+  char            name[DT_MASKS_FORM_NAME_LEN];
+} dt_masks_form_info_t;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // DT_DEVELOP_MASKS_TYPES_H
+
+// clang-format off
+// modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py
+// vim: shiftwidth=2 expandtab tabstop=2 cindent
+// kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;
+// clang-format on

--- a/src/develop/supervisor.c
+++ b/src/develop/supervisor.c
@@ -24,7 +24,8 @@
 #include "common/introspection.h"    // dt_introspection_field_t
 #include "develop/imageop.h"         // dt_iop_module_t (introspection accessors)
 #include "develop/blend.h"           // dt_develop_blend_params_t + name tables
-#include "develop/masks.h"           // dt_masks_form_t + group members
+#include "develop/masks_types.h"     // dt_masks_type_t, dt_masks_form_info_t, dt_masks_member_t
+#include "develop/masks_group.h"     // dt_masks_form_get_info(), dt_masks_group_copy_members()
 #include "caches/pixelpipe_cache.h" // DT_PIXELPIPE_CACHE_HASH_INVALID
 #include "develop/pixelpipe_hb.h"    // dt_pixelpipe_get_pipe_name
 
@@ -98,7 +99,7 @@ typedef struct dt_sv_entry_t
   char img_filename[128];
 
   // form facet
-  int formid;
+  int form_id;   // supervisor's own copy; NOT a masks member -- see the note in check_module_boundaries.sh
   int form_type;
   char form_name[64];
 
@@ -214,35 +215,30 @@ uint64_t dt_supervisor_form_key(const int formid)
   return _form_key(formid);
 }
 
-static const char *_form_type_name(const int type)
-{
-  if(type & DT_MASKS_CIRCLE)   return "circle";
-  if(type & DT_MASKS_ELLIPSE)  return "ellipse";
-  if(type & DT_MASKS_POLYGON)  return "path";
-  if(type & DT_MASKS_BRUSH)    return "brush";
-  if(type & DT_MASKS_GRADIENT) return "gradient";
-  if(type & DT_MASKS_GROUP)    return "group";
-  return "?";
-}
-
 // For a group form, the members (its `points` are group refs). Each member is an
 // object { id, hash } where hash is the member's form key, so the GUI can make it
 // a clickable link to the member form object.
 static JsonArray *_form_members_json(const dt_masks_form_t *form)
 {
-  if(!form || !(form->type & DT_MASKS_GROUP) || !form->points) return NULL;
+  dt_masks_form_info_t info;
+  if(!dt_masks_form_get_info(form, &info) || !info.is_group || info.member_count == 0) return NULL;
+
+  // Rows by value and in stored order -- which is the compositing order, so the array this
+  // emits is the one the GUI can read top to bottom.
+  dt_masks_member_t *members = g_new0(dt_masks_member_t, info.member_count);
+  const guint count = dt_masks_group_copy_members(form, members, info.member_count);
+
   JsonArray *a = json_array_new();
-  for(GList *p = form->points; p; p = g_list_next(p))
+  for(guint i = 0; i < count; i++)
   {
-    const dt_masks_form_group_t *g = (const dt_masks_form_group_t *)p->data;
-    if(!g) continue;
     JsonObject *o = json_object_new();
-    json_object_set_int_member(o, "id", g->formid);
+    json_object_set_int_member(o, "id", members[i].formid);
     char buf[32];
-    g_snprintf(buf, sizeof(buf), "0x%016" G_GINT64_MODIFIER "x", _form_key(g->formid));
+    g_snprintf(buf, sizeof(buf), "0x%016" G_GINT64_MODIFIER "x", _form_key(members[i].formid));
     json_object_set_string_member(o, "hash", buf);
     json_array_add_object_element(a, o);
   }
+  g_free(members);
   return a;
 }
 
@@ -254,14 +250,15 @@ static JsonArray *_forms_json(GList *forms)
   for(GList *f = forms; f; f = g_list_next(f))
   {
     const dt_masks_form_t *form = (const dt_masks_form_t *)f->data;
-    if(!form) continue;
+    dt_masks_form_info_t info;
+    if(!dt_masks_form_get_info(form, &info)) continue;
     JsonObject *o = json_object_new();
-    json_object_set_int_member(o, "id", form->formid);
+    json_object_set_int_member(o, "id", info.formid);
     char buf[32];
-    g_snprintf(buf, sizeof(buf), "0x%016" G_GINT64_MODIFIER "x", _form_key(form->formid));
+    g_snprintf(buf, sizeof(buf), "0x%016" G_GINT64_MODIFIER "x", _form_key(info.formid));
     json_object_set_string_member(o, "hash", buf); // clickable link to the form object
-    if(form->name[0]) json_object_set_string_member(o, "name", form->name);
-    json_object_set_string_member(o, "type", _form_type_name(form->type));
+    if(info.name[0]) json_object_set_string_member(o, "name", info.name);
+    json_object_set_string_member(o, "type", dt_masks_type_name(info.type));
     JsonArray *members = _form_members_json(form);
     if(members) json_object_set_array_member(o, "members", members);
     json_array_add_object_element(out, o);
@@ -1337,9 +1334,12 @@ void dt_supervisor_image(const dt_sv_op_t op, const int32_t imgid, const dt_imag
 
 void dt_supervisor_form(const dt_sv_op_t op, const dt_masks_form_t *form)
 {
-  if(!dt_supervisor_active() || !_sv.inited || !form) return;
+  if(!dt_supervisor_active() || !_sv.inited) return;
 
-  const uint64_t key = _form_key(form->formid);
+  dt_masks_form_info_t info;
+  if(!dt_masks_form_get_info(form, &info)) return;
+
+  const uint64_t key = _form_key(info.formid);
   // Build the group members outside the lock (read-only walk of form->points).
   JsonArray *members = _form_members_json(form);
 
@@ -1347,19 +1347,19 @@ void dt_supervisor_form(const dt_sv_op_t op, const dt_masks_form_t *form)
   gboolean created;
   dt_sv_entry_t *e = _entry_get_locked(key, &created);
   e->facets |= DT_SV_F_FORM;
-  e->formid = form->formid;
-  e->form_type = form->type;
-  if(form->name[0]) g_strlcpy(e->form_name, form->name, sizeof(e->form_name));
+  e->form_id = info.formid;
+  e->form_type = info.type;
+  if(info.name[0]) g_strlcpy(e->form_name, info.name, sizeof(e->form_name));
   // First sighting is a create regardless of the caller's intent (a form may be
   // seen first via a history snapshot rather than its allocation).
   const dt_sv_op_t eff_op = created ? DT_SV_CREATE : op;
   const gboolean resurrected = _touch_alive_locked(e, created, eff_op);
 
   JsonObject *root = _envelope(eff_op, "form", key, -1, -1, e->alive, resurrected);
-  json_object_set_int_member(root, "id", form->formid);
+  json_object_set_int_member(root, "id", info.formid);
   if(e->form_name[0]) json_object_set_string_member(root, "name", e->form_name);
-  json_object_set_string_member(root, "type", _form_type_name(form->type));
-  json_object_set_int_member(root, "version", form->version);
+  json_object_set_string_member(root, "type", dt_masks_type_name(info.type));
+  json_object_set_int_member(root, "version", info.version);
   if(members) json_object_set_array_member(root, "members", members);
   dt_pthread_mutex_unlock(&_sv.lock);
 
@@ -1402,7 +1402,7 @@ gchar *dt_supervisor_describe(const uint64_t hash)
 
   if(e->facets & DT_SV_F_FORM)
   {
-    g_string_append_printf(s, "form #%d %s", e->formid, _form_type_name(e->form_type));
+    g_string_append_printf(s, "form #%d %s", e->form_id, dt_masks_type_name((dt_masks_type_t)e->form_type));
     if(e->form_name[0]) g_string_append_printf(s, " (%s)", e->form_name);
   }
   else if(e->facets & DT_SV_F_IMAGE)

--- a/src/iop/spots.c
+++ b/src/iop/spots.c
@@ -650,9 +650,13 @@ static int _process(struct dt_iop_module_t *self, const dt_dev_pixelpipe_t *pipe
         // we get the mask
         float *mask = NULL;
         int posx, posy, width, height;
+        /* Only a real failure aborts the module. A shape with nothing to draw (EMPTY) falls
+         * through to the zero-size check below and is skipped like any other empty shape --
+         * aborting here would silently drop every REMAINING shape in the group. The out
+         * parameters are guaranteed written on every outcome, so that check is safe to reach. */
         if(dt_masks_get_mask(self, (dt_dev_pixelpipe_t *)pipe, piece, form, &mask, &width, &height, &posx,
                              &posy)
-           != DT_MASKS_RASTER_OK)
+           == DT_MASKS_RASTER_ERROR)
         {
           return 1;
         }

--- a/src/tests/unittests/test_masks_raster_contract.c
+++ b/src/tests/unittests/test_masks_raster_contract.c
@@ -39,6 +39,7 @@
 #include "develop/masks.h"
 #include "develop/masks/masks_functions.h"
 #include "develop/masks/masks_touched.h"
+#include "develop/masks_group.h"
 
 #include <stdarg.h>
 #include <stddef.h>
@@ -205,6 +206,130 @@ static void _area_and_mask_always_write_their_out_parameters(void **state)
   }
 }
 
+
+/* ---------------------------------------------------------------------------------------
+ * The read side of the group API (develop/masks_group.h).
+ *
+ * These pin the contract rather than any implementation: what a caller is promised when it asks
+ * the module a question instead of reading its structs. The group fixture is built on the stack
+ * with its membership rows in a plain array, so the ORDER under test is unambiguous.
+ * ------------------------------------------------------------------------------------- */
+
+static void _form_info_describes_a_shape(void **state)
+{
+  (void)state;
+  dt_masks_form_t form = { 0 };
+  form.type = DT_MASKS_CIRCLE;
+  form.formid = 4242;
+  form.version = 6;
+  g_strlcpy(form.name, "circle #2", sizeof(form.name));
+
+  dt_masks_form_info_t info;
+  assert_true(dt_masks_form_get_info(&form, &info));
+  assert_int_equal(info.formid, 4242);
+  assert_int_equal(info.version, 6);
+  assert_false(info.is_group);
+  assert_false(info.is_retouch);
+  assert_int_equal(info.member_count, 0);   // not a group
+  assert_string_equal(info.name, "circle #2");
+
+  // A clone shape belongs to retouch, and the predicate for that was hand-written in eight files.
+  form.type = DT_MASKS_CIRCLE | DT_MASKS_CLONE;
+  assert_true(dt_masks_form_get_info(&form, &info));
+  assert_true(info.is_retouch);
+}
+
+static void _form_info_leaves_out_untouched_on_failure(void **state)
+{
+  (void)state;
+  dt_masks_form_info_t info;
+  info.formid = -999;   // a default the caller wants to survive a failed call
+  assert_false(dt_masks_form_get_info(NULL, &info));
+  assert_int_equal(info.formid, -999);
+}
+
+static void _copy_members_preserves_order_and_reports_the_total(void **state)
+{
+  (void)state;
+  dt_masks_form_group_t rows[3] = {
+    { .formid = 11, .parentid = 7, .state = DT_MASKS_STATE_USE | DT_MASKS_STATE_UNION,        .opacity = 0.25f },
+    { .formid = 22, .parentid = 7, .state = DT_MASKS_STATE_USE | DT_MASKS_STATE_INTERSECTION, .opacity = 0.50f },
+    { .formid = 33, .parentid = 7, .state = DT_MASKS_STATE_USE | DT_MASKS_STATE_DIFFERENCE,   .opacity = 1.00f },
+  };
+  dt_masks_form_t group = { 0 };
+  group.type = DT_MASKS_GROUP;
+  for(int i = 0; i < 3; i++) group.points = g_list_append(group.points, &rows[i]);
+
+  dt_masks_form_info_t info;
+  assert_true(dt_masks_form_get_info(&group, &info));
+  assert_true(info.is_group);
+  assert_int_equal(info.member_count, 3);
+
+  // NULL storage asks for the count only.
+  assert_int_equal(dt_masks_group_copy_members(&group, NULL, 0), 3);
+
+  dt_masks_member_t members[3];
+  assert_int_equal(dt_masks_group_copy_members(&group, members, 3), 3);
+  for(guint i = 0; i < 3; i++)
+  {
+    // Order is the contract: it is the compositing order, the GTK row order, and the index into
+    // retouch's rt_forms[] and spots' clone_algo[] -- the last two persisted in the user's
+    // database. A filtering or reordering implementation passes every other test in this file.
+    assert_int_equal(members[i].index, i);
+    assert_int_equal(members[i].formid, rows[i].formid);
+    assert_int_equal(members[i].parentid, rows[i].parentid);
+    assert_int_equal((int)members[i].state, rows[i].state);
+  }
+  assert_true(members[0].opacity == rows[0].opacity);
+
+  // A short buffer still reports the total, and writes exactly what fits.
+  dt_masks_member_t two[2];
+  two[0].formid = two[1].formid = -1;
+  assert_int_equal(dt_masks_group_copy_members(&group, two, 2), 3);
+  assert_int_equal(two[0].formid, 11);
+  assert_int_equal(two[1].formid, 22);
+
+  g_list_free(group.points);
+}
+
+static void _copy_members_refuses_anything_that_is_not_a_group(void **state)
+{
+  (void)state;
+  // A shape's ->points holds geometry nodes, not membership rows -- the same field, a different
+  // element type, told apart only by this bit. Refusing here is what keeps that polymorphism
+  // unreachable from outside the module.
+  dt_masks_node_circle_t node = { 0 };
+  dt_masks_form_t shape = { 0 };
+  shape.type = DT_MASKS_CIRCLE;
+  shape.points = g_list_append(NULL, &node);
+
+  dt_masks_member_t members[4];
+  assert_int_equal(dt_masks_group_copy_members(&shape, members, 4), 0);
+  assert_int_equal(dt_masks_group_copy_members(NULL, members, 4), 0);
+
+  g_list_free(shape.points);
+}
+
+static void _type_tokens_are_the_persisted_conf_key_spellings(void **state)
+{
+  (void)state;
+  /* These strings build plugins/darkroom/<plugin>/<type>/<feature>, declared in
+   * data/anselconfig.xml.in. A shape reading a key that is not in confgen gets 0, so renaming a
+   * token here silently resets that setting for every existing user. In particular the polygon
+   * token is "polygon" and must never become "path" -- another part of the tree spells it that
+   * way in machine-readable JSON, and unifying on that spelling is the trap. */
+  assert_string_equal(dt_masks_type_name(DT_MASKS_CIRCLE), "circle");
+  assert_string_equal(dt_masks_type_name(DT_MASKS_ELLIPSE), "ellipse");
+  assert_string_equal(dt_masks_type_name(DT_MASKS_POLYGON), "polygon");
+  assert_string_equal(dt_masks_type_name(DT_MASKS_BRUSH), "brush");
+  assert_string_equal(dt_masks_type_name(DT_MASKS_GRADIENT), "gradient");
+  assert_string_equal(dt_masks_type_name(DT_MASKS_GROUP), "group");
+  assert_string_equal(dt_masks_type_name(DT_MASKS_NONE), "unknown");
+
+  // The type is a bit field, so a clone circle is still a circle for the conf key.
+  assert_string_equal(dt_masks_type_name(DT_MASKS_CIRCLE | DT_MASKS_CLONE), "circle");
+}
+
 int main(void)
 {
   const struct CMUnitTest tests[] = {
@@ -213,6 +338,11 @@ int main(void)
     cmocka_unit_test(_a_shape_with_no_rasteriser_is_an_error),
     cmocka_unit_test(_an_unbuildable_outline_is_never_reported_as_built),
     cmocka_unit_test(_area_and_mask_always_write_their_out_parameters),
+    cmocka_unit_test(_form_info_describes_a_shape),
+    cmocka_unit_test(_form_info_leaves_out_untouched_on_failure),
+    cmocka_unit_test(_copy_members_preserves_order_and_reports_the_total),
+    cmocka_unit_test(_copy_members_refuses_anything_that_is_not_a_group),
+    cmocka_unit_test(_type_tokens_are_the_persisted_conf_key_spellings),
   };
 
   return cmocka_run_group_tests(tests, NULL, NULL);

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -2124,15 +2124,7 @@ void leave(dt_view_t *self)
   }
 
   // clear masks
-  dt_pthread_rwlock_wrlock(&dev->masks_mutex);
-  // dev->forms and dev->allforms are independent claims on possibly-shared objects:
-  // release both, do not unconditionally free -- a form referenced by both only
-  // reaches refcount 0 once (mirrors dt_dev_cleanup() in develop.c).
-  g_list_free_full(dev->forms, (void (*)(void *))dt_masks_form_unref);
-  dev->forms = NULL;
-  g_list_free_full(dev->allforms, (void (*)(void *))dt_masks_form_unref);
-  dev->allforms = NULL;
-  dt_pthread_rwlock_unlock(&dev->masks_mutex);
+  dt_masks_release_all_forms(dev);
 
   // Fetch the new thumbnail if needed. Ensure it runs after we save history.
   dt_thumbtable_refresh_thumbnail(dt_gui_get_ui()->thumbtable_lighttable, dt_dev_get_global()->image_storage.id, TRUE);

--- a/src/views/studio_capture.c
+++ b/src/views/studio_capture.c
@@ -35,7 +35,7 @@
 #include "develop/dev_history.h"
 #include "develop/dev_pixelpipe.h"
 #include "develop/imageop.h"
-#include "develop/masks.h"
+#include "develop/masks/masks_history.h"   // dt_masks_release_all_forms()
 #include "caches/pixelpipe_cache.h"
 #include "develop/pixelpipe_hb.h"
 #include "gui/dtgtk/thumbtable.h"
@@ -357,15 +357,7 @@ static void _studio_dev_teardown(dt_studio_capture_t *d)
     dev->form_gui = NULL;
   }
 
-  dt_pthread_rwlock_wrlock(&dev->masks_mutex);
-  // dev->forms and dev->allforms are independent claims on possibly-shared objects:
-  // release both, do not unconditionally free -- a form referenced by both only
-  // reaches refcount 0 once (mirrors dt_dev_cleanup() in develop.c).
-  g_list_free_full(dev->forms, (void (*)(void *))dt_masks_form_unref);
-  dev->forms = NULL;
-  g_list_free_full(dev->allforms, (void (*)(void *))dt_masks_form_unref);
-  dev->allforms = NULL;
-  dt_pthread_rwlock_unlock(&dev->masks_mutex);
+  dt_masks_release_all_forms(dev);
 
   dev->image_storage.id = -1;
 

--- a/tools/check_module_boundaries.sh
+++ b/tools/check_module_boundaries.sh
@@ -398,12 +398,12 @@ fi
 #                  reached as plain GLists. This is the count behind the bug that came back
 #                  four times, and it only reaches zero when resolving a shape is something
 #                  callers ask the module to do.
-masks_include_baseline=24
+masks_include_baseline=23
 masks_gui_include_baseline=11
 masks_member_baseline=102
 masks_write_baseline=27
 masks_alloc_baseline=4
-masks_forms_baseline=88
+masks_forms_baseline=76
 
 # Members no other struct in the tree uses. Keep it that way: adding an ambiguous name here
 # buys a bigger number and loses the gate.

--- a/tools/check_module_boundaries.sh
+++ b/tools/check_module_boundaries.sh
@@ -375,7 +375,7 @@ fi
 #                  in this tree uses (formid, form_dragging, creation_formids, ...) and leaves
 #                  out the ambiguous ones a masks form shares with half the codebase (points,
 #                  type, name, state, opacity). That undercounts -- the audit's full census
-#                  found ~385 by reading declarations, this finds 102 -- and undercounting is
+#                  found ~385 by reading declarations, this finds far fewer -- and undercounting is
 #                  the right error for a gate. A ratchet that moves when somebody renames an
 #                  unrelated `->state` is a ratchet that gets switched off. Every match this
 #                  does report is real: they land in exactly five files, and no other.
@@ -383,10 +383,10 @@ fi
 #   writes         The same members, assigned to. A write from outside is the sharper half:
 #                  it is a caller mutating a refcounted, copy-on-write object without going
 #                  through dt_masks_cow_touch(), which is how a snapshot ends up observing a
-#                  half-rewritten form. One of the 27 is a false positive and stays counted
-#                  because it is stable: supervisor.c's own event struct also has a `formid`
-#                  field, so `e->formid = form->formid` matches on the left as well as reading
-#                  a real one on the right.
+#                  half-rewritten form. Every remaining match is a real one: the single false
+#                  positive this count used to carry -- supervisor.c's own event struct, whose
+#                  `formid` field matched on the left of `e->formid = form->formid` -- is gone,
+#                  because that field was renamed when the file was converted.
 #
 #   allocations    malloc/calloc of a masks type outside the module: four places build a
 #                  group-membership entry or a circle node by hand and rely on the module's
@@ -398,10 +398,10 @@ fi
 #                  reached as plain GLists. This is the count behind the bug that came back
 #                  four times, and it only reaches zero when resolving a shape is something
 #                  callers ask the module to do.
-masks_include_baseline=23
+masks_include_baseline=22
 masks_gui_include_baseline=11
-masks_member_baseline=102
-masks_write_baseline=27
+masks_member_baseline=94
+masks_write_baseline=26
 masks_alloc_baseline=4
 masks_forms_baseline=76
 


### PR DESCRIPTION
P2 of the masks enclosure plan (#1299): the API that replaces direct struct access, and the first two consumers taken to **zero** direct accesses. Four commits — the design document, then three bisectable code commits.

> Sits on #1310 (P0) and #1311 (P1); GitHub shows their commits until they merge, after which I rebase. P2 **must** sit on P1: it lowers the baselines P1 introduces, and the ratchet fails if a count falls without its baseline moving in the same commit.

## How the API was arrived at

Every one of the ~385 external accesses in the five consumer files was surveyed and grouped by **what the caller actually wants** — in domain terms, not struct mechanics — then three independent API designs were judged against that survey. `doc/masks-enclosure-p2.md` (commit 1) records the whole design, including **five findings that contradict what all three proposals assumed**. Two are worth repeating here because they change what is safe to build:

- **`dt_masks_form_set_interaction_value()` does not copy-on-write for opacity.** All three wanted to route opacity writes through it as "the API that exists but nobody found". The touch is in the *caller*, so reusing it would have shipped the `retouch.c:598` bug into the new API.
- **`dt_masks_form_group_t` can never be made opaque and its layout can never change** — `common/xmp_sidecar.cc` casts an XMP blob straight to an array of them and validates the length against `sizeof`. It *is* the on-disk format in every user's sidecars. That is precisely why a **value type** has to be what everyone else consumes.

## The convention

**The first parameter names the world.** A `GList *` first resolves against a borrowed refcounted snapshot; a `const dt_masks_form_t *` first is a resolved handle and is thread-neutral; a `dt_develop_t *` first touches the live list and owns the lock and the copy-on-write. Only resolvers come in pairs — which is what will make a cross-thread resolve visible at the call site instead of invisible.

Two new headers, both free of the pixel pipeline: `develop/masks_types.h` (the vocabulary, `<glib.h>` only — the `colorprofiles/profile_types.h` cut) and `develop/masks_group.h` (the questions; **no GTK**, unlike `masks_gui.h`). `masks.h` includes the first, so all 24 of its current includers are unaffected.

## The three code commits

1. **Vocabulary header + the read side** — `dt_masks_form_get_info()`, `dt_masks_group_copy_members()`, `dt_masks_type_name()`. Moves no ratchet count: it only makes it *possible* to ask instead of read.
2. **`dt_masks_release_all_forms()`** — replaces the four-line "release both lists" block copy-pasted verbatim into `dt_dev_cleanup()`, the darkroom's `leave()` and studio capture's `leave()`, comment and all. Each copy had to know the same non-obvious thing: `forms` and `allforms` are *independent* claims, so a form held by both only reaches refcount 0 on the second unref.
3. **`supervisor.c` converted** — the tree's purest violation (8 struct reads, zero API calls) and therefore the right pilot.

## Two contracts that are asserted, not just commented

- **Order.** The stored member order is the compositing order, the GTK row order, *and* the index into `retouch.c`'s `rt_forms[]` and `spots.c`'s `clone_algo[]` — the last two persisted in every user's database. `copy_members` never filters, never recurses, never reorders, and a row that cannot be read **still consumes its index**. This is the change's biggest silent risk: supervisor only emits ids, so a reordering implementation would pass every other test here and silently re-pair every shape with the wrong clone algorithm the moment `spots.c` converts. There is a test for it.
- **Tokens.** `dt_masks_type_name()` returns the spelling that builds `plugins/darkroom/<plugin>/<type>/<feature>`, declared in `anselconfig.xml.in`. Polygon is `"polygon"` and can never become `"path"` — a key outside confgen reads 0, silently resetting that user's setting. Supervisor's JSON therefore changes `"path"` → `"polygon"` and `"?"` → `"unknown"`; nothing in the tree parses those.

## Ratchet

| count | before | after |
|---|---|---|
| `masks.h` includers | 24 | **22** |
| member reads | 102 | **94** |
| member writes | 27 | **26** |
| `->forms` touches | 88 | **76** |

Each baseline is lowered in the commit that earns it. The gate *demanded* all three of commit 3's before I edited them — that "fell" branch is the half of a ratchet that stops ground being given back quietly. The single documented false positive is gone too (supervisor's own `formid` field, renamed), so that paragraph is deleted from section 9: a note explaining why a number is not zero is a standing invitation to stop there.

**What the numbers overstate**, stated because they do: neither converted file becomes `masks.h`-free — `supervisor.c` reached it transitively before this PR and `studio_capture.c` still does through `masks_gui.h:50`. The literal count falls; that edge dies when the `blend.h` supply line is cut in its own PR.

## Verification

- **Bit-identical exports** vs the branch base, both resolutions, image *and* `--export_masks` page: 0 differing of 18M and 72M.
- **`build-nofeatures` clean** — not optional here: three commits move `#include` lines, and that is the configuration which caught the last include-supply-line break.
- Release build clean; `check_module_boundaries.sh` exit 0 after **each** commit; `pragma_once_to_guards.py --verify` clean; `include_graph.py` reports **cycles 0**; `test_masks_raster_contract` 10/10 with five new read-API cases.

Part of #1299.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
