### PR TITLE
nightly-manifest: let the website push rebuild the site

### DIFF
--- a/.github/workflows/nightly-manifest.yml
+++ b/.github/workflows/nightly-manifest.yml
@@ -86,10 +86,11 @@ jobs:
             ansel-nightly.json
           retention-days: 30
 
-      # One shallow clone, one file, one commit, per downstream repository. [skip ci]
-      # on the website because Hugo rebuilds on its own schedule anyway (*/4 h) and a
-      # data-only change is not worth a full build queue entry -- remove it if the
-      # download page must follow within minutes rather than hours.
+      # One shallow clone, one file, one commit, per downstream repository. The website
+      # push deliberately does NOT carry [skip ci]: the data file is what the download
+      # buttons render from, so its commit is exactly the one that must rebuild the
+      # site. With [skip ci] the first real manifest sat unrendered until the next
+      # 4-hourly scheduled build, and the page kept showing the retired v0.0.0 assets.
       - name: Publish downstream
         env:
           TOKEN: ${{ secrets.NIGHTLY_PUBLISH_TOKEN }}
@@ -129,6 +130,6 @@ jobs:
             rm -rf "${dir}"
           }
 
-          publish ansel-website  nightly.json        data/nightly.json               "nightly: ${summary} [skip ci]"
+          publish ansel-website  nightly.json        data/nightly.json               "nightly: ${summary}"
           publish homebrew-ansel ansel-nightly.rb    Casks/ansel-nightly.rb          "ansel-nightly: ${summary}"
           publish scoop-ansel    ansel-nightly.json  bucket/ansel-nightly.json       "ansel-nightly: ${summary}"


### PR DESCRIPTION
Part of #1320.

The push of `data/nightly.json` to ansel-website carried `[skip ci]`, on the theory that a data-only change could wait for Hugo's 4-hourly scheduled build. It's the opposite: that file is what the download buttons render from, so its commit is precisely the one that must rebuild the site.

What happened today: website#21 merged at 14:36; the 15:46 scheduled build saw an empty data file and fell back to the API (finding only `v0.0.0` assets, since the monthly release didn't exist yet); the first real manifest landed at 16:26 with `[skip ci]` — and the live page kept showing `v0.0.0` links until a manual build.

One line removed, comment rewritten to say why. actionlint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)