### PR TITLE
masks: a brush's outline is not its border, so its segments can be selected

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -984,6 +984,28 @@ last node's own coordinate sits at the very end of the forward pass. Everything 
 drawn centerline (the outline stroking, the source shape, the clone link's midpoint) uses that
 helper.
 
+### A brush's outline encloses the whole stroke, so "inside the border" cannot mean "on the border"
+
+`dt_masks_find_closest_handle_common()` (`masks_gui.c`) answers in one fixed order — source,
+border, segment, shape — so whatever a shape's `get_distance()` reports as `inside_border`
+preempts its segment. For a closed shape the two are disjoint regions: a polygon's `inside_border`
+is the feather ring, true only *between* the outline and the form, so a cursor on the centerline
+falls through to the segment test.
+
+A brush has no such ring. Its `points` are the centerline walked there and back (zero area) and
+its `border` is the outline wrapping the whole painted band, so a point-in-polygon test on that
+border is true across the entire stroke. Reporting that as `inside_border` makes the brush's
+segment — drag to move it, Ctrl+Click to insert a node — unreachable everywhere, while the shape
+still looks perfectly hoverable. For a brush, `inside` is "enclosed by the outline" and
+`inside_border` is "within cursor reach of the outline itself, and no centerline segment is
+closer": the outline carries no drag action of its own (border width is edited through the
+per-node handle and the wheel), so on a thin stroke, where outline and centerline are both within
+reach at once, the segment wins.
+
+`_brush_get_distance()`'s source pass walks a different outline, so its distances need their own
+accumulator — sharing one running minimum lets a clone source near the form veto every segment hit
+on the form itself.
+
 ### A drawing pass must not leave a path in the cairo context
 
 Cairo keeps the current path across calls, so a leftover is painted by the next `cairo_stroke()`

--- a/src/develop/masks/brush.c
+++ b/src/develop/masks/brush.c
@@ -1177,6 +1177,44 @@ static void _brush_get_distance(float point_x, float point_y, float radius,
     }
   }
 
+  // we check if we are near a segment of the centerline. This runs BEFORE the outline test:
+  // the outline wraps the whole stroke, so on a thin brush both are within cursor reach at
+  // once, and the segment is the one carrying an action (move it, Ctrl+Click to add a node)
+  // while the outline has none of its own.
+  if(gui_points->points && gui_points->points_count > 2 + corner_count * 3)
+  {
+    // Own accumulator: the source pass above walks a different outline, and its distances
+    // must not veto a segment hit on the form itself.
+    float min_dist_points = FLT_MAX;
+    int current_seg = 1;
+    for(int i = corner_count * 3; i < gui_points->points_count; i++)
+    {
+      // do we change of path segment ?
+      if(gui_points->points[i * 2 + 1] == gui_points->points[current_seg * 6 + 3]
+         && gui_points->points[i * 2] == gui_points->points[current_seg * 6 + 2])
+      {
+        current_seg = (current_seg + 1) % corner_count;
+      }
+      //distance from tested point to current form point
+      const float yy = gui_points->points[i * 2 + 1];
+      const float xx = gui_points->points[i * 2];
+
+      const float dx = point_x - xx;
+      const float dy = point_y - yy;
+      const float dd = (dx * dx) + (dy * dy);
+      if(dd < min_dist_points)
+      {
+        min_dist_points = dd;
+
+        if(current_seg > 0 && dd < radius2)
+        {
+          *near_handle = current_seg - 1;
+        }
+      }
+    }
+    min_dist = MIN(min_dist, min_dist_points);
+  }
+
  // we check if it's inside borders
   if(gui_points->border && gui_points->border_count > 2 + corner_count * 3)
   {
@@ -1203,38 +1241,12 @@ static void _brush_get_distance(float point_x, float point_y, float radius,
       last_y = yy;
     }
 
-    *inside = *inside_border = (nearest != -1 || (crossings & 1));
-  }
-
-  // and we check if we are near_handle a segment
-  if(gui_points->points && gui_points->points_count > 2 + corner_count * 3)
-  {
-    int current_seg = 1;
-    for(int i = corner_count * 3; i < gui_points->points_count; i++)
-    {
-      // do we change of path segment ?
-      if(gui_points->points[i * 2 + 1] == gui_points->points[current_seg * 6 + 3]
-         && gui_points->points[i * 2] == gui_points->points[current_seg * 6 + 2])
-      {
-        current_seg = (current_seg + 1) % corner_count;
-      }
-      //distance from tested point to current form point
-      const float yy = gui_points->points[i * 2 + 1];
-      const float xx = gui_points->points[i * 2];
-
-      const float dx = point_x - xx;
-      const float dy = point_y - yy;
-      const float dd = (dx * dx) + (dy * dy);
-      if(dd < min_dist)
-      {
-        min_dist = dd;
-
-        if(current_seg > 0 && dd < radius2)
-        {
-          *near_handle = current_seg - 1;
-        }
-      }
-    }
+    // Being enclosed by the outline is what makes the stroke hoverable at all, but it is not
+    // a hit on the border itself: only proximity to the outline is, and only where no
+    // centerline segment is closer. Reporting the whole band as border made the segment
+    // unreachable, since the shared hit test answers on the border before the segment.
+    *inside = (nearest != -1 || (crossings & 1));
+    *inside_border = (nearest != -1) && (*near_handle < 0);
   }
 
   *distance = min_dist;


### PR DESCRIPTION
Fixes #1307.

A segment of a brush shape cannot be selected, while the same segment on a polygon can.

## Cause

`dt_masks_find_closest_handle_common()` (`src/develop/masks/masks_gui.c`) answers in one fixed order — source, border, segment, shape — and returns on the first match. `_brush_get_distance()` reported the whole painted band as "inside the border":

```c
*inside = *inside_border = (nearest != -1 || (crossings & 1));
```

`crossings & 1` is a point-in-polygon test on the brush's border outline, which wraps the stroke there and back — so it is true anywhere on the trait, and the answer never got as far as the segment. The segment was unreachable everywhere on the shape, while everything downstream of the hit test already handled it: dragging it moves the two nodes bounding it, Ctrl+Click inserts a node, and the hint message documents both.

A closed shape does not have the problem, because there the two regions are disjoint: a polygon's `inside_border` is the feather ring, true only *between* the outline and the form, so a cursor on the centerline falls through to the segment test.

## Change

A brush has no such ring — its `points` are the centerline walked there and back, which encloses no area — so the distinction is drawn differently:

- `inside` is "enclosed by the outline", `inside_border` is "within cursor reach of the outline itself, and no centerline segment is closer". That needs the segment pass to run before the outline pass.
- On a thin stroke, where outline and centerline are both within reach of the cursor at once, the segment wins. The outline carries no drag action of its own: border width is edited through the per-node handle and the wheel.
- The segment pass gets its own running minimum. It shared one with the pass measuring the clone source, so a source sitting near the form vetoed every segment hit on the form itself.

Dragging the whole shape from inside the band, hovering the outline, the per-node handles and the source are unchanged.

## Test

Manual, in the darkroom on a drawn mask: hovering a segment between two nodes highlights it and shows its hint; dragging it moves both bounding nodes; Ctrl+Click inserts a node there; the shape still drags as a whole from inside the band; the outline still highlights on hover. Checked on a thin brush too, where the segment now takes priority over the outline.

`CLAUDE.md` records the invariant.