### PR TITLE
masks: opacity is set by identity, so it can copy-on-write

### DIFF
--- a/src/develop/blend_gui.c
+++ b/src/develop/blend_gui.c
@@ -2280,21 +2280,15 @@ static GtkWidget *_blendop_masks_group_ctx_menu(dt_iop_gui_blend_data_t *bd, dt_
   GtkWidget *menu = gtk_menu_new();
   gtk_style_context_add_class(gtk_widget_get_style_context(menu), "dt-masks-context-menu");
 
-  // Same shape-parameter sliders (size/fading/rotation/opacity) as the darkroom canvas's
-  // own shape context menu (dt_masks_create_menu). Touch the parent group before resolving
-  // the entry pointer, same rule as _blendop_masks_group_operation_callback: the sliders
-  // mutate this entry in place across the whole drag/scroll interaction.
-  dt_masks_form_t *parent_group = dt_masks_get_from_id(module->dev, parentid);
-  if(!IS_NULL_PTR(parent_group) && (parent_group->type & DT_MASKS_GROUP))
-    parent_group = dt_masks_cow_touch(module->dev, parent_group);
-  dt_masks_form_group_t *op_form = (!IS_NULL_PTR(parent_group) && (parent_group->type & DT_MASKS_GROUP))
-                                       ? dt_masks_form_group_find_entry(parent_group, formid, NULL)
-                                       : NULL;
+  // Same shape-parameter sliders (size/fading/rotation/opacity) as the darkroom canvas's own
+  // shape context menu (dt_masks_create_menu). The sliders name the row by identity and let the
+  // write API copy-on-write per step, so this no longer has to touch the parent group up front --
+  // which never worked anyway once a slider started committing history mid-drag.
   dt_masks_form_t *form = dt_masks_get_from_id(module->dev, formid);
 
-  if(!IS_NULL_PTR(op_form) && !IS_NULL_PTR(form))
+  if(!IS_NULL_PTR(form))
   {
-    dt_masks_gui_populate_interaction_sliders(menu, module->dev, form, op_form, module->dev->form_gui, module);
+    dt_masks_gui_populate_interaction_sliders(menu, module->dev, form, parentid, module->dev->form_gui, module);
     gtk_menu_shell_append(GTK_MENU_SHELL(menu), gtk_separator_menu_item_new());
   }
 

--- a/src/develop/masks/masks.c
+++ b/src/develop/masks/masks.c
@@ -1451,6 +1451,67 @@ gboolean dt_masks_form_get_info(const dt_masks_form_t *form, dt_masks_form_info_
   return TRUE;
 }
 
+/* One place builds the value type callers see, so a row is never copied out field by field at
+ * three separate call sites -- each of which would have to be found again the day
+ * dt_masks_member_t grows a field. @p entry may be NULL: the member comes back zeroed but KEEPS
+ * its index, for the reason dt_masks_group_copy_members() spells out below. */
+static void _member_from_entry(dt_masks_member_t *const out, const dt_masks_form_group_t *const entry,
+                               const guint index)
+{
+  if(IS_NULL_PTR(out)) return;
+
+  out->index = index;
+
+  if(IS_NULL_PTR(entry))
+  {
+    out->formid = 0;
+    out->parentid = 0;
+    out->state = DT_MASKS_STATE_NONE;
+    out->opacity = 0.0f;
+    return;
+  }
+
+  out->formid = entry->formid;
+  out->parentid = entry->parentid;
+  out->state = (dt_masks_state_t)entry->state;
+  out->opacity = entry->opacity;
+}
+
+
+/* Resolve one membership row from (group, formid), the identity the whole write API is keyed on.
+ *
+ * @p touch says whether the caller is about to MUTATE the row, and the asymmetry is the point:
+ *  - a writer must touch FIRST and resolve from what the touch returned, because cloning a group
+ *    clones its membership blocks with it -- a row resolved before the touch belongs to the copy
+ *    that was just abandoned, and the mutation lands in memory nothing reads;
+ *  - a reader must NOT touch. Copy-on-write is for writers; touching on a read would clone a
+ *    shared group every time the GUI merely asks what a shape's opacity is.
+ */
+static dt_masks_form_group_t *_resolve_member(dt_develop_t *dev, const int group_id, const int formid,
+                                              const gboolean touch, guint *const out_index)
+{
+  if(!IS_NULL_PTR(out_index)) *out_index = 0;
+
+  dt_masks_form_t *group = dt_masks_get_from_id(dev, group_id);
+  if(IS_NULL_PTR(group) || !(group->type & DT_MASKS_GROUP)) return NULL;
+
+  if(touch) group = dt_masks_cow_touch(dev, group);
+  if(IS_NULL_PTR(group)) return NULL;
+
+  guint index = 0;
+  for(GList *node = group->points; node; node = g_list_next(node), index++)
+  {
+    dt_masks_form_group_t *const entry = (dt_masks_form_group_t *)node->data;
+    if(IS_NULL_PTR(entry) || entry->formid != formid) continue;
+
+    if(!IS_NULL_PTR(out_index)) *out_index = index;
+    return entry;
+  }
+
+  return NULL;
+}
+
+
 guint dt_masks_group_copy_members(const dt_masks_form_t *group, dt_masks_member_t *out,
                                   const guint out_max)
 {
@@ -1464,27 +1525,11 @@ guint dt_masks_group_copy_members(const dt_masks_form_t *group, dt_masks_member_
   {
     if(IS_NULL_PTR(out) || total >= out_max) continue;
 
-    dt_masks_member_t *const member = &out[total];
-    member->index = total;
-
     /* A row that cannot be read STILL CONSUMES ITS INDEX. Position is the compositing order and
      * the index into retouch's rt_forms[] and spots' clone_algo[], both persisted in the user's
      * database, so dropping a row here would silently re-pair every later shape with the wrong
-     * algorithm. It comes back zeroed instead. */
-    const dt_masks_form_group_t *const entry = (const dt_masks_form_group_t *)node->data;
-    if(IS_NULL_PTR(entry))
-    {
-      member->formid = 0;
-      member->parentid = 0;
-      member->state = DT_MASKS_STATE_NONE;
-      member->opacity = 0.0f;
-      continue;
-    }
-
-    member->formid = entry->formid;
-    member->parentid = entry->parentid;
-    member->state = (dt_masks_state_t)entry->state;
-    member->opacity = entry->opacity;
+     * algorithm. _member_from_entry() zeroes it instead, index kept. */
+    _member_from_entry(&out[total], (const dt_masks_form_group_t *)node->data, total);
   }
 
   /* The TOTAL, always -- a caller that passed a short buffer needs to know it was short, and a
@@ -1518,39 +1563,101 @@ dt_masks_result_t dt_masks_group_set_member_operation(dt_develop_t *dev, const i
   if(operation != DT_MASKS_STATE_INVERSE && !(operation & DT_MASKS_STATE_IS_COMBINE_OP))
     return DT_MASKS_INVALID;
 
-  dt_masks_form_t *group = dt_masks_get_from_id(dev, group_id);
-  if(IS_NULL_PTR(group) || !(group->type & DT_MASKS_GROUP)) return DT_MASKS_NOT_FOUND;
-
-  /* Touch FIRST, then resolve the row from what the touch returned. Cloning a group clones its
-   * membership blocks with it, so a row resolved before the touch belongs to the copy that was
-   * just abandoned -- the mutation would land in memory nothing reads. */
-  group = dt_masks_cow_touch(dev, group);
-  if(IS_NULL_PTR(group)) return DT_MASKS_NOT_FOUND;
-
   guint index = 0;
-  for(GList *node = group->points; node; node = g_list_next(node), index++)
+  dt_masks_form_group_t *const entry = _resolve_member(dev, group_id, formid, TRUE, &index);
+  if(IS_NULL_PTR(entry)) return DT_MASKS_NOT_FOUND;
+
+  const int before = entry->state;
+  if(operation == DT_MASKS_STATE_INVERSE)
+    entry->state ^= DT_MASKS_STATE_INVERSE;
+  else
+    entry->state = (entry->state & ~DT_MASKS_STATE_IS_COMBINE_OP) | operation;
+
+  _member_from_entry(out, entry, index);
+  return (entry->state == before) ? DT_MASKS_UNCHANGED : DT_MASKS_OK;
+}
+
+
+/* Depth-first walk for the group that references @p formid. @p grp NULL means "start from every
+ * top-level group in dev->forms". @p max_depth is a cycle brake, not a modelling limit: a group
+ * referencing an ancestor of itself would otherwise recurse forever, and nothing in the data model
+ * forbids one being written to XMP. */
+static dt_masks_form_t *_find_holder(dt_develop_t *dev, dt_masks_form_t *grp, const int formid,
+                                     const int max_depth)
+{
+  if(max_depth <= 0) return NULL;
+
+  if(IS_NULL_PTR(grp))
   {
-    dt_masks_form_group_t *const entry = (dt_masks_form_group_t *)node->data;
-    if(IS_NULL_PTR(entry) || entry->formid != formid) continue;
-
-    const int before = entry->state;
-    if(operation == DT_MASKS_STATE_INVERSE)
-      entry->state ^= DT_MASKS_STATE_INVERSE;
-    else
-      entry->state = (entry->state & ~DT_MASKS_STATE_IS_COMBINE_OP) | operation;
-
-    if(!IS_NULL_PTR(out))
+    for(GList *forms = dev->forms; forms; forms = g_list_next(forms))
     {
-      out->formid = entry->formid;
-      out->parentid = entry->parentid;
-      out->index = index;
-      out->state = (dt_masks_state_t)entry->state;
-      out->opacity = entry->opacity;
+      dt_masks_form_t *const form = (dt_masks_form_t *)forms->data;
+      if(IS_NULL_PTR(form) || !(form->type & DT_MASKS_GROUP)) continue;
+
+      dt_masks_form_t *const found = _find_holder(dev, form, formid, max_depth - 1);
+      if(!IS_NULL_PTR(found)) return found;
     }
-    return (entry->state == before) ? DT_MASKS_UNCHANGED : DT_MASKS_OK;
+    return NULL;
   }
 
-  return DT_MASKS_NOT_FOUND;
+  for(GList *points = grp->points; points; points = g_list_next(points))
+  {
+    const dt_masks_form_group_t *const point = (const dt_masks_form_group_t *)points->data;
+    if(IS_NULL_PTR(point)) continue;
+    if(point->formid == formid) return grp;
+
+    dt_masks_form_t *const sub = dt_masks_get_from_id(dev, point->formid);
+    if(IS_NULL_PTR(sub) || !(sub->type & DT_MASKS_GROUP)) continue;
+
+    dt_masks_form_t *const found = _find_holder(dev, sub, formid, max_depth - 1);
+    if(!IS_NULL_PTR(found)) return found;
+  }
+  return NULL;
+}
+
+
+int dt_masks_group_find_holder(dt_develop_t *dev, const int formid)
+{
+  if(IS_NULL_PTR(dev) || formid == 0) return 0;
+
+  const dt_masks_form_t *const grp = _find_holder(dev, NULL, formid, 32);
+  return IS_NULL_PTR(grp) ? 0 : grp->formid;
+}
+
+
+dt_masks_result_t dt_masks_group_get_member(dt_develop_t *dev, const int group_id, const int formid,
+                                            dt_masks_member_t *out)
+{
+  if(IS_NULL_PTR(dev)) return DT_MASKS_INVALID;
+
+  guint index = 0;
+  const dt_masks_form_group_t *const entry = _resolve_member(dev, group_id, formid, FALSE, &index);
+  if(IS_NULL_PTR(entry)) return DT_MASKS_NOT_FOUND;
+
+  _member_from_entry(out, entry, index);
+  return DT_MASKS_OK;
+}
+
+
+dt_masks_result_t dt_masks_group_set_member_opacity(dt_develop_t *dev, const int group_id, const int formid,
+                                                    const float opacity, dt_masks_member_t *out)
+{
+  if(IS_NULL_PTR(dev)) return DT_MASKS_INVALID;
+
+  /* Reject NaN rather than clamp it. CLAMPF() is written as a pair of ordered comparisons, and
+   * every comparison against NaN is false, so it would quietly return the LOW bound: a NaN
+   * arriving from a caller's own arithmetic would blank the shape instead of being reported. */
+  if(!isfinite(opacity)) return DT_MASKS_INVALID;
+
+  guint index = 0;
+  dt_masks_form_group_t *const entry = _resolve_member(dev, group_id, formid, TRUE, &index);
+  if(IS_NULL_PTR(entry)) return DT_MASKS_NOT_FOUND;
+
+  const float before = entry->opacity;
+  entry->opacity = CLAMPF(opacity, 0.0f, 1.0f);
+
+  _member_from_entry(out, entry, index);
+  return (entry->opacity == before) ? DT_MASKS_UNCHANGED : DT_MASKS_OK;
 }
 
 // clang-format off

--- a/src/develop/masks/masks_functions.h
+++ b/src/develop/masks/masks_functions.h
@@ -181,8 +181,6 @@ void _check_id(dt_develop_t *dev, dt_masks_form_t *mask_form);
 void _set_group_name_from_module(dt_iop_module_t *module, dt_masks_form_t *group_form);
 dt_masks_form_t *_group_create(dt_develop_t *develop, dt_iop_module_t *module, dt_masks_type_t group_type);
 dt_masks_form_t *_group_from_module(dt_develop_t *develop, dt_iop_module_t *module);
-float _change_opacity(dt_masks_form_group_t *form_group, float value,
-                             const dt_masks_increment_t increment, const int flow);
 int _find_in_group(dt_develop_t *dev, dt_masks_form_t *group_form, int form_id);
 
 #ifdef __cplusplus

--- a/src/develop/masks/masks_gui.c
+++ b/src/develop/masks/masks_gui.c
@@ -265,7 +265,14 @@ GtkWidget *dt_masks_shape_buttons_create(const dt_masks_shape_buttons_config_t *
 
 typedef struct dt_masks_gui_interaction_slider_t
 {
-  dt_masks_form_group_t *form_group;
+  /* The row this slider drives, named by IDENTITY and never held as a pointer. A slider outlives
+   * many mutations of the group it points into: it commits history on every step, each commit
+   * re-snapshots dev->forms, and the next step's copy-on-write then clones the group -- so a
+   * cached dt_masks_form_group_t* would, from the second step on, address the abandoned copy
+   * while the snapshots it was supposed to leave frozen kept the edits. */
+  dt_develop_t *dev;
+  int group_id;
+  int formid;
   dt_masks_form_gui_t *gui;
   dt_iop_module_t *module;
   dt_masks_interaction_t interaction;
@@ -283,21 +290,20 @@ typedef struct dt_masks_gui_interaction_slider_t
 // waiting for the context menu to be closed.
 static void _masks_gui_interaction_commit(dt_masks_gui_interaction_slider_t *data)
 {
-  if(IS_NULL_PTR(data) || IS_NULL_PTR(data->form_group) || IS_NULL_PTR(data->gui)) return;
+  if(IS_NULL_PTR(data) || IS_NULL_PTR(data->gui)) return;
 
   dt_dev_add_history_item(data->gui->dev, data->module, TRUE, TRUE);
   DT_DEBUG_CONTROL_SIGNAL_RAISE(dt_control_signal_get_global(), DT_SIGNAL_MASK_CHANGED,
-                                data->form_group->formid, data->form_group->parentid,
-                                DT_MASKS_EVENT_UPDATE);
+                                data->formid, data->group_id, DT_MASKS_EVENT_UPDATE);
 }
 
 static void _masks_gui_interaction_apply_value(dt_masks_gui_interaction_slider_t *data, float value)
 {
-  if(IS_NULL_PTR(data) || IS_NULL_PTR(data->form_group)) return;
+  if(IS_NULL_PTR(data) || IS_NULL_PTR(data->dev)) return;
 
   if(data->increment == DT_MASKS_INCREMENT_ABSOLUTE) // aka opacity
   {
-    dt_masks_form_set_interaction_value(data->form_group, data->interaction, value,
+    dt_masks_form_set_interaction_value(data->dev, data->group_id, data->formid, data->interaction, value,
                                         data->increment, 1, data->gui, data->module);
     data->last_value = value;
     _masks_gui_interaction_commit(data);
@@ -309,7 +315,7 @@ static void _masks_gui_interaction_apply_value(dt_masks_gui_interaction_slider_t
 
   // Slider value is a log2 scale factor in [-3;3], so apply the delta in log space.
   const float scale = exp2f(delta);
-  dt_masks_form_set_interaction_value(data->form_group, data->interaction, scale,
+  dt_masks_form_set_interaction_value(data->dev, data->group_id, data->formid, data->interaction, scale,
                                       DT_MASKS_INCREMENT_SCALE, 1.f, data->gui, data->module);
   data->last_value = value;
   _masks_gui_interaction_commit(data);
@@ -398,12 +404,13 @@ static gboolean _masks_gui_menu_item_forward_event(GtkWidget *widget, GdkEvent *
 static void _masks_gui_interaction_slider_changed(GtkWidget *widget, gpointer user_data)
 {
   dt_masks_gui_interaction_slider_t *data = (dt_masks_gui_interaction_slider_t *)user_data;
-  if(IS_NULL_PTR(data) || IS_NULL_PTR(data->form_group)) return;
+  if(IS_NULL_PTR(data) || IS_NULL_PTR(data->dev)) return;
 
   _masks_gui_interaction_apply_value(data, dt_bauhaus_slider_get(widget));
 }
 
-GtkWidget *dt_masks_gui_add_interaction_slider(GtkWidget *menu, const char *label, dt_masks_form_group_t *form_group,
+GtkWidget *dt_masks_gui_add_interaction_slider(GtkWidget *menu, const char *label, dt_develop_t *dev,
+                                               const int group_id, const int formid,
                                                dt_masks_interaction_t interaction, dt_masks_increment_t increment,
                                                float min, float max, float step, float value, int digits,
                                                const char *format, float factor,
@@ -433,7 +440,9 @@ GtkWidget *dt_masks_gui_add_interaction_slider(GtkWidget *menu, const char *labe
   gtk_widget_set_can_focus(slider, TRUE);
 
   dt_masks_gui_interaction_slider_t *data = g_malloc0(sizeof(dt_masks_gui_interaction_slider_t));
-  data->form_group = form_group;
+  data->dev = dev;
+  data->group_id = group_id;
+  data->formid = formid;
   data->gui = gui;
   data->module = module;
   data->interaction = interaction;
@@ -680,62 +689,67 @@ static void _masks_operation_callback(GtkWidget *menu, gpointer user_data)
 // Shared by the darkroom canvas context menu (dt_masks_create_menu) and the blend module's
 // own shape-list context menus (develop/blend_gui.c), so both offer the same shape parameters.
 void dt_masks_gui_populate_interaction_sliders(GtkWidget *menu, dt_develop_t *dev, dt_masks_form_t *form,
-                                               dt_masks_form_group_t *op_form,
+                                               const int group_id,
                                                dt_masks_form_gui_t *gui, dt_iop_module_t *module)
 {
-  if(IS_NULL_PTR(menu) || IS_NULL_PTR(form) || IS_NULL_PTR(op_form)) return;
+  if(IS_NULL_PTR(menu) || IS_NULL_PTR(form) || IS_NULL_PTR(dev)) return;
 
-  const float opacity = dt_masks_form_get_interaction_value(dev, op_form, DT_MASKS_INTERACTION_OPACITY);
+  /* The row has to exist -- opacity is read from it, and every slider writes back to it -- but
+   * asking by identity means no caller has to resolve one and hand it over, and none of them has
+   * to copy-on-write the group merely to open a menu. */
+  if(dt_masks_group_get_member(dev, group_id, form->formid, NULL) != DT_MASKS_OK) return;
+
+  const float opacity = dt_masks_form_get_interaction_value(dev, group_id, form->formid, DT_MASKS_INTERACTION_OPACITY);
 
   if(form->type & DT_MASKS_GRADIENT)
   {
     // For gradients, DT_MASKS_INTERACTION_HARDNESS is the shape curvature and
     // DT_MASKS_INTERACTION_SIZE is the fade extent -- expose them under their actual names.
-    const float curvature = dt_masks_form_get_interaction_value(dev, op_form, DT_MASKS_INTERACTION_HARDNESS);
-    const float fade = dt_masks_form_get_interaction_value(dev, op_form, DT_MASKS_INTERACTION_SIZE);
-    float rotation = dt_masks_form_get_interaction_value(dev, op_form, DT_MASKS_INTERACTION_ROTATION);
+    const float curvature = dt_masks_form_get_interaction_value(dev, group_id, form->formid, DT_MASKS_INTERACTION_HARDNESS);
+    const float fade = dt_masks_form_get_interaction_value(dev, group_id, form->formid, DT_MASKS_INTERACTION_SIZE);
+    float rotation = dt_masks_form_get_interaction_value(dev, group_id, form->formid, DT_MASKS_INTERACTION_ROTATION);
     if(!isfinite(rotation)) rotation = 0.0f;
     if(rotation > 180.0f) rotation -= 360.0f;
 
-    dt_masks_gui_add_interaction_slider(menu, _("Curvature"), op_form, DT_MASKS_INTERACTION_HARDNESS,
+    dt_masks_gui_add_interaction_slider(menu, _("Curvature"), dev, group_id, form->formid, DT_MASKS_INTERACTION_HARDNESS,
                                       DT_MASKS_INCREMENT_ABSOLUTE, -2.0f, 2.0f, 0.01f,
                                       isfinite(curvature) ? curvature : 0.0f, 3, "%", 50.0f,
                                       gui, module);
-    dt_masks_gui_add_interaction_slider(menu, _("Fade"), op_form, DT_MASKS_INTERACTION_SIZE,
+    dt_masks_gui_add_interaction_slider(menu, _("Fade"), dev, group_id, form->formid, DT_MASKS_INTERACTION_SIZE,
                                       DT_MASKS_INCREMENT_ABSOLUTE, 0.0f, 1.0f, 0.001f,
                                       isfinite(fade) ? fade : 1.0f, 3, "%", 100.0f,
                                       gui, module);
-    dt_masks_gui_add_interaction_slider(menu, _("Rotation"), op_form, DT_MASKS_INTERACTION_ROTATION,
+    dt_masks_gui_add_interaction_slider(menu, _("Rotation"), dev, group_id, form->formid, DT_MASKS_INTERACTION_ROTATION,
                                       DT_MASKS_INCREMENT_ABSOLUTE, -180.0f, 180.0f, 1.0f,
                                       rotation, 1, "\302\260", 1.0f,
                                       gui, module);
   }
   else
   {
-    const float hardness = dt_masks_form_get_interaction_value(dev, op_form, DT_MASKS_INTERACTION_HARDNESS);
+    const float hardness = dt_masks_form_get_interaction_value(dev, group_id, form->formid, DT_MASKS_INTERACTION_HARDNESS);
 
-    dt_masks_gui_add_interaction_slider(menu, _("Size"), op_form, DT_MASKS_INTERACTION_SIZE,
+    dt_masks_gui_add_interaction_slider(menu, _("Size"), dev, group_id, form->formid, DT_MASKS_INTERACTION_SIZE,
                                       DT_MASKS_INCREMENT_SCALE, -4.f, 4.0f, 0.01f, 0.0f, 2, "x", 1.0f,
                                       gui, module);
-    dt_masks_gui_add_interaction_slider(menu, _("Fading"), op_form, DT_MASKS_INTERACTION_HARDNESS,
+    dt_masks_gui_add_interaction_slider(menu, _("Fading"), dev, group_id, form->formid, DT_MASKS_INTERACTION_HARDNESS,
                                       DT_MASKS_INCREMENT_ABSOLUTE, 0.f, 1.0f, 0.01f,
                                       isfinite(hardness) ? hardness : 1.0f, 3, "%", 100.0f,
                                       gui, module);
 
     if(form->type & DT_MASKS_ELLIPSE)
     {
-      float rotation = dt_masks_form_get_interaction_value(dev, op_form, DT_MASKS_INTERACTION_ROTATION);
+      float rotation = dt_masks_form_get_interaction_value(dev, group_id, form->formid, DT_MASKS_INTERACTION_ROTATION);
       if(!isfinite(rotation)) rotation = 0.0f;
       if(rotation > 180.0f) rotation -= 360.0f;
 
-      dt_masks_gui_add_interaction_slider(menu, _("Rotation"), op_form, DT_MASKS_INTERACTION_ROTATION,
+      dt_masks_gui_add_interaction_slider(menu, _("Rotation"), dev, group_id, form->formid, DT_MASKS_INTERACTION_ROTATION,
                                         DT_MASKS_INCREMENT_ABSOLUTE, -180.0f, 180.0f, 1.0f,
                                         rotation, 1, "\302\260", 1.0f,
                                         gui, module);
     }
   }
 
-  dt_masks_gui_add_interaction_slider(menu, _("Opacity"), op_form, DT_MASKS_INTERACTION_OPACITY,
+  dt_masks_gui_add_interaction_slider(menu, _("Opacity"), dev, group_id, form->formid, DT_MASKS_INTERACTION_OPACITY,
                                     DT_MASKS_INCREMENT_ABSOLUTE, 0.0f, 1.0f, 0.01f,
                                     isfinite(opacity) ? opacity : 1.0f, 3, "%", 100.0f,
                                     gui, module);
@@ -881,7 +895,7 @@ GtkWidget *dt_masks_create_menu(dt_masks_form_gui_t *gui, dt_masks_form_t *form,
     // Common menu items
   if(!gui->creation && (gui->form_selected || gui->node_selected) && op_form)
   {
-    dt_masks_gui_populate_interaction_sliders(menu, gui->dev, form, op_form, gui, gui->dev->gui_module);
+    dt_masks_gui_populate_interaction_sliders(menu, gui->dev, form, grp->formid, gui, gui->dev->gui_module);
     gtk_menu_shell_append(GTK_MENU_SHELL(menu), gtk_separator_menu_item_new());
   }
 
@@ -1378,58 +1392,6 @@ dt_masks_form_group_t *dt_masks_form_group_from_parentid(dt_develop_t *dev, int 
 // dt_masks_group_add_form guards against this interactively via _find_in_group, but a raw
 // DB/XMP load does not validate it) cannot stack-overflow the caller; the UI never nests
 // groups anywhere near this deep (see the `depth < 3` guards in libs/masks.c).
-static dt_masks_form_t *_masks_find_any_parent_group(dt_develop_t *dev, dt_masks_form_t *grp, int form_id,
-                                                      int max_depth)
-{
-  if(max_depth <= 0) return NULL;
-
-  if(IS_NULL_PTR(grp))
-  {
-    for(GList *forms = dev->forms; forms; forms = g_list_next(forms))
-    {
-      dt_masks_form_t *form = (dt_masks_form_t *)forms->data;
-      if(form->type & DT_MASKS_GROUP)
-      {
-        dt_masks_form_t *found = _masks_find_any_parent_group(dev, form, form_id, max_depth - 1);
-        if(found) return found;
-      }
-    }
-    return NULL;
-  }
-
-  for(GList *points = grp->points; points; points = g_list_next(points))
-  {
-    dt_masks_form_group_t *point = (dt_masks_form_group_t *)points->data;
-    if(point->formid == form_id) return grp;
-    dt_masks_form_t *sub = dt_masks_get_from_id(dev, point->formid);
-    if(sub && (sub->type & DT_MASKS_GROUP))
-    {
-      dt_masks_form_t *found = _masks_find_any_parent_group(dev, sub, form_id, max_depth - 1);
-      if(found) return found;
-    }
-  }
-  return NULL;
-}
-
-/**
- * @brief Find any group that currently references `form_id`, searching every top-level group
- * in dev->forms and their nested subgroups (first match wins -- a shape used by more than one
- * module has no single "correct" answer). Touches the owning group for COW safety before
- * resolving the entry pointer, same rule as dt_masks_form_group_from_parentid's callers use
- * when they already know the parent.
- * @param out_parentid if non-NULL, receives the owning group's formid (0 if none found).
- */
-dt_masks_form_group_t *dt_masks_form_group_find_any(dt_develop_t *dev, int form_id, int *out_parentid)
-{
-  if(out_parentid) *out_parentid = 0;
-
-  dt_masks_form_t *grp = _masks_find_any_parent_group(dev, NULL, form_id, 32);
-  if(IS_NULL_PTR(grp)) return NULL;
-
-  grp = dt_masks_cow_touch(dev, grp);
-  if(out_parentid) *out_parentid = grp->formid;
-  return dt_masks_form_group_find_entry(grp, form_id, NULL);
-}
 
 /**
  * @brief Get the selected group entry from the GUI selection index.
@@ -4296,17 +4258,22 @@ void dt_masks_iop_value_changed_callback(GtkWidget *widget, struct dt_iop_module
   dt_dev_add_history_item(module->dev, module, TRUE, TRUE);
 }
 
-float dt_masks_form_get_interaction_value(dt_develop_t *dev, dt_masks_form_group_t *form_group,
+float dt_masks_form_get_interaction_value(dt_develop_t *dev, const int group_id, const int formid,
                                           dt_masks_interaction_t interaction)
 {
-  if(IS_NULL_PTR(form_group)) return NAN;
+  if(IS_NULL_PTR(dev)) return NAN;
 
   if(interaction == DT_MASKS_INTERACTION_OPACITY)
   {
-    return form_group->opacity;
+    /* Opacity is a property of the MEMBERSHIP, not of the shape: the same shape referenced by two
+     * groups carries two opacities, which is why this one needs the group id and the others do
+     * not. */
+    dt_masks_member_t member = { 0 };
+    if(dt_masks_group_get_member(dev, group_id, formid, &member) != DT_MASKS_OK) return NAN;
+    return member.opacity;
   }
 
-  dt_masks_form_t *target_form = dt_masks_get_from_id(dev, form_group->formid);
+  dt_masks_form_t *target_form = dt_masks_get_from_id(dev, formid);
   if(IS_NULL_PTR(target_form) || IS_NULL_PTR(target_form->functions) || IS_NULL_PTR(target_form->functions->get_interaction_value)) return NAN;
 
   return target_form->functions->get_interaction_value(target_form, interaction);
@@ -4352,22 +4319,29 @@ int dt_masks_center_view_on_form(dt_develop_t *dev, const dt_masks_form_t *mask_
   return 0;
 }
 
-float dt_masks_form_set_interaction_value(dt_masks_form_group_t *form_group,
+float dt_masks_form_set_interaction_value(dt_develop_t *dev, const int group_id, const int formid,
                                           dt_masks_interaction_t interaction,
                                           float value, dt_masks_increment_t increment, int flow,
                                           dt_masks_form_gui_t *mask_gui, dt_iop_module_t *module)
 {
-  if(IS_NULL_PTR(form_group)) return NAN;
+  if(IS_NULL_PTR(dev)) return NAN;
 
   if(interaction == DT_MASKS_INTERACTION_OPACITY)
   {
-    const float result = _change_opacity(form_group, value, increment, flow);
-    return result;
+    /* Read, apply the increment, write back -- all by identity. The write API owns the
+     * copy-on-write, so nothing here holds a row across the mutation. */
+    dt_masks_member_t member = { 0 };
+    if(dt_masks_group_get_member(dev, group_id, formid, &member) != DT_MASKS_OK) return NAN;
+
+    const float target = dt_masks_apply_increment(member.opacity, value, increment, flow);
+    const dt_masks_result_t result = dt_masks_group_set_member_opacity(dev, group_id, formid, target, &member);
+    if(result != DT_MASKS_OK && result != DT_MASKS_UNCHANGED) return NAN;
+
+    dt_toast_log(_("Opacity: %3.2f%%"), member.opacity * 100.f);
+    return member.opacity;
   }
 
-  dt_develop_t *dev = !IS_NULL_PTR(mask_gui) ? mask_gui->dev : (!IS_NULL_PTR(module) ? module->dev : NULL);
-  if(IS_NULL_PTR(dev)) return NAN;
-  dt_masks_form_t *target_form = dt_masks_get_from_id(dev, form_group->formid);
+  dt_masks_form_t *target_form = dt_masks_get_from_id(dev, formid);
   if(IS_NULL_PTR(target_form) || !target_form->functions
      || !target_form->functions->set_interaction_value) return NAN;
 
@@ -4899,36 +4873,30 @@ void dt_masks_set_edit_mode(struct dt_iop_module_t *module, dt_masks_edit_mode_t
   dt_control_queue_redraw_center();
 }
 
-float _change_opacity(dt_masks_form_group_t *form_group, float value,
-                             const dt_masks_increment_t increment, const int flow)
-{
-  if(IS_NULL_PTR(form_group)) return 0;
-
-  form_group->opacity = CLAMPF(dt_masks_apply_increment(form_group->opacity, value, increment, flow), 0.0f, 1.0f);
-  dt_toast_log(_("Opacity: %3.2f%%"), form_group->opacity * 100.f);
-  return form_group->opacity;
-}
-
 int dt_masks_form_change_opacity(dt_develop_t *dev, dt_masks_form_t *mask_form, int parent_id, int scroll_up,
                                  const int flow)
 {
   if(IS_NULL_PTR(mask_form)) return 0;
 
-  // dt_masks_form_set_interaction_value() below mutates the group_entry in place, which is
-  // memory owned by the parent group, not by mask_form -- touch the parent (not mask_form)
-  // before resolving the entry, or a shared parent's group_entry gets mutated behind the back
-  // of a snapshot that still references it.
-  dt_masks_form_t *parent_form = dt_masks_get_from_id(dev, parent_id);
-  if(IS_NULL_PTR(parent_form) || !(parent_form->type & DT_MASKS_GROUP)) return 0;
-  parent_form = dt_masks_cow_touch(dev, parent_form);
+  // Read, apply the increment, write back by identity. The write API owns the copy-on-write, so
+  // neither half of this holds a row pointer across the other -- which is what the previous
+  // touch-then-resolve-then-mutate-in-place version had to get right by hand.
+  dt_masks_member_t member = { 0 };
+  if(dt_masks_group_get_member(dev, parent_id, mask_form->formid, &member) != DT_MASKS_OK) return 0;
 
-  dt_masks_form_group_t *form_group = dt_masks_form_group_find_entry(parent_form, mask_form->formid, NULL);
-  if(IS_NULL_PTR(form_group)) return 0;
+  const float amount = scroll_up ? 0.02f : -0.02f;
+  const float target = dt_masks_apply_increment(member.opacity, amount, DT_MASKS_INCREMENT_OFFSET, flow);
 
-  float amount = scroll_up ? 0.02f : -0.02f;
-  const float changed = dt_masks_form_set_interaction_value(form_group, DT_MASKS_INTERACTION_OPACITY,
-                                                            amount, DT_MASKS_INCREMENT_OFFSET, flow, NULL, NULL);
-  return !isnan(changed);
+  const dt_masks_result_t result = dt_masks_group_set_member_opacity(dev, parent_id, mask_form->formid,
+                                                                     target, &member);
+  if(result != DT_MASKS_OK && result != DT_MASKS_UNCHANGED) return 0;
+
+  dt_toast_log(_("Opacity: %3.2f%%"), member.opacity * 100.f);
+
+  // UNCHANGED still counts as handled: this return value is what every shape's scrolled handler
+  // gives back to say it consumed the event, so reporting 0 once the opacity is already pinned at
+  // 0 or 1 would let that scroll step fall through and zoom the canvas instead.
+  return (result == DT_MASKS_OK || result == DT_MASKS_UNCHANGED);
 }
 
 // clang-format off

--- a/src/develop/masks_group.h
+++ b/src/develop/masks_group.h
@@ -135,6 +135,59 @@ const char *dt_masks_type_name(dt_masks_type_t type);
 dt_masks_result_t dt_masks_group_set_member_operation(struct dt_develop_t *dev, int group_id, int formid,
                                                       dt_masks_state_t operation, dt_masks_member_t *out);
 
+/**
+ * @brief Read one group member by identity.
+ *
+ * The pointer-free counterpart to dt_masks_group_copy_members() when only one row is wanted, and
+ * the read half of the read-modify-write a caller needs when it can only express a change as an
+ * increment on the current value.
+ *
+ * Deliberately does NOT copy-on-write. Touching a group on a plain read would clone a shared group
+ * every time the GUI asks what a shape's opacity is -- copy-on-write is a writer's obligation.
+ *
+ * @param out (may be NULL, though then the call only answers "does this row exist") receives the
+ *            row, including its index.
+ * @return OK, or NOT_FOUND for no such group, a form that is not a group, or no such member.
+ */
+dt_masks_result_t dt_masks_group_get_member(struct dt_develop_t *dev, int group_id, int formid,
+                                            dt_masks_member_t *out);
+
+/**
+ * @brief Which group references @p formid, searching every group in dev->forms depth-first.
+ *
+ * A shape's own dt_masks_form_t does not record who holds it, and the row's parentid records where
+ * it was AUTHORED, not where it currently lives -- so a caller holding only a shape id, as the
+ * mask-manager tree does when it lists shapes at top level, has to search. Returns the first
+ * holder found; a shape referenced by two groups has no single answer, and the caller wanting a
+ * specific one already knows which.
+ *
+ * @return the holding group's formid, or 0 for none (and for a NULL dev or a zero @p formid).
+ */
+int dt_masks_group_find_holder(struct dt_develop_t *dev, int formid);
+
+/**
+ * @brief Set a group member's opacity.
+ *
+ * Same id-keyed contract as dt_masks_group_set_member_operation() above, and it exists for a
+ * failure this codebase actually shipped. Opacity used to be written through a resolved
+ * dt_masks_form_group_t*, which CANNOT copy-on-write: it has the row but not the group that owns
+ * it, so every caller had to touch the group itself. Callers compensated by touching the parent
+ * once, when a context menu was built, and then mutating the row in place for the whole
+ * interaction -- but the opacity slider commits history on every step, and each commit
+ * re-snapshots dev->forms and shares the group again. The up-front touch was consumed by the first
+ * commit, so from the second step on, every drag rewrote the opacity inside history snapshots that
+ * were supposed to be frozen, and undo could not restore it. Taking ids instead of a row makes
+ * that arrangement unrepresentable.
+ *
+ * @param opacity clamped to [0;1]. NaN is INVALID rather than clamped -- see the implementation.
+ * @param out (may be NULL) receives the row AFTER the change, including the clamped opacity, so a
+ *            caller driving a slider can show what was actually stored.
+ * @return OK when the value changed, UNCHANGED when the row already held it (skip the history
+ *         commit), NOT_FOUND for no such group or member, INVALID for a NULL dev or a NaN.
+ */
+dt_masks_result_t dt_masks_group_set_member_opacity(struct dt_develop_t *dev, int group_id, int formid,
+                                                    float opacity, dt_masks_member_t *out);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/develop/masks_gui.h
+++ b/src/develop/masks_gui.h
@@ -644,7 +644,7 @@ dt_masks_form_group_t *dt_masks_form_group_find_entry(dt_masks_form_t *group_for
  * already knowing which group (if any) it belongs to, e.g. a flat "all shapes" row.
  * @param out_parentid if non-NULL, receives the owning group's formid (0 if none found).
  */
-dt_masks_form_group_t *dt_masks_form_group_find_any(dt_develop_t *dev, int formid, int *out_parentid);
+
 int dt_masks_group_index_from_formid(const dt_masks_form_t *group_form, int formid);
 dt_masks_form_group_t *dt_masks_form_get_selected_group(const struct dt_masks_form_t *form,
                                                         const struct dt_masks_form_gui_t *gui);
@@ -715,7 +715,7 @@ gboolean dt_masks_is_anything_hovered(const dt_masks_form_gui_t *mask_gui);
  */
 dt_masks_form_group_t *dt_masks_form_get_selected_group_live(const struct dt_masks_form_t *form,
                                                              const struct dt_masks_form_gui_t *gui);
-float dt_masks_form_get_interaction_value(dt_develop_t *dev, dt_masks_form_group_t *form_group,
+float dt_masks_form_get_interaction_value(dt_develop_t *dev, int group_id, int formid,
                                           dt_masks_interaction_t interaction);
 gboolean dt_masks_form_get_gravity_center(dt_develop_t *dev, const struct dt_masks_form_t *form, float center[2], float *area);
 void dt_masks_form_update_gravity_center(dt_develop_t *dev, struct dt_masks_form_t *form);
@@ -724,7 +724,7 @@ void dt_masks_form_update_gravity_center(dt_develop_t *dev, struct dt_masks_form
  * hit-testing read site recomputes lazily on first actual use. */
 void dt_masks_form_invalidate_gravity_center(struct dt_masks_form_t *form);
 int dt_masks_center_view_on_form(struct dt_develop_t *dev, const struct dt_masks_form_t *form);
-float dt_masks_form_set_interaction_value(dt_masks_form_group_t *form_group,
+float dt_masks_form_set_interaction_value(dt_develop_t *dev, int group_id, int formid,
                                           dt_masks_interaction_t interaction,
                                           float value, dt_masks_increment_t increment, int flow,
                                           struct dt_masks_form_gui_t *gui, struct dt_iop_module_t *module);
@@ -861,7 +861,8 @@ GtkWidget *dt_masks_create_menu(dt_masks_form_gui_t *gui, dt_masks_form_t *form,
  * canvas context menu (dt_masks_create_menu) and the blend module's own shape-list
  * context menus, so both stay in sync.
  */
-GtkWidget *dt_masks_gui_add_interaction_slider(GtkWidget *menu, const char *label, dt_masks_form_group_t *form_group,
+GtkWidget *dt_masks_gui_add_interaction_slider(GtkWidget *menu, const char *label, dt_develop_t *dev,
+                                               int group_id, int formid,
                                                dt_masks_interaction_t interaction, dt_masks_increment_t increment,
                                                float min, float max, float step, float value, int digits,
                                                const char *format, float factor,
@@ -875,7 +876,7 @@ GtkWidget *dt_masks_gui_add_interaction_slider(GtkWidget *menu, const char *labe
  * group's `points` list.
  */
 void dt_masks_gui_populate_interaction_sliders(GtkWidget *menu, dt_develop_t *dev, dt_masks_form_t *form,
-                                               dt_masks_form_group_t *op_form,
+                                               int group_id,
                                                dt_masks_form_gui_t *gui, struct dt_iop_module_t *module);
 
 int dt_masks_gui_confirm_delete_form_dialog(const char *form_name);

--- a/src/iop/retouch.c
+++ b/src/iop/retouch.c
@@ -69,6 +69,7 @@
 #include "develop/imageop_math.h"
 #include "develop/imageop_gui.h"
 #include "develop/masks.h"
+#include "develop/masks_group.h"
 #include "develop/masks_gui.h"
 #include "develop/tiling.h"
 #include "gui/actions/menu.h"
@@ -592,14 +593,22 @@ static void rt_load_shape_algo_in_gui(dt_iop_module_t *self, const int form_sele
 
 static void rt_masks_form_change_opacity(dt_iop_module_t *self, int formid, float opacity)
 {
-  dt_masks_form_group_t *grpt = rt_get_mask_point_group(self, formid);
-  if(!IS_NULL_PTR(grpt))
-  {
-    grpt->opacity = CLAMP(opacity, 0.05f, 1.0f);
-    dt_conf_set_float("plugins/darkroom/masks/opacity", grpt->opacity);
+  const dt_develop_blend_params_t *bp = self->blend_params;
+  if(IS_NULL_PTR(bp)) return;
 
-    dt_dev_add_history_item(self->dev, self, TRUE, TRUE);
-  }
+  /* Retouch keeps a 5% floor of its own, applied BEFORE the call: a fully transparent clone or
+   * heal is indistinguishable from a deleted one in this module's list, so it never offers 0 the
+   * way a generic mask does. The API clamps to [0;1] and would accept it. */
+  dt_masks_member_t member = { 0 };
+  const dt_masks_result_t result = dt_masks_group_set_member_opacity(self->dev, bp->mask_id, formid,
+                                                                     CLAMP(opacity, 0.05f, 1.0f), &member);
+  if(result != DT_MASKS_OK && result != DT_MASKS_UNCHANGED) return;
+
+  dt_conf_set_float("plugins/darkroom/masks/opacity", member.opacity);
+
+  /* Only a real change earns a history step. Re-setting the opacity a shape already has used to
+   * push an undo entry that undid nothing. */
+  if(result == DT_MASKS_OK) dt_dev_add_history_item(self->dev, self, TRUE, TRUE);
 }
 
 static float rt_masks_form_get_opacity(dt_iop_module_t *self, int formid)

--- a/src/libs/masks.c
+++ b/src/libs/masks.c
@@ -1087,26 +1087,14 @@ static GtkWidget *_tree_context_menu(GtkTreeSelection *selection, GtkTreeModel *
   // just one nested under a group in the tree: _lib_masks_list_recurs also lists every shape
   // at top level regardless of group membership (TREE_GROUPID == 0 there), so when the tree
   // doesn't hand us the parent directly, look up whichever group actually references it.
-  // Touch the parent group before resolving the entry, same rule as elsewhere: the sliders
-  // mutate this entry in place across the whole drag/scroll interaction.
   if(nb == 1 && !IS_NULL_PTR(grp) && !(grp->type & DT_MASKS_GROUP))
   {
-    dt_masks_form_group_t *op_form = NULL;
-    if(from_group)
-    {
-      dt_masks_form_t *parent_group = dt_masks_get_from_id(dt_dev_get_global(), parentid);
-      if(!IS_NULL_PTR(parent_group) && (parent_group->type & DT_MASKS_GROUP))
-        parent_group = dt_masks_cow_touch(dt_dev_get_global(), parent_group);
-      op_form = dt_masks_form_group_find_entry(parent_group, grpid, NULL);
-    }
-    else
-    {
-      op_form = dt_masks_form_group_find_any(dt_dev_get_global(), grpid, NULL);
-    }
+    const int holding_group = from_group ? parentid
+                                         : dt_masks_group_find_holder(dt_dev_get_global(), grpid);
 
-    if(!IS_NULL_PTR(op_form))
+    if(holding_group != 0)
     {
-      dt_masks_gui_populate_interaction_sliders(GTK_WIDGET(menu), dt_dev_get_global(), grp, op_form,
+      dt_masks_gui_populate_interaction_sliders(GTK_WIDGET(menu), dt_dev_get_global(), grp, holding_group,
                                                 dt_dev_get_global()->form_gui, module);
       gtk_menu_shell_append(menu, gtk_separator_menu_item_new());
     }

--- a/src/tests/unittests/test_masks_raster_contract.c
+++ b/src/tests/unittests/test_masks_raster_contract.c
@@ -361,6 +361,10 @@ static void _write_fixture_init(_write_fixture_t *f)
                                         .opacity = 1.0f };
   f->group.type = DT_MASKS_GROUP;
   f->group.formid = 7;
+  /* The vtable is what makes a group's membership rows copyable: dt_masks_dup_masks_form() sizes
+   * each ->points payload from functions->point_struct_size, and a form whose functions are NULL
+   * clones with an EMPTY membership list. Needed by the copy-on-write case below. */
+  f->group.functions = &dt_masks_functions_group;
   /* Sole owner: dt_masks_cow_touch() returns the form unchanged at refcount 1, without taking a
    * lock or walking dev->forms, so the setter runs end to end on a stack fixture. */
   dt_atomic_set_int(&f->group.refcount, 1);
@@ -452,6 +456,125 @@ static void _set_operation_rejects_what_it_cannot_do(void **state)
   _write_fixture_cleanup(&f);
 }
 
+
+/* ---------------------------------------------------------------------------------------
+ * dt_masks_group_get_member() / dt_masks_group_set_member_opacity().
+ * ------------------------------------------------------------------------------------- */
+
+static void _get_member_reads_a_row_by_identity(void **state)
+{
+  (void)state;
+  _write_fixture_t f;
+  _write_fixture_init(&f);
+
+  dt_masks_member_t m;
+  assert_int_equal(dt_masks_group_get_member(&f.dev, 7, 22, &m), DT_MASKS_OK);
+  assert_int_equal(m.formid, 22);
+  assert_int_equal(m.parentid, 7);
+  assert_int_equal(m.index, 1);
+  assert_true(m.opacity == 1.0f);
+
+  // NULL out is a legitimate existence probe -- the menu builders use it exactly that way
+  assert_int_equal(dt_masks_group_get_member(&f.dev, 7, 11, NULL), DT_MASKS_OK);
+
+  assert_int_equal(dt_masks_group_get_member(&f.dev, 999, 11, &m), DT_MASKS_NOT_FOUND);
+  assert_int_equal(dt_masks_group_get_member(&f.dev, 7, 999, &m), DT_MASKS_NOT_FOUND);
+  assert_int_equal(dt_masks_group_get_member(NULL, 7, 11, &m), DT_MASKS_INVALID);
+
+  _write_fixture_cleanup(&f);
+}
+
+static void _set_opacity_clamps_and_reports_what_it_stored(void **state)
+{
+  (void)state;
+  _write_fixture_t f;
+  _write_fixture_init(&f);
+
+  dt_masks_member_t m;
+  assert_int_equal(dt_masks_group_set_member_opacity(&f.dev, 7, 11, 0.25f, &m), DT_MASKS_OK);
+  assert_true(f.rows[0].opacity == 0.25f);
+  assert_true(m.opacity == 0.25f);
+
+  // out-of-range is clamped, and the caller is told the CLAMPED value -- a slider showing what it
+  // asked for rather than what was stored is how a control drifts away from its own model
+  assert_int_equal(dt_masks_group_set_member_opacity(&f.dev, 7, 11, 4.0f, &m), DT_MASKS_OK);
+  assert_true(f.rows[0].opacity == 1.0f);
+  assert_true(m.opacity == 1.0f);
+
+  assert_int_equal(dt_masks_group_set_member_opacity(&f.dev, 7, 11, -2.0f, &m), DT_MASKS_OK);
+  assert_true(f.rows[0].opacity == 0.0f);
+
+  // and re-setting the value it already holds is not a change: every shape's scrolled handler
+  // treats this as "handled" but must not push an undo step for it
+  assert_int_equal(dt_masks_group_set_member_opacity(&f.dev, 7, 11, 0.0f, &m), DT_MASKS_UNCHANGED);
+
+  assert_int_equal(dt_masks_group_set_member_opacity(&f.dev, 999, 11, 0.5f, NULL), DT_MASKS_NOT_FOUND);
+  assert_int_equal(dt_masks_group_set_member_opacity(&f.dev, 7, 999, 0.5f, NULL), DT_MASKS_NOT_FOUND);
+  assert_int_equal(dt_masks_group_set_member_opacity(NULL, 7, 11, 0.5f, NULL), DT_MASKS_INVALID);
+
+  _write_fixture_cleanup(&f);
+}
+
+static void _set_opacity_refuses_a_nan_rather_than_clamping_it(void **state)
+{
+  (void)state;
+  _write_fixture_t f;
+  _write_fixture_init(&f);
+
+  /* CLAMPF() is a pair of ordered comparisons and every comparison against NaN is false, so
+   * clamping a NaN yields the LOW bound: a NaN reaching this from a caller's own arithmetic would
+   * silently blank the shape instead of being reported. */
+  assert_int_equal(dt_masks_group_set_member_opacity(&f.dev, 7, 11, NAN, NULL), DT_MASKS_INVALID);
+  assert_true(f.rows[0].opacity == 0.5f);
+
+  _write_fixture_cleanup(&f);
+}
+
+static void _a_shared_group_is_cloned_before_its_opacity_changes(void **state)
+{
+  (void)state;
+  _write_fixture_t f;
+  _write_fixture_init(&f);
+
+  /* Refcount 2 is what a history commit leaves behind: the dev's live form list holds one
+   * reference and the frozen snapshot holds the other. It is the state an opacity slider is in from its SECOND step
+   * onward, because each step commits history -- which is exactly why writing through a row
+   * pointer resolved once, when the menu was built, could not stay correct. */
+  dt_atomic_set_int(&f.group.refcount, 2);
+
+  dt_masks_member_t m;
+  assert_int_equal(dt_masks_group_set_member_opacity(&f.dev, 7, 11, 0.25f, &m), DT_MASKS_OK);
+
+  // The snapshot still reads what it froze. This assertion IS the bug that motivated the API.
+  assert_true(f.rows[0].opacity == 0.5f);
+
+  // dev->forms carries the clone, and the clone carries the edit
+  dt_masks_form_t *const live = (dt_masks_form_t *)f.dev.forms->data;
+  assert_ptr_not_equal(live, &f.group);
+  assert_true(m.opacity == 0.25f);
+
+  dt_masks_member_t read_back;
+  assert_int_equal(dt_masks_group_get_member(&f.dev, 7, 11, &read_back), DT_MASKS_OK);
+  assert_true(read_back.opacity == 0.25f);
+
+  dt_masks_form_unref(live);
+  _write_fixture_cleanup(&f);
+}
+
+static void _find_holder_names_the_group_that_references_a_shape(void **state)
+{
+  (void)state;
+  _write_fixture_t f;
+  _write_fixture_init(&f);
+
+  assert_int_equal(dt_masks_group_find_holder(&f.dev, 22), 7);
+  assert_int_equal(dt_masks_group_find_holder(&f.dev, 999), 0);
+  assert_int_equal(dt_masks_group_find_holder(&f.dev, 0), 0);
+  assert_int_equal(dt_masks_group_find_holder(NULL, 22), 0);
+
+  _write_fixture_cleanup(&f);
+}
+
 int main(void)
 {
   const struct CMUnitTest tests[] = {
@@ -469,6 +592,11 @@ int main(void)
     cmocka_unit_test(_setting_the_state_it_already_has_is_unchanged),
     cmocka_unit_test(_inverse_toggles_and_leaves_the_operator_alone),
     cmocka_unit_test(_set_operation_rejects_what_it_cannot_do),
+    cmocka_unit_test(_get_member_reads_a_row_by_identity),
+    cmocka_unit_test(_set_opacity_clamps_and_reports_what_it_stored),
+    cmocka_unit_test(_set_opacity_refuses_a_nan_rather_than_clamping_it),
+    cmocka_unit_test(_a_shared_group_is_cloned_before_its_opacity_changes),
+    cmocka_unit_test(_find_holder_names_the_group_that_references_a_shape),
   };
 
   return cmocka_run_group_tests(tests, NULL, NULL);

--- a/tools/check_module_boundaries.sh
+++ b/tools/check_module_boundaries.sh
@@ -398,12 +398,24 @@ fi
 #                  reached as plain GLists. This is the count behind the bug that came back
 #                  four times, and it only reaches zero when resolving a shape is something
 #                  callers ask the module to do.
+#
+#   rows           Files outside the module that name dt_masks_form_group_t at all -- the
+#                  group-membership row. A row cannot copy-on-write: it is memory owned by the
+#                  group, so whoever holds one must have touched the group first, and must not
+#                  keep holding it afterwards because the touch replaces it. Every caller that
+#                  resolves one is a caller that has to get both halves right by hand, and the
+#                  opacity sliders are the proof they do not: they touched once, when the menu
+#                  was built, then wrote through the row for the whole drag while committing
+#                  history at every step -- so from the second step on they edited the very
+#                  snapshots that were supposed to be frozen. The module's own interface headers
+#                  are excluded; naming the type there is the design, not the leak.
 masks_include_baseline=19
 masks_gui_include_baseline=11
 masks_member_baseline=88
 masks_write_baseline=26
 masks_alloc_baseline=4
 masks_forms_baseline=76
+masks_row_baseline=38
 
 # Members no other struct in the tree uses. Keep it that way: adding an ambiguous name here
 # buys a bigger number and loses the gate.
@@ -435,12 +447,21 @@ masks_alloc_now=$(grep -rnE '\b(malloc|calloc|g_malloc[0-9n]*|g_new[0-9]*)[[:spa
 masks_forms_now=$(grep -rnE '\->(forms|allforms)\b' src/ --include='*.c' --include='*.cc' 2>/dev/null \
                   | grep -v '^src/develop/masks/' | masks_strip | wc -l)
 
+# The module's own public headers declare the type; only its CONSUMERS are leakage.
+masks_own_headers='^src/develop/masks/|^src/develop/masks\.h|^src/develop/masks_types\.h'
+masks_own_headers="${masks_own_headers}|^src/develop/masks_group\.h|^src/develop/masks_gui\.h"
+masks_row_now=$(grep -rnE '\bdt_masks_form_group_t\b' \
+                src/ --include='*.c' --include='*.cc' --include='*.h' 2>/dev/null \
+                | grep -vE "${masks_own_headers}" | masks_strip | wc -l)
+
 echo "masks:         ${masks_include_now} include masks.h, ${masks_gui_include_now} include masks_gui.h" \
      "(baselines ${masks_include_baseline}, ${masks_gui_include_baseline}),"
 echo "               ${masks_member_now} external struct-member reads, ${masks_write_now} of them writes" \
      "(baselines ${masks_member_baseline}, ${masks_write_baseline}),"
 echo "               ${masks_alloc_now} external allocations, ${masks_forms_now} direct ->forms touches" \
-     "(baselines ${masks_alloc_baseline}, ${masks_forms_baseline})."
+     "(baselines ${masks_alloc_baseline}, ${masks_forms_baseline}),"
+echo "               ${masks_row_now} external mentions of a membership row" \
+     "(baseline ${masks_row_baseline})."
 
 masks_findings=0
 masks_check() { # name now baseline
@@ -460,6 +481,7 @@ masks_check "struct-member reads"  "${masks_member_now}"      "${masks_member_ba
 masks_check "struct-member writes" "${masks_write_now}"       "${masks_write_baseline}"
 masks_check "external allocations" "${masks_alloc_now}"       "${masks_alloc_baseline}"
 masks_check "direct ->forms"       "${masks_forms_now}"       "${masks_forms_baseline}"
+masks_check "membership rows named externally" "${masks_row_now}" "${masks_row_baseline}"
 findings=$((findings + masks_findings))
 
 


### PR DESCRIPTION
Continues the masks enclosure (#1299), on top of master — independent of #1331 and #1332.

## The bug

A group membership row (`dt_masks_form_group_t`) **cannot copy-on-write**. It is memory owned by the group, so a caller holding one must have touched the group *first* — and must not keep holding it afterwards, because the touch replaces it with a clone. Every function that took a `dt_masks_form_group_t *` pushed both halves of that onto its callers.

The opacity sliders are where it broke. Two of the three context menus touched the parent group **once**, when the menu was built, then wrote through the resolved row for the whole interaction — with a comment saying exactly that:

```c
// Touch the parent group before resolving the entry, same rule as elsewhere: the sliders
// mutate this entry in place across the whole drag/scroll interaction.
```

But each slider step commits history, and **each commit re-snapshots the form list and shares the group again**. The up-front touch is consumed by the first commit. From the second step onward, every drag was rewriting the opacity inside snapshots that were supposed to be frozen — so undo could not restore the old value. The third menu, the darkroom canvas one, never touched at all.

`iop/retouch.c` had no copy-on-write on this path in any form: it resolved the row from the live group and assigned straight into it.

## The fix

Opacity is now written the way the combination operator already is — by identity:

```c
dt_masks_group_set_member_opacity(dev, group_id, formid, opacity, out);
dt_masks_group_get_member(dev, group_id, formid, out);
```

The setter resolves the group, touches it, and only then walks to the row — the order the previous tranche established, and the only one that works, since cloning a group clones its membership blocks with it. The getter deliberately does **not** touch: copy-on-write is a writer's obligation, and cloning a group merely to ask a shape's opacity would be a new cost on every menu open.

`NaN` is refused rather than clamped. `CLAMPF()` is a pair of ordered comparisons and every comparison against NaN is false, so clamping one silently yields the **low** bound and blanks the shape.

With that in place the row pointer leaves the interaction path entirely:

- the slider caches `(dev, group_id, formid)` instead of a row, so it survives the clone its own history commits provoke;
- `get`/`set_interaction_value` take ids, and the opacity branch goes through the write API;
- `dt_masks_gui_populate_interaction_sliders` takes a group id, so neither `blend_gui.c` nor `libs/masks.c` touches a group to open a menu any more;
- `_change_opacity` is gone, and with it an un-prefixed global;
- `dt_masks_form_group_find_any` — one caller, which only ever wanted the id — is replaced by `dt_masks_group_find_holder()`, returning an `int` and not copy-on-writing a group on what is a read.

## Deliberate behaviour changes

- **Re-setting an opacity a shape already has no longer pushes an undo step.** It still counts as a *handled* scroll event — reporting "not handled" once opacity is pinned at 0 or 1 would let that step fall through and zoom the canvas instead.
- **Retouch keeps its own 0.05 floor**, applied before the call, since the generic API clamps to `[0;1]`.

## Verification

- **5 new tests** (19 total, all pass). The one that matters puts the group at **refcount 2** — what a history commit leaves behind, and the state a slider is in from its second step — and asserts the snapshot still reads what it froze. It fails against the previous code.
- Release, `build-nofeatures`: clean. All four static gates clean, cycles 0.
- **Export A/B vs master (`1d18ce3` → `90703cb`), `_DSC9410.NEF` (66 mask rows), `--export_masks 1 --disable-opencl`: bit-identical, 0/2883600 differing on both the image and the mask page.** Note this confirms a *prediction* rather than proving the fix: `dt_masks_group_copy_members` has one production caller (`develop/supervisor.c`) and everything else here is GUI-only, so no export path reaches this change. The GUI behaviour itself can only be checked in the GUI.

## Ratchet

New counter: files outside the module that name `dt_masks_form_group_t` at all — **baseline 38, down from 41**. The existing member counters cannot see this work: they track field *names*, and both `opacity` and `state` collide with unrelated structs across the tree (`job->state`, `worker->state`, `dab->opacity`, …), so adding them would buy a bigger number and lose the gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)