### PR TITLE
nightly: a daily snapshot of download counters, so they become a history

### DIFF
--- a/.github/workflows/nightly-manifest.yml
+++ b/.github/workflows/nightly-manifest.yml
@@ -151,22 +151,30 @@ jobs:
             rm -rf "${dir}"
           }
 
+          publish ansel-website  nightly.json        data/nightly.json               "nightly: ${summary}"
+
           # Download statistics: one dated snapshot of every lifetime counter (GitHub
           # asset download_count, Docker Hub pull_count) appended to the series the
           # website already holds. Counters vanish with the assets the prune deletes;
-          # the series is what keeps the history. Best effort: a failure here must not
-          # stop the manifest from publishing.
+          # the series is what keeps the history.
+          #
+          # Strictly after the manifest publish, and every command guarded: this shell
+          # runs under `set -e`, so an unguarded failure here would have aborted the
+          # step before the manifest was published (Sentry's review caught the
+          # unguarded `append`). Whatever fails, publish() skips an empty file.
+          : > download-stats.json
           if python3 tools/download_stats.py snapshot > today.json 2>stats.err; then
             curl -fsSL --max-time 30 -o series.json \
               "https://raw.githubusercontent.com/aurelienpierreeng/ansel-website/master/data/download-stats.json" \
               || echo '[]' > series.json
-            python3 tools/download_stats.py append series.json today.json > download-stats.json
-            echo "download stats: $(python3 -c 'import json;print(len(json.load(open("download-stats.json"))))') day(s) on record"
+            if python3 tools/download_stats.py append series.json today.json > download-stats.json 2>stats.err; then
+              echo "download stats: $(python3 -c 'import json;print(len(json.load(open("download-stats.json"))))' 2>/dev/null || echo '?') day(s) on record"
+            else
+              echo "::warning::download stats append failed: $(cat stats.err)"; : > download-stats.json
+            fi
           else
-            echo "::warning::download stats snapshot failed: $(cat stats.err)"; : > download-stats.json
+            echo "::warning::download stats snapshot failed: $(cat stats.err)"
           fi
-
-          publish ansel-website  nightly.json        data/nightly.json               "nightly: ${summary}"
           publish ansel-website  download-stats.json data/download-stats.json        "download stats: $(date -u +%Y-%m-%d)"
           publish homebrew-ansel ansel-nightly.rb    Casks/ansel-nightly.rb          "ansel-nightly: ${summary}"
           publish scoop-ansel    ansel-nightly.json  bucket/ansel-nightly.json       "ansel-nightly: ${summary}"

--- a/.github/workflows/nightly-manifest.yml
+++ b/.github/workflows/nightly-manifest.yml
@@ -114,6 +114,7 @@ jobs:
       - name: Publish downstream
         env:
           TOKEN: ${{ secrets.NIGHTLY_PUBLISH_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}   # read-only: the stats snapshot lists releases
         run: |
           if [[ -z "${TOKEN}" ]]; then
             echo "::warning::NIGHTLY_PUBLISH_TOKEN is not set; manifest built but not published"
@@ -150,6 +151,22 @@ jobs:
             rm -rf "${dir}"
           }
 
+          # Download statistics: one dated snapshot of every lifetime counter (GitHub
+          # asset download_count, Docker Hub pull_count) appended to the series the
+          # website already holds. Counters vanish with the assets the prune deletes;
+          # the series is what keeps the history. Best effort: a failure here must not
+          # stop the manifest from publishing.
+          if python3 tools/download_stats.py snapshot > today.json 2>stats.err; then
+            curl -fsSL --max-time 30 -o series.json \
+              "https://raw.githubusercontent.com/aurelienpierreeng/ansel-website/master/data/download-stats.json" \
+              || echo '[]' > series.json
+            python3 tools/download_stats.py append series.json today.json > download-stats.json
+            echo "download stats: $(python3 -c 'import json;print(len(json.load(open("download-stats.json"))))') day(s) on record"
+          else
+            echo "::warning::download stats snapshot failed: $(cat stats.err)"; : > download-stats.json
+          fi
+
           publish ansel-website  nightly.json        data/nightly.json               "nightly: ${summary}"
+          publish ansel-website  download-stats.json data/download-stats.json        "download stats: $(date -u +%Y-%m-%d)"
           publish homebrew-ansel ansel-nightly.rb    Casks/ansel-nightly.rb          "ansel-nightly: ${summary}"
           publish scoop-ansel    ansel-nightly.json  bucket/ansel-nightly.json       "ansel-nightly: ${summary}"

--- a/tools/download_stats.py
+++ b/tools/download_stats.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+#   This file is part of the Ansel project.
+#   Copyright (C) 2026 Aurélien PIERRE.
+#
+#   Ansel is free software: you can redistribute it and/or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation, either version 3 of the License, or
+#   (at your option) any later version.
+#
+#   Ansel is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with Ansel.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Download statistics for the nightly packages, as a daily series.
+
+    download_stats.py snapshot                > today.json
+    download_stats.py append series.json today.json > series.json
+
+GitHub keeps one lifetime `download_count` per release asset and nothing else -- delete
+the asset (the monthly prune does, and so did moving August 2026 between releases) and
+its count is gone. Docker Hub keeps one lifetime `pull_count` per repository. Neither is
+a time series. This turns them into one: a snapshot of every counter, once a day, appended
+to a list that only ever grows. Downloads *between* two dates are the difference of two
+snapshots; the loss on deletion stops mattering once the day before is on record.
+
+Every route a user takes ends up in these counters: the website's buttons, the in-app
+"Update to the latest nightly build", the Homebrew cask and the Scoop manifest all
+download the release asset, and AppImageUpdate fetches the .zsync and ranges of the
+AppImage. Neither Homebrew nor Scoop has analytics for third-party taps; there is
+nothing to add from their side.
+
+The build month of an asset is read from its release tag (nightly-YYYY-MM) when the tag
+carries one, and from the asset's creation date otherwise -- an asset moved between
+releases is created anew, so its date is the day it was moved, not the night it was built.
+"""
+
+import collections
+import datetime
+import json
+import re
+import os
+import sys
+import urllib.request
+
+REPO = "aurelienpierreeng/ansel"
+API = "https://api.github.com"
+DOCKER_IMAGE = "aurelienpierre/ansel"
+DOCKER_HUB = "https://hub.docker.com/v2/repositories"
+MONTH_TAG_RE = re.compile(r"^nightly-(\d{4}-\d{2})$")
+
+# Filename suffix -> format key. Same vocabulary as nightly_manifest.py, plus the
+# updater's .zsync, which is its own line: those are AppImageUpdate fetching the newest
+# build incrementally, not a person clicking a button.
+FORMATS = [
+    (".AppImage.zsync", "zsync"),
+    ("-x86_64.AppImage", "appimage"),
+    ("-x86_64.flatpak", "flatpak"),
+    ("-arm64.dmg", "dmg-arm64"),
+    ("-i386.dmg", "dmg-i386"),
+    ("-win64.exe", "exe"),
+    ("-docker.tar.zst", "docker-archive"),
+]
+
+
+def format_of(name):
+    for suffix, key in FORMATS:
+        if name.endswith(suffix):
+            return key
+    return "other"
+
+
+def get_json(url, token=None):
+    req = urllib.request.Request(url, headers={
+        "Accept": "application/vnd.github+json", "User-Agent": "ansel-download-stats",
+        **({"Authorization": f"Bearer {token}"} if token else {}),
+    })
+    with urllib.request.urlopen(req, timeout=60) as r:
+        return json.loads(r.read().decode("utf-8"))
+
+
+def github_releases(token):
+    page, out = 1, []
+    while True:
+        batch = get_json(f"{API}/repos/{REPO}/releases?per_page=100&page={page}", token)
+        if not batch:
+            return out
+        out.extend(batch)
+        page += 1
+
+
+def snapshot(token):
+    by_format = collections.Counter()
+    by_month = collections.Counter()
+    by_release = collections.Counter()
+    assets = 0
+    for rel in github_releases(token):
+        tag = rel["tag_name"]
+        m = MONTH_TAG_RE.match(tag)
+        for a in rel["assets"]:
+            n = int(a.get("download_count") or 0)
+            month = m.group(1) if m else (a.get("created_at") or "")[:7]
+            by_format[format_of(a["name"])] += n
+            by_month[month] += n
+            by_release[tag] += n
+            assets += 1
+
+    docker = None
+    try:
+        hub = get_json(f"{DOCKER_HUB}/{DOCKER_IMAGE}/")
+        docker = {"pull_count": int(hub.get("pull_count") or 0), "star_count": int(hub.get("star_count") or 0)}
+    except Exception as e:  # noqa: BLE001 -- Docker Hub down must not lose the GitHub half
+        print(f"docker hub unreachable: {e}", file=sys.stderr)
+
+    return {
+        "date": datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%d"),
+        "github": {
+            "total": sum(by_format.values()),
+            "assets": assets,
+            "by_format": dict(sorted(by_format.items())),
+            "by_month": dict(sorted(by_month.items())),
+            "by_release": dict(sorted(by_release.items())),
+        },
+        "docker_hub": docker,
+    }
+
+
+def append(series, snap):
+    """One entry per date, the newest snapshot for a date winning; sorted by date."""
+    entries = {s["date"]: s for s in series if isinstance(s, dict) and "date" in s}
+    entries[snap["date"]] = snap
+    return [entries[d] for d in sorted(entries)]
+
+
+def main():
+    cmd = sys.argv[1] if len(sys.argv) > 1 else ""
+    if cmd == "snapshot":
+        json.dump(snapshot(os.environ.get("GITHUB_TOKEN")), sys.stdout, indent=1)
+        sys.stdout.write("\n")
+    elif cmd == "append" and len(sys.argv) == 4:
+        try:
+            series = json.load(open(sys.argv[2], encoding="utf-8"))
+        except (FileNotFoundError, json.JSONDecodeError):
+            series = []
+        if not isinstance(series, list):
+            series = []
+        snap = json.load(open(sys.argv[3], encoding="utf-8"))
+        json.dump(append(series, snap), sys.stdout, separators=(",", ":"))
+        sys.stdout.write("\n")
+    else:
+        sys.exit(__doc__)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/download_stats.py
+++ b/tools/download_stats.py
@@ -108,6 +108,19 @@ def snapshot(token):
             by_release[tag] += n
             assets += 1
 
+    # Repository clones, per day, from the traffic API: the closest thing to "downloads"
+    # for people who build from source. Only the last 14 days are exposed and the call
+    # needs write access to the repository, so it is best effort: a token without it
+    # (possibly the workflow's own GITHUB_TOKEN) yields a warning and no traffic block,
+    # and the snapshot is otherwise complete. The raw count is dominated by CI -- every
+    # workflow job clones -- so `uniques` (distinct cloners) is the figure to read.
+    traffic = None
+    try:
+        clones = get_json(f"{API}/repos/{REPO}/traffic/clones?per=day", token)
+        traffic = {c["timestamp"][:10]: {"clones": c["count"], "uniques": c["uniques"]} for c in clones.get("clones", [])}
+    except Exception as e:  # noqa: BLE001
+        print(f"traffic API unavailable ({e}); snapshot has no clone counts", file=sys.stderr)
+
     docker = None
     try:
         hub = get_json(f"{DOCKER_HUB}/{DOCKER_IMAGE}/")
@@ -125,12 +138,25 @@ def snapshot(token):
             "by_release": dict(sorted(by_release.items())),
         },
         "docker_hub": docker,
+        "traffic": traffic,
     }
 
 
 def append(series, snap):
-    """One entry per date, the newest snapshot for a date winning; sorted by date."""
+    """One entry per date, the newest snapshot for a date winning; sorted by date.
+
+    Clone traffic is a rolling 14-day window, so each snapshot's `traffic` is folded
+    into the series' own by-date map (`series[-1]["traffic_by_day"]` carries it forward):
+    a day seen in several snapshots keeps the last value, and days older than the
+    window survive because they were recorded when they were inside it."""
     entries = {s["date"]: s for s in series if isinstance(s, dict) and "date" in s}
+    by_day = {}
+    for s in series:
+        by_day.update(s.get("traffic_by_day") or {})
+        by_day.update(s.get("traffic") or {})
+    by_day.update(snap.get("traffic") or {})
+    snap = dict(snap)
+    snap["traffic_by_day"] = dict(sorted(by_day.items()))
     entries[snap["date"]] = snap
     return [entries[d] for d in sorted(entries)]
 


### PR DESCRIPTION
Part of #1320.

GitHub keeps one lifetime `download_count` per release asset and nothing else — delete the asset and the count is gone. The monthly prune does that every month, and moving August 2026 into its monthly release this afternoon re-created 154 assets at zero: July's ~7 000 downloads are on record, August's are not. Docker Hub keeps one lifetime `pull_count`. Neither is a time series.

`tools/download_stats.py snapshot` reads every counter — per format, per build month (from the `nightly-YYYY-MM` tag, since a moved asset's creation date is the day it was moved), per release, plus Docker Hub — and `append` adds it to the series the website holds in `data/download-stats.json`, one entry per date. Downloads between two dates are the difference of two snapshots; deletion stops mattering once the day before is on record. It runs inside the manifest job after every nightly, best effort: a failure warns and never blocks the manifest.

Today's snapshot: 949 assets, **49 561** downloads lifetime (exe 17 354, AppImage 16 828, arm64 dmg 10 729, i386 dmg 3 869, zsync 781), Docker Hub **3 728** pulls. Append tested: empty → 1 entry, same date again → still 1, ~0.5 kB per day.

The website side (charts on the homepage from this series) is a separate PR on ansel-website.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Added after review

- **Sentry's finding** (unguarded `append` under `set -e`) — fixed: the statistics block now runs strictly *after* the manifest publish, and every command in it is guarded; simulated an `append` exiting 3, the step completes with the manifest published.
- **Repository clones per day** from the traffic API, folded across its rolling 14-day window so a day recorded once survives after leaving the window (tested: a window that moved on by 10 days kept the earlier days). Best effort: the endpoint needs write access to the repository, and whether the workflow's own `GITHUB_TOKEN` has it is what the first CI run will tell — a warning and no `traffic` block otherwise, nothing else affected. The raw count is CI (833 clones for 15 distinct cloners on Aug 27); **uniques** is the figure to read.