### PR TITLE
iop: do not prepare a module that will not run

### DIFF
--- a/src/iop/colorequal.c
+++ b/src/iop/colorequal.c
@@ -769,6 +769,25 @@ static size_t _build_viewer_control_nodes(const dt_iop_colorequal_params_t *p,
 void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pixelpipe_t *pipe,
                    dt_dev_pixelpipe_iop_t *piece)
 {
+  /* Nothing to prepare for a piece that will not run. dt_iop_commit_params() commits DISABLED
+   * modules too -- deliberately, because some of them self-enable there on runtime context. This
+   * one does not, and process()/process_cl() are the only readers of piece->data, so nothing
+   * downstream can observe what we skip.
+   *
+   * The return has to come BEFORE the profile lookup below, not merely before the LUT build.
+   * dt_colorspaces_add_profile() memoises, but the FIRST caller pays for it, and in the whole
+   * pipeline DT_COLORSPACE_HLG_REC2020 is asked for by nothing except this module and iop/colorprimaries.c.
+   * On an image that enables neither, that profile -- two matrices plus six eagerly built
+   * 65536-entry LUTs, tone-curve inversion included -- was being constructed for nobody.
+   *
+   * Returning rather than clearing also keeps a LUT that was already built: toggle the module off
+   * and on again and the memo survives; only a real parameter change rebuilds.
+   *
+   * piece->enabled is set from history immediately before every dt_iop_commit_params() call
+   * (dev_pixelpipe.c 288, 1288, 1367; pixelpipe_hb.c:700 at node creation), so it is settled here.
+   */
+  if(!piece->enabled) return;
+
   const dt_iop_colorequal_params_t *p = (const dt_iop_colorequal_params_t *)p1;
   dt_iop_colorequal_data_t *d = (dt_iop_colorequal_data_t *)piece->data;
   const dt_iop_order_iccprofile_info_t *lut_profile

--- a/src/iop/colorprimaries.c
+++ b/src/iop/colorprimaries.c
@@ -795,6 +795,25 @@ static void _build_clut(dt_iop_colorprimaries_data_t *d, const dt_iop_colorprima
 void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pixelpipe_t *pipe,
                    dt_dev_pixelpipe_iop_t *piece)
 {
+  /* Nothing to prepare for a piece that will not run. dt_iop_commit_params() commits DISABLED
+   * modules too -- deliberately, because some of them self-enable there on runtime context. This
+   * one does not, and process()/process_cl() are the only readers of piece->data, so nothing
+   * downstream can observe what we skip.
+   *
+   * The return has to come BEFORE the profile lookup below, not merely before the LUT build.
+   * dt_colorspaces_add_profile() memoises, but the FIRST caller pays for it, and in the whole
+   * pipeline DT_COLORSPACE_HLG_REC2020 is asked for by nothing except this module and iop/colorequal.c.
+   * On an image that enables neither, that profile -- two matrices plus six eagerly built
+   * 65536-entry LUTs, tone-curve inversion included -- was being constructed for nobody.
+   *
+   * Returning rather than clearing also keeps a LUT that was already built: toggle the module off
+   * and on again and the memo survives; only a real parameter change rebuilds.
+   *
+   * piece->enabled is set from history immediately before every dt_iop_commit_params() call
+   * (dev_pixelpipe.c 288, 1288, 1367; pixelpipe_hb.c:700 at node creation), so it is settled here.
+   */
+  if(!piece->enabled) return;
+
   const dt_iop_colorprimaries_params_t *p = (const dt_iop_colorprimaries_params_t *)p1;
   dt_iop_colorprimaries_data_t *d = (dt_iop_colorprimaries_data_t *)piece->data;
   const dt_iop_order_iccprofile_info_t *lut_profile


### PR DESCRIPTION
Found while profiling a drawn-mask export for #1299 — unrelated to masks, and bigger than it first looked.

## The problem

`dt_iop_commit_params()` commits **every** module in the pipe, enabled or not, and the comment says why:

```c
// We need to commit also modules that are disabled because some of them
// may self-enabled at commit time, depending on image input.
```

`colorequal` and `colorprimaries` don't self-enable — but each did two expensive things unconditionally, on images whose history contains **neither** module.

**1. A 64-level colour LUT**, gated only on the profiles resolving:

```
[colorequal]     build_clut level=64             total=124.2 ms
[colorprimaries] build_clut level=64 anchors=100 total= 37.8 ms
```

**2. An ICC profile resolution, above that** — and this is the one I nearly missed. Each calls `dt_colorspaces_add_profile(DT_COLORSPACE_HLG_REC2020, …)`: two matrices plus **six eagerly built 65536-entry LUTs**, tone-curve inversion included. It memoises, but the first caller pays — and in the whole pipeline **nothing else asks for HLG_REC2020**. These two modules are its only consumers, so on an image that enables neither, that profile was constructed for nobody. `cmsReverseToneCurveEx` alone was **2.85% of an entire export**.

My first attempt gated only the LUT build and left the profile lookup above it. The profile then showed `cmsReverseToneCurveEx` still at 2.85%, which is what sent me back for the second half.

## The fix

Both return immediately when the piece is not enabled, before either cost.

`piece->enabled` is set from history right before every `dt_iop_commit_params()` call (`dev_pixelpipe.c` 288, 1288, 1367; `pixelpipe_hb.c:700` at node creation), and nothing re-enables a piece afterwards — the only post-commit assignment is `detailmask`'s own, and the three modules that raise `piece->enabled` inside `commit_params` (`colorin`, `gamma`, `finalscale`) raise it for *themselves*. `process()`/`process_cl()` are the only readers of `piece->data` in either module; neither has a tiling, ROI or format callback.

Returning rather than clearing also **preserves an already-built LUT**, so toggling a module off and on keeps the memo; only a real parameter change rebuilds.

## Measured

The box has a busy browser on it, so single-sided timings were useless — I alternated two staged builds run by run instead, so background load can't favour either side. Five rounds, medians, **pipeline creation**:

| | master | this branch |
|---|---|---|
| wall | 0.614 s | **0.345 s** |
| CPU | 0.760 s | **0.306 s** |

`cmsReverseToneCurveEx` disappears from the profile entirely. Export is **pixel-identical** — image page *and* `--export_masks` page, 0 of 5126400 on both.

The darkroom creates these pieces per pipe, so entering it paid this twice.

## Scope

Of the other modules that precompute in `commit_params`, `lens` and `filmicrgb` are genuinely enabled on this image, and `colorchecker`, `rgblevels` and `splittoningrgb` never surfaced in the profile. The two fixed here are the ones that measure.

Release, `build-nofeatures`, all four static gates and the unit tests: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)