### PR TITLE
masks: blend.h stops delivering the masks module to 33 files

### DIFF
--- a/doc/masks-enclosure-p2.md
+++ b/doc/masks-enclosure-p2.md
@@ -303,10 +303,21 @@ zero callers, because they shipped ahead of their consumers.)
   `dt_masks_blur_9x9`, `dt_masks_calc_rawdetail_mask`, `dt_masks_calc_detail_mask` into
   `masks_detail.h`: pure pixel math, no form involvement. `iop/detailmask.c` and `iop/demosaic.c`
   name nothing else from `masks.h` and both drop it. Includers 22 → 20.
-- **PR 3 — `blend.h` stops being the masks module's delivery van.** Remove `masks.h` from
-  `blend.h:43`, the edge the gate's own comment calls worth more than the other twenty put together.
-  `blend.h` names zero masks symbols; the work is entirely a fan-out of explicit includes across its
-  33 includers, each confirmed against the symbols the file actually names, verified in
-  build-nofeatures.
+- **PR 3 — `blend.h` stops being the masks module's delivery van.** *(Done.)* Remove `masks.h`
+  from `blend.h:43`. `blend.h` names zero masks symbols, but it does declare functions taking
+  `dt_iop_module_t` and `dt_develop_t`, so it takes `develop/develop.h` directly instead — the
+  house rule that a header includes what its own declarations need. Three supply lines broke and
+  were fixed by naming what the file actually uses: `common/times.h` in `common/opencl.c` and
+  `darktable.c`, and `DEVELOP_MASKS_NB_SHAPES` — pure vocabulary — moved into `masks_types.h` so
+  `blend_gui.h` can take the light header. `masks_types.h` also gained the forward typedef of
+  `dt_masks_form_t`, so a file that only passes a form along needs the name and not the layout.
+
+  **Measured correction to this plan.** The claim that this edge is "worth more than the other
+  twenty put together" does not survive measurement: `masks.h`'s transitive fan-in is **50 before
+  and 50 after**. The files that reached it through `blend.h` reach it another way. What the change
+  actually achieves is that **only two headers still include `masks.h`** — `masks_gui.h`, which is
+  external-facing, and `masks/masks_functions.h`, which is module-private. So the reach will not
+  drop until the `masks_gui.h` edge is cut, and that — not `blend.h` — is the one carrying the
+  surface to the rest of the tree. Retarget the next header tranche accordingly.
 - **Then** the write API against `libs/masks.c` and `blend_gui.c` (the six COW holes), and finally
   the P2b per-shape geometry axis for `retouch.c` and `spots.c`.

--- a/src/common/opencl.c
+++ b/src/common/opencl.c
@@ -73,6 +73,7 @@
 #include "develop/blend.h"
 #include "develop/pixelpipe.h"
 #include "caches/pixelpipe_cache.h"
+#include "common/times.h"   // dt_get_wtime(). conditional-ok: this whole file is inside #ifdef HAVE_OPENCL
 
 #include <assert.h>
 #include <locale.h>

--- a/src/darktable.c
+++ b/src/darktable.c
@@ -199,6 +199,7 @@
 
 #include "common/dbus.h"
 #include "common/utility.h"
+#include "common/times.h"   // dt_times_t, dt_get_times(), dt_get_wtime(), dt_show_times()
 
 #if defined(__SUNOS__)
 #include <sys/varargs.h>

--- a/src/develop/blend.h
+++ b/src/develop/blend.h
@@ -40,7 +40,7 @@
 #include "develop/iop_profile.h"
 #include "history/history.h"   // dt_dev_operation_t (raster_mask_source)
 #include "common/opencl.h"
-#include "develop/masks.h"
+#include "develop/develop.h"   // dt_develop_t, and dt_iop_module_t/_so_t through imageop.h
 #include "develop/pixelpipe.h"
 
 #ifdef __cplusplus

--- a/src/develop/blend_gui.h
+++ b/src/develop/blend_gui.h
@@ -32,6 +32,7 @@
 #define DT_DEVELOP_BLEND_GUI_H
 
 #include "develop/blend.h"
+#include "develop/masks_types.h"   // DEVELOP_MASKS_NB_SHAPES
 #include "develop/imageop.h"
 #include "gui/color_picker_proxy.h"
 #include "widgets/collapsible_section.h"

--- a/src/develop/masks.h
+++ b/src/develop/masks.h
@@ -445,8 +445,6 @@ void dt_masks_cleanup_unused(dt_develop_t *dev);
 
 
 
-#define DEVELOP_MASKS_NB_SHAPES 5
-
 
 
 

--- a/src/develop/masks_types.h
+++ b/src/develop/masks_types.h
@@ -45,6 +45,18 @@ extern "C" {
  * because sizeof(form->name) stops being available once the struct is not in scope. */
 #define DT_MASKS_FORM_NAME_LEN 128
 
+/** The form itself, named but not defined here.
+ *
+ * A caller that only passes a form along, or hands it to develop/masks_group.h to be asked about,
+ * needs the name and not the layout -- which is the whole point of this header. develop/masks.h
+ * completes the type for the code that genuinely manipulates it; repeating the typedef is legal C11
+ * and is what lets both headers stand alone. */
+typedef struct dt_masks_form_t dt_masks_form_t;
+
+/** How many shape kinds a user can draw: circle, ellipse, polygon, brush, gradient. Vocabulary,
+ * not model -- the GUIs size their shape-button arrays with it. */
+#define DEVELOP_MASKS_NB_SHAPES 5
+
 /**forms types */
 typedef enum dt_masks_type_t
 {

--- a/tools/check_module_boundaries.sh
+++ b/tools/check_module_boundaries.sh
@@ -398,7 +398,7 @@ fi
 #                  reached as plain GLists. This is the count behind the bug that came back
 #                  four times, and it only reaches zero when resolving a shape is something
 #                  callers ask the module to do.
-masks_include_baseline=20
+masks_include_baseline=19
 masks_gui_include_baseline=11
 masks_member_baseline=94
 masks_write_baseline=26


### PR DESCRIPTION
Next tranche of the masks enclosure (#1299). `develop/blend.h` included `develop/masks.h` and named **not one** masks symbol — so its 33 includers, most of the IOPs in the tree, received the whole forms model transitively because blending and drawn masks are adjacent concepts, not because any of them asked.

> Sits on #1310 → #1311 → #1312 → #1314; GitHub shows their commits until they merge, after which I rebase. This tranche is one commit.

## The change

The include isn't deleted, it's **corrected**. `blend.h` declares functions taking `dt_iop_module_t`, `dt_iop_module_so_t` and `dt_develop_t`, and `masks.h` was supplying those through its own include of `develop.h`. So `blend.h` now includes `develop/develop.h` — the house rule that a header includes what its own declarations need, and nothing more.

Three supply lines broke when it went, each fixed by naming what the file genuinely uses rather than by restoring the chain:

- `common/opencl.c` and `darktable.c` call `dt_get_wtime()`/`dt_get_times()` and name `dt_times_t`, and neither included `common/times.h`. They do now.
- `blend_gui.h` sizes two arrays with `DEVELOP_MASKS_NB_SHAPES` — pure vocabulary, so it moves to `masks_types.h` and `blend_gui.h` takes the light header.
- `supervisor.c` needs the *name* `dt_masks_form_t`, not its layout, so `masks_types.h` forward-typedefs it and `masks.h` completes it for code that manipulates one.

## A measured correction to the plan

`doc/masks-enclosure-p2.md` called this "the edge worth more than the other twenty put together". **That does not survive measurement.** `masks.h`'s transitive fan-in is **50 before and 50 after** — everything reaching it through `blend.h` reaches it another way.

What the change *does* achieve, and it is worth having: **only two headers still include `masks.h`** — `develop/masks_gui.h`, which faces outward, and `masks/masks_functions.h`, which is module-private. The reach will not fall until the `masks_gui.h` edge is cut, and **that** is the one actually carrying the surface to the rest of the tree.

The doc is updated to say so rather than leaving the wrong prediction standing, and the next header tranche should be retargeted accordingly. I'd rather record this than quietly claim the win the plan advertised.

**Ratchet: `masks.h` includers 20 → 19**, baseline lowered in the same commit.

## Verification

- **Release and `build-nofeatures` both clean.** Mandatory here, not ceremony: this removes an include supply line, and the no-features build is what surfaced all three breakages above.
- **Exports bit-identical** to the branch base at fit and full resolution, image *and* `--export_masks` page: 0 differing of 18M and 72M.
- `check_module_boundaries.sh` exits 0; `test_masks_raster_contract` 10/10.

Part of #1299.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
