### PR TITLE
sentry: the environment carries the platform, so crash rates can be read per package

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1593,6 +1593,12 @@ silently falls back to default instead of erroring.
 
 ## Nightly distribution
 
+The Sentry **environment** is `<build channel>-<platform>` (`nightly-windows`,
+`self-build-linux`, `package-fedora-macos`): the sessions API groups crash-free rates by
+release and environment and by nothing else, so this is how the website shows a build's crash
+rate per package. Split on the LAST hyphen — a channel can contain hyphens. Sessions from before
+this carry the bare channel; readers must accept both.
+
 Nightlies land in one `nightly-YYYY-MM` pre-release per month (GitHub caps a *release* at
 1000 assets; five formats a night filled the old rolling `v0.0.0` in under a year).
 `tools/nightly_manifest.py` writes `nightly.json` — the newest build per format — after

--- a/src/common/sentry.c
+++ b/src/common/sentry.c
@@ -532,7 +532,8 @@ static void _sentry_set_context(void)
   sentry_set_extra("build_cflags", sentry_value_new_string(DT_BUILD_C_FLAGS));
   sentry_set_tag("opencl", cl_enabled ? "yes" : "no");
 
-  // Distribution channel as a searchable tag (also set as the Sentry environment in
+  // Distribution channel as a searchable tag (the Sentry environment carries it too, with
+  // the platform appended -- see dt_sentry_init) so the channel alone stays queryable in
   // dt_sentry_init), so official nightly builds can be told apart from self-builds.
   sentry_set_tag("build_channel", DT_BUILD_CHANNEL);
 
@@ -563,6 +564,19 @@ static void _sentry_set_context(void)
   sentry_set_extra("total_session_seconds",
                    sentry_value_new_int64(dt_conf_get_int64(DT_SENTRY_TOTAL_SESSION_KEY)));
 }
+
+// One word for the platform, the same three the website's package tables use.
+static const char *_sentry_platform(void)
+{
+#if defined(_WIN32)
+  return "windows";
+#elif defined(__APPLE__)
+  return "macos";
+#else
+  return "linux";
+#endif
+}
+
 
 void dt_sentry_init(const gboolean have_gui)
 {
@@ -599,7 +613,16 @@ void dt_sentry_init(const gboolean have_gui)
   // Environment separates official nightly builds from local/self-builds in the
   // dashboard and release-health metrics. The compiler/optimization build type is
   // kept separately as the "build_type" extra.
-  sentry_options_set_environment(options, DT_BUILD_CHANNEL);
+  // The environment is the build channel AND the platform, "nightly-windows". Sentry's
+  // sessions API groups crash-free rates by project, release, environment and status
+  // and by nothing else -- no OS, no tag -- so the platform has to ride in here for the
+  // website to show a build's crash rate per package rather than one figure for the
+  // Windows installer, the AppImage and both dmgs alike. Channel first, platform last:
+  // a channel may itself contain hyphens ("package-fedora"), so readers split on the
+  // LAST one. Sessions recorded before this carry the bare channel.
+  char environment[128];
+  snprintf(environment, sizeof(environment), "%s-%s", DT_BUILD_CHANNEL, _sentry_platform());
+  sentry_options_set_environment(options, environment);
   sentry_options_set_debug(options, (dt_get_debug_flags() & DT_DEBUG_CONTROL) ? 1 : 0);
 
   // Stamp non-crash events with the session length...


### PR DESCRIPTION
Part of #1320; needed by the website's download page.

Sentry's sessions API groups crash-free rates by **project, release, environment and session status — and nothing else** ([docs](https://docs.sentry.io/api/releases/retrieve-release-health-session-statistics/)): no OS, no tag. With the environment set to the bare build channel, one commit is one release across platforms, so the download page could only show one crash-free figure for the Windows installer, the AppImage and both dmgs of a build.

The environment becomes `<channel>-<platform>`: `nightly-windows`, `self-build-linux`, `package-fedora-macos`. Channel first, platform last — a channel can contain hyphens, so readers split on the **last** one. The `build_channel` tag is unchanged, so the channel alone stays queryable in Sentry; sessions recorded before this carry the bare channel and the website accepts both (all-platform rate, marked as such, until a build has sessions under the new names).

Side effects to know: Sentry's environment dropdown grows from 2 values to ~6 per channel family; any saved search or alert filtering on `environment:nightly` exactly needs `nightly-*`. The website's optional `RELIABILITY_ENVIRONMENT` filter is unset in CI and unaffected.

Compiled `sentry.c` against the build's own flags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Correction, after looking at how the site's per-OS chart works

The reliability trend chart already shows crash-free rates per OS — as an **estimate**: crashed sessions per OS from Sentry's *events* (`os.name`, deduplicated by session) over sessions started per OS from **PostHog**. Two opt-in populations stitched together. The download page's tables now use that same estimate (marked `≈`) so they agree with the chart, with an all-platform fallback (`*`).

What this PR adds is the **exact** figure: with the platform in the environment, Sentry's own sessions API yields crash-free per platform from one population — numerator and denominator from the same sessions — and the tables prefer it whenever a build has sessions under the new names. So the change is still worth making; it upgrades an estimate to a measurement rather than enabling the column.