### PR TITLE
masks: one constructor for a group membership row, instead of four

### DIFF
--- a/src/develop/masks/masks_gui.c
+++ b/src/develop/masks/masks_gui.c
@@ -4466,27 +4466,43 @@ float dt_masks_get_set_conf_value_with_toast(dt_masks_form_t *mask_form, const c
   return value;
 }
 
-dt_masks_form_group_t *dt_masks_group_add_form(dt_develop_t *dev, dt_masks_form_t *group_form, dt_masks_form_t *mask_form)
+dt_masks_form_group_t *dt_masks_group_add_form_with_state(dt_develop_t *dev, dt_masks_form_t *group_form,
+                                                          dt_masks_form_t *mask_form, const int parentid,
+                                                          const dt_masks_state_t state, const float opacity)
 {
-  // add a form to group and check for self inclusion
-
+  if(IS_NULL_PTR(group_form) || IS_NULL_PTR(mask_form)) return NULL;
   if(!(group_form->type & DT_MASKS_GROUP)) return NULL;
-  // either the form to add is not a group, so no risk
-  // or we go through all points of form to see if we find a ref to grp->formid
-  if(!(mask_form->type & DT_MASKS_GROUP) || _find_in_group(dev, mask_form, group_form->formid) == 0)
+
+  /* Either the form being added is not a group, so there is no risk, or we walk it looking for a
+   * reference back to this group. This is the guard the hand-rolled call sites skipped. */
+  if((mask_form->type & DT_MASKS_GROUP) && _find_in_group(dev, mask_form, group_form->formid) != 0)
   {
-    dt_masks_form_group_t *group_entry = malloc(sizeof(dt_masks_form_group_t));
-    group_entry->formid = mask_form->formid;
-    group_entry->parentid = group_form->formid;
-    group_entry->state = DT_MASKS_STATE_SHOW | DT_MASKS_STATE_USE | DT_MASKS_STATE_UNION;
-    group_entry->opacity = dt_conf_get_float("plugins/darkroom/masks/opacity");
-    group_form->points = g_list_append(group_form->points, group_entry);
-    dt_masks_form_update_gravity_center(dev, group_form);
-    return group_entry;
+    dt_control_log(_("Masks can not contain themselves"));
+    return NULL;
   }
 
-  dt_control_log(_("Masks can not contain themselves"));
-  return NULL;
+  dt_masks_form_group_t *group_entry = malloc(sizeof(dt_masks_form_group_t));
+  if(IS_NULL_PTR(group_entry)) return NULL;
+
+  group_entry->formid = mask_form->formid;
+  group_entry->parentid = parentid;
+  group_entry->state = state;
+  group_entry->opacity = opacity;
+  group_form->points = g_list_append(group_form->points, group_entry);
+
+  /* The group's cached centre of gravity is now stale, and hit-testing reads it. The hand-rolled
+   * sites left it stale. */
+  dt_masks_form_update_gravity_center(dev, group_form);
+  return group_entry;
+}
+
+dt_masks_form_group_t *dt_masks_group_add_form(dt_develop_t *dev, dt_masks_form_t *group_form, dt_masks_form_t *mask_form)
+{
+  if(IS_NULL_PTR(mask_form)) return NULL;
+  if(IS_NULL_PTR(group_form)) return NULL;
+  return dt_masks_group_add_form_with_state(dev, group_form, mask_form, group_form->formid,
+                                            DT_MASKS_STATE_SHOW | DT_MASKS_STATE_USE | DT_MASKS_STATE_UNION,
+                                            dt_conf_get_float("plugins/darkroom/masks/opacity"));
 }
 
 void dt_masks_group_ungroup(dt_develop_t *dev, dt_masks_form_t *dest_group, dt_masks_form_t *group_form)

--- a/src/develop/masks_gui.h
+++ b/src/develop/masks_gui.h
@@ -595,6 +595,27 @@ void dt_masks_group_ungroup(dt_develop_t *dev, dt_masks_form_t *dest_grp, dt_mas
 void dt_masks_group_update_name(dt_iop_module_t *module);
 dt_masks_form_group_t *dt_masks_group_add_form(dt_develop_t *dev, dt_masks_form_t *grp, dt_masks_form_t *form);
 
+/** Add a shape to a group with an EXPLICIT combination state and opacity, rather than the
+ * defaults dt_masks_group_add_form() applies (SHOW|USE|UNION at the configured opacity).
+ *
+ * This exists because three call sites wanted their own state and opacity and therefore built the
+ * membership row by hand -- malloc, four assignments, g_list_append -- which silently skipped both
+ * of the things the real adder does: the self-inclusion guard that stops a group containing
+ * itself, and the gravity-centre refresh the group needs before anything hit-tests it.
+ *
+ * Takes the group by pointer, not by id, because the callers legitimately build into a group that
+ * is not in dev->forms yet: it is created, filled, and only then published. Copy-on-write is the
+ * caller's business here for the same reason -- an unpublished group is referenced by nobody, and
+ * a published one must be touched before this is called, exactly as for dt_masks_group_add_form().
+ *
+ * @param parentid the row's AUTHORED origin, which is NOT always the group holding it: two
+ *        callers assemble a temporary group for an ungroup/regroup round trip and keep each row
+ *        pointing at the group it really came from. Pass grp->formid unless you mean otherwise.
+ * @return the new row, or NULL if the group is not a group or the add would nest it in itself. */
+dt_masks_form_group_t *dt_masks_group_add_form_with_state(dt_develop_t *dev, dt_masks_form_t *grp,
+                                                          dt_masks_form_t *form, int parentid,
+                                                          dt_masks_state_t state, float opacity);
+
 /** utils functions */
 int dt_masks_point_in_form_exact(const float *pts, int num_pts, const float *points, int points_start, int points_count);
 

--- a/src/iop/retouch.c
+++ b/src/iop/retouch.c
@@ -682,12 +682,8 @@ static void rt_show_forms_for_current_scale(dt_iop_module_t *self)
       dt_masks_form_t *form = dt_masks_get_from_id(self->dev, formid);
       if(IS_NULL_PTR(form)) continue;
       
-      dt_masks_form_group_t *fpt = (dt_masks_form_group_t *)malloc(sizeof(dt_masks_form_group_t));
-      fpt->formid = formid;
-      fpt->parentid = grid;
-      fpt->state = DT_MASKS_STATE_USE | DT_MASKS_STATE_UNION;
-      fpt->opacity = 1.0f;
-      grp->points = g_list_append(grp->points, fpt);
+      dt_masks_group_add_form_with_state(self->dev, grp, form, grid,
+                                         DT_MASKS_STATE_USE | DT_MASKS_STATE_UNION, 1.0f);
     }
   }
 

--- a/src/libs/masks.c
+++ b/src/libs/masks.c
@@ -362,12 +362,10 @@ static void _tree_group(GtkButton *button, dt_lib_module_t *self)
 
       if(id > 0)
       {
-        dt_masks_form_group_t *fpt = (dt_masks_form_group_t *)malloc(sizeof(dt_masks_form_group_t));
-        fpt->formid = id;
-        fpt->parentid = mask->formid;
-        fpt->opacity = 1.0f;
-        fpt->state = DT_MASKS_STATE_USE | DT_MASKS_STATE_UNION;
-        mask->points = g_list_append(mask->points, fpt);
+        dt_masks_form_t *member = dt_masks_get_from_id(dt_dev_get_global(), id);
+        if(!IS_NULL_PTR(member))
+          dt_masks_group_add_form_with_state(dt_dev_get_global(), mask, member, mask->formid,
+                                             DT_MASKS_STATE_USE | DT_MASKS_STATE_UNION, 1.0f);
       }
     }
   }
@@ -912,12 +910,7 @@ static void _tree_selection_change(GtkTreeSelection *selection, dt_lib_masks_t *
       if(!IS_NULL_PTR(form))
       {
         if(nb == 1) selected_form = form;
-        dt_masks_form_group_t *fpt = (dt_masks_form_group_t *)malloc(sizeof(dt_masks_form_group_t));
-        fpt->formid = id;
-        fpt->parentid = grid;
-        fpt->state = DT_MASKS_STATE_USE;
-        fpt->opacity = 1.0f;
-        grp->points = g_list_append(grp->points, fpt);
+        dt_masks_group_add_form_with_state(dev, grp, form, grid, DT_MASKS_STATE_USE, 1.0f);
         // we eventually set the "show masks" icon of iops
         if(nb == 1 && (form->type & DT_MASKS_GROUP))
         {

--- a/tools/check_module_boundaries.sh
+++ b/tools/check_module_boundaries.sh
@@ -400,9 +400,9 @@ fi
 #                  callers ask the module to do.
 masks_include_baseline=19
 masks_gui_include_baseline=11
-masks_member_baseline=88
-masks_write_baseline=26
-masks_alloc_baseline=4
+masks_member_baseline=83
+masks_write_baseline=20
+masks_alloc_baseline=1
 masks_forms_baseline=76
 
 # Members no other struct in the tree uses. Keep it that way: adding an ambiguous name here


### PR DESCRIPTION
Next step of the write API (#1299, P2). This one moves the ratchet counter that had **never** moved: external allocations of masks types, 4 → 1.

> Independent of #1331 (the handler collapse) — different regions of `libs/masks.c`, so whichever merges second may need a trivial rebase.

## What was wrong

Three call sites built a membership row by hand — `malloc`, four assignments, `g_list_append` — because `dt_masks_group_add_form()` applies fixed defaults (`SHOW|USE|UNION` at the configured opacity) and each wanted its own state and opacity.

Hand-rolling cost them **both** of the other things that function does:

- the **self-inclusion guard**, the only thing stopping a group being nested inside itself;
- `dt_masks_form_update_gravity_center()`, so the group's cached centre stayed stale while hit-testing reads it.

`dt_masks_group_add_form_with_state()` takes state and opacity explicitly and does everything else; `dt_masks_group_add_form()` becomes a thin wrapper supplying the defaults. One place in the tree now allocates a `dt_masks_form_group_t`.

## Two things the plan got wrong

Both found by reading the call sites rather than trusting the design note — worth recording, because the note is in `doc/masks-enclosure-p2.md` and someone will follow it:

1. **It cannot be keyed on a group id.** Two of the three callers assemble a group that is *not in `dev->forms` yet* — created, filled, published only afterwards — so there is no id to resolve it by. It takes the group by pointer, like the function it generalises.
2. **`parentid` is not always the holding group's id**, and stamping it as such (which the note prescribed) would have silently rewritten it at two sites. Those two build a *temporary* group for an ungroup/regroup round trip and deliberately keep each row pointing at the group it really came from — which is what the field means, and what `masks_types.h` already documents. So it is a parameter, not something the function infers.

## Behaviour changes — three, all deliberate, all safer

The three sites now refuse to nest a group in itself; they refresh the group's gravity centre; and `libs/masks.c`'s shape-to-new-group path resolves the shape **before** adding a row for it, instead of adding a row that may point at nothing — the same dangling-row case that produced a garbage bounding box in `_group_get_mask()`.

## Ratchet

| count | before | after |
|---|---|---|
| external allocations | 4 | **1** |
| member reads | 88 | **83** |
| member writes | 26 | **20** |

The one allocation left is `iop/spots.c`'s v1-params migration building a circle **node** — the per-shape geometry axis, not this one.

## Verification

Build clean, tests 14/14, all three gates clean **against the committed state**, and exports bit-identical to master at fit and full resolution, image and `--export_masks` page. (Pixel parity can't reach these GUI paths, which is why the behaviour changes are spelled out above rather than implied by a green diff.)

Part of #1299.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
