### PR TITLE
nightly: version strings survive the monthly tags, and the Docker image gets one

### DIFF
--- a/.ci/Dockerfile
+++ b/.ci/Dockerfile
@@ -59,8 +59,11 @@ COPY . /src
 ARG ANSEL_VERSION=unknown-version
 ARG ANSEL_COMMIT_HASH=unknown
 ARG ANSEL_BUILD_CHANNEL=self-build
+# Both reach tools/create_version_c.sh through the environment. The version is NOT a
+# cmake -DPROJECT_VERSION: project(VERSION) takes dotted digits only and rejects the
+# nightly string at configure time.
 ENV ANSEL_COMMIT_HASH=${ANSEL_COMMIT_HASH}
+ENV ANSEL_VERSION=${ANSEL_VERSION}
 RUN sh /src/build.sh --install \
-      --cmake-option "-DPROJECT_VERSION=${ANSEL_VERSION}" \
       --cmake-option "-DBUILD_CHANNEL=${ANSEL_BUILD_CHANNEL}" && \
     rm -rf /src/build /src/src

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -41,12 +41,14 @@ jobs:
         uses: actions/checkout@v6
         with:
           ref: ${{ env.BRANCH }}
-          fetch-depth: 1
+          # Full history: get_git_version_string.sh must reach the last version tag, or
+          # the version degrades to a bare hash. (An earlier edit put this only in a
+          # comment and left the key at 1; the first master run showed VERSION "b4597470".)
+          fetch-depth: 0
           fetch-tags: true
           submodules: true
       # The image is built from a context without .git (.dockerignore), so the version
       # string and commit hash are computed here, where git is, and passed in.
-      # fetch-depth: 0 because get_git_version_string.sh needs to reach the last tag.
       - name: Compute version
         run: |
           version=$(sh tools/get_git_version_string.sh)

--- a/.github/workflows/nightly-manifest.yml
+++ b/.github/workflows/nightly-manifest.yml
@@ -72,7 +72,7 @@ jobs:
           {
             echo "### Newest build per format"
             echo '```'
-            python3 -c 'import json;[print(f"{k:10s} {v[\"version\"]}  {v[\"uploaded\"]}") for k,v in json.load(open("nightly.json"))["formats"].items()]'
+            python3 tools/nightly_manifest.py summary nightly.json
             echo '```'
           } >> "$GITHUB_STEP_SUMMARY"
 
@@ -100,7 +100,7 @@ jobs:
           fi
           git config --global user.name  "ansel-nightly[bot]"
           git config --global user.email "nightly@ansel.photos"
-          summary=$(python3 -c 'import json;d=json.load(open("nightly.json"))["formats"];print(", ".join(f"{k} {v[\"version\"]}" for k,v in d.items()))')
+          summary=$(python3 tools/nightly_manifest.py oneline nightly.json)
 
           publish() {  # repo  src  dest  message
             local repo=$1 src=$2 dest=$3 msg=$4 dir

--- a/tools/create_version_c.sh
+++ b/tools/create_version_c.sh
@@ -49,6 +49,14 @@ fi
 # release. Unlike the abbreviated hash in the version string (whose length varies)
 # or the commit count (unavailable on shallow clones), `git rev-parse HEAD` returns
 # the same 40-char value on every clone type. Empty for source archives.
+# A build with no .git (the Docker image's context excludes it) gets "unknown-version"
+# from CMake's source-package branch. The host that started that build knows the real
+# string and hands it in as ANSEL_VERSION; it wins over the placeholder, never over a
+# real version. It is NOT passed as -DPROJECT_VERSION: project(VERSION ...) accepts only
+# dotted digits, and 0.0.0+4810~gabc is rejected at configure time.
+if [ "$NEW_VERSION" = "unknown-version" ] && [ -n "${ANSEL_VERSION:-}" ]; then
+  NEW_VERSION="$ANSEL_VERSION"
+fi
 # The commit hash may be handed in (ANSEL_COMMIT_HASH) by a build that has no .git
 # directory -- the Docker image's context excludes it -- and the git call must not be
 # fatal without one. Under `set -e` a failing command substitution in a plain assignment

--- a/tools/get_git_version_string.sh
+++ b/tools/get_git_version_string.sh
@@ -27,7 +27,12 @@
 #   
 #   
 #   
-VERSION="$(git describe --tags 2>/dev/null)"
+# --exclude: nightlies are hosted on one nightly-YYYY-MM pre-release per month, and that
+# tag sits on master. Without the exclusion `git describe --tags` would pick it the day
+# after it is created, and every build would be called nightly-2026-08+3~g... instead of
+# 0.0.0+4810~g... -- which is what the filename convention, the nightly manifest, the
+# Homebrew cask and the NSIS installer all parse. Version tags only.
+VERSION="$(git describe --tags --exclude 'nightly-*' 2>/dev/null)"
 
 if [ $? -eq 0 ] ;
 then

--- a/tools/nightly_manifest.py
+++ b/tools/nightly_manifest.py
@@ -274,11 +274,26 @@ def render_scoop(manifest):
     return json.dumps(doc, indent=4) + "\n"
 
 
+def render_summary(manifest):
+    """A table for the run summary, one line per format; says so when there is none."""
+    formats = manifest.get("formats", {})
+    if not formats:
+        return "(no nightly-* release carries any asset yet)\n"
+    return "".join(f"{k:10s} {v.get('version') or '?':32s} {v.get('uploaded') or ''}\n"
+                   for k, v in formats.items())
+
+
+def render_oneline(manifest):
+    """One line for a commit message: `appimage 0.0.0+4810.g..., exe 0.0.0+4810.g...`."""
+    formats = manifest.get("formats", {})
+    return ", ".join(f"{k} {v.get('version') or '?'}" for k, v in formats.items()) or "no builds"
+
+
 def main():
     ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
     sub = ap.add_subparsers(dest="cmd", required=True)
     m = sub.add_parser("manifest"); m.add_argument("--no-hashes", action="store_true")
-    for name in ("cask", "scoop"):
+    for name in ("cask", "scoop", "summary", "oneline"):
         sub.add_parser(name).add_argument("manifest")
     args = ap.parse_args()
 
@@ -287,7 +302,8 @@ def main():
         json.dump(doc, sys.stdout, indent=1); sys.stdout.write("\n")
         return
     doc = json.load(open(args.manifest, encoding="utf-8"))
-    sys.stdout.write(render_cask(doc) if args.cmd == "cask" else render_scoop(doc))
+    render = {"cask": render_cask, "scoop": render_scoop, "summary": render_summary, "oneline": render_oneline}
+    sys.stdout.write(render[args.cmd](doc))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Follow-up to #1321, fixing the two first-run failures on master and one defect that would have fired tomorrow. Part of #1320.

## Docker — [33260544467](https://github.com/aurelienpierreeng/ansel/actions/runs/33260544467)

`CMake Error at CMakeLists.txt:26 (project): VERSION "b4597470" format invalid`. Two faults at once:

- The checkout was still `fetch-depth: 1` — my earlier edit had put `fetch-depth: 0` in a **comment** and left the key alone — so `git describe` reached no tag and degraded to a bare hash.
- The version was passed as `-DPROJECT_VERSION`, which feeds `project(VERSION …)`, and that accepts dotted digits only. `0.0.0+4810~gabc` would have been rejected just the same, so this path could never have worked.

The version now reaches `tools/create_version_c.sh` through the environment (`ANSEL_VERSION`, beside the existing `ANSEL_COMMIT_HASH`) and only replaces the `unknown-version` placeholder a `.git`-less build produces; a real version is never overridden (tested both ways). Full-history checkout, and the key was grepped after the edit this time.

## nightly-manifest — [33260676797](https://github.com/aurelienpierreeng/ansel/actions/runs/33260676797)

Python `SyntaxError`: a `python3 -c` one-liner in the YAML carried `\"` escapes inside single shell quotes. The two reports are now `summary` and `oneline` subcommands of the script, tested on a full manifest **and on an empty one** — which is what every run sees until the first `nightly-*` release carries an asset.

## The one that had not fired yet

Nightlies are hosted on a `nightly-YYYY-MM` tag on master, and `git describe --tags` picks the newest reachable tag. From the day after that tag is created, every build would have been named `nightly-2026-08+3~g…` instead of `0.0.0+4810~g…` — the string the filename convention, the manifest parser, the Homebrew cask and the NSIS installer all read. `get_git_version_string.sh` now uses `--exclude 'nightly-*'`; tagging HEAD with one and running it gives the same string as without.

## Verification

- `create_version_c.sh` with no `.git` + `ANSEL_VERSION` → exit 0, correct version and hash in `version_gen.c`; with a real `$2` the env is ignored.
- `summary`/`oneline` on the live-data manifest and on `{"formats":{}}`.
- `git tag nightly-2026-08 HEAD` → version string unchanged.
- actionlint 1.7.12 clean on both workflows; YAML parses; `fetch-depth: 0` confirmed by grep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)