### PR TITLE
nightly-manifest: a token that can read clone traffic, and no more silent 403

### DIFF
--- a/.github/workflows/nightly-manifest.yml
+++ b/.github/workflows/nightly-manifest.yml
@@ -115,6 +115,12 @@ jobs:
         env:
           TOKEN: ${{ secrets.NIGHTLY_PUBLISH_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}   # read-only: the stats snapshot lists releases
+          # Optional. The traffic API (clones per day) needs the "Administration: read"
+          # repository permission, which the workflow's own GITHUB_TOKEN does not carry
+          # -- the first run confirmed it, silently: a series with no traffic block. A
+          # fine-grained PAT with that one permission on this repository restores it;
+          # without one the snapshot is complete except for clones.
+          STATS_TOKEN: ${{ secrets.NIGHTLY_STATS_TOKEN }}
         run: |
           if [[ -z "${TOKEN}" ]]; then
             echo "::warning::NIGHTLY_PUBLISH_TOKEN is not set; manifest built but not published"
@@ -163,7 +169,10 @@ jobs:
           # step before the manifest was published (Sentry's review caught the
           # unguarded `append`). Whatever fails, publish() skips an empty file.
           : > download-stats.json
-          if python3 tools/download_stats.py snapshot > today.json 2>stats.err; then
+          if GITHUB_TOKEN="${STATS_TOKEN:-$GITHUB_TOKEN}" python3 tools/download_stats.py snapshot > today.json 2>stats.err; then
+            # A partial snapshot is still a success; say what was left out rather
+            # than letting a 403 on the traffic API vanish into a file nobody reads.
+            [[ -s stats.err ]] && echo "::notice::download stats: $(tr '\n' ' ' < stats.err)"
             curl -fsSL --max-time 30 -o series.json \
               "https://raw.githubusercontent.com/aurelienpierreeng/ansel-website/master/data/download-stats.json" \
               || echo '[]' > series.json

--- a/doc/nightly-distribution.md
+++ b/doc/nightly-distribution.md
@@ -96,6 +96,7 @@ skipped, with a warning, when it is absent — nothing fails a nightly for want 
 | `NIGHTLY_PUBLISH_TOKEN` | secret | nightly-manifest | fine-grained PAT, **Contents: read & write** on `ansel-website`, `homebrew-ansel`, `scoop-ansel`. Nothing else. |
 | `R2_ACCOUNT_ID` `R2_ACCESS_KEY_ID` `R2_SECRET_ACCESS_KEY` `R2_BUCKET` | secrets | flatpak-nightly | an R2 bucket (public, custom domain) and an API token scoped to it. Free tier: 10 GB, 1 M writes and 10 M reads a month, **egress free**. A pruned repo is a few hundred MB. |
 | `FLATPAK_REPO_URL` | variable | flatpak-nightly | the public URL of that bucket, default `https://flatpak.ansel.photos` |
+| `NIGHTLY_STATS_TOKEN` | secret | nightly-manifest | fine-grained PAT with **Administration: read** on `aurelienpierreeng/ansel` and nothing else — the one permission GitHub lists for the traffic endpoints (repository clones per day). The workflow's built-in `GITHUB_TOKEN` cannot read them: the first production run produced a series with no `traffic` block. Without this secret the download statistics are complete except for clones. |
 | `FLATPAK_GPG_KEY` `FLATPAK_GPG_KEY_ID` | secrets | flatpak-nightly | an ASCII-armoured private key made for this and its id. Signs the repo and the bundle, and is embedded (public half) in `ansel.flatpakrepo`, so clients add the remote without `--no-gpg-verify`. `gpg --quick-gen-key "Ansel nightly <nightly@ansel.photos>" ed25519 sign never` then `gpg --export-secret-keys --armor <id>`. |
 
 Docker Hub keeps its existing `DOCKERHUB_USERNAME` / `DOCKERHUB_TOKEN`.


### PR DESCRIPTION
Follow-up to #1333, part of #1320.

The first production run of the download statistics wrote a series with **no `traffic` block** and said nothing. Cause: the traffic endpoints require the **Administration: read** repository permission ([GitHub's permission table](https://docs.github.com/en/rest/authentication/permissions-required-for-fine-grained-personal-access-tokens) lists `GET /repos/{owner}/{repo}/traffic/clones` there, and marks it unavailable to the built-in token), and the resulting 403 went to a stderr file the step only prints on outright failure.

- The snapshot now runs with `NIGHTLY_STATS_TOKEN` when that secret exists — a fine-grained PAT with **Administration: read on `aurelienpierreeng/ansel` only** — and with `GITHUB_TOKEN` otherwise, so nothing regresses without it (fallback expression tested both ways).
- A snapshot that succeeded with something left out prints what was left out as a `::notice::` on the run.
- `doc/nightly-distribution.md`'s secrets table gains the entry.

To create the token: Settings → Developer settings → Fine-grained tokens → repository access *only* `ansel`, permission *Administration: Read-only* — then `gh secret set NIGHTLY_STATS_TOKEN --repo aurelienpierreeng/ansel`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)