### PR TITLE
nightly: describe each monthly release, with the text v0.0.0 carried

### DIFF
--- a/.github/workflows/nightly-manifest.yml
+++ b/.github/workflows/nightly-manifest.yml
@@ -40,7 +40,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: read
+  contents: write   # to title and describe a freshly created monthly release
 
 concurrency:
   group: nightly-manifest
@@ -57,6 +57,26 @@ jobs:
         with:
           fetch-depth: 1
           submodules: false
+
+      # tip creates each month's release with the tag as its name and no body, and it
+      # preserves whatever body exists on later uploads. So the text is applied once, by
+      # the first run after the release appears, and never rewritten: the check is on
+      # an empty body, not on a date, so an edit made by hand on the release survives.
+      - name: Describe the monthly release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          tag="nightly-$(date -u +%Y-%m)"
+          if ! gh release view "${tag}" --repo "${GITHUB_REPOSITORY}" --json body -q .body >/dev/null 2>&1; then
+            echo "${tag}: no release yet"; exit 0
+          fi
+          if [[ -n "$(gh release view "${tag}" --repo "${GITHUB_REPOSITORY}" --json body -q .body)" ]]; then
+            echo "${tag}: already described"; exit 0
+          fi
+          gh release edit "${tag}" --repo "${GITHUB_REPOSITORY}" \
+            --title "Nightly builds, $(LC_ALL=C date -u +%B\ %Y)" \
+            --notes-file packaging/nightly-release-notes.md
+          echo "${tag}: described"
 
       - name: Build the manifest
         env:

--- a/packaging/nightly-release-notes.md
+++ b/packaging/nightly-release-notes.md
@@ -1,0 +1,34 @@
+## Welcome
+
+This pre-release collects the packages produced by the nightly builds during the month in its name. Nightly builds run automatically every morning around 05:00–06:00 UTC from the `master` branch (the "fairly stable" channel), and produce packages for:
+
+- **Linux, AppImage** (`.AppImage`) — any distribution shipping at least glibc 2.39 (Ubuntu 24.04, Debian 13, Fedora 40, openSUSE Leap 16, Arch, …). Runs anywhere without installing.
+- **Linux, Flatpak** (`.flatpak`) — a single-file bundle: `flatpak install --user Ansel-*.flatpak`. Needs the `org.gnome.Platform//49` runtime from Flathub.
+- **Windows** (`.exe`) — an installer for Windows 10 and 11.
+- **macOS** (`.dmg`) — two packages: `arm64` for Apple Silicon (M1 and later), `i386` for Intel Macs.
+- **Docker** — the image is pushed to [Docker Hub](https://hub.docker.com/r/aurelienpierre/ansel) (`aurelienpierre/ansel:current`, and one tag per build) and also saved here as `Ansel-*-docker.tar.zst`, so a given night's image stays retrievable: `zstd -d < Ansel-*-docker.tar.zst | docker load`.
+
+This is meant for continuous testing and continuous delivery, in a "quickly broken, quickly fixed" way. [Learn more about Ansel channels](https://ansel.photos/en/doc/install/). For maximum stability, wait for production releases.
+
+## One release per month
+
+Each month gets its own pre-release, `nightly-YYYY-MM`, and every night's packages are added to the current month. Months older than a year are deleted. The newest package of each kind is always listed on the [download page](https://ansel.photos/en/), and a nightly build tells you itself when a newer one exists (*Help ▸ Update to the latest nightly build*).
+
+You can also let your package manager track the nightlies:
+
+- macOS: `brew tap aurelienpierreeng/ansel && brew install --cask ansel-nightly`
+- Windows: `scoop bucket add ansel https://github.com/aurelienpierreeng/scoop-ansel && scoop install ansel-nightly`
+- Linux AppImage: [AppImageUpdate](https://github.com/AppImageCommunity/AppImageUpdate) fetches the newest build as an incremental download.
+
+## Understanding package names
+
+All packages follow the same naming convention: `Ansel-x.y.z+N.g0000000000-architecture.extension`
+
+- `x.y.z` is the tag of the latest stable release. It only ever increases, and tells you how old or recent a package is compared to the one you have installed.
+- `+N` is the number of commits on the branch since that release. It also only ever increases: a higher `N` is a newer build.
+- `.g` means the package comes straight from Git,
+- the ten hexadecimal characters after `.g` identify the exact commit the package was built from. They follow no order, but they pin a precise state of the source code, which is what to quote when reporting a bug. The same commit can be found in the Git log and in the application's *About* dialog.
+- `architecture` tells you which CPU the package is built for: `x86_64` or `win64` for 64-bit Intel/AMD, `arm64` for Apple Silicon, `i386` for Intel Macs.
+- `.extension` is the OS-flavoured package: `.AppImage`, `.flatpak`, `.exe`, `.dmg`, or `-docker.tar.zst`.
+
+The `.AppImage.zsync` files exist for auto-updaters, to allow incremental updates. They have to be here for technical reasons; end users should not download them.


### PR DESCRIPTION
Part of #1320. `tip` creates each month's release with the tag as its name and an empty body, and preserves whatever body exists on later uploads — so the user-facing text lives in `packaging/nightly-release-notes.md` and the manifest job applies it **once**, when it finds the current month's release with an empty body. A hand edit on a release therefore survives every later upload.

The text is `v0.0.0`'s, reused and brought up to date:

- AppImage baseline is **glibc 2.39** (Ubuntu 24.04) since the runner moved — the old text still said 2.31 / Ubuntu 20.04
- Flatpak bundle, the Docker `.tar.zst` archive beside Docker Hub, `arm64` + `i386` macOS packages
- one release per month, 12-month retention, the download page and the in-app *Help ▸ Update…* as the way to find the newest build
- `brew` / `scoop` / AppImageUpdate routes
- the commit hash in filenames is ten characters, not nine

Applied by hand to `nightly-2026-08` already (title *Nightly builds, August 2026*), and `v0.0.0` now carries a short "retired, see the monthly releases" body instead of the old text. actionlint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)