### PR TITLE
tagging: refresh completions and fix clear interaction

### DIFF
--- a/src/libs/CMakeLists.txt
+++ b/src/libs/CMakeLists.txt
@@ -18,7 +18,7 @@ set(MODULES ${MODULES} module_toolbox)
 # modules
 add_library(export MODULE "export.c" "export_metadata.c")
 add_library(styles MODULE "styles.c")
-add_library(tagging MODULE "tagging.c")
+add_library(tagging MODULE "tagging.c" "tagging_completion.c")
 add_library(collect MODULE "collect.c")
 add_library(metadata MODULE "metadata.c")
 add_library(metadata_view MODULE "metadata_view.c")

--- a/src/libs/tagging.c
+++ b/src/libs/tagging.c
@@ -76,6 +76,7 @@
 #include "widgets/dialog.h"
 #include "widgets/label.h"
 #include "widgets/scroll_wrap.h"
+#include "widgets/widget_settings.h"  // dt_gui_widget_freeze(), dt_gui_widgets_suppressed()
 
 #define FLOATING_ENTRY_WIDTH DT_PIXEL_APPLY_DPI(150)
 
@@ -94,7 +95,6 @@ typedef struct dt_lib_tagging_t
   GtkTreeStore *attached_treestore, *dictionary_treestore;
   GtkTreeModelFilter *dictionary_listfilter, *dictionary_treefilter;
   GHashTable *collection_tags;
-  gulong entry_key_handler_id;
   GtkWidget *floating_tag_window;
   GList *floating_tag_imgs;
   gboolean tree_flag, suggestion_flag, sort_count_flag, hide_path_flag, dttags_flag;
@@ -141,7 +141,7 @@ typedef enum dt_tag_sort_id
 static void _save_last_tag_used(const char *tags, dt_lib_tagging_t *d);
 static void _refresh_collection_tags(dt_lib_module_t *self);
 static void _size_recent_tags_list();
-static gboolean _enter_key_pressed(GtkWidget *entry, GdkEventKey *event, dt_lib_module_t *self);
+static void _entry_clear_suppressed(GtkEntry *entry);
 static gboolean _lib_tagging_tag_redo_accel(GtkAccelGroup *accel_group, GObject *accelerable, guint keyval,
                                             GdkModifierType mods, gpointer user_data);
 static gboolean _lib_tagging_tag_show_accel(GtkAccelGroup *accel_group, GObject *accelerable, guint keyval,
@@ -1379,15 +1379,7 @@ static void _create_tag_from_entry(dt_lib_module_t *self, GtkEntry *src)
   /** record last tag used */
   _save_last_tag_used(tag, d);
 
-  if(src == d->entry)
-  {
-    g_signal_handler_disconnect(d->entry, d->entry_key_handler_id);
-    dt_tagging_entry_clear(d->entry);
-    d->entry_key_handler_id = g_signal_connect(G_OBJECT(d->entry), "key-press-event",
-                                               G_CALLBACK(_enter_key_pressed), self);
-  }
-  else
-    dt_tagging_entry_clear(src);
+  _entry_clear_suppressed(src);
 
   _init_treeview(self, 0);
   _init_treeview(self, 1);
@@ -1408,8 +1400,26 @@ static void _new_button_clicked(GtkButton *button, dt_lib_module_t *self)
   _create_tag_from_entry(self, d->dict_entry);
 }
 
+/* Clear a tag entry without its own key handler taking the programmatic change for user input.
+ *
+ * dt_gui_widget_freeze() (widgets/widget_settings.h) is the application-wide way to say that, and
+ * the one this file already uses everywhere else: it raises the suppression depth for the rest of
+ * the enclosing scope and drops it on every exit path, while each widget callback opens by asking
+ * dt_gui_widgets_suppressed(). Disconnecting the handler by id and reconnecting it around the
+ * clear expressed the same intent, but had to be spelled out identically at four call sites, and
+ * left the entry with NO key handler at all if anything between the two ever returned early. */
+static void _entry_clear_suppressed(GtkEntry *entry)
+{
+  dt_gui_widget_freeze();
+  dt_tagging_entry_clear(entry);
+}
+
 static gboolean _enter_key_pressed(GtkWidget *entry, GdkEventKey *event, dt_lib_module_t *self)
 {
+  // A programmatic clear of the entry is not the user pressing a key. FALSE, not TRUE: a
+  // suppressed callback declines the event rather than swallowing it.
+  if(dt_gui_widgets_suppressed()) return FALSE;
+
   dt_lib_tagging_t *d = (dt_lib_tagging_t *)self->data;
   guint key = dt_keys_mainpad_alternatives(event->keyval);
   switch(key)
@@ -1424,10 +1434,7 @@ static gboolean _enter_key_pressed(GtkWidget *entry, GdkEventKey *event, dt_lib_
     {
       if(_select_next_user_attached_tag(0, d->attached_view))
       {
-        g_signal_handler_disconnect(d->entry, d->entry_key_handler_id);
-        dt_tagging_entry_clear(d->entry);
-        d->entry_key_handler_id = g_signal_connect(G_OBJECT(d->entry), "key-press-event",
-                                                   G_CALLBACK(_enter_key_pressed), self);
+        _entry_clear_suppressed(d->entry);
         gtk_widget_grab_focus(GTK_WIDGET(d->attached_view));
       }
       return TRUE;
@@ -1443,16 +1450,7 @@ static void _entry_clear_icon(GtkEntry *entry, const GtkEntryIconPosition positi
 {
   if(position != GTK_ENTRY_ICON_SECONDARY) return;
 
-  dt_lib_tagging_t *d = (dt_lib_tagging_t *)self->data;
-  if(entry == d->entry)
-  {
-    g_signal_handler_disconnect(d->entry, d->entry_key_handler_id);
-    dt_tagging_entry_clear(d->entry);
-    d->entry_key_handler_id = g_signal_connect(G_OBJECT(d->entry), "key-press-event",
-                                               G_CALLBACK(_enter_key_pressed), self);
-  }
-  else
-    dt_tagging_entry_clear(entry);
+  _entry_clear_suppressed(entry);
   gtk_widget_grab_focus(GTK_WIDGET(entry));
 }
 
@@ -2719,11 +2717,8 @@ void gui_reset(dt_lib_module_t *self)
 {
   dt_lib_tagging_t *d = (dt_lib_tagging_t *)self->data;
   // clear entry boxes and query
-  g_signal_handler_disconnect(d->entry, d->entry_key_handler_id);
-  dt_tagging_entry_clear(d->entry);
-  d->entry_key_handler_id = g_signal_connect(G_OBJECT(d->entry), "key-press-event",
-                                             G_CALLBACK(_enter_key_pressed), self);
-  dt_tagging_entry_clear(d->dict_entry);
+  _entry_clear_suppressed(d->entry);
+  _entry_clear_suppressed(d->dict_entry);
   _set_keyword(self);
   _init_treeview(self, 1);
   _update_atdetach_buttons(self);
@@ -3252,8 +3247,7 @@ void gui_init(dt_lib_module_t *self)
   // handling (accepting a keyboard-highlighted popup match into the entry text) runs
   // before ours: otherwise a tag gets created from the raw typed prefix instead of the
   // selected suggestion (#905)
-  d->entry_key_handler_id = g_signal_connect(G_OBJECT(d->entry), "key-press-event",
-                                             G_CALLBACK(_enter_key_pressed), self);
+  g_signal_connect(G_OBJECT(d->entry), "key-press-event", G_CALLBACK(_enter_key_pressed), self);
 
   // ── tag management popup window (persistent, hidden until requested) ────
   d->manage_window = gtk_window_new(GTK_WINDOW_TOPLEVEL);

--- a/src/libs/tagging.c
+++ b/src/libs/tagging.c
@@ -94,6 +94,7 @@ typedef struct dt_lib_tagging_t
   GtkTreeStore *attached_treestore, *dictionary_treestore;
   GtkTreeModelFilter *dictionary_listfilter, *dictionary_treefilter;
   GHashTable *collection_tags;
+  gulong entry_key_handler_id;
   GtkWidget *floating_tag_window;
   GList *floating_tag_imgs;
   gboolean tree_flag, suggestion_flag, sort_count_flag, hide_path_flag, dttags_flag;
@@ -140,6 +141,7 @@ typedef enum dt_tag_sort_id
 static void _save_last_tag_used(const char *tags, dt_lib_tagging_t *d);
 static void _refresh_collection_tags(dt_lib_module_t *self);
 static void _size_recent_tags_list();
+static gboolean _enter_key_pressed(GtkWidget *entry, GdkEventKey *event, dt_lib_module_t *self);
 static gboolean _lib_tagging_tag_redo_accel(GtkAccelGroup *accel_group, GObject *accelerable, guint keyval,
                                             GdkModifierType mods, gpointer user_data);
 static gboolean _lib_tagging_tag_show_accel(GtkAccelGroup *accel_group, GObject *accelerable, guint keyval,
@@ -1377,8 +1379,15 @@ static void _create_tag_from_entry(dt_lib_module_t *self, GtkEntry *src)
   /** record last tag used */
   _save_last_tag_used(tag, d);
 
-  /** clear input box */
-  gtk_entry_set_text(src, "");
+  if(src == d->entry)
+  {
+    g_signal_handler_disconnect(d->entry, d->entry_key_handler_id);
+    dt_tagging_entry_clear(d->entry);
+    d->entry_key_handler_id = g_signal_connect(G_OBJECT(d->entry), "key-press-event",
+                                               G_CALLBACK(_enter_key_pressed), self);
+  }
+  else
+    dt_tagging_entry_clear(src);
 
   _init_treeview(self, 0);
   _init_treeview(self, 1);
@@ -1415,7 +1424,10 @@ static gboolean _enter_key_pressed(GtkWidget *entry, GdkEventKey *event, dt_lib_
     {
       if(_select_next_user_attached_tag(0, d->attached_view))
       {
-        gtk_entry_set_text(GTK_ENTRY(entry), "");
+        g_signal_handler_disconnect(d->entry, d->entry_key_handler_id);
+        dt_tagging_entry_clear(d->entry);
+        d->entry_key_handler_id = g_signal_connect(G_OBJECT(d->entry), "key-press-event",
+                                                   G_CALLBACK(_enter_key_pressed), self);
         gtk_widget_grab_focus(GTK_WIDGET(d->attached_view));
       }
       return TRUE;
@@ -1424,6 +1436,24 @@ static gboolean _enter_key_pressed(GtkWidget *entry, GdkEventKey *event, dt_lib_
       break;
   }
   return FALSE;
+}
+
+static void _entry_clear_icon(GtkEntry *entry, const GtkEntryIconPosition position,
+                              GdkEvent *event, dt_lib_module_t *self)
+{
+  if(position != GTK_ENTRY_ICON_SECONDARY) return;
+
+  dt_lib_tagging_t *d = (dt_lib_tagging_t *)self->data;
+  if(entry == d->entry)
+  {
+    g_signal_handler_disconnect(d->entry, d->entry_key_handler_id);
+    dt_tagging_entry_clear(d->entry);
+    d->entry_key_handler_id = g_signal_connect(G_OBJECT(d->entry), "key-press-event",
+                                               G_CALLBACK(_enter_key_pressed), self);
+  }
+  else
+    dt_tagging_entry_clear(entry);
+  gtk_widget_grab_focus(GTK_WIDGET(entry));
 }
 
 
@@ -2689,8 +2719,11 @@ void gui_reset(dt_lib_module_t *self)
 {
   dt_lib_tagging_t *d = (dt_lib_tagging_t *)self->data;
   // clear entry boxes and query
-  gtk_entry_set_text(d->entry, "");
-  gtk_entry_set_text(d->dict_entry, "");
+  g_signal_handler_disconnect(d->entry, d->entry_key_handler_id);
+  dt_tagging_entry_clear(d->entry);
+  d->entry_key_handler_id = g_signal_connect(G_OBJECT(d->entry), "key-press-event",
+                                             G_CALLBACK(_enter_key_pressed), self);
+  dt_tagging_entry_clear(d->dict_entry);
   _set_keyword(self);
   _init_treeview(self, 1);
   _update_atdetach_buttons(self);
@@ -2720,43 +2753,6 @@ static void _refresh_collection_tags(dt_lib_module_t *self)
     g_hash_table_add(d->collection_tags, g_strdup(tag->tag));
   }
   dt_tag_free_result(&tags);
-}
-
-static gboolean _match_selected_func(GtkEntryCompletion *completion, GtkTreeModel *model, GtkTreeIter *iter, gpointer user_data)
-{
-  const int column = gtk_entry_completion_get_text_column(completion);
-  char *tag = NULL;
-
-  if(gtk_tree_model_get_column_type(model, column) != G_TYPE_STRING) return TRUE;
-
-  GtkEditable *e = (GtkEditable *)gtk_entry_completion_get_entry(completion);
-  if(!GTK_IS_EDITABLE(e))
-  {
-    return FALSE;
-  }
-
-  gtk_tree_model_get(model, iter, column, &tag, -1);
-
-  gint cut_off, cur_pos = gtk_editable_get_position(e);
-
-  gchar *currentText = gtk_editable_get_chars(e, 0, -1);
-  const gchar *lastTag = g_strrstr(currentText, ",");
-  if(IS_NULL_PTR(lastTag))
-  {
-    cut_off = 0;
-  }
-  else
-  {
-    cut_off = (int)(g_utf8_strlen(currentText, -1) - g_utf8_strlen(lastTag, -1))+1;
-  }
-  dt_free(currentText);
-
-  gtk_editable_delete_text(e, cut_off, cur_pos);
-  cur_pos = cut_off;
-  gtk_editable_insert_text(e, tag, -1, &cur_pos);
-  gtk_editable_set_position(e, cur_pos);
-  dt_free(tag);  // release result of gtk_tree_model_get
-  return TRUE;
 }
 
 static gboolean _completion_match_func(GtkEntryCompletion *completion, const gchar *key, GtkTreeIter *iter,
@@ -3220,7 +3216,7 @@ void gui_init(dt_lib_module_t *self)
   gtk_entry_set_placeholder_text(GTK_ENTRY(w), _("enter or pick a tag, Enter to attach"));
   gtk_entry_set_icon_from_icon_name(GTK_ENTRY(w), GTK_ENTRY_ICON_SECONDARY, "edit-clear-symbolic");
   gtk_entry_set_icon_tooltip_text(GTK_ENTRY(w), GTK_ENTRY_ICON_SECONDARY, _("clear entry"));
-  g_signal_connect(G_OBJECT(w), "icon-release", G_CALLBACK(dt_tagging_entry_clear_icon), NULL);
+  g_signal_connect(G_OBJECT(w), "icon-release", G_CALLBACK(_entry_clear_icon), self);
   gtk_box_pack_start(hbox, w, TRUE, TRUE, 0);
   gtk_widget_add_events(GTK_WIDGET(w), GDK_KEY_RELEASE_MASK);
   d->entry = GTK_ENTRY(w);
@@ -3245,7 +3241,8 @@ void gui_init(dt_lib_module_t *self)
     gtk_entry_completion_set_popup_completion(completion, TRUE);
     gtk_entry_completion_set_popup_set_width(completion, FALSE);
     gtk_entry_completion_set_minimum_key_length(completion, 1);
-    g_signal_connect(G_OBJECT(completion), "match-selected", G_CALLBACK(_match_selected_func), self);
+    g_signal_connect(G_OBJECT(completion), "match-selected",
+                     G_CALLBACK(dt_tagging_completion_match_selected), self);
     gtk_entry_completion_set_match_func(completion, _completion_match_func, self, NULL);
     gtk_entry_set_completion(d->entry, completion);
     g_object_unref(completion);
@@ -3255,7 +3252,8 @@ void gui_init(dt_lib_module_t *self)
   // handling (accepting a keyboard-highlighted popup match into the entry text) runs
   // before ours: otherwise a tag gets created from the raw typed prefix instead of the
   // selected suggestion (#905)
-  g_signal_connect(G_OBJECT(d->entry), "key-press-event", G_CALLBACK(_enter_key_pressed), (gpointer)self);
+  d->entry_key_handler_id = g_signal_connect(G_OBJECT(d->entry), "key-press-event",
+                                             G_CALLBACK(_enter_key_pressed), self);
 
   // ── tag management popup window (persistent, hidden until requested) ────
   d->manage_window = gtk_window_new(GTK_WINDOW_TOPLEVEL);
@@ -3280,7 +3278,7 @@ void gui_init(dt_lib_module_t *self)
   gtk_entry_set_placeholder_text(GTK_ENTRY(w), _("type to filter the tag dictionary below"));
   gtk_entry_set_icon_from_icon_name(GTK_ENTRY(w), GTK_ENTRY_ICON_SECONDARY, "edit-clear-symbolic");
   gtk_entry_set_icon_tooltip_text(GTK_ENTRY(w), GTK_ENTRY_ICON_SECONDARY, _("clear entry"));
-  g_signal_connect(G_OBJECT(w), "icon-release", G_CALLBACK(dt_tagging_entry_clear_icon), NULL);
+  g_signal_connect(G_OBJECT(w), "icon-release", G_CALLBACK(_entry_clear_icon), self);
   gtk_widget_add_events(GTK_WIDGET(w), GDK_KEY_RELEASE_MASK);
   g_signal_connect(G_OBJECT(w), "changed", G_CALLBACK(_tag_name_changed), (gpointer)self);
   d->dict_entry = GTK_ENTRY(w);
@@ -3625,7 +3623,8 @@ static gboolean _lib_tagging_tag_show_accel(GtkAccelGroup *accel_group, GObject 
   gtk_entry_completion_set_inline_completion(completion, TRUE);
   gtk_entry_completion_set_popup_set_width(completion, FALSE);
   gtk_entry_completion_set_minimum_key_length(completion, 0);
-  g_signal_connect(G_OBJECT(completion), "match-selected", G_CALLBACK(_match_selected_func), self);
+  g_signal_connect(G_OBJECT(completion), "match-selected",
+                   G_CALLBACK(dt_tagging_completion_match_selected), self);
   gtk_entry_completion_set_match_func(completion, _completion_match_func, self, NULL);
   gtk_entry_set_completion(GTK_ENTRY(entry), completion);
 

--- a/src/libs/tagging.c
+++ b/src/libs/tagging.c
@@ -67,6 +67,7 @@
 #include "widgets/accelerators.h"
 #include "gui/drag_and_drop.h"
 #include "libs/lib.h"
+#include "libs/tagging_completion.h"
 #include "libs/lib_api.h"
 #ifdef GDK_WINDOWING_QUARTZ
 #include "osx/osx.h"
@@ -137,7 +138,6 @@ typedef enum dt_tag_sort_id
 } dt_tag_sort_id;
 
 static void _save_last_tag_used(const char *tags, dt_lib_tagging_t *d);
-static void _refresh_completion_store(dt_lib_module_t *self);
 static void _refresh_collection_tags(dt_lib_module_t *self);
 static void _size_recent_tags_list();
 static gboolean _lib_tagging_tag_redo_accel(GtkAccelGroup *accel_group, GObject *accelerable, guint keyval,
@@ -640,10 +640,11 @@ static void _lib_tagging_redraw_callback(gpointer instance, dt_lib_module_t *sel
 
 static void _lib_tagging_tags_changed_callback(gpointer instance, dt_lib_module_t *self)
 {
+  dt_lib_tagging_t *d = (dt_lib_tagging_t *)self->data;
   _init_treeview(self, 0);
   _init_treeview(self, 1);
   // the set of known tags may have changed (created / deleted / renamed)
-  _refresh_completion_store(self);
+  dt_tagging_completion_refresh(d->completion_store);
   _refresh_collection_tags(self);
 }
 
@@ -1089,6 +1090,7 @@ static GList *_selected_tagids(GtkTreeView *view)
 // detach the given tag ids from the images to act on, then refresh the views
 static void _detach_tagids(GList *tagids, dt_lib_module_t *self)
 {
+  dt_lib_tagging_t *d = (dt_lib_tagging_t *)self->data;
   if(IS_NULL_PTR(tagids)) return;
   GList *imgs = dt_act_on_get_images();
   if(IS_NULL_PTR(imgs)) return;
@@ -1110,7 +1112,7 @@ static void _detach_tagids(GList *tagids, dt_lib_module_t *self)
 
   _init_treeview(self, 0);
   _init_treeview(self, 1);
-  _refresh_completion_store(self);
+  dt_tagging_completion_refresh(d->completion_store);
   _refresh_collection_tags(self);
   if(changed) _raise_signal_tag_changed(self);
 }
@@ -1382,7 +1384,7 @@ static void _create_tag_from_entry(dt_lib_module_t *self, GtkEntry *src)
   _init_treeview(self, 1);
   // _raise_signal_tag_changed() may block the tags-changed callback, so refresh
   // the autocompletion explicitly to pick up the freshly created tag
-  _refresh_completion_store(self);
+  dt_tagging_completion_refresh(d->completion_store);
   _refresh_collection_tags(self);
   char *tagname = strrchr(d->last_tag, ',');
   if(res) _raise_signal_tag_changed(self);
@@ -1524,6 +1526,8 @@ static void _pop_menu_dictionary_delete_node(GtkWidget *menuitem, dt_lib_module_
   dt_image_synch_xmps(tagged_images);
   g_list_free(tagged_images);
   tagged_images = NULL;
+  dt_tagging_completion_refresh(d->completion_store);
+  _refresh_collection_tags(self);
   _raise_signal_tag_changed(self);
   dt_free(tagname);
 }
@@ -1643,6 +1647,8 @@ static void _pop_menu_dictionary_create_tag(GtkWidget *menuitem, dt_lib_module_t
         dt_tag_set_synonyms(new_tagid, new_synonyms_list);
       dt_free(new_synonyms_list);
       _init_treeview(self, 1);
+      dt_tagging_completion_refresh(d->completion_store);
+      _raise_signal_tag_changed(self);
       _show_tag_on_view(view, new_tagname, FALSE, TRUE);
     }
     dt_free(new_tagname);
@@ -1847,6 +1853,8 @@ static void _pop_menu_dictionary_edit_tag(GtkWidget *menuitem, dt_lib_module_t *
         dt_free(new_prefix_tag);
       }
 
+      dt_tagging_completion_refresh(d->completion_store);
+      _refresh_collection_tags(self);
       _raise_signal_tag_changed(self);
       dt_tag_free_result(&tag_family);
       dt_image_synch_xmps(tagged_images);
@@ -1940,6 +1948,8 @@ static gboolean _apply_rename_path(GtkWidget *dialog, const char *tagname,
     }
     _init_treeview(self, 0);
     _init_treeview(self, 1);
+    dt_tagging_completion_refresh(d->completion_store);
+    _refresh_collection_tags(self);
     dt_image_synch_xmps(tagged_images);
     _raise_signal_tag_changed(self);
     _show_tag_on_view(d->dictionary_view, newtag, FALSE, TRUE);
@@ -2096,6 +2106,7 @@ static void _pop_menu_dictionary_copy_tag(GtkWidget *menuitem, dt_lib_module_t *
 // delete the given tag ids from the database (after a single confirmation), then refresh
 static void _delete_tagids(GList *tagids, dt_lib_module_t *self)
 {
+  dt_lib_tagging_t *d = (dt_lib_tagging_t *)self->data;
   if(IS_NULL_PTR(tagids)) return;
   const guint nb = g_list_length(tagids);
 
@@ -2145,7 +2156,7 @@ static void _delete_tagids(GList *tagids, dt_lib_module_t *self)
 
   _init_treeview(self, 0);
   _init_treeview(self, 1);
-  _refresh_completion_store(self);
+  dt_tagging_completion_refresh(d->completion_store);
   _refresh_collection_tags(self);
   dt_image_synch_xmps(affected);
   g_list_free(affected);
@@ -2178,6 +2189,8 @@ static void _pop_menu_dictionary_set_as_tag(GtkWidget *menuitem, dt_lib_module_t
   dt_control_log(_("tag %s created"), tagname);
 
   _init_treeview(self, 1);
+  dt_tagging_completion_refresh(d->completion_store);
+  _raise_signal_tag_changed(self);
   _show_tag_on_view(d->dictionary_view, tagname, FALSE, TRUE);
   dt_free(tagname);
 
@@ -2691,25 +2704,6 @@ int position()
 // Single-column model feeding the tag entry autocompletion (full tag path).
 enum { DT_COMPL_COL_PATH = 0, DT_COMPL_NUM_COLS };
 
-// (Re)populate the entry autocompletion store with every known tag.
-static void _refresh_completion_store(dt_lib_module_t *self)
-{
-  dt_lib_tagging_t *d = (dt_lib_tagging_t *)self->data;
-  if(!d->completion_store) return;
-  gtk_list_store_clear(d->completion_store);
-  GList *tags = NULL;
-  dt_tag_get_with_usage(&tags);
-  for(GList *t = tags; t; t = g_list_next(t))
-  {
-    const dt_tag_t *tag = (const dt_tag_t *)t->data;
-    if(IS_NULL_PTR(tag->tag)) continue;
-    GtkTreeIter iter;
-    gtk_list_store_append(d->completion_store, &iter);
-    gtk_list_store_set(d->completion_store, &iter, DT_COMPL_COL_PATH, tag->tag, -1);
-  }
-  dt_tag_free_result(&tags);
-}
-
 // (Re)build the set of tags used by the current collection. Used to seed the
 // entry autocompletion when nothing has been typed yet.
 static void _refresh_collection_tags(dt_lib_module_t *self)
@@ -3087,7 +3081,6 @@ static void _recent_tags_changed(GtkSpinButton *spin, dt_lib_module_t *self)
   _refresh_suggestions(self);
 }
 
-// clear the GtkEntry when its built-in secondary (clear) icon is pressed
 static void _entry_clear_icon(GtkEntry *entry, GtkEntryIconPosition pos, GdkEvent *event, gpointer user_data)
 {
   if(pos == GTK_ENTRY_ICON_SECONDARY) gtk_entry_set_text(entry, "");
@@ -3445,7 +3438,7 @@ void gui_init(dt_lib_module_t *self)
   _set_keyword(self);
   _init_treeview(self, 1);
   _update_atdetach_buttons(self);
-  _refresh_completion_store(self);
+  dt_tagging_completion_refresh(d->completion_store);
   _refresh_collection_tags(self);
 
   dt_accels_new_action_shortcut(dt_gui_get_accels(), _lib_tagging_tag_show_accel, self, NULL,
@@ -3532,6 +3525,8 @@ static gboolean _lib_tagging_tag_key_press(GtkWidget *entry, GdkEventKey *event,
 
       _init_treeview(self, 0);
       _init_treeview(self, 1);
+      dt_tagging_completion_refresh(d->completion_store);
+      _refresh_collection_tags(self);
       gtk_widget_destroy(d->floating_tag_window);
       gtk_window_present(GTK_WINDOW(dt_gui_main_window()));
       if(res) _raise_signal_tag_changed(self);
@@ -3567,6 +3562,8 @@ static gboolean _lib_tagging_tag_redo_accel(GtkAccelGroup *accel_group, GObject 
     imgs = NULL;
     _init_treeview(self, 0);
     _init_treeview(self, 1);
+    dt_tagging_completion_refresh(d->completion_store);
+    _refresh_collection_tags(self);
     if(res) _raise_signal_tag_changed(self);
   }
 

--- a/src/libs/tagging.c
+++ b/src/libs/tagging.c
@@ -3081,11 +3081,6 @@ static void _recent_tags_changed(GtkSpinButton *spin, dt_lib_module_t *self)
   _refresh_suggestions(self);
 }
 
-static void _entry_clear_icon(GtkEntry *entry, GtkEntryIconPosition pos, GdkEvent *event, gpointer user_data)
-{
-  if(pos == GTK_ENTRY_ICON_SECONDARY) gtk_entry_set_text(entry, "");
-}
-
 // validate button next to the entry: attach the typed/picked tag (same as pressing Enter)
 static void _validate_button_clicked(GtkButton *button, dt_lib_module_t *self)
 {
@@ -3225,7 +3220,7 @@ void gui_init(dt_lib_module_t *self)
   gtk_entry_set_placeholder_text(GTK_ENTRY(w), _("enter or pick a tag, Enter to attach"));
   gtk_entry_set_icon_from_icon_name(GTK_ENTRY(w), GTK_ENTRY_ICON_SECONDARY, "edit-clear-symbolic");
   gtk_entry_set_icon_tooltip_text(GTK_ENTRY(w), GTK_ENTRY_ICON_SECONDARY, _("clear entry"));
-  g_signal_connect(G_OBJECT(w), "icon-press", G_CALLBACK(_entry_clear_icon), NULL);
+  g_signal_connect(G_OBJECT(w), "icon-release", G_CALLBACK(dt_tagging_entry_clear_icon), NULL);
   gtk_box_pack_start(hbox, w, TRUE, TRUE, 0);
   gtk_widget_add_events(GTK_WIDGET(w), GDK_KEY_RELEASE_MASK);
   d->entry = GTK_ENTRY(w);
@@ -3247,6 +3242,7 @@ void gui_init(dt_lib_module_t *self)
     gtk_entry_completion_set_model(completion, GTK_TREE_MODEL(d->completion_store));
     gtk_entry_completion_set_text_column(completion, DT_COMPL_COL_PATH);
     gtk_entry_completion_set_inline_completion(completion, TRUE);
+    gtk_entry_completion_set_popup_completion(completion, TRUE);
     gtk_entry_completion_set_popup_set_width(completion, FALSE);
     gtk_entry_completion_set_minimum_key_length(completion, 1);
     g_signal_connect(G_OBJECT(completion), "match-selected", G_CALLBACK(_match_selected_func), self);
@@ -3284,7 +3280,7 @@ void gui_init(dt_lib_module_t *self)
   gtk_entry_set_placeholder_text(GTK_ENTRY(w), _("type to filter the tag dictionary below"));
   gtk_entry_set_icon_from_icon_name(GTK_ENTRY(w), GTK_ENTRY_ICON_SECONDARY, "edit-clear-symbolic");
   gtk_entry_set_icon_tooltip_text(GTK_ENTRY(w), GTK_ENTRY_ICON_SECONDARY, _("clear entry"));
-  g_signal_connect(G_OBJECT(w), "icon-press", G_CALLBACK(_entry_clear_icon), NULL);
+  g_signal_connect(G_OBJECT(w), "icon-release", G_CALLBACK(dt_tagging_entry_clear_icon), NULL);
   gtk_widget_add_events(GTK_WIDGET(w), GDK_KEY_RELEASE_MASK);
   g_signal_connect(G_OBJECT(w), "changed", G_CALLBACK(_tag_name_changed), (gpointer)self);
   d->dict_entry = GTK_ENTRY(w);

--- a/src/libs/tagging_completion.c
+++ b/src/libs/tagging_completion.c
@@ -36,3 +36,11 @@ void dt_tagging_completion_refresh(GtkListStore *store)
   }
   dt_tag_free_result(&tags);
 }
+
+void dt_tagging_entry_clear_icon(GtkEntry *entry, const GtkEntryIconPosition position,
+                                 GdkEvent *event, gpointer user_data)
+{
+  if(position != GTK_ENTRY_ICON_SECONDARY) return;
+  gtk_entry_set_text(entry, "");
+  gtk_widget_grab_focus(GTK_WIDGET(entry));
+}

--- a/src/libs/tagging_completion.c
+++ b/src/libs/tagging_completion.c
@@ -20,6 +20,7 @@
 
 #include "metadata/tags.h"
 #include "system/macros.h"
+#include "system/mem_alloc.h"
 
 void dt_tagging_completion_refresh(GtkListStore *store)
 {
@@ -37,11 +38,38 @@ void dt_tagging_completion_refresh(GtkListStore *store)
   dt_tag_free_result(&tags);
 }
 
-void dt_tagging_entry_clear_icon(GtkEntry *entry, const GtkEntryIconPosition position,
-                                 GdkEvent *event, gpointer user_data)
+gboolean dt_tagging_completion_match_selected(GtkEntryCompletion *completion, GtkTreeModel *model,
+                                              GtkTreeIter *iter, gpointer user_data)
 {
-  if(position != GTK_ENTRY_ICON_SECONDARY) return;
+  const int column = gtk_entry_completion_get_text_column(completion);
+  if(gtk_tree_model_get_column_type(model, column) != G_TYPE_STRING) return TRUE;
 
+  GtkEditable *entry = GTK_EDITABLE(gtk_entry_completion_get_entry(completion));
+  if(!GTK_IS_EDITABLE(entry)) return FALSE;
+
+  char *tag = NULL;
+  gtk_tree_model_get(model, iter, column, &tag, -1);
+  gint cursor_position = gtk_editable_get_position(entry);
+  gchar *current_text = gtk_editable_get_chars(entry, 0, -1);
+  const gchar *last_tag = g_strrstr(current_text, ",");
+  const gint cut_off = last_tag
+                         ? (int)(g_utf8_strlen(current_text, -1) - g_utf8_strlen(last_tag, -1)) + 1
+                         : 0;
+  dt_free(current_text);
+
+  const gboolean inline_completion = gtk_entry_completion_get_inline_completion(completion);
+  gtk_entry_completion_set_inline_completion(completion, FALSE);
+  gtk_editable_delete_text(entry, cut_off, cursor_position);
+  cursor_position = cut_off;
+  gtk_editable_insert_text(entry, tag, -1, &cursor_position);
+  gtk_editable_set_position(entry, cursor_position);
+  gtk_entry_completion_set_inline_completion(completion, inline_completion);
+  dt_free(tag);
+  return TRUE;
+}
+
+void dt_tagging_entry_clear(GtkEntry *entry)
+{
   GtkEntryCompletion *completion = gtk_entry_get_completion(entry);
   if(!IS_NULL_PTR(completion))
   {
@@ -54,5 +82,4 @@ void dt_tagging_entry_clear_icon(GtkEntry *entry, const GtkEntryIconPosition pos
     gtk_entry_set_completion(entry, completion);
     g_object_unref(completion);
   }
-  gtk_widget_grab_focus(GTK_WIDGET(entry));
 }

--- a/src/libs/tagging_completion.c
+++ b/src/libs/tagging_completion.c
@@ -1,0 +1,38 @@
+/*
+    This file is part of Ansel,
+    Copyright (C) 2026 Paolo SANTUCCI.
+
+    Ansel is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Ansel is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Ansel.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "libs/tagging_completion.h"
+
+#include "metadata/tags.h"
+#include "system/macros.h"
+
+void dt_tagging_completion_refresh(GtkListStore *store)
+{
+  gtk_list_store_clear(store);
+  GList *tags = NULL;
+  dt_tag_get_with_usage(&tags);
+  for(GList *tag_iter = tags; tag_iter; tag_iter = g_list_next(tag_iter))
+  {
+    const dt_tag_t *tag = (const dt_tag_t *)tag_iter->data;
+    if(IS_NULL_PTR(tag->tag)) continue;
+    GtkTreeIter store_iter;
+    gtk_list_store_append(store, &store_iter);
+    gtk_list_store_set(store, &store_iter, 0, tag->tag, -1);
+  }
+  dt_tag_free_result(&tags);
+}

--- a/src/libs/tagging_completion.c
+++ b/src/libs/tagging_completion.c
@@ -41,6 +41,18 @@ void dt_tagging_entry_clear_icon(GtkEntry *entry, const GtkEntryIconPosition pos
                                  GdkEvent *event, gpointer user_data)
 {
   if(position != GTK_ENTRY_ICON_SECONDARY) return;
+
+  GtkEntryCompletion *completion = gtk_entry_get_completion(entry);
+  if(!IS_NULL_PTR(completion))
+  {
+    g_object_ref(completion);
+    gtk_entry_set_completion(entry, NULL);
+  }
   gtk_entry_set_text(entry, "");
+  if(!IS_NULL_PTR(completion))
+  {
+    gtk_entry_set_completion(entry, completion);
+    g_object_unref(completion);
+  }
   gtk_widget_grab_focus(GTK_WIDGET(entry));
 }

--- a/src/libs/tagging_completion.h
+++ b/src/libs/tagging_completion.h
@@ -22,3 +22,7 @@
 
 /** Replace a completion model's contents with the current tag vocabulary. */
 void dt_tagging_completion_refresh(GtkListStore *store);
+
+/** Clear a tag entry from its secondary icon while retaining text-input focus. */
+void dt_tagging_entry_clear_icon(GtkEntry *entry, GtkEntryIconPosition position,
+                                 GdkEvent *event, gpointer user_data);

--- a/src/libs/tagging_completion.h
+++ b/src/libs/tagging_completion.h
@@ -1,0 +1,24 @@
+/*
+    This file is part of Ansel,
+    Copyright (C) 2026 Paolo SANTUCCI.
+
+    Ansel is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Ansel is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Ansel.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+#include <gtk/gtk.h>
+
+/** Replace a completion model's contents with the current tag vocabulary. */
+void dt_tagging_completion_refresh(GtkListStore *store);

--- a/src/libs/tagging_completion.h
+++ b/src/libs/tagging_completion.h
@@ -23,6 +23,9 @@
 /** Replace a completion model's contents with the current tag vocabulary. */
 void dt_tagging_completion_refresh(GtkListStore *store);
 
-/** Clear a tag entry from its secondary icon while retaining text-input focus. */
-void dt_tagging_entry_clear_icon(GtkEntry *entry, GtkEntryIconPosition position,
-                                 GdkEvent *event, gpointer user_data);
+/** Replace the active comma-separated token with the selected completion row. */
+gboolean dt_tagging_completion_match_selected(GtkEntryCompletion *completion, GtkTreeModel *model,
+                                              GtkTreeIter *iter, gpointer user_data);
+
+/** Cancel pending completion work and clear an entry while preserving its completion. */
+void dt_tagging_entry_clear(GtkEntry *entry);

--- a/src/tests/unittests/CMakeLists.txt
+++ b/src/tests/unittests/CMakeLists.txt
@@ -11,6 +11,7 @@ set(DATABASE_UNIT_TESTS
   test_history_repository
   test_preset_repository
   test_tag_selection_metadata
+  test_tagging_completion_model
   test_metadata_notify
   # Not database tests, but they want the same standalone-binary-linking-lib_ansel treatment,
   # and splitting the list to say so would be more ceremony than it is worth.
@@ -45,3 +46,6 @@ foreach(test ${DATABASE_UNIT_TESTS})
                           RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/../..)
   endif()
 endforeach()
+
+target_sources(test_tagging_completion_model PRIVATE
+  ${CMAKE_SOURCE_DIR}/src/libs/tagging_completion.c)

--- a/src/tests/unittests/CMakeLists.txt
+++ b/src/tests/unittests/CMakeLists.txt
@@ -11,6 +11,7 @@ set(DATABASE_UNIT_TESTS
   test_history_repository
   test_preset_repository
   test_tag_selection_metadata
+  test_tagging_completion
   test_tagging_completion_model
   test_metadata_notify
   # Not database tests, but they want the same standalone-binary-linking-lib_ansel treatment,
@@ -47,5 +48,8 @@ foreach(test ${DATABASE_UNIT_TESTS})
   endif()
 endforeach()
 
+target_sources(test_tagging_completion PRIVATE
+  ${CMAKE_SOURCE_DIR}/src/libs/tagging_completion.c)
 target_sources(test_tagging_completion_model PRIVATE
   ${CMAKE_SOURCE_DIR}/src/libs/tagging_completion.c)
+set_tests_properties(test_tagging_completion PROPERTIES SKIP_RETURN_CODE 77)

--- a/src/tests/unittests/test_tagging_completion.c
+++ b/src/tests/unittests/test_tagging_completion.c
@@ -24,56 +24,271 @@
 #include <stdint.h>
 #include <cmocka.h>
 
-static void test_clear_action_cancels_pending_inline_completion(void **state)
+typedef struct dt_tagging_completion_test_t
 {
-  (void)state;
-  GtkWidget *window = gtk_window_new(GTK_WINDOW_TOPLEVEL);
-  GtkWidget *entry = gtk_entry_new();
-  GtkListStore *store = gtk_list_store_new(1, G_TYPE_STRING);
+  GtkWidget *window;
+  GtkEntry *entry;
+  GtkListStore *store;
+  GtkEntryCompletion *completion;
+} dt_tagging_completion_test_t;
+
+typedef struct dt_return_handler_state_t
+{
+  guint entry_calls;
+  gchar *text;
+} dt_return_handler_state_t;
+
+static void _append_completion(dt_tagging_completion_test_t *test, const char *text)
+{
   GtkTreeIter iter;
-  gtk_list_store_append(store, &iter);
-  gtk_list_store_set(store, &iter, 0, "subjects|animals", -1);
-  GtkEntryCompletion *completion = gtk_entry_completion_new();
-  gtk_entry_completion_set_model(completion, GTK_TREE_MODEL(store));
-  gtk_entry_completion_set_text_column(completion, 0);
-  gtk_entry_completion_set_inline_completion(completion, TRUE);
-  gtk_entry_completion_set_popup_completion(completion, TRUE);
-  gtk_entry_completion_set_minimum_key_length(completion, 1);
-  gtk_entry_set_completion(GTK_ENTRY(entry), completion);
-  g_signal_connect(entry, "icon-release", G_CALLBACK(dt_tagging_entry_clear_icon), NULL);
-  gtk_container_add(GTK_CONTAINER(window), entry);
-  gtk_widget_show_all(window);
-  gtk_widget_grab_focus(entry);
+  gtk_list_store_append(test->store, &iter);
+  gtk_list_store_set(test->store, &iter, 0, text, -1);
+}
 
-  gtk_entry_set_text(GTK_ENTRY(entry), "subjects");
-  g_signal_emit_by_name(entry, "icon-release", GTK_ENTRY_ICON_SECONDARY, NULL);
+static void _drain_gtk_events()
+{
   while(gtk_events_pending()) gtk_main_iteration();
+}
 
-  gboolean popup_completion = FALSE, popup_mapped = FALSE;
-  g_object_get(completion, "popup-completion", &popup_completion, NULL);
+static gboolean _quit_main_loop(GMainLoop *loop)
+{
+  g_main_loop_quit(loop);
+  return G_SOURCE_REMOVE;
+}
+
+static void _wait_for_completion_sources()
+{
+  GMainLoop *loop = g_main_loop_new(NULL, FALSE);
+  g_timeout_add(250, (GSourceFunc)_quit_main_loop, loop);
+  g_main_loop_run(loop);
+  g_main_loop_unref(loop);
+}
+
+static gboolean _completion_popup_is_mapped(GtkWidget *entry_window)
+{
+  gboolean mapped = FALSE;
   GList *toplevels = gtk_window_list_toplevels();
   for(GList *toplevel = toplevels; toplevel; toplevel = g_list_next(toplevel))
   {
     GtkWidget *widget = GTK_WIDGET(toplevel->data);
-    if(widget != window && gtk_widget_get_mapped(widget)) popup_mapped = TRUE;
+    if(widget != entry_window && gtk_widget_get_mapped(widget)) mapped = TRUE;
   }
   g_list_free(toplevels);
-  assert_string_equal(gtk_entry_get_text(GTK_ENTRY(entry)), "");
-  assert_true(gtk_widget_is_focus(entry));
-  assert_ptr_equal(gtk_entry_get_completion(GTK_ENTRY(entry)), completion);
-  assert_true(popup_completion);
-  assert_false(popup_mapped);
+  return mapped;
+}
 
-  gtk_widget_destroy(window);
-  g_object_unref(completion);
-  g_object_unref(store);
+static gboolean _send_key(GtkWidget *widget, const guint keyval)
+{
+  GdkEventKey event = { 0 };
+  event.type = GDK_KEY_PRESS;
+  event.window = g_object_ref(gtk_widget_get_window(widget));
+  event.send_event = TRUE;
+  event.time = GDK_CURRENT_TIME;
+  event.keyval = keyval;
+  gboolean handled = FALSE;
+  g_signal_emit_by_name(widget, "key-press-event", &event, &handled);
+  g_object_unref(event.window);
+  return handled;
+}
+
+static gboolean _match_last_hierarchical_token(GtkEntryCompletion *completion, const gchar *key,
+                                               GtkTreeIter *iter, gpointer user_data)
+{
+  gchar *candidate = NULL;
+  gtk_tree_model_get(gtk_entry_completion_get_model(completion), iter, 0, &candidate, -1);
+  const gchar *token = g_strrstr(key, ",");
+  token = token ? token + 1 : key;
+  while(*token == ' ') token++;
+  const gboolean matches = g_str_has_prefix(candidate, token);
+  g_free(candidate);
+  return matches;
+}
+
+static int _setup_completion(void **state)
+{
+  dt_tagging_completion_test_t *test = g_malloc0(sizeof(*test));
+  test->window = gtk_window_new(GTK_WINDOW_TOPLEVEL);
+  test->entry = GTK_ENTRY(gtk_entry_new());
+  test->store = gtk_list_store_new(1, G_TYPE_STRING);
+  _append_completion(test, "subjects|animals");
+  _append_completion(test, "places|france|paris");
+  test->completion = gtk_entry_completion_new();
+  gtk_entry_completion_set_model(test->completion, GTK_TREE_MODEL(test->store));
+  gtk_entry_completion_set_text_column(test->completion, 0);
+  gtk_entry_completion_set_inline_completion(test->completion, TRUE);
+  gtk_entry_completion_set_popup_completion(test->completion, TRUE);
+  gtk_entry_completion_set_minimum_key_length(test->completion, 1);
+  gtk_entry_completion_set_match_func(test->completion, _match_last_hierarchical_token, NULL, NULL);
+  g_signal_connect(test->completion, "match-selected",
+                   G_CALLBACK(dt_tagging_completion_match_selected), NULL);
+  gtk_entry_set_completion(test->entry, test->completion);
+  gtk_container_add(GTK_CONTAINER(test->window), GTK_WIDGET(test->entry));
+  gtk_widget_show_all(test->window);
+  gtk_window_set_focus(GTK_WINDOW(test->window), GTK_WIDGET(test->entry));
+  gtk_window_present(GTK_WINDOW(test->window));
+  gdk_window_focus(gtk_widget_get_window(test->window), GDK_CURRENT_TIME);
+  _wait_for_completion_sources();
+  GdkEvent *focus_event = gdk_event_new(GDK_FOCUS_CHANGE);
+  focus_event->focus_change.window = g_object_ref(gtk_widget_get_window(GTK_WIDGET(test->entry)));
+  focus_event->focus_change.in = TRUE;
+  gtk_widget_send_focus_change(GTK_WIDGET(test->entry), focus_event);
+  gdk_event_free(focus_event);
+  assert_true(gtk_widget_has_focus(GTK_WIDGET(test->entry)));
+  *state = test;
+  return 0;
+}
+
+static int _teardown_completion(void **state)
+{
+  dt_tagging_completion_test_t *test = *state;
+  gtk_entry_set_completion(test->entry, NULL);
+  gtk_widget_destroy(test->window);
+  _wait_for_completion_sources();
+  g_object_unref(test->completion);
+  g_object_unref(test->store);
+  g_free(test);
+  return 0;
+}
+
+static gboolean _record_plain_return(GtkWidget *entry, GdkEventKey *event, dt_return_handler_state_t *state)
+{
+  if(event->keyval != GDK_KEY_Return) return FALSE;
+  state->entry_calls++;
+  g_free(state->text);
+  state->text = g_strdup(gtk_entry_get_text(GTK_ENTRY(entry)));
+  return FALSE;
+}
+
+static void test_clear_cancels_completion_before_model_refresh(void **state)
+{
+  dt_tagging_completion_test_t *test = *state;
+
+  gtk_entry_set_text(test->entry, "subjects");
+  dt_tagging_entry_clear(test->entry);
+  gtk_list_store_clear(test->store);
+  _append_completion(test, "subjects|animals");
+  _append_completion(test, "subjects|architecture");
+  _wait_for_completion_sources();
+
+  assert_string_equal(gtk_entry_get_text(test->entry), "");
+  assert_ptr_equal(gtk_entry_get_completion(test->entry), test->completion);
+  assert_false(_completion_popup_is_mapped(test->window));
+}
+
+static void test_completion_survives_repeated_single_and_hierarchical_clears(void **state)
+{
+  dt_tagging_completion_test_t *test = *state;
+
+  gtk_entry_set_text(test->entry, "subjects");
+  dt_tagging_entry_clear(test->entry);
+  _wait_for_completion_sources();
+  assert_string_equal(gtk_entry_get_text(test->entry), "");
+  assert_false(_completion_popup_is_mapped(test->window));
+
+  gtk_entry_set_text(test->entry, "subjects|animals, places");
+  dt_tagging_entry_clear(test->entry);
+  _wait_for_completion_sources();
+  assert_string_equal(gtk_entry_get_text(test->entry), "");
+  assert_false(_completion_popup_is_mapped(test->window));
+
+  gint position = 0;
+  gtk_editable_insert_text(GTK_EDITABLE(test->entry), "places", -1, &position);
+  _wait_for_completion_sources();
+  gtk_entry_completion_insert_prefix(test->completion);
+  _drain_gtk_events();
+
+  assert_ptr_equal(gtk_entry_get_completion(test->entry), test->completion);
+  assert_string_equal(gtk_entry_get_text(test->entry), "places|france|paris");
+}
+
+static void test_clear_supports_entry_without_completion(void **state)
+{
+  GtkEntry *entry = GTK_ENTRY(gtk_entry_new());
+  gtk_entry_set_text(entry, "places|france");
+
+  dt_tagging_entry_clear(entry);
+
+  assert_string_equal(gtk_entry_get_text(entry), "");
+  assert_null(gtk_entry_get_completion(entry));
+  gtk_widget_destroy(GTK_WIDGET(entry));
+}
+
+static void test_selected_completion_replaces_only_the_active_token(void **state)
+{
+  dt_tagging_completion_test_t *test = *state;
+  gtk_entry_completion_set_inline_completion(test->completion, FALSE);
+  gtk_entry_set_text(test->entry, "subjects|animals, pla");
+  gtk_editable_set_position(GTK_EDITABLE(test->entry), -1);
+  gtk_entry_completion_set_inline_completion(test->completion, TRUE);
+  GtkTreeIter iter;
+  assert_true(gtk_tree_model_get_iter_first(GTK_TREE_MODEL(test->store), &iter));
+  assert_true(gtk_tree_model_iter_next(GTK_TREE_MODEL(test->store), &iter));
+
+  gboolean handled = FALSE;
+  g_signal_emit_by_name(test->completion, "match-selected",
+                        GTK_TREE_MODEL(test->store), &iter, &handled);
+  _wait_for_completion_sources();
+
+  assert_true(handled);
+  assert_string_equal(gtk_entry_get_text(test->entry),
+                      "subjects|animals,places|france|paris");
+  assert_true(gtk_entry_completion_get_inline_completion(test->completion));
+  assert_ptr_equal(gtk_entry_get_completion(test->entry), test->completion);
+  assert_false(_completion_popup_is_mapped(test->window));
+}
+
+static void test_completion_keeps_return_priority_after_reattach(void **state)
+{
+  dt_tagging_completion_test_t *test = *state;
+  dt_return_handler_state_t handler_state = { 0 };
+  if(!gtk_window_is_active(GTK_WINDOW(test->window))) skip();
+
+  gulong handler_id = g_signal_connect(test->entry, "key-press-event",
+                                       G_CALLBACK(_record_plain_return), &handler_state);
+
+  g_signal_handler_disconnect(test->entry, handler_id);
+  dt_tagging_entry_clear(test->entry);
+  handler_id = g_signal_connect(test->entry, "key-press-event",
+                                G_CALLBACK(_record_plain_return), &handler_state);
+  gint position = 0;
+  gtk_editable_insert_text(GTK_EDITABLE(test->entry), "subjects|animals, pla", -1, &position);
+  _wait_for_completion_sources();
+  if(!_completion_popup_is_mapped(test->window))
+  {
+    g_signal_handler_disconnect(test->entry, handler_id);
+    skip();
+  }
+  assert_true(_send_key(GTK_WIDGET(test->entry), GDK_KEY_Down));
+  assert_true(_send_key(GTK_WIDGET(test->entry), GDK_KEY_Return));
+  _wait_for_completion_sources();
+
+  assert_string_equal(gtk_entry_get_text(test->entry),
+                      "subjects|animals,places|france|paris");
+  assert_int_equal(handler_state.entry_calls, 0);
+  assert_false(_completion_popup_is_mapped(test->window));
+  assert_true(gtk_entry_completion_get_inline_completion(test->completion));
+
+  _send_key(GTK_WIDGET(test->entry), GDK_KEY_Return);
+  assert_int_equal(handler_state.entry_calls, 1);
+  assert_string_equal(handler_state.text, "subjects|animals,places|france|paris");
+
+  g_signal_handler_disconnect(test->entry, handler_id);
+  g_free(handler_state.text);
 }
 
 int main(int argc, char **argv)
 {
   if(!gtk_init_check(&argc, &argv)) return 77;
   const struct CMUnitTest tests[] = {
-    cmocka_unit_test(test_clear_action_cancels_pending_inline_completion),
+    cmocka_unit_test_setup_teardown(test_clear_cancels_completion_before_model_refresh,
+                                    _setup_completion, _teardown_completion),
+    cmocka_unit_test_setup_teardown(test_completion_survives_repeated_single_and_hierarchical_clears,
+                                    _setup_completion, _teardown_completion),
+    cmocka_unit_test(test_clear_supports_entry_without_completion),
+    cmocka_unit_test_setup_teardown(test_selected_completion_replaces_only_the_active_token,
+                                    _setup_completion, _teardown_completion),
+    cmocka_unit_test_setup_teardown(test_completion_keeps_return_priority_after_reattach,
+                                    _setup_completion, _teardown_completion),
   };
   return cmocka_run_group_tests(tests, NULL, NULL);
 }

--- a/src/tests/unittests/test_tagging_completion.c
+++ b/src/tests/unittests/test_tagging_completion.c
@@ -24,7 +24,7 @@
 #include <stdint.h>
 #include <cmocka.h>
 
-static void test_clear_action_clears_entry_and_retains_focus(void **state)
+static void test_clear_action_cancels_pending_inline_completion(void **state)
 {
   (void)state;
   GtkWidget *window = gtk_window_new(GTK_WINDOW_TOPLEVEL);
@@ -36,24 +36,34 @@ static void test_clear_action_clears_entry_and_retains_focus(void **state)
   GtkEntryCompletion *completion = gtk_entry_completion_new();
   gtk_entry_completion_set_model(completion, GTK_TREE_MODEL(store));
   gtk_entry_completion_set_text_column(completion, 0);
+  gtk_entry_completion_set_inline_completion(completion, TRUE);
   gtk_entry_completion_set_popup_completion(completion, TRUE);
   gtk_entry_completion_set_minimum_key_length(completion, 1);
   gtk_entry_set_completion(GTK_ENTRY(entry), completion);
   g_signal_connect(entry, "icon-release", G_CALLBACK(dt_tagging_entry_clear_icon), NULL);
   gtk_container_add(GTK_CONTAINER(window), entry);
-  gtk_entry_set_text(GTK_ENTRY(entry), "subjects");
   gtk_widget_show_all(window);
   gtk_widget_grab_focus(entry);
-  gtk_entry_completion_complete(completion);
+
+  gtk_entry_set_text(GTK_ENTRY(entry), "subjects");
+  g_signal_emit_by_name(entry, "icon-release", GTK_ENTRY_ICON_SECONDARY, NULL);
   while(gtk_events_pending()) gtk_main_iteration();
 
-  g_signal_emit_by_name(entry, "icon-release", GTK_ENTRY_ICON_SECONDARY, NULL);
-
-  gboolean popup_completion = FALSE;
+  gboolean popup_completion = FALSE, popup_mapped = FALSE;
   g_object_get(completion, "popup-completion", &popup_completion, NULL);
+  GList *toplevels = gtk_window_list_toplevels();
+  for(GList *toplevel = toplevels; toplevel; toplevel = g_list_next(toplevel))
+  {
+    GtkWidget *widget = GTK_WIDGET(toplevel->data);
+    if(widget != window && gtk_widget_get_mapped(widget)) popup_mapped = TRUE;
+  }
+  g_list_free(toplevels);
   assert_string_equal(gtk_entry_get_text(GTK_ENTRY(entry)), "");
   assert_true(gtk_widget_is_focus(entry));
+  assert_ptr_equal(gtk_entry_get_completion(GTK_ENTRY(entry)), completion);
   assert_true(popup_completion);
+  assert_false(popup_mapped);
+
   gtk_widget_destroy(window);
   g_object_unref(completion);
   g_object_unref(store);
@@ -63,7 +73,7 @@ int main(int argc, char **argv)
 {
   if(!gtk_init_check(&argc, &argv)) return 77;
   const struct CMUnitTest tests[] = {
-    cmocka_unit_test(test_clear_action_clears_entry_and_retains_focus),
+    cmocka_unit_test(test_clear_action_cancels_pending_inline_completion),
   };
   return cmocka_run_group_tests(tests, NULL, NULL);
 }

--- a/src/tests/unittests/test_tagging_completion.c
+++ b/src/tests/unittests/test_tagging_completion.c
@@ -1,0 +1,69 @@
+/*
+    This file is part of Ansel,
+    Copyright (C) 2026 Paolo SANTUCCI.
+
+    Ansel is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Ansel is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Ansel.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "libs/tagging_completion.h"
+
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>  // NOLINT(misc-include-cleaner)
+#include <stdint.h>
+#include <cmocka.h>
+
+static void test_clear_action_clears_entry_and_retains_focus(void **state)
+{
+  (void)state;
+  GtkWidget *window = gtk_window_new(GTK_WINDOW_TOPLEVEL);
+  GtkWidget *entry = gtk_entry_new();
+  GtkListStore *store = gtk_list_store_new(1, G_TYPE_STRING);
+  GtkTreeIter iter;
+  gtk_list_store_append(store, &iter);
+  gtk_list_store_set(store, &iter, 0, "subjects|animals", -1);
+  GtkEntryCompletion *completion = gtk_entry_completion_new();
+  gtk_entry_completion_set_model(completion, GTK_TREE_MODEL(store));
+  gtk_entry_completion_set_text_column(completion, 0);
+  gtk_entry_completion_set_popup_completion(completion, TRUE);
+  gtk_entry_completion_set_minimum_key_length(completion, 1);
+  gtk_entry_set_completion(GTK_ENTRY(entry), completion);
+  g_signal_connect(entry, "icon-release", G_CALLBACK(dt_tagging_entry_clear_icon), NULL);
+  gtk_container_add(GTK_CONTAINER(window), entry);
+  gtk_entry_set_text(GTK_ENTRY(entry), "subjects");
+  gtk_widget_show_all(window);
+  gtk_widget_grab_focus(entry);
+  gtk_entry_completion_complete(completion);
+  while(gtk_events_pending()) gtk_main_iteration();
+
+  g_signal_emit_by_name(entry, "icon-release", GTK_ENTRY_ICON_SECONDARY, NULL);
+
+  gboolean popup_completion = FALSE;
+  g_object_get(completion, "popup-completion", &popup_completion, NULL);
+  assert_string_equal(gtk_entry_get_text(GTK_ENTRY(entry)), "");
+  assert_true(gtk_widget_is_focus(entry));
+  assert_true(popup_completion);
+  gtk_widget_destroy(window);
+  g_object_unref(completion);
+  g_object_unref(store);
+}
+
+int main(int argc, char **argv)
+{
+  if(!gtk_init_check(&argc, &argv)) return 77;
+  const struct CMUnitTest tests[] = {
+    cmocka_unit_test(test_clear_action_clears_entry_and_retains_focus),
+  };
+  return cmocka_run_group_tests(tests, NULL, NULL);
+}

--- a/src/tests/unittests/test_tagging_completion_model.c
+++ b/src/tests/unittests/test_tagging_completion_model.c
@@ -1,0 +1,64 @@
+/*
+    This file is part of Ansel,
+    Copyright (C) 2026 Paolo SANTUCCI.
+
+    Ansel is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Ansel is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Ansel.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "testdb.h"
+
+#include "libs/tagging_completion.h"
+#include "metadata/tags.h"
+
+static gboolean _store_contains(GtkTreeModel *model, const char *path)
+{
+  GtkTreeIter iter;
+  gboolean valid = gtk_tree_model_get_iter_first(model, &iter);
+  while(valid)
+  {
+    char *candidate = NULL;
+    gtk_tree_model_get(model, &iter, 0, &candidate, -1);
+    const gboolean found = !g_strcmp0(candidate, path);
+    g_free(candidate);
+    if(found) return TRUE;
+    valid = gtk_tree_model_iter_next(model, &iter);
+  }
+  return FALSE;
+}
+
+static void test_refresh_exposes_new_hierarchical_tag(void **state)
+{
+  (void)state;
+  GtkListStore *store = gtk_list_store_new(1, G_TYPE_STRING);
+  guint tagid = 0;
+
+  assert_true(dt_tag_new("subjects|animals", &tagid));
+  dt_tagging_completion_refresh(store);
+  assert_true(_store_contains(GTK_TREE_MODEL(store), "subjects|animals"));
+
+  assert_true(dt_tag_new("subjects|animals|beetles", &tagid));
+  assert_false(_store_contains(GTK_TREE_MODEL(store), "subjects|animals|beetles"));
+
+  dt_tagging_completion_refresh(store);
+  assert_true(_store_contains(GTK_TREE_MODEL(store), "subjects|animals|beetles"));
+  g_object_unref(store);
+}
+
+int main(void)
+{
+  const struct CMUnitTest tests[] = {
+    cmocka_unit_test(test_refresh_exposes_new_hierarchical_tag),
+  };
+  return cmocka_run_group_tests(tests, testdb_setup, testdb_teardown);
+}


### PR DESCRIPTION
## Summary

- refresh global and collection-scoped tag completion caches immediately after tag creation, rename, deletion, quick-tag, and redo operations
- handle tag-entry clear icons on release and retain entry focus while preserving popup completion
- add headless-safe model coverage and a GTK clear/focus regression test

Fixes #1253
Fixes #1254

## Tests

- `cmake --build build_test --target test_tagging_completion test_tagging_completion_model tagging -j4`
- `ctest --test-dir build_test -R '^test_tagging_completion(_model)?$' --output-on-failure`
- `tools/check_module_boundaries.sh`

The GTK test skips only when no display is available; the completion-model test remains headless-safe.

I am not able to test this on Windows GTK.