### PR TITLE
masks: lower the membership-row baseline to what three merged PRs actually left

### DIFF
--- a/tools/check_module_boundaries.sh
+++ b/tools/check_module_boundaries.sh
@@ -415,7 +415,7 @@ masks_member_baseline=83
 masks_write_baseline=20
 masks_alloc_baseline=1
 masks_forms_baseline=76
-masks_row_baseline=38
+masks_row_baseline=35
 
 # Members no other struct in the tree uses. Keep it that way: adding an ambiguous name here
 # buys a bigger number and loses the gate.


### PR DESCRIPTION
**master is currently red on its own** — `tools/check_module_boundaries.sh` exits 1 on a pristine checkout, so every PR inherits the failure. This one-line change fixes it.

```
35 external mentions of a membership row (baseline 38).
masks: membership rows named externally fell (38 -> 35).
```

## Nothing regressed — this is my bookkeeping error

The counter was added by #1335 with baseline 38, measured on a tree that did **not** yet contain #1331 or #1332. All three were branched off master independently rather than stacked (to avoid the stacked-PR problems this repo has), so each measured a baseline its siblings had not been applied to. #1331 and #1332 each removed mentions of their own, and the merged total landed three below the number #1335 recorded.

The gate then did exactly its job: it is fall-only, and it refuses a fall that no commit accounted for.

**The general lesson**, which I'll not repeat: a fall-only ratchet cannot be measured on parallel branches. Every branch is individually correct about master, and the merge of all of them is lower than any one predicted. The number has to be re-measured after the last sibling merges, not before the first.

Baseline set to **35**, which is what pristine `origin/master` reports. Gate exits 0.

Once this lands, #1338 needs a rebase — its CI failure is this and nothing else.

🤖 Generated with [Claude Code](https://claude.com/claude-code)