### PR TITLE
nightly-manifest: never publish an empty manifest

### DIFF
--- a/.github/workflows/nightly-manifest.yml
+++ b/.github/workflows/nightly-manifest.yml
@@ -98,6 +98,15 @@ jobs:
             echo "::warning::NIGHTLY_PUBLISH_TOKEN is not set; manifest built but not published"
             exit 0
           fi
+          # An empty manifest is never published: it would replace a good file
+          # downstream with "no builds" -- which is what happened on the first run,
+          # before any nightly-* release existed. The website falls back to the API on
+          # an empty file, but nothing should have to.
+          if ! python3 tools/nightly_manifest.py check nightly.json; then
+            echo "::warning::manifest names no build; nothing published"
+            echo "Nothing published: the manifest is empty." >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
           git config --global user.name  "ansel-nightly[bot]"
           git config --global user.email "nightly@ansel.photos"
           summary=$(python3 tools/nightly_manifest.py oneline nightly.json)

--- a/tools/nightly_manifest.py
+++ b/tools/nightly_manifest.py
@@ -283,6 +283,16 @@ def render_summary(manifest):
                    for k, v in formats.items())
 
 
+def check(manifest):
+    """Exit status 0 when the manifest names at least one build, 1 when it is empty.
+
+    The workflow gates publishing on this: an empty manifest -- no nightly-* release
+    yet, or a GitHub API hiccup that returned nothing -- must never overwrite a good
+    file downstream. The first run on master did exactly that to the website's data
+    file before this existed."""
+    return 0 if manifest.get("formats") else 1
+
+
 def render_oneline(manifest):
     """One line for a commit message: `appimage 0.0.0+4810.g..., exe 0.0.0+4810.g...`."""
     formats = manifest.get("formats", {})
@@ -293,7 +303,7 @@ def main():
     ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
     sub = ap.add_subparsers(dest="cmd", required=True)
     m = sub.add_parser("manifest"); m.add_argument("--no-hashes", action="store_true")
-    for name in ("cask", "scoop", "summary", "oneline"):
+    for name in ("cask", "scoop", "summary", "oneline", "check"):
         sub.add_parser(name).add_argument("manifest")
     args = ap.parse_args()
 
@@ -302,6 +312,8 @@ def main():
         json.dump(doc, sys.stdout, indent=1); sys.stdout.write("\n")
         return
     doc = json.load(open(args.manifest, encoding="utf-8"))
+    if args.cmd == "check":
+        sys.exit(check(doc))
     render = {"cask": render_cask, "scoop": render_scoop, "summary": render_summary, "oneline": render_oneline}
     sys.stdout.write(render[args.cmd](doc))
 


### PR DESCRIPTION
Part of #1320. Found by the first successful run on master ([33261050046](https://github.com/aurelienpierreeng/ansel/actions/runs/33261050046)): with no `nightly-*` release yet, the job built a manifest with no formats and pushed it to ansel-website as `data/nightly.json` → `"formats": []`.

Harmless there — the shortcode falls back to the GitHub API on an empty file — but an API hiccup returning nothing would do the same to a good file, and nothing downstream should have to defend against it.

`nightly_manifest.py check` exits 1 for an empty manifest; the publish step stops there with a warning and a summary line, and the artifact is still kept on the run. Tested: full manifest → 0, `{"formats":{}}` → 1; actionlint clean.

Confirms in passing that `NIGHTLY_PUBLISH_TOKEN` is set and works: the website push went through.

🤖 Generated with [Claude Code](https://claude.com/claude-code)