### PR TITLE
macOS: Fix missing dependencies for libansel

### DIFF
--- a/packaging/macosx/3_make_hb_ansel_package.sh
+++ b/packaging/macosx/3_make_hb_ansel_package.sh
@@ -299,7 +299,7 @@ sed -i -e "s#$homebrewHome/lib/gdk-pixbuf-2.0/2.10.0/loaders#@executable_path/..
 mv "$loadersCacheFile" "$dtResourcesDir"/etc/gtk-3.0/
 
 # Install homebrew dependencies of lib subdirectories
-dtLibFiles=$(find -E "$dtResourcesDir"/lib/*/* -regex '.*\.(so|dylib)')
+dtLibFiles=$(find -E "$dtResourcesDir"/lib/* -regex '.*\.(so|dylib)')
 for dtLibFile in $dtLibFiles; do
     install_dependencies "$dtLibFile"
 done


### PR DESCRIPTION
Because we put libansel directly under the lib dir, which is different from the original Darktable's putting it in a sub dir, we need to tweak the lib files finding command.