### PR TITLE
masks: a shape's soft edge is called fading, in the code and in the keys that persist it

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1073,20 +1073,22 @@ only because the callback is shared.
 
 The mapping is one conf key per wheel/modifier combination
 (`plugins/darkroom/masks/scroll/{plain,shift,primary,primary_shift}`, enum values `none` |
-`size` | `hardness` | `opacity` | `rotation`, declared in `data/anselconfig.xml.in`) behind
+`size` | `fading` | `opacity` | `rotation`, declared in `data/anselconfig.xml.in`) behind
 `dt_masks_scroll_mapping_get/set()` and `dt_masks_scroll_get_interaction()` (`masks_gui.h`).
 Those enum values are a storage format: never translate them, never reorder them against
 `dt_masks_interaction_t`. The mapping is **application-wide** — which property the wheel edits
 is a user habit, not a property of a shape or of the module owning the mask — and its defaults
 reproduce the historical modifier behaviour, so a user who never opens the panel sees no change.
 
-A gradient spells the two shared properties its own way: `SIZE` is the fade extent, `HARDNESS`
-the curvature. That is also how the context-menu sliders name them, and why
-`dt_masks_interaction_alias_name()` exists.
+A gradient spells one of the shared properties its own way: `FADING` is the curvature. `SIZE`
+is the fade extent but keeps the shared name, since it is the shape's size in the only sense a
+gradient has one. That is also how the context-menu sliders name them, and why
+`dt_masks_interaction_alias_name()` exists — it answers `NULL` for every property a gradient
+names like everyone else.
 
 Scope is the selection's business, not the wheel's: `dt_masks_gui_change_affects_selected_node_or_all()`
-already restricts a size/hardness change to the selected node. A shape must not additionally
-*substitute* a property based on selection state — the polygon used to force hardness on a plain
+already restricts a size/fading change to the selected node. A shape must not additionally
+*substitute* a property based on selection state — the polygon used to force fading on a plain
 wheel whenever a node was selected, which made the mapping unreachable for that shape.
 
 The GUI is the "Mouse wheel" collapsible section of the Drawn tab (`blend_gui.c`), one radio
@@ -1485,7 +1487,7 @@ reconfigure on same-size re-entry).
 
 A `GtkLabel` with `gtk_label_set_angle()` requests the width of its *slanted* bounding box, so a
 diagonal column title makes its whole column that wide — measured on the masks wheel-mapping
-grid: 102 px for "Hardness/Curvature" at 45° against 24 px for the radio button underneath it.
+grid: 102 px for "Fading/Curvature" at 45° against 24 px for the radio button underneath it.
 Zeroing `column-spacing` does not help, because the spacing was never what separated the cells.
 
 Two things fix it, and both are needed. Give the grid `GTK_ALIGN_START`: handed more width than

--- a/data/anselconfig.xml.in
+++ b/data/anselconfig.xml.in
@@ -942,8 +942,8 @@
     <type>
       <enum>
         <option>off</option>
-        <option>hardness (relative)</option>
-        <option>hardness (absolute)</option>
+        <option>fading (relative)</option>
+        <option>fading (absolute)</option>
         <option>opacity (relative)</option>
         <option>opacity (absolute)</option>
         <option>brush size (relative)</option>
@@ -951,7 +951,7 @@
     </type>
     <default>off</default>
     <shortdescription>Pen pressure mapping</shortdescription>
-    <longdescription>off - pressure reading ignored, hardness/opacity/brush size - pressure reading controls specified attribute, absolute/relative - pressure reading is taken directly as attribute value or multiplied with pre-defined setting.</longdescription>
+    <longdescription>off - pressure reading ignored, fading/opacity/brush size - pressure reading controls specified attribute, absolute/relative - pressure reading is taken directly as attribute value or multiplied with pre-defined setting.</longdescription>
   </dtconfig>
   <dtconfig>
     <name>plugins/darkroom/masks/scroll/plain</name>
@@ -959,7 +959,7 @@
       <enum>
         <option>none</option>
         <option>size</option>
-        <option>hardness</option>
+        <option>fading</option>
         <option>opacity</option>
         <option>rotation</option>
       </enum>
@@ -974,12 +974,12 @@
       <enum>
         <option>none</option>
         <option>size</option>
-        <option>hardness</option>
+        <option>fading</option>
         <option>opacity</option>
         <option>rotation</option>
       </enum>
     </type>
-    <default>hardness</default>
+    <default>fading</default>
     <shortdescription>Mask property edited by shift + mouse wheel</shortdescription>
     <longdescription>Which property of the hovered mask shape the mouse wheel edits for this modifier combination. Set from the mouse wheel section of a module's Drawn mask tab. none - this combination does nothing.</longdescription>
   </dtconfig>
@@ -989,7 +989,7 @@
       <enum>
         <option>none</option>
         <option>size</option>
-        <option>hardness</option>
+        <option>fading</option>
         <option>opacity</option>
         <option>rotation</option>
       </enum>
@@ -1004,7 +1004,7 @@
       <enum>
         <option>none</option>
         <option>size</option>
-        <option>hardness</option>
+        <option>fading</option>
         <option>opacity</option>
         <option>rotation</option>
       </enum>
@@ -2307,7 +2307,7 @@
     <longdescription/>
   </dtconfig>
   <dtconfig>
-    <name>plugins/darkroom/spots/brush/hardness</name>
+    <name>plugins/darkroom/spots/brush/fading</name>
     <type>float</type>
     <default>0.66</default>
     <shortdescription/>
@@ -2482,7 +2482,7 @@
     <longdescription/>
   </dtconfig>
   <dtconfig>
-    <name>plugins/darkroom/masks/polygon/hardness</name>
+    <name>plugins/darkroom/masks/polygon/fading</name>
     <type>float</type>
     <default>0.05</default>
     <shortdescription/>
@@ -2524,7 +2524,7 @@
     <longdescription/>
   </dtconfig>
   <dtconfig>
-    <name>plugins/darkroom/masks/brush/hardness</name>
+    <name>plugins/darkroom/masks/brush/fading</name>
     <type>float</type>
     <default>0.66</default>
     <shortdescription/>

--- a/doc/masks-enclosure-p2.md
+++ b/doc/masks-enclosure-p2.md
@@ -236,7 +236,7 @@ assumptions — took for granted. They are the reason to read this document befo
    against retouch *and* spots together.
 4. **The type-token set feeds persisted conf keys.** `_get_mask_type()` feeds
    `dt_masks_get_set_conf_value()`, which builds `plugins/darkroom/<plugin>/<type>/<feature>` — keys
-   declared in `data/anselconfig.xml.in` as `.../polygon/hardness` etc. So the token is **polygon**,
+   declared in `data/anselconfig.xml.in` as `.../polygon/fading` etc. So the token is **polygon**,
    never supervisor's "path": adopting supervisor's spelling in a unified function would silently
    repoint every polygon shape at a non-confgen key defaulting to 0.
 5. **Two ratchet mechanics decide how the API is *consumed*.** Section 9 counts `->` only, so a

--- a/src/develop/blend_gui.c
+++ b/src/develop/blend_gui.c
@@ -3781,7 +3781,7 @@ void dt_iop_gui_blend_masks_update(dt_iop_module_t *module)
 /* Property columns, in display order. DT_MASKS_INTERACTION_UNDEF ("nothing") is a column like
  * the others -- it is how a row is unmapped -- and comes last, after what it opts out of. */
 static const dt_masks_interaction_t _blendop_scroll_columns[]
-    = { DT_MASKS_INTERACTION_SIZE, DT_MASKS_INTERACTION_HARDNESS, DT_MASKS_INTERACTION_OPACITY,
+    = { DT_MASKS_INTERACTION_SIZE, DT_MASKS_INTERACTION_FADING, DT_MASKS_INTERACTION_OPACITY,
         DT_MASKS_INTERACTION_ROTATION, DT_MASKS_INTERACTION_UNDEF };
 
 static void _blendop_masks_scroll_toggled(GtkToggleButton *button, gpointer user_data)
@@ -3851,7 +3851,7 @@ static GtkWidget *_blendop_masks_create_scroll_grid(void)
     gtk_widget_set_halign(header, GTK_ALIGN_START);
     gtk_widget_set_valign(header, GTK_ALIGN_END);
     /* Spanning, not one cell: a label rotated 45 degrees requests the width of its slanted
-     * bounding box (measured: 102px for "Hardness/Curvature" against 24px for a radio), and a
+     * bounding box (measured: 102px for "Fading/Curvature" against 24px for a radio), and a
      * single-cell title makes its whole column that wide. Letting each title span the columns
      * to its right -- the direction it leans into, whose header space is free -- constrains the
      * sum instead of one column, and every column falls back to the width of its radio. */

--- a/src/develop/masks.h
+++ b/src/develop/masks.h
@@ -84,7 +84,7 @@ GList dev->forms
   |        | dt_masks_form_t  --------------------> dt_masks_type_t type; const dt_masks_functions_t *functions;
   |              |                                   float source[2]; char name[128]; int formid; int version;
   |              { GList *points;
-  |                  | dt_masks_node_brush_t ----->  float node[2]; float pressure; float hardness; float size;
+  |                  | dt_masks_node_brush_t ----->  float node[2]; float pressure; float fading; float size;
   |                  |                                dt_masks_pressure_sensitivity_t pressure_sensitivity;
   |                  | dt_masks_node_brush_t -----> ...
   |                  |
@@ -170,8 +170,8 @@ typedef enum dt_masks_gradient_states_t
 typedef enum dt_masks_pressure_sensitivity_t
 {
   DT_MASKS_PRESSURE_OFF = 0,
-  DT_MASKS_PRESSURE_HARDNESS_REL = 1,
-  DT_MASKS_PRESSURE_HARDNESS_ABS = 2,
+  DT_MASKS_PRESSURE_FADING_REL = 1,
+  DT_MASKS_PRESSURE_FADING_ABS = 2,
   DT_MASKS_PRESSURE_OPACITY_REL = 3,
   DT_MASKS_PRESSURE_OPACITY_ABS = 4,
   DT_MASKS_PRESSURE_BRUSHSIZE_REL = 5
@@ -226,7 +226,7 @@ typedef struct dt_masks_node_brush_t
   float ctrl2[2];
   float border[2];
   float density;
-  float hardness;
+  float fading;
   dt_masks_points_states_t state;
 } dt_masks_node_brush_t;
 

--- a/src/develop/masks/brush.c
+++ b/src/develop/masks/brush.c
@@ -55,8 +55,8 @@
 #include "widgets/accelerators.h"
 #include "widgets/widget_settings.h"
 
-#define HARDNESS_MIN 0.00001f
-#define HARDNESS_MAX 1.0f
+#define FADING_MIN 0.00001f
+#define FADING_MAX 1.0f
 
 #define BORDER_MIN 0.00005f
 #define BORDER_MAX 0.5f
@@ -65,7 +65,7 @@
  * @brief Get squared distance of a point to the segment, including payload deltas.
  *
  * Uses the first and last points as segment endpoints and adds weighted distance
- * in border/hardness/density space to preserve brush dynamics.
+ * in border/fading/density space to preserve brush dynamics.
  */
 static float _brush_point_line_distance2(int point_index, int point_count,
                                          const float *point_buffer, const float *payload_buffer)
@@ -73,17 +73,17 @@ static float _brush_point_line_distance2(int point_index, int point_count,
   const float point_x = point_buffer[2 * point_index];
   const float point_y = point_buffer[2 * point_index + 1];
   const float point_border = payload_buffer[4 * point_index];
-  const float point_hardness = payload_buffer[4 * point_index + 1];
+  const float point_fading = payload_buffer[4 * point_index + 1];
   const float point_density = payload_buffer[4 * point_index + 2];
   const float start_x = point_buffer[0];
   const float start_y = point_buffer[1];
   const float start_border = payload_buffer[0];
-  const float start_hardness = payload_buffer[1];
+  const float start_fading = payload_buffer[1];
   const float start_density = payload_buffer[2];
   const float end_x = point_buffer[2 * (point_count - 1)];
   const float end_y = point_buffer[2 * (point_count - 1) + 1];
   const float end_border = payload_buffer[4 * (point_count - 1)];
-  const float end_hardness = payload_buffer[4 * (point_count - 1) + 1];
+  const float end_fading = payload_buffer[4 * (point_count - 1) + 1];
   const float end_density = payload_buffer[4 * (point_count - 1) + 2];
   const float bweight = 1.0f;
   const float hweight = 0.01f;
@@ -92,7 +92,7 @@ static float _brush_point_line_distance2(int point_index, int point_count,
   const float segment_dx = end_x - start_x;
   const float segment_dy = end_y - start_y;
   const float segment_db = end_border - start_border;
-  const float segment_dh = end_hardness - start_hardness;
+  const float segment_dh = end_fading - start_fading;
   const float segment_dd = end_density - start_density;
 
   const float dot = (point_x - start_x) * segment_dx + (point_y - start_y) * segment_dy;
@@ -106,7 +106,7 @@ static float _brush_point_line_distance2(int point_index, int point_count,
     dx = point_x - start_x;
     dy = point_y - start_y;
     db = point_border - start_border;
-    dh = point_hardness - start_hardness;
+    dh = point_fading - start_fading;
     dd = point_density - start_density;
   }
   else if(t < 0.0f)
@@ -114,7 +114,7 @@ static float _brush_point_line_distance2(int point_index, int point_count,
     dx = point_x - start_x;
     dy = point_y - start_y;
     db = point_border - start_border;
-    dh = point_hardness - start_hardness;
+    dh = point_fading - start_fading;
     dd = point_density - start_density;
   }
   else if(t > 1.0f)
@@ -122,7 +122,7 @@ static float _brush_point_line_distance2(int point_index, int point_count,
     dx = point_x - end_x;
     dy = point_y - end_y;
     db = point_border - end_border;
-    dh = point_hardness - end_hardness;
+    dh = point_fading - end_fading;
     dd = point_density - end_density;
   }
   else
@@ -130,7 +130,7 @@ static float _brush_point_line_distance2(int point_index, int point_count,
     dx = point_x - (start_x + t * segment_dx);
     dy = point_y - (start_y + t * segment_dy);
     db = point_border - (start_border + t * segment_db);
-    dh = point_hardness - (start_hardness + t * segment_dh);
+    dh = point_fading - (start_fading + t * segment_dh);
     dd = point_density - (start_density + t * segment_dd);
   }
 
@@ -181,7 +181,7 @@ static GList *_brush_ramer_douglas_peucker(const float *point_buffer, int point_
     first_node->node[1] = point_buffer[1];
     first_node->ctrl1[0] = first_node->ctrl1[1] = first_node->ctrl2[0] = first_node->ctrl2[1] = -1.0f;
     first_node->border[0] = first_node->border[1] = payload_buffer[0];
-    first_node->hardness = payload_buffer[1];
+    first_node->fading = payload_buffer[1];
     first_node->density = payload_buffer[2];
     first_node->state = DT_MASKS_POINT_STATE_NORMAL;
     result_list = g_list_append(result_list, (gpointer)first_node);
@@ -191,7 +191,7 @@ static GList *_brush_ramer_douglas_peucker(const float *point_buffer, int point_
     last_node->node[1] = point_buffer[(point_count - 1) * 2 + 1];
     last_node->ctrl1[0] = last_node->ctrl1[1] = last_node->ctrl2[0] = last_node->ctrl2[1] = -1.0f;
     last_node->border[0] = last_node->border[1] = payload_buffer[(point_count - 1) * 4];
-    last_node->hardness = payload_buffer[(point_count - 1) * 4 + 1];
+    last_node->fading = payload_buffer[(point_count - 1) * 4 + 1];
     last_node->density = payload_buffer[(point_count - 1) * 4 + 2];
     last_node->state = DT_MASKS_POINT_STATE_NORMAL;
     result_list = g_list_append(result_list, (gpointer)last_node);
@@ -845,16 +845,16 @@ static int _brush_get_pts_border(dt_develop_t *develop, dt_masks_form_t *mask_fo
     if(cw > 0)
     {
       const float pa[7] = { point1->node[0] * iwd - dx, point1->node[1] * iht - dy, point1->ctrl2[0] * iwd - dx,
-                            point1->ctrl2[1] * iht - dy, point1->border[1] * MIN(iwd, iht), point1->hardness,
+                            point1->ctrl2[1] * iht - dy, point1->border[1] * MIN(iwd, iht), point1->fading,
                             point1->density };
       const float pb[7] = { point2->node[0] * iwd - dx, point2->node[1] * iht - dy, point2->ctrl1[0] * iwd - dx,
-                            point2->ctrl1[1] * iht - dy, point2->border[0] * MIN(iwd, iht), point2->hardness,
+                            point2->ctrl1[1] * iht - dy, point2->border[0] * MIN(iwd, iht), point2->fading,
                             point2->density };
       const float pc[7] = { point2->node[0] * iwd - dx, point2->node[1] * iht - dy, point2->ctrl2[0] * iwd - dx,
-                            point2->ctrl2[1] * iht - dy, point2->border[1] * MIN(iwd, iht), point2->hardness,
+                            point2->ctrl2[1] * iht - dy, point2->border[1] * MIN(iwd, iht), point2->fading,
                             point2->density };
       const float pd[7] = { point3->node[0] * iwd - dx, point3->node[1] * iht - dy, point3->ctrl1[0] * iwd - dx,
-                            point3->ctrl1[1] * iht - dy, point3->border[0] * MIN(iwd, iht), point3->hardness,
+                            point3->ctrl1[1] * iht - dy, point3->border[0] * MIN(iwd, iht), point3->fading,
                             point3->density };
       memcpy(p1, pa, sizeof(float) * 7);
       memcpy(p2, pb, sizeof(float) * 7);
@@ -864,16 +864,16 @@ static int _brush_get_pts_border(dt_develop_t *develop, dt_masks_form_t *mask_fo
     else
     {
       const float pa[7] = { point1->node[0] * iwd - dx, point1->node[1] * iht - dy, point1->ctrl1[0] * iwd - dx,
-                            point1->ctrl1[1] * iht - dy, point1->border[1] * MIN(iwd, iht), point1->hardness,
+                            point1->ctrl1[1] * iht - dy, point1->border[1] * MIN(iwd, iht), point1->fading,
                             point1->density };
       const float pb[7] = { point2->node[0] * iwd - dx, point2->node[1] * iht - dy, point2->ctrl2[0] * iwd - dx,
-                            point2->ctrl2[1] * iht - dy, point2->border[0] * MIN(iwd, iht), point2->hardness,
+                            point2->ctrl2[1] * iht - dy, point2->border[0] * MIN(iwd, iht), point2->fading,
                             point2->density };
       const float pc[7] = { point2->node[0] * iwd - dx, point2->node[1] * iht - dy, point2->ctrl1[0] * iwd - dx,
-                            point2->ctrl1[1] * iht - dy, point2->border[1] * MIN(iwd, iht), point2->hardness,
+                            point2->ctrl1[1] * iht - dy, point2->border[1] * MIN(iwd, iht), point2->fading,
                             point2->density };
       const float pd[7] = { point3->node[0] * iwd - dx, point3->node[1] * iht - dy, point3->ctrl2[0] * iwd - dx,
-                            point3->ctrl2[1] * iht - dy, point3->border[0] * MIN(iwd, iht), point3->hardness,
+                            point3->ctrl2[1] * iht - dy, point3->border[0] * MIN(iwd, iht), point3->fading,
                             point3->density };
       memcpy(p1, pa, sizeof(float) * 7);
       memcpy(p2, pb, sizeof(float) * 7);
@@ -881,7 +881,7 @@ static int _brush_get_pts_border(dt_develop_t *develop, dt_masks_form_t *mask_fo
       memcpy(p4, pd, sizeof(float) * 7);
     }
 
-    // 1st. special case: render abrupt transitions between different opacity and/or hardness values
+    // 1st. special case: render abrupt transitions between different opacity and/or fading values
     if((fabsf(p1[5] - p2[5]) > 0.05f || fabsf(p1[6] - p2[6]) > 0.05f)
        || (start_stamp && n == 2 * node_count - 1))
     {
@@ -1350,14 +1350,14 @@ static int _find_closest_handle(dt_masks_form_t *mask_form, dt_masks_form_gui_t 
 }
 
 
-static int _init_hardness(dt_masks_form_t *mask_form, int parentid, dt_masks_form_gui_t *mask_gui,
-                          const float amount, const dt_masks_increment_t increment, const int flow)
+static int _init_fading(dt_masks_form_t *mask_form, int parentid, dt_masks_form_gui_t *mask_gui,
+                        const float amount, const dt_masks_increment_t increment, const int flow)
 {
-  const float masks_hardness = dt_masks_get_set_conf_value_with_toast(mask_form, "hardness", amount,
-                                                                      HARDNESS_MIN, HARDNESS_MAX, increment, flow,
-                                                                      _("hardness: %3.2f%%"), 100.0f);
+  const float masks_fading = dt_masks_get_set_conf_value_with_toast(mask_form, "fading", amount,
+                                                                    FADING_MIN, FADING_MAX, increment, flow,
+                                                                    _("fading: %3.2f%%"), 100.0f);
   if(mask_gui->guipoints_count > 0)
-    dt_masks_dynbuf_set(mask_gui->guipoints_payload, -3, masks_hardness);
+    dt_masks_dynbuf_set(mask_gui->guipoints_payload, -3, masks_fading);
   return 1;
 }
 
@@ -1365,7 +1365,7 @@ static int _init_size(dt_masks_form_t *mask_form, int parentid, dt_masks_form_gu
                       const float amount, const dt_masks_increment_t increment, const int flow)
 {
   const float masks_border = dt_masks_get_set_conf_value_with_toast(mask_form, "border", amount,
-                                                                    HARDNESS_MIN, HARDNESS_MAX, increment, flow,
+                                                                    FADING_MIN, FADING_MAX, increment, flow,
                                                                     _("size: %3.2f%%"), 2.f * 100.f);
   if(mask_gui->guipoints_count > 0)
     dt_masks_dynbuf_set(mask_gui->guipoints_payload, -4, masks_border);
@@ -1392,20 +1392,20 @@ static float _brush_get_interaction_value(const dt_masks_form_t *mask_form, dt_m
       if(size <= 0.0f) return NAN;
       return size;
     }
-    case DT_MASKS_INTERACTION_HARDNESS:
+    case DT_MASKS_INTERACTION_FADING:
     {
-      float hardness_sum = 0.0f;
-      int hardness_count = 0;
+      float fading_sum = 0.0f;
+      int fading_count = 0;
 
       for(const GList *point_node = mask_form->points; point_node; point_node = g_list_next(point_node))
       {
         const dt_masks_node_brush_t *node = (const dt_masks_node_brush_t *)point_node->data;
         if(IS_NULL_PTR(node)) continue;
-        hardness_sum += node->hardness;
-        hardness_count++;
+        fading_sum += node->fading;
+        fading_count++;
       }
 
-      return hardness_count > 0 ? hardness_sum / (float)hardness_count : NAN;
+      return fading_count > 0 ? fading_sum / (float)fading_count : NAN;
     }
     default:
       return NAN;
@@ -1437,9 +1437,9 @@ static gboolean _brush_get_gravity_center(dt_develop_t *dev, const dt_masks_form
   return ok;
 }
 
-static int _change_hardness(dt_masks_form_t *mask_form, int parentid, dt_masks_form_gui_t *mask_gui,
-                            struct dt_iop_module_t *module, int index, const float amount,
-                            const dt_masks_increment_t increment, const int flow);
+static int _change_fading(dt_masks_form_t *mask_form, int parentid, dt_masks_form_gui_t *mask_gui,
+                          struct dt_iop_module_t *module, int index, const float amount,
+                          const dt_masks_increment_t increment, const int flow);
 static int _change_size(dt_masks_form_t *mask_form, int parentid, dt_masks_form_gui_t *mask_gui,
                         struct dt_iop_module_t *module, int index, const float amount,
                         const dt_masks_increment_t increment, const int flow);
@@ -1459,17 +1459,17 @@ static float _brush_set_interaction_value(dt_masks_form_t *mask_form, dt_masks_i
     case DT_MASKS_INTERACTION_SIZE:
       if(!_change_size(mask_form, 0, mask_gui, module, index, value, increment, flow)) return NAN;
       return _brush_get_interaction_value(mask_form, interaction);
-    case DT_MASKS_INTERACTION_HARDNESS:
-      if(!_change_hardness(mask_form, 0, mask_gui, module, index, value, increment, flow)) return NAN;
+    case DT_MASKS_INTERACTION_FADING:
+      if(!_change_fading(mask_form, 0, mask_gui, module, index, value, increment, flow)) return NAN;
       return _brush_get_interaction_value(mask_form, interaction);
     default:
       return NAN;
   }
 }
 
-static int _change_hardness(dt_masks_form_t *mask_form, int parentid, dt_masks_form_gui_t *mask_gui,
-                            struct dt_iop_module_t *module, int index, const float amount,
-                            const dt_masks_increment_t increment, const int flow)
+static int _change_fading(dt_masks_form_t *mask_form, int parentid, dt_masks_form_gui_t *mask_gui,
+                          struct dt_iop_module_t *module, int index, const float amount,
+                          const dt_masks_increment_t increment, const int flow)
 {
   if(IS_NULL_PTR(mask_form) || IS_NULL_PTR(mask_form->points)) return 0;
   int node_index = 0;
@@ -1481,14 +1481,14 @@ static int _change_hardness(dt_masks_form_t *mask_form, int parentid, dt_masks_f
     if(dt_masks_gui_change_affects_selected_node_or_all(mask_gui, node_index))
     {
       dt_masks_node_brush_t *node = (dt_masks_node_brush_t *)node_entry->data;
-      const float current_hardness = node->hardness;
-      result_amount = dt_masks_apply_increment_precomputed(current_hardness, amount, scale_amount, offset_amount, increment);
+      const float current_fading = node->fading;
+      result_amount = dt_masks_apply_increment_precomputed(current_fading, amount, scale_amount, offset_amount, increment);
 
-      node->hardness = CLAMPF(result_amount, HARDNESS_MIN, HARDNESS_MAX);
+      node->fading = CLAMPF(result_amount, FADING_MIN, FADING_MAX);
     }
   }
 
-  dt_masks_get_set_conf_value(mask_form, "hardness", result_amount, HARDNESS_MIN, HARDNESS_MAX, increment, flow);
+  dt_masks_get_set_conf_value(mask_form, "fading", result_amount, FADING_MIN, FADING_MAX, increment, flow);
 
   // we recreate the form points
   dt_masks_gui_form_create(mask_form, mask_gui, index, module);
@@ -1532,7 +1532,7 @@ static int _change_size(dt_masks_form_t *mask_form, int parentid, dt_masks_form_
     }
   }
 
-  dt_masks_get_set_conf_value(mask_form, "border", amount, HARDNESS_MIN, HARDNESS_MAX, increment, flow);
+  dt_masks_get_set_conf_value(mask_form, "border", amount, FADING_MIN, FADING_MAX, increment, flow);
 
   // we recreate the form points
   if(!IS_NULL_PTR(mask_gui) && !IS_NULL_PTR(module)) dt_masks_gui_form_create(mask_form, mask_gui, index, module);
@@ -1553,7 +1553,7 @@ static int _brush_events_mouse_scrolled(struct dt_iop_module_t *module, double w
   
   /* `state` is the caller's raw key state, kept for the callback signature: the property to
    * act on was already resolved from it by dt_masks_scroll_get_interaction(). A brush owns no
-   * rotation, so that mapping falls through and the wheel does nothing here. Size and hardness
+   * rotation, so that mapping falls through and the wheel does nothing here. Size and fading
    * apply to the selected node when there is one, to every node otherwise -- that scoping is
    * the selection's business (dt_masks_gui_change_affects_selected_node_or_all), not the
    * wheel's. */
@@ -1561,9 +1561,9 @@ static int _brush_events_mouse_scrolled(struct dt_iop_module_t *module, double w
   {
     switch(interaction)
     {
-      case DT_MASKS_INTERACTION_HARDNESS:
-        return _init_hardness(mask_form, parentid, mask_gui, scroll_up ? 1.02f : 0.98f,
-                              DT_MASKS_INCREMENT_SCALE, flow);
+      case DT_MASKS_INTERACTION_FADING:
+        return _init_fading(mask_form, parentid, mask_gui, scroll_up ? 1.02f : 0.98f,
+                            DT_MASKS_INCREMENT_SCALE, flow);
       case DT_MASKS_INTERACTION_OPACITY:
         return _init_opacity(mask_form, parentid, mask_gui, scroll_up ? +0.02f : -0.02f,
                              DT_MASKS_INCREMENT_OFFSET, flow);
@@ -1587,9 +1587,9 @@ static int _brush_events_mouse_scrolled(struct dt_iop_module_t *module, double w
     {
       case DT_MASKS_INTERACTION_OPACITY:
         return dt_masks_form_change_opacity(mask_gui->dev, mask_form, parentid, scroll_up, flow);
-      case DT_MASKS_INTERACTION_HARDNESS:
-        return _change_hardness(mask_form, parentid, mask_gui, module, index, scroll_up ? -0.01f : 0.01f,
-                                DT_MASKS_INCREMENT_OFFSET, flow);
+      case DT_MASKS_INTERACTION_FADING:
+        return _change_fading(mask_form, parentid, mask_gui, module, index, scroll_up ? -0.01f : 0.01f,
+                              DT_MASKS_INCREMENT_OFFSET, flow);
       case DT_MASKS_INTERACTION_SIZE:
         return _change_size(mask_form, parentid, mask_gui, module, index, scroll_up ? 1.02f : 0.98f,
                             DT_MASKS_INCREMENT_SCALE, flow);
@@ -1607,10 +1607,10 @@ static void _get_pressure_sensitivity(dt_masks_form_gui_t *mask_gui)
   const char *psens = dt_conf_get_string_const("pressure_sensitivity");
   if(!IS_NULL_PTR(psens))
   {
-    if(!strcmp(psens, "hardness (absolute)"))
-      mask_gui->pressure_sensitivity = DT_MASKS_PRESSURE_HARDNESS_ABS;
-    else if(!strcmp(psens, "hardness (relative)"))
-      mask_gui->pressure_sensitivity = DT_MASKS_PRESSURE_HARDNESS_REL;
+    if(!strcmp(psens, "fading (absolute)"))
+      mask_gui->pressure_sensitivity = DT_MASKS_PRESSURE_FADING_ABS;
+    else if(!strcmp(psens, "fading (relative)"))
+      mask_gui->pressure_sensitivity = DT_MASKS_PRESSURE_FADING_REL;
     else if(!strcmp(psens, "opacity (absolute)"))
       mask_gui->pressure_sensitivity = DT_MASKS_PRESSURE_OPACITY_ABS;
     else if(!strcmp(psens, "opacity (relative)"))
@@ -1658,7 +1658,7 @@ static void _add_node_to_segment(struct dt_iop_module_t *module, dt_masks_form_t
   dt_masks_node_brush_t *point1 = (dt_masks_node_brush_t *)next_pt->data;
   new_node->border[0] = point0->border[0] * (1.0f - t) + point1->border[0] * t;
   new_node->border[1] = point0->border[1] * (1.0f - t) + point1->border[1] * t;
-  new_node->hardness = point0->hardness * (1.0f - t) + point1->hardness * t;
+  new_node->fading = point0->fading * (1.0f - t) + point1->fading * t;
   new_node->density = point0->density * (1.0f - t) + point1->density * t;
 
   mask_form->points = g_list_insert(mask_form->points, new_node, selected_segment + 1);
@@ -1701,9 +1701,9 @@ static int _brush_events_button_pressed(struct dt_iop_module_t *module, double w
     {
       // The trick is to use the incremental setting, set to 1.0 to re-use the generic getter/setter without changing value
       float masks_border = dt_masks_get_set_conf_value(mask_form, "border", 1.0f,
-                                                       HARDNESS_MIN, HARDNESS_MAX, TRUE, 1);
-      float masks_hardness = dt_masks_get_set_conf_value(mask_form, "hardness", 1.0f,
-                                                         HARDNESS_MIN, HARDNESS_MAX, TRUE, 1);
+                                                       FADING_MIN, FADING_MAX, TRUE, 1);
+      float masks_fading = dt_masks_get_set_conf_value(mask_form, "fading", 1.0f,
+                                                       FADING_MIN, FADING_MAX, TRUE, 1);
     
       if(dt_modifier_is(state, DT_PRIMARY_MASK | GDK_SHIFT_MASK) || dt_modifier_is(state, GDK_SHIFT_MASK))
       {
@@ -1720,7 +1720,7 @@ static int _brush_events_button_pressed(struct dt_iop_module_t *module, double w
         mask_gui->guipoints_payload = dt_masks_dynbuf_init(400000, "brush guipoints_payload");
       if(IS_NULL_PTR(mask_gui->guipoints_payload)) return 1;
       dt_masks_dynbuf_add_2(mask_gui->guipoints, mask_gui->pos[0], mask_gui->pos[1]);
-      dt_masks_dynbuf_add_2(mask_gui->guipoints_payload, masks_border, masks_hardness);
+      dt_masks_dynbuf_add_2(mask_gui->guipoints_payload, masks_border, masks_fading);
       dt_masks_dynbuf_add_2(mask_gui->guipoints_payload, masks_density, pressure);
       dt_control_mouse_is_painting(TRUE);
       mask_gui->guipoints_count = 1;
@@ -1859,13 +1859,13 @@ static void _apply_pen_pressure(dt_masks_form_gui_t *mask_gui, float *payload_bu
     switch(mask_gui->pressure_sensitivity)
     {
       case DT_MASKS_PRESSURE_BRUSHSIZE_REL:
-        payload[0] = MAX(HARDNESS_MIN, payload[0] * pressure);
+        payload[0] = MAX(FADING_MIN, payload[0] * pressure);
         break;
-      case DT_MASKS_PRESSURE_HARDNESS_ABS:
-        payload[1] = MAX(HARDNESS_MIN, pressure);
+      case DT_MASKS_PRESSURE_FADING_ABS:
+        payload[1] = MAX(FADING_MIN, pressure);
         break;
-      case DT_MASKS_PRESSURE_HARDNESS_REL:
-        payload[1] = MAX(HARDNESS_MIN, payload[1] * pressure);
+      case DT_MASKS_PRESSURE_FADING_REL:
+        payload[1] = MAX(FADING_MIN, payload[1] * pressure);
         break;
       case DT_MASKS_PRESSURE_OPACITY_ABS:
         payload[2] = MAX(0.05f, pressure);
@@ -1895,7 +1895,7 @@ static int _brush_events_button_released(struct dt_iop_module_t *module, double 
 
   // The trick is to use the incremental setting, set to 1.0 to re-use the generic getter/setter without changing value
   float masks_border = dt_masks_get_set_conf_value(mask_form, "border", 1.0f,
-                                                   HARDNESS_MIN, HARDNESS_MAX, TRUE, 1);
+                                                   FADING_MIN, FADING_MAX, TRUE, 1);
 
   if(mask_gui->creation && which == 1)
   {
@@ -1918,10 +1918,10 @@ static int _brush_events_button_released(struct dt_iop_module_t *module, double 
         const float y = dt_masks_dynbuf_get(mask_gui->guipoints, -1) - 0.01f;
         dt_masks_dynbuf_add_2(mask_gui->guipoints, x, y);
         const float border = dt_masks_dynbuf_get(mask_gui->guipoints_payload, -4);
-        const float hardness = dt_masks_dynbuf_get(mask_gui->guipoints_payload, -3);
+        const float fading = dt_masks_dynbuf_get(mask_gui->guipoints_payload, -3);
         const float density = dt_masks_dynbuf_get(mask_gui->guipoints_payload, -2);
         const float pressure = dt_masks_dynbuf_get(mask_gui->guipoints_payload, -1);
-        dt_masks_dynbuf_add_2(mask_gui->guipoints_payload, border, hardness);
+        dt_masks_dynbuf_add_2(mask_gui->guipoints_payload, border, fading);
         dt_masks_dynbuf_add_2(mask_gui->guipoints_payload, density, pressure);
         mask_gui->guipoints_count++;
       }
@@ -1936,7 +1936,7 @@ static int _brush_events_button_released(struct dt_iop_module_t *module, double 
       _apply_pen_pressure(mask_gui, guipoints_payload);
 
       // accuracy level for node elimination, dependent on brush size
-      const float epsilon2 = _get_brush_smoothing() * sqf(MAX(HARDNESS_MIN, masks_border));
+      const float epsilon2 = _get_brush_smoothing() * sqf(MAX(FADING_MIN, masks_border));
 
       // we simplify the path and generate the nodes
       mask_form->points = _brush_ramer_douglas_peucker(guipoints, mask_gui->guipoints_count,
@@ -2033,9 +2033,9 @@ static int _brush_events_mouse_moved(struct dt_iop_module_t *module, double widg
     {
       dt_masks_dynbuf_add_2(mask_gui->guipoints, mask_gui->pos[0], mask_gui->pos[1]);
       const float border = dt_masks_dynbuf_get(mask_gui->guipoints_payload, -4);
-      const float hardness = dt_masks_dynbuf_get(mask_gui->guipoints_payload, -3);
+      const float fading = dt_masks_dynbuf_get(mask_gui->guipoints_payload, -3);
       const float density = dt_masks_dynbuf_get(mask_gui->guipoints_payload, -2);
-      dt_masks_dynbuf_add_2(mask_gui->guipoints_payload, border, hardness);
+      dt_masks_dynbuf_add_2(mask_gui->guipoints_payload, border, fading);
       dt_masks_dynbuf_add_2(mask_gui->guipoints_payload, density, pressure);
       mask_gui->guipoints_count++;
       return 1;
@@ -2370,11 +2370,11 @@ static void _brush_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks_fo
 
       const float masks_border = dt_masks_get_set_conf_value(mask_form, "border", 1.0f, BORDER_MIN, BORDER_MAX,
                                                              DT_MASKS_INCREMENT_SCALE, 1);
-      const float masks_hardness = dt_masks_get_set_conf_value(mask_form, "hardness", 1.0f, HARDNESS_MIN,
-                                                               HARDNESS_MAX, DT_MASKS_INCREMENT_SCALE, 1);
+      const float masks_fading = dt_masks_get_set_conf_value(mask_form, "fading", 1.0f, FADING_MIN,
+                                                             FADING_MAX, DT_MASKS_INCREMENT_SCALE, 1);
       const float opacity = dt_conf_get_float("plugins/darkroom/masks/opacity");
 
-      const float radius1 = masks_border * masks_hardness * min_iwd_iht;
+      const float radius1 = masks_border * masks_fading * min_iwd_iht;
       const float radius2 = masks_border * min_iwd_iht;
 
       float xpos = mask_gui->pos[0];
@@ -2405,7 +2405,7 @@ static void _brush_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks_fo
     }
     else
     {
-      float masks_border = 0.0f, masks_hardness = 0.0f, masks_density = 0.0f;
+      float masks_border = 0.0f, masks_fading = 0.0f, masks_density = 0.0f;
       float radius = 0.0f, oldradius = 0.0f, opacity = 0.0f, oldopacity = 0.0f, pressure = 0.0f;
       int stroked = 1;
 
@@ -2416,17 +2416,17 @@ static void _brush_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks_fo
       cairo_set_line_join(cr, CAIRO_LINE_JOIN_ROUND);
       cairo_set_line_cap(cr, CAIRO_LINE_CAP_ROUND);
       masks_border = guipoints_payload[0];
-      masks_hardness = guipoints_payload[1];
+      masks_fading = guipoints_payload[1];
       masks_density = guipoints_payload[2];
       pressure = guipoints_payload[3];
 
       switch(mask_gui->pressure_sensitivity)
       {
-        case DT_MASKS_PRESSURE_HARDNESS_ABS:
-          masks_hardness = MAX(HARDNESS_MIN, pressure);
+        case DT_MASKS_PRESSURE_FADING_ABS:
+          masks_fading = MAX(FADING_MIN, pressure);
           break;
-        case DT_MASKS_PRESSURE_HARDNESS_REL:
-          masks_hardness = MAX(HARDNESS_MIN, masks_hardness * pressure);
+        case DT_MASKS_PRESSURE_FADING_REL:
+          masks_fading = MAX(FADING_MIN, masks_fading * pressure);
           break;
         case DT_MASKS_PRESSURE_OPACITY_ABS:
           masks_density = MAX(0.05f, pressure);
@@ -2435,7 +2435,7 @@ static void _brush_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks_fo
           masks_density = MAX(0.05f, masks_density * pressure);
           break;
         case DT_MASKS_PRESSURE_BRUSHSIZE_REL:
-          masks_border = MAX(HARDNESS_MIN, masks_border * pressure);
+          masks_border = MAX(FADING_MIN, masks_border * pressure);
           break;
         default:
         case DT_MASKS_PRESSURE_OFF:
@@ -2443,7 +2443,7 @@ static void _brush_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks_fo
           break;
       }
 
-      radius = oldradius = masks_border * masks_hardness * min_iwd_iht;
+      radius = oldradius = masks_border * masks_fading * min_iwd_iht;
       opacity = oldopacity = masks_density;
 
       cairo_set_line_width(cr,  DT_PIXEL_APPLY_DPI(2 * radius));
@@ -2455,17 +2455,17 @@ static void _brush_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks_fo
         cairo_line_to(cr, guipoints[i * 2], guipoints[i * 2 + 1]);
         stroked = 0;
         masks_border = guipoints_payload[i * 4];
-        masks_hardness = guipoints_payload[i * 4 + 1];
+        masks_fading = guipoints_payload[i * 4 + 1];
         masks_density = guipoints_payload[i * 4 + 2];
         pressure = guipoints_payload[i * 4 + 3];
 
         switch(mask_gui->pressure_sensitivity)
         {
-          case DT_MASKS_PRESSURE_HARDNESS_ABS:
-            masks_hardness = MAX(HARDNESS_MIN, pressure);
+          case DT_MASKS_PRESSURE_FADING_ABS:
+            masks_fading = MAX(FADING_MIN, pressure);
             break;
-          case DT_MASKS_PRESSURE_HARDNESS_REL:
-            masks_hardness = MAX(HARDNESS_MIN, masks_hardness * pressure);
+          case DT_MASKS_PRESSURE_FADING_REL:
+            masks_fading = MAX(FADING_MIN, masks_fading * pressure);
             break;
           case DT_MASKS_PRESSURE_OPACITY_ABS:
             masks_density = MAX(0.05f, pressure);
@@ -2474,7 +2474,7 @@ static void _brush_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks_fo
             masks_density = MAX(0.05f, masks_density * pressure);
             break;
           case DT_MASKS_PRESSURE_BRUSHSIZE_REL:
-            masks_border = MAX(HARDNESS_MIN, masks_border * pressure);
+            masks_border = MAX(FADING_MIN, masks_border * pressure);
             break;
           default:
           case DT_MASKS_PRESSURE_OFF:
@@ -2482,7 +2482,7 @@ static void _brush_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks_fo
             break;
         }
 
-        radius = masks_border * masks_hardness * min_iwd_iht;
+        radius = masks_border * masks_fading * min_iwd_iht;
         opacity = masks_density;
 
         if(radius != oldradius || opacity != oldopacity)
@@ -2801,13 +2801,13 @@ static dt_masks_raster_result_t _brush_get_area(const dt_iop_module_t *const mod
 
 /** we write a falloff segment */
 static void _brush_falloff(float *const restrict buffer, int segment_start[2], int segment_end[2],
-                           int offset_x, int offset_y, int buffer_width, float hardness, float density)
+                           int offset_x, int offset_y, int buffer_width, float fading, float density)
 {
   // segment length
   const int segment_length = sqrt((segment_end[0] - segment_start[0]) * (segment_end[0] - segment_start[0])
                                   + (segment_end[1] - segment_start[1]) * (segment_end[1] - segment_start[1]))
                              + 1;
-  const int solid_length = (int)segment_length * hardness;
+  const int solid_length = (int)segment_length * fading;
   const int soft_length = segment_length - solid_length;
 
   const float segment_dx = segment_end[0] - segment_start[0];
@@ -2964,13 +2964,13 @@ static dt_masks_raster_result_t _brush_get_mask(const dt_iop_module_t *const mod
 
 /** we write a falloff segment respecting limits of buffer */
 static inline void _brush_falloff_roi(float *buffer, const int *segment_start, const int *segment_end,
-                                      int buffer_width, int buffer_height, float hardness, float density)
+                                      int buffer_width, int buffer_height, float fading, float density)
 {
   // segment length (increase by 1 to avoid division-by-zero special case handling)
   const int segment_length = sqrt((segment_end[0] - segment_start[0]) * (segment_end[0] - segment_start[0])
                                   + (segment_end[1] - segment_start[1]) * (segment_end[1] - segment_start[1]))
                              + 1;
-  const int solid_length = hardness * segment_length;
+  const int solid_length = fading * segment_length;
 
   const float step_x = (float)(segment_end[0] - segment_start[0]) / (float)segment_length;
   const float step_y = (float)(segment_end[1] - segment_start[1]) / (float)segment_length;

--- a/src/develop/masks/circle.c
+++ b/src/develop/masks/circle.c
@@ -47,8 +47,8 @@
 #include "math/openmp_maths.h"
 #include "widgets/accelerators.h"
 
-#define HARDNESS_MIN 0.0005f
-#define HARDNESS_MAX 1.0f
+#define FADING_MIN 0.0005f
+#define FADING_MAX 1.0f
 
 #define BORDER_MIN 0.00005f
 #define BORDER_MAX 0.5f
@@ -184,17 +184,17 @@ static int _circle_get_creation_preview(dt_masks_form_t *form, dt_masks_form_gui
   return err;
 }
 
-static int _init_hardness(dt_masks_form_t *form, const float amount, const dt_masks_increment_t increment, const int flow)
+static int _init_fading(dt_masks_form_t *form, const float amount, const dt_masks_increment_t increment, const int flow)
 {
-  dt_masks_get_set_conf_value_with_toast(form, "border", amount, HARDNESS_MIN, HARDNESS_MAX,
-                                         increment, flow, _("Hardness: %3.2f%%"), 100.0f);
+  dt_masks_get_set_conf_value_with_toast(form, "border", amount, FADING_MIN, FADING_MAX,
+                                         increment, flow, _("Fading: %3.2f%%"), 100.0f);
   return 1;
 }
 
 static int _init_size(dt_masks_form_t *form, const float amount, const dt_masks_increment_t increment, const int flow)
 {
 
-  dt_masks_get_set_conf_value_with_toast(form, "size", amount, HARDNESS_MIN, HARDNESS_MAX,
+  dt_masks_get_set_conf_value_with_toast(form, "size", amount, FADING_MIN, FADING_MAX,
                                          increment, flow, _("Size: %3.2f%%"), 2.f * 100.f);
   return 1;
 }
@@ -216,7 +216,7 @@ static float _circle_get_interaction_value(const dt_masks_form_t *form, dt_masks
   {
     case DT_MASKS_INTERACTION_SIZE:
       return circle->radius;
-    case DT_MASKS_INTERACTION_HARDNESS:
+    case DT_MASKS_INTERACTION_FADING:
       return circle->border;
     default:
       return NAN;
@@ -234,8 +234,8 @@ static gboolean _circle_get_gravity_center(dt_develop_t *dev, const dt_masks_for
   return TRUE;
 }
 
-static int _change_hardness(dt_masks_form_t *form, dt_masks_form_gui_t *gui, struct dt_iop_module_t *module,
-                            int index, const float amount, const dt_masks_increment_t increment, const int flow);
+static int _change_fading(dt_masks_form_t *form, dt_masks_form_gui_t *gui, struct dt_iop_module_t *module,
+                          int index, const float amount, const dt_masks_increment_t increment, const int flow);
 static int _change_size(dt_masks_form_t *form, dt_masks_form_gui_t *gui, struct dt_iop_module_t *module,
                         int index, const float amount, const dt_masks_increment_t increment, const int flow);
 
@@ -254,24 +254,24 @@ static float _circle_set_interaction_value(dt_masks_form_t *form, dt_masks_inter
     case DT_MASKS_INTERACTION_SIZE:
       if(!_change_size(form, gui, module, index, value, increment, flow)) return NAN;
       return _circle_get_interaction_value(form, interaction);
-    case DT_MASKS_INTERACTION_HARDNESS:
-      if(!_change_hardness(form, gui, module, index, value, increment, flow)) return NAN;
+    case DT_MASKS_INTERACTION_FADING:
+      if(!_change_fading(form, gui, module, index, value, increment, flow)) return NAN;
       return _circle_get_interaction_value(form, interaction);
     default:
       return NAN;
   }
 }
 
-static int _change_hardness(dt_masks_form_t *form, dt_masks_form_gui_t *gui, struct dt_iop_module_t *module, int index, const float amount, const dt_masks_increment_t increment, const int flow)
+static int _change_fading(dt_masks_form_t *form, dt_masks_form_gui_t *gui, struct dt_iop_module_t *module, int index, const float amount, const dt_masks_increment_t increment, const int flow)
 {
   if(IS_NULL_PTR(form) || IS_NULL_PTR(form->points)) return 0;
   dt_masks_node_circle_t *circle = (dt_masks_node_circle_t *)(form->points)->data;
   if(IS_NULL_PTR(circle)) return 0;
 
   circle->border = CLAMPF(dt_masks_apply_increment(circle->border, amount, increment, flow),
-                          HARDNESS_MIN, HARDNESS_MAX);
+                          FADING_MIN, FADING_MAX);
 
-  _init_hardness(form, amount, increment, flow);
+  _init_fading(form, amount, increment, flow);
 
   // we recreate the form points
   dt_masks_gui_form_create(form, gui, index, module);
@@ -326,8 +326,8 @@ static int _circle_events_mouse_scrolled(struct dt_iop_module_t *module, double 
     {
       case DT_MASKS_INTERACTION_OPACITY:
         return _init_opacity(form, up ? +0.02f : -0.02f, DT_MASKS_INCREMENT_OFFSET, flow);
-      case DT_MASKS_INTERACTION_HARDNESS:
-        return _init_hardness(form, up ? +1.02f : 0.98f, DT_MASKS_INCREMENT_SCALE, flow);
+      case DT_MASKS_INTERACTION_FADING:
+        return _init_fading(form, up ? +1.02f : 0.98f, DT_MASKS_INCREMENT_SCALE, flow);
       case DT_MASKS_INTERACTION_SIZE:
         return _init_size(form, up ? +1.02f : 0.98f, DT_MASKS_INCREMENT_SCALE, flow);
       default:
@@ -340,8 +340,8 @@ static int _circle_events_mouse_scrolled(struct dt_iop_module_t *module, double 
     {
       case DT_MASKS_INTERACTION_OPACITY:
         return dt_masks_form_change_opacity(gui->dev, form, parentid, up, flow);
-      case DT_MASKS_INTERACTION_HARDNESS:
-        return _change_hardness(form, gui, module, index, up ? +1.02f : 0.98f, DT_MASKS_INCREMENT_SCALE, flow);
+      case DT_MASKS_INTERACTION_FADING:
+        return _change_fading(form, gui, module, index, up ? +1.02f : 0.98f, DT_MASKS_INCREMENT_SCALE, flow);
       case DT_MASKS_INTERACTION_SIZE:
         return _change_size(form, gui, module, index, up ? +1.02f : 0.98f, DT_MASKS_INCREMENT_SCALE, flow);
       default:

--- a/src/develop/masks/ellipse.c
+++ b/src/develop/masks/ellipse.c
@@ -49,8 +49,8 @@
 #include "widgets/accelerators.h"
 
 
-#define HARDNESS_MIN 0.0005f
-#define HARDNESS_MAX 1.0f
+#define FADING_MIN 0.0005f
+#define FADING_MAX 1.0f
 
 #define BORDER_MIN 0.00005f
 #define BORDER_MAX 0.5f
@@ -546,17 +546,17 @@ static int _find_closest_handle(dt_masks_form_t *mask_form, dt_masks_form_gui_t 
                                              _ellipse_distance_cb, _ellipse_post_select_cb, NULL);
 }
 
-static int _init_hardness(dt_masks_form_t *form, const float amount, const dt_masks_increment_t increment, const int flow)
+static int _init_fading(dt_masks_form_t *form, const float amount, const dt_masks_increment_t increment, const int flow)
 {
-  dt_masks_get_set_conf_value_with_toast(form, "border", amount, HARDNESS_MIN, HARDNESS_MAX,
-                                         increment, flow, _("Hardness: %3.2f%%"), 100.0f);
+  dt_masks_get_set_conf_value_with_toast(form, "border", amount, FADING_MIN, FADING_MAX,
+                                         increment, flow, _("Fading: %3.2f%%"), 100.0f);
   return 1;
 }
 
 static int _init_size(dt_masks_form_t *form, const float amount, const dt_masks_increment_t increment, const int flow)
 {
-  float mask_radius_a = dt_masks_get_set_conf_value(form, "radius_a", amount, HARDNESS_MIN, HARDNESS_MAX, increment, flow);
-  float mask_radius_b = dt_masks_get_set_conf_value(form, "radius_b", amount, HARDNESS_MIN, HARDNESS_MAX, increment, flow);
+  float mask_radius_a = dt_masks_get_set_conf_value(form, "radius_a", amount, FADING_MIN, FADING_MAX, increment, flow);
+  float mask_radius_b = dt_masks_get_set_conf_value(form, "radius_b", amount, FADING_MIN, FADING_MAX, increment, flow);
   dt_toast_log(_("Size: %3.2f%%"), fmaxf(mask_radius_a, mask_radius_b) * 2.f * 100.f);
   return 1;
 }
@@ -585,7 +585,7 @@ static float _ellipse_get_interaction_value(const dt_masks_form_t *form, dt_mask
   {
     case DT_MASKS_INTERACTION_SIZE:
       return fmaxf(ellipse->radius[0], ellipse->radius[1]);
-    case DT_MASKS_INTERACTION_HARDNESS:
+    case DT_MASKS_INTERACTION_FADING:
       return ellipse->border;
     case DT_MASKS_INTERACTION_ROTATION:
       return ellipse->rotation;
@@ -605,8 +605,8 @@ static gboolean _ellipse_get_gravity_center(dt_develop_t *dev, const dt_masks_fo
   return TRUE;
 }
 
-static int _change_hardness(dt_masks_form_t *form, dt_masks_form_gui_t *gui, struct dt_iop_module_t *module,
-                            int index, const float amount, const dt_masks_increment_t increment, const int flow);
+static int _change_fading(dt_masks_form_t *form, dt_masks_form_gui_t *gui, struct dt_iop_module_t *module,
+                          int index, const float amount, const dt_masks_increment_t increment, const int flow);
 static int _change_size(dt_masks_form_t *form, dt_masks_form_gui_t *gui, struct dt_iop_module_t *module,
                         int index, const float amount, const dt_masks_increment_t increment, const int flow);
 static int _change_rotation(dt_masks_form_t *form, dt_masks_form_gui_t *gui, struct dt_iop_module_t *module,
@@ -627,8 +627,8 @@ static float _ellipse_set_interaction_value(dt_masks_form_t *form, dt_masks_inte
     case DT_MASKS_INTERACTION_SIZE:
       if(!_change_size(form, gui, module, index, value, increment, flow)) return NAN;
       return _ellipse_get_interaction_value(form, interaction);
-    case DT_MASKS_INTERACTION_HARDNESS:
-      if(!_change_hardness(form, gui, module, index, value, increment, flow)) return NAN;
+    case DT_MASKS_INTERACTION_FADING:
+      if(!_change_fading(form, gui, module, index, value, increment, flow)) return NAN;
       return _ellipse_get_interaction_value(form, interaction);
     case DT_MASKS_INTERACTION_ROTATION:
       if(!_change_rotation(form, gui, module, index, value, increment, flow)) return NAN;
@@ -638,16 +638,16 @@ static float _ellipse_set_interaction_value(dt_masks_form_t *form, dt_masks_inte
   }
 }
 
-static int _change_hardness(dt_masks_form_t *form, dt_masks_form_gui_t *gui, struct dt_iop_module_t *module, int index, const float amount, const dt_masks_increment_t increment, const int flow)
+static int _change_fading(dt_masks_form_t *form, dt_masks_form_gui_t *gui, struct dt_iop_module_t *module, int index, const float amount, const dt_masks_increment_t increment, const int flow)
 {
   if(IS_NULL_PTR(form) || IS_NULL_PTR(form->points)) return 0;
   dt_masks_node_ellipse_t *ellipse = (dt_masks_node_ellipse_t *)(form->points)->data;
   if(IS_NULL_PTR(ellipse)) return 0;
 
   ellipse->border = CLAMPF(dt_masks_apply_increment(ellipse->border, amount, increment, flow),
-                           HARDNESS_MIN, HARDNESS_MAX);
+                           FADING_MIN, FADING_MAX);
 
-  _init_hardness(form, amount, increment, flow);
+  _init_fading(form, amount, increment, flow);
 
   // we recreate the form points
   dt_masks_gui_form_create(form, gui, index, module);
@@ -719,8 +719,8 @@ static int _ellipse_events_mouse_scrolled(struct dt_iop_module_t *module, double
         return _init_rotation(form, (up ? +0.2f : -0.2f), DT_MASKS_INCREMENT_OFFSET, flow);
       case DT_MASKS_INTERACTION_OPACITY:
         return _init_opacity(form, up ? +0.02f : -0.02f, DT_MASKS_INCREMENT_OFFSET, flow);
-      case DT_MASKS_INTERACTION_HARDNESS:
-        return _init_hardness(form, (up ? 1.03f : 0.97f), DT_MASKS_INCREMENT_SCALE, flow);
+      case DT_MASKS_INTERACTION_FADING:
+        return _init_fading(form, (up ? 1.03f : 0.97f), DT_MASKS_INCREMENT_SCALE, flow);
       case DT_MASKS_INTERACTION_SIZE:
         return _init_size(form, (up ? 1.03f : 0.97f), DT_MASKS_INCREMENT_SCALE, flow);
       default:
@@ -735,8 +735,8 @@ static int _ellipse_events_mouse_scrolled(struct dt_iop_module_t *module, double
         return _change_rotation(form, gui, module, index, (up ? +0.2f : -0.2f), DT_MASKS_INCREMENT_OFFSET, flow);
       case DT_MASKS_INTERACTION_OPACITY:
         return dt_masks_form_change_opacity(gui->dev, form, parentid, up, flow);
-      case DT_MASKS_INTERACTION_HARDNESS:
-        return _change_hardness(form, gui, module, index, (up ? 1.02f : 0.98f), DT_MASKS_INCREMENT_SCALE, flow);
+      case DT_MASKS_INTERACTION_FADING:
+        return _change_fading(form, gui, module, index, (up ? 1.02f : 0.98f), DT_MASKS_INCREMENT_SCALE, flow);
       case DT_MASKS_INTERACTION_SIZE:
         return _change_size(form, gui, module, index, (up ? 1.02f : 0.98f), DT_MASKS_INCREMENT_SCALE, flow);
       default:
@@ -1702,7 +1702,7 @@ static void _ellipse_set_hint_message(const dt_masks_form_gui_t *const gui, cons
   else if(gui->border_selected)
     g_strlcat(msgbuf, _("<b>Rotate</b>: Drag"), msgbuf_len);
   else if(gui->form_selected)
-    g_strlcat(msgbuf, _("<b>Move</b>: Drag, <b>Hardness mode</b>: Shift+Click"), msgbuf_len);
+    g_strlcat(msgbuf, _("<b>Move</b>: Drag, <b>Fading mode</b>: Shift+Click"), msgbuf_len);
 }
 
 static void _ellipse_sanitize_config(dt_masks_type_t type)

--- a/src/develop/masks/gradient.c
+++ b/src/develop/masks/gradient.c
@@ -404,7 +404,7 @@ static float _gradient_get_interaction_value(const dt_masks_form_t *form, dt_mas
   {
     case DT_MASKS_INTERACTION_SIZE:
       return gradient->extent;
-    case DT_MASKS_INTERACTION_HARDNESS:
+    case DT_MASKS_INTERACTION_FADING:
       return gradient->curvature;
     case DT_MASKS_INTERACTION_ROTATION:
       return gradient->rotation;
@@ -446,7 +446,7 @@ static float _gradient_set_interaction_value(dt_masks_form_t *form, dt_masks_int
     case DT_MASKS_INTERACTION_SIZE:
       if(!_change_extent(form, gui, module, index, value, increment, flow)) return NAN;
       return _gradient_get_interaction_value(form, interaction);
-    case DT_MASKS_INTERACTION_HARDNESS:
+    case DT_MASKS_INTERACTION_FADING:
       if(!_change_curvature(form, gui, module, index, value, increment, flow)) return NAN;
       return _gradient_get_interaction_value(form, interaction);
     case DT_MASKS_INTERACTION_ROTATION:
@@ -535,7 +535,7 @@ static int _gradient_events_mouse_scrolled(struct dt_iop_module_t *module, doubl
   
   /* `state` is the caller's raw key state, kept for the callback signature: the property to
    * act on was already resolved from it by dt_masks_scroll_get_interaction(). A gradient
-   * spells the two shared properties its own way -- SIZE is the fade extent, HARDNESS is the
+   * spells the two shared properties its own way -- SIZE is the fade extent, FADING is the
    * curvature -- which is also how the context menu names them (masks_gui.c). */
   if(gui->creation)
   {
@@ -545,7 +545,7 @@ static int _gradient_events_mouse_scrolled(struct dt_iop_module_t *module, doubl
         return _init_rotation(form, (up ? +0.2f : -0.2f), DT_MASKS_INCREMENT_OFFSET, flow);
       case DT_MASKS_INTERACTION_OPACITY:
         return _init_opacity(form, up ? +0.02f : -0.02f, DT_MASKS_INCREMENT_OFFSET, flow);
-      case DT_MASKS_INTERACTION_HARDNESS:
+      case DT_MASKS_INTERACTION_FADING:
         return _init_curvature(form, up ? +0.02f : -0.02f, DT_MASKS_INCREMENT_OFFSET, flow);
       case DT_MASKS_INTERACTION_SIZE:
         return _init_extent(form, (up ? +1.02f : 0.98f), DT_MASKS_INCREMENT_SCALE, flow);
@@ -561,7 +561,7 @@ static int _gradient_events_mouse_scrolled(struct dt_iop_module_t *module, doubl
         return _change_rotation(form, gui, module, index, (up ? +0.2f : -0.2f), DT_MASKS_INCREMENT_OFFSET, flow);
       case DT_MASKS_INTERACTION_OPACITY:
         return dt_masks_form_change_opacity(gui->dev, form, parentid, up, flow);
-      case DT_MASKS_INTERACTION_HARDNESS:
+      case DT_MASKS_INTERACTION_FADING:
         return _change_curvature(form, gui, module, index, (up ? +0.02f : -0.02f), DT_MASKS_INCREMENT_OFFSET, flow);
       case DT_MASKS_INTERACTION_SIZE:
         return _change_extent(form, gui, module, index, (up ? 1.02f : 0.98f), DT_MASKS_INCREMENT_SCALE, flow);

--- a/src/develop/masks/group.c
+++ b/src/develop/masks/group.c
@@ -640,7 +640,7 @@ __OMP_FOR_SIMD__(aligned(dest, newmask : 64)  if(npixels > 10000)
  * What has to be in the key is everything the fold reads:
  *
  *   - each shape's own content, via dt_masks_form_get_own_hash() -- for a brush that is every
- *     node's position, border, hardness and density, which is exactly what its rasterisation is
+ *     node's position, border, fading and density, which is exactly what its rasterisation is
  *     a function of;
  *   - each membership's state and opacity, which decide the combine operator and its weight;
  *   - the ROI, which decides the pixels;

--- a/src/develop/masks/masks.c
+++ b/src/develop/masks/masks.c
@@ -1544,7 +1544,7 @@ const char *dt_masks_type_name(const dt_masks_type_t type)
    *
    * These tokens are PERSISTED: they build plugins/darkroom/<plugin>/<type>/<feature>, declared in
    * data/anselconfig.xml.in. "polygon" can never become "path" -- a key outside confgen reads 0,
-   * which would silently reset the user's hardness. */
+   * which would silently reset the user's fading. */
   if(type & DT_MASKS_CIRCLE) return "circle";
   else if(type & DT_MASKS_POLYGON) return "polygon";
   else if(type & DT_MASKS_ELLIPSE) return "ellipse";

--- a/src/develop/masks/masks_gui.c
+++ b/src/develop/masks/masks_gui.c
@@ -703,19 +703,19 @@ void dt_masks_gui_populate_interaction_sliders(GtkWidget *menu, dt_develop_t *de
 
   if(form->type & DT_MASKS_GRADIENT)
   {
-    // For gradients, DT_MASKS_INTERACTION_HARDNESS is the shape curvature and
-    // DT_MASKS_INTERACTION_SIZE is the fade extent -- expose them under their actual names.
-    const float curvature = dt_masks_form_get_interaction_value(dev, group_id, form->formid, DT_MASKS_INTERACTION_HARDNESS);
+    // For gradients, DT_MASKS_INTERACTION_FADING is the shape curvature -- expose it
+    // under its actual name.
+    const float curvature = dt_masks_form_get_interaction_value(dev, group_id, form->formid, DT_MASKS_INTERACTION_FADING);
     const float fade = dt_masks_form_get_interaction_value(dev, group_id, form->formid, DT_MASKS_INTERACTION_SIZE);
     float rotation = dt_masks_form_get_interaction_value(dev, group_id, form->formid, DT_MASKS_INTERACTION_ROTATION);
     if(!isfinite(rotation)) rotation = 0.0f;
     if(rotation > 180.0f) rotation -= 360.0f;
 
-    dt_masks_gui_add_interaction_slider(menu, _("Curvature"), dev, group_id, form->formid, DT_MASKS_INTERACTION_HARDNESS,
+    dt_masks_gui_add_interaction_slider(menu, _("Curvature"), dev, group_id, form->formid, DT_MASKS_INTERACTION_FADING,
                                       DT_MASKS_INCREMENT_ABSOLUTE, -2.0f, 2.0f, 0.01f,
                                       isfinite(curvature) ? curvature : 0.0f, 3, "%", 50.0f,
                                       gui, module);
-    dt_masks_gui_add_interaction_slider(menu, _("Fade"), dev, group_id, form->formid, DT_MASKS_INTERACTION_SIZE,
+    dt_masks_gui_add_interaction_slider(menu, _("Size"), dev, group_id, form->formid, DT_MASKS_INTERACTION_SIZE,
                                       DT_MASKS_INCREMENT_ABSOLUTE, 0.0f, 1.0f, 0.001f,
                                       isfinite(fade) ? fade : 1.0f, 3, "%", 100.0f,
                                       gui, module);
@@ -726,14 +726,14 @@ void dt_masks_gui_populate_interaction_sliders(GtkWidget *menu, dt_develop_t *de
   }
   else
   {
-    const float hardness = dt_masks_form_get_interaction_value(dev, group_id, form->formid, DT_MASKS_INTERACTION_HARDNESS);
+    const float fading = dt_masks_form_get_interaction_value(dev, group_id, form->formid, DT_MASKS_INTERACTION_FADING);
 
     dt_masks_gui_add_interaction_slider(menu, _("Size"), dev, group_id, form->formid, DT_MASKS_INTERACTION_SIZE,
                                       DT_MASKS_INCREMENT_SCALE, -4.f, 4.0f, 0.01f, 0.0f, 2, "x", 1.0f,
                                       gui, module);
-    dt_masks_gui_add_interaction_slider(menu, _("Fading"), dev, group_id, form->formid, DT_MASKS_INTERACTION_HARDNESS,
+    dt_masks_gui_add_interaction_slider(menu, _("Fading"), dev, group_id, form->formid, DT_MASKS_INTERACTION_FADING,
                                       DT_MASKS_INCREMENT_ABSOLUTE, 0.f, 1.0f, 0.01f,
-                                      isfinite(hardness) ? hardness : 1.0f, 3, "%", 100.0f,
+                                      isfinite(fading) ? fading : 1.0f, 3, "%", 100.0f,
                                       gui, module);
 
     if(form->type & DT_MASKS_ELLIPSE)
@@ -2505,7 +2505,7 @@ static void _set_cursor_shape(dt_masks_form_gui_t *mask_gui)
     dt_masks_form_t *creation_form = dt_masks_get_visible_form(mask_gui->dev);
     if(!IS_NULL_PTR(creation_form) && (creation_form->type & DT_MASKS_BRUSH))
     {
-      // The brush tool draws its own filled size/hardness preview circle at the cursor
+      // The brush tool draws its own filled size/fading preview circle at the cursor
       // position (_brush_events_post_expose) -- a system cursor on top of it is redundant.
       dt_control_set_cursor_visible(FALSE);
       return;
@@ -2911,7 +2911,7 @@ static const char *const _scroll_conf_keys[DT_MASKS_SCROLL_MODIFIER_LAST]
  * them, never reorder them against dt_masks_interaction_t, and keep them in sync with the enum
  * declared for these four keys in data/anselconfig.xml.in. */
 static const char *const _interaction_conf_values[DT_MASKS_INTERACTION_LAST]
-    = { "none", "size", "hardness", "opacity", "rotation" };
+    = { "none", "size", "fading", "opacity", "rotation" };
 
 /* Both enums declare only non-negative enumerators, so a compiler is free to give them an
  * unsigned underlying type -- clang does, and then `x < 0' is a tautology it rejects under
@@ -2962,8 +2962,8 @@ const char *dt_masks_interaction_name(dt_masks_interaction_t interaction)
   {
     case DT_MASKS_INTERACTION_SIZE:
       return N_("Size");
-    case DT_MASKS_INTERACTION_HARDNESS:
-      return N_("Hardness");
+    case DT_MASKS_INTERACTION_FADING:
+      return N_("Fading");
     case DT_MASKS_INTERACTION_OPACITY:
       return N_("Opacity");
     case DT_MASKS_INTERACTION_ROTATION:
@@ -2978,12 +2978,11 @@ const char *dt_masks_interaction_alias_name(dt_masks_interaction_t interaction)
 {
   switch(interaction)
   {
-    case DT_MASKS_INTERACTION_SIZE:
-      return N_("Fade");
-    case DT_MASKS_INTERACTION_HARDNESS:
+    case DT_MASKS_INTERACTION_FADING:
       return N_("Curvature");
     default:
-      // Opacity and rotation mean the same thing to every shape, and "nothing" is not a property.
+      // Size, opacity and rotation mean the same thing to every shape, and "nothing" is not
+      // a property.
       return NULL;
   }
 }

--- a/src/develop/masks/polygon.c
+++ b/src/develop/masks/polygon.c
@@ -60,8 +60,8 @@
 #include "gui/actions/menu.h"
 #include <assert.h>
 
-#define HARDNESS_MIN 0.0005f
-#define HARDNESS_MAX 1.0f
+#define FADING_MIN 0.0005f
+#define FADING_MAX 1.0f
 
 #define BORDER_MIN 0.00005f
 #define BORDER_MAX 0.5f
@@ -1328,20 +1328,20 @@ static float _polygon_get_interaction_value(const dt_masks_form_t *mask_form,
       if(size <= 0.0f) return NAN;
       return size;
     }
-    case DT_MASKS_INTERACTION_HARDNESS:
+    case DT_MASKS_INTERACTION_FADING:
     {
-      float hardness_sum = 0.0f;
-      int hardness_count = 0;
+      float fading_sum = 0.0f;
+      int fading_count = 0;
 
       for(const GList *point_node = mask_form->points; point_node; point_node = g_list_next(point_node))
       {
         const dt_masks_node_polygon_t *node = (const dt_masks_node_polygon_t *)point_node->data;
         if(IS_NULL_PTR(node)) continue;
-        hardness_sum += node->border[0] + node->border[1];
-        hardness_count += 2;
+        fading_sum += node->border[0] + node->border[1];
+        fading_count += 2;
       }
 
-      return hardness_count > 0 ? hardness_sum / (float)hardness_count : NAN;
+      return fading_count > 0 ? fading_sum / (float)fading_count : NAN;
     }
     default:
       return NAN;
@@ -1377,9 +1377,9 @@ static gboolean _polygon_get_gravity_center(dt_develop_t *dev, const dt_masks_fo
 static int _change_size(dt_masks_form_t *mask_form, int parent_id, dt_masks_form_gui_t *mask_gui,
                         struct dt_iop_module_t *module, int form_index, const float amount,
                         const dt_masks_increment_t increment, const int flow);
-static int _change_hardness(dt_masks_form_t *mask_form, int parent_id, dt_masks_form_gui_t *mask_gui,
-                            struct dt_iop_module_t *module, int form_index, const float amount,
-                            const dt_masks_increment_t increment, int flow);
+static int _change_fading(dt_masks_form_t *mask_form, int parent_id, dt_masks_form_gui_t *mask_gui,
+                          struct dt_iop_module_t *module, int form_index, const float amount,
+                          const dt_masks_increment_t increment, int flow);
 
 static float _polygon_set_interaction_value(dt_masks_form_t *mask_form,
                                             dt_masks_interaction_t interaction, float value,
@@ -1397,8 +1397,8 @@ static float _polygon_set_interaction_value(dt_masks_form_t *mask_form,
     case DT_MASKS_INTERACTION_SIZE:
       if(!_change_size(mask_form, 0, mask_gui, module, index, value, increment, flow)) return NAN;
       return _polygon_get_interaction_value(mask_form, interaction);
-    case DT_MASKS_INTERACTION_HARDNESS:
-      if(!_change_hardness(mask_form, 0, mask_gui, module, index, value, increment, flow)) return NAN;
+    case DT_MASKS_INTERACTION_FADING:
+      if(!_change_fading(mask_form, 0, mask_gui, module, index, value, increment, flow)) return NAN;
       return _polygon_get_interaction_value(mask_form, interaction);
     default:
       return NAN;
@@ -1638,15 +1638,15 @@ static gboolean _polygon_form_gravity_center(const dt_masks_form_t *mask_form,
 }
 
 /**
- * @brief Initialize hardness from config and emit the toast with a size-normalized percentage.
+ * @brief Initialize fading from config and emit the toast with a size-normalized percentage.
  */
-static int _init_hardness(dt_masks_form_t *mask_form, const float amount,
-                          const dt_masks_increment_t increment, const int flow,
-                          const float mask_size, const float border_size)
+static int _init_fading(dt_masks_form_t *mask_form, const float amount,
+                        const dt_masks_increment_t increment, const int flow,
+                        const float mask_size, const float border_size)
 {
-  const float mask_hardness = dt_masks_get_set_conf_value(mask_form, "hardness", amount,
-                                                          HARDNESS_MIN, HARDNESS_MAX, increment, flow);
-  dt_toast_log(_("Hardness: %3.2f%%"), (border_size * mask_hardness) / mask_size * 100.0f);
+  const float mask_fading = dt_masks_get_set_conf_value(mask_form, "fading", amount,
+                                                        FADING_MIN, FADING_MAX, increment, flow);
+  dt_toast_log(_("Fading: %3.2f%%"), (border_size * mask_fading) / mask_size * 100.0f);
   return 1;
 }
 
@@ -1723,11 +1723,11 @@ static int _change_size(dt_masks_form_t *mask_form, int parent_id, dt_masks_form
 }
 
 /**
- * @brief Change polygon hardness for the active node scope or the full shape.
+ * @brief Change polygon fading for the active node scope or the full shape.
  */
-static int _change_hardness(dt_masks_form_t *mask_form, int parent_id, dt_masks_form_gui_t *mask_gui,
-                            struct dt_iop_module_t *module, int form_index, const float amount,
-                            const dt_masks_increment_t increment, int flow)
+static int _change_fading(dt_masks_form_t *mask_form, int parent_id, dt_masks_form_gui_t *mask_gui,
+                          struct dt_iop_module_t *module, int form_index, const float amount,
+                          const dt_masks_increment_t increment, int flow)
 {
   int node_index = 0;
   const float scale_amount = powf(amount, (float)flow);
@@ -1742,10 +1742,10 @@ static int _change_hardness(dt_masks_form_t *mask_form, int parent_id, dt_masks_
 
       node->border[0] = CLAMPF(dt_masks_apply_increment_precomputed(node->border[0], amount, scale_amount,
                                                                      offset_amount, increment),
-                               HARDNESS_MIN, HARDNESS_MAX);
+                               FADING_MIN, FADING_MAX);
       node->border[1] = CLAMPF(dt_masks_apply_increment_precomputed(node->border[1], amount, scale_amount,
                                                                      offset_amount, increment),
-                               HARDNESS_MIN, HARDNESS_MAX);
+                               FADING_MIN, FADING_MAX);
     }
   }
 
@@ -1753,7 +1753,7 @@ static int _change_hardness(dt_masks_form_t *mask_form, int parent_id, dt_masks_
   float border_size = 0.0f;
   _polygon_get_sizes(module, mask_form, mask_gui, form_index, &mask_size, &border_size);
 
-  _init_hardness(mask_form, amount, increment, flow, mask_size, border_size);
+  _init_fading(mask_form, amount, increment, flow, mask_size, border_size);
 
   // Rebuild the cached GUI geometry.
   dt_masks_gui_form_create(mask_form, mask_gui, form_index, module);
@@ -1762,7 +1762,7 @@ static int _change_hardness(dt_masks_form_t *mask_form, int parent_id, dt_masks_
 }
 
 /**
- * @brief Handle mouse wheel updates for polygon size/hardness/opacity.
+ * @brief Handle mouse wheel updates for polygon size/fading/opacity.
  */
 /* Shape handlers receive widget-space coordinates, while normalized output-image
  * coordinates come from `mask_gui->rel_pos` and absolute output-image
@@ -1784,18 +1784,18 @@ static int _polygon_events_mouse_scrolled(struct dt_iop_module_t *module, double
   /* `state` is the caller's raw key state, kept for the callback signature: the property to
    * act on was already resolved from it by dt_masks_scroll_get_interaction(). A polygon owns
    * no rotation, so that mapping falls through and the wheel does nothing here. Size and
-   * hardness apply to the selected node when there is one, to every node otherwise -- that
+   * fading apply to the selected node when there is one, to every node otherwise -- that
    * scoping is the selection's business (dt_masks_gui_change_affects_selected_node_or_all),
-   * not the wheel's, which is why a selected node no longer forces hardness. */
+   * not the wheel's, which is why a selected node no longer forces fading. */
   if(mask_gui->edit_mode == DT_MASKS_EDIT_FULL && dt_masks_is_anything_selected(mask_gui))
   {
     switch(interaction)
     {
       case DT_MASKS_INTERACTION_OPACITY:
         return dt_masks_form_change_opacity(mask_gui->dev, mask_form, parent_id, up, flow);
-      case DT_MASKS_INTERACTION_HARDNESS:
-        return _change_hardness(mask_form, parent_id, mask_gui, module, form_index, up ? +0.01f : -0.01f,
-                                DT_MASKS_INCREMENT_OFFSET, flow);
+      case DT_MASKS_INTERACTION_FADING:
+        return _change_fading(mask_form, parent_id, mask_gui, module, form_index, up ? +0.01f : -0.01f,
+                              DT_MASKS_INCREMENT_OFFSET, flow);
       case DT_MASKS_INTERACTION_SIZE:
         return _change_size(mask_form, parent_id, mask_gui, module, form_index, up ? 1.02f : 0.98f,
                             DT_MASKS_INCREMENT_SCALE, flow);
@@ -1858,7 +1858,7 @@ static int _polygon_events_button_pressed(struct dt_iop_module_t *module, double
 
       else // we create a node
       {
-        float masks_border = MIN(dt_conf_get_float("plugins/darkroom/masks/polygon/hardness"), HARDNESS_MAX);
+        float masks_border = MIN(dt_conf_get_float("plugins/darkroom/masks/polygon/fading"), FADING_MAX);
 
         int node_count = g_list_length(mask_form->points);
         // change the values
@@ -1868,7 +1868,7 @@ static int _polygon_events_button_pressed(struct dt_iop_module_t *module, double
         dt_masks_gui_cursor_to_raw_norm(mask_gui->dev, mask_gui, polygon_node->node);
 
         polygon_node->ctrl1[0] = polygon_node->ctrl1[1] = polygon_node->ctrl2[0] = polygon_node->ctrl2[1] = -1.0;
-        polygon_node->border[0] = polygon_node->border[1] = MAX(HARDNESS_MIN, masks_border);
+        polygon_node->border[0] = polygon_node->border[1] = MAX(FADING_MIN, masks_border);
         polygon_node->state = DT_MASKS_POINT_STATE_NORMAL;
   
         if(node_count == 0)
@@ -1878,7 +1878,7 @@ static int _polygon_events_button_pressed(struct dt_iop_module_t *module, double
           polygon_first_node->node[0] = polygon_node->node[0];
           polygon_first_node->node[1] = polygon_node->node[1];
           polygon_first_node->ctrl1[0] = polygon_first_node->ctrl1[1] = polygon_first_node->ctrl2[0] = polygon_first_node->ctrl2[1] = -1.0;
-          polygon_first_node->border[0] = polygon_first_node->border[1] = MAX(HARDNESS_MIN, masks_border);
+          polygon_first_node->border[0] = polygon_first_node->border[1] = MAX(FADING_MIN, masks_border);
           polygon_first_node->state = DT_MASKS_POINT_STATE_NORMAL;
           mask_form->points = g_list_append(mask_form->points, polygon_first_node);
 
@@ -3638,7 +3638,7 @@ static void _polygon_set_hint_message(const dt_masks_form_gui_t *const mask_gui,
   else if(mask_gui->source_selected)
     g_strlcat(msgbuf, _("<b>Move source</b>: Drag"), msgbuf_len);
   else if(mask_gui->handle_border_hovered >= 0)
-    g_strlcat(msgbuf, _("<b>Node hardness</b>: Drag"), msgbuf_len);
+    g_strlcat(msgbuf, _("<b>Node fading</b>: Drag"), msgbuf_len);
   else if(mask_gui->handle_hovered >= 0)
     g_strlcat(msgbuf, _("<b>Node curvature</b>: Drag"), msgbuf_len);
   // The node operations below need the node to be selected, which the first click does.

--- a/src/develop/masks_group.h
+++ b/src/develop/masks_group.h
@@ -101,7 +101,7 @@ guint dt_masks_group_copy_members(const struct dt_masks_form_t *group,
  * came from may be gone.
  *
  * THESE TOKENS ARE PERSISTED. They build the conf keys plugins/darkroom/<plugin>/<type>/<feature>
- * declared in data/anselconfig.xml.in (".../polygon/hardness" and friends), so the polygon token
+ * declared in data/anselconfig.xml.in (".../polygon/fading" and friends), so the polygon token
  * is "polygon" and can never become "path": a shape reading a key that is not in confgen gets 0,
  * which would silently reset the user's setting. dt_masks_type_t is a bit field, so first match
  * wins and the order below is load-bearing.

--- a/src/develop/masks_gui.h
+++ b/src/develop/masks_gui.h
@@ -704,7 +704,7 @@ const char *dt_masks_interaction_name(dt_masks_interaction_t interaction);
 /**
  * @brief The other word for a property, when a shape family spells it its own way.
  *
- * A gradient stores its fade extent in the SIZE slot and its curvature in the HARDNESS one --
+ * A gradient stores its fade extent in the SIZE slot and its curvature in the FADING one --
  * same property of the interaction API, different vocabulary in front of the user, which is
  * also why the context menu renames those two sliders for gradients. Any UI naming a property
  * generically must show both words, or the gradient's own vocabulary has no visible home.
@@ -755,7 +755,7 @@ float dt_masks_form_set_interaction_value(dt_develop_t *dev, int group_id, int f
  * or setting it in an absolute fashion, then save it to configuration.
  *
  * @param form the shape to change. We will read its type internally
- * @param feature the propertie to change: hardness, size, curvature (for gradients)
+ * @param feature the propertie to change: fading, size, curvature (for gradients)
  * @param new_value if increment is set to absolute, this is directly the updated value. if increment is offset, the updated value is old_value + new_value. if increment is scale, the updated value is old value * new_value.
  * @param v_min minimum acceptable value of the property for sanitization
  * @param v_max maximum acceptable value of the property for sanitization
@@ -878,7 +878,7 @@ GtkWidget *dt_masks_create_menu(dt_masks_form_gui_t *gui, dt_masks_form_t *form,
 
 /**
  * @brief Append a bauhaus-slider menu item to a mask context menu, bound to one shape
- * interaction (size, fading/hardness, rotation, opacity). Shared by the darkroom
+ * interaction (size, fading, rotation, opacity). Shared by the darkroom
  * canvas context menu (dt_masks_create_menu) and the blend module's own shape-list
  * context menus, so both stay in sync.
  */

--- a/src/develop/masks_types.h
+++ b/src/develop/masks_types.h
@@ -124,7 +124,7 @@ typedef enum dt_masks_interaction_t
 {
   DT_MASKS_INTERACTION_UNDEF = 0,    // no property: an unmapped wheel combination does nothing
   DT_MASKS_INTERACTION_SIZE = 1,     // property of the form (shape), explicit
-  DT_MASKS_INTERACTION_HARDNESS = 2, // property of the form (shape), explicit
+  DT_MASKS_INTERACTION_FADING = 2,   // property of the form (shape), explicit
   DT_MASKS_INTERACTION_OPACITY = 3,  // property of the group in which the form is included, explicit
   DT_MASKS_INTERACTION_ROTATION = 4, // property of the form (shape), explicit
   DT_MASKS_INTERACTION_LAST


### PR DESCRIPTION
Every shape already exposed this property as **Fading** in its own panel, while the code, the toasts and the conf keys underneath still said *hardness*. The two names now agree.

## What moved

- The interaction slot is `DT_MASKS_INTERACTION_FADING`; the per-shape helpers are `_init_fading()` / `_change_fading()`; the bounds are `FADING_MIN` / `FADING_MAX`; the toasts read `Fading: …`. Same for `dt_masks_node_brush_t.fading` and `DT_MASKS_PRESSURE_FADING_{REL,ABS}`.
- The gradient's own slider follows the same rule from the other end. It was labelled **Fade** because `DT_MASKS_INTERACTION_SIZE` holds its fade extent — but that is the shape's size in the only sense a gradient has one, so it is labelled **Size** like everywhere else, and `dt_masks_interaction_alias_name()` now answers `NULL` for that slot. Only `FADING` keeps an alias, *Curvature*, which is what a gradient genuinely calls it. The wheel-mapping column header goes from `Hardness/Curvature` to `Fading/Curvature`.
- Comments, doc comments, `CLAUDE.md` and `doc/masks-enclosure-p2.md` follow.

## Persisted strings move too — no migration, on purpose

The four `masks/scroll/*` mapping values, the `pressure_sensitivity` enum and the `plugins/darkroom/<plugin>/<shape>/fading` keys are renamed **in lockstep with `data/anselconfig.xml.in`**, so nothing ever reads a key outside confgen.

This half was not optional: the C side already spelled the brush's conf token `"fading"` and matched `"fading (absolute)"` / `"(relative)"` for pen pressure, while confgen still declared `hardness` — so the brush was reading a key outside confgen (→ 0) and pen pressure never matched at all.

**User-visible consequence:** an existing user's wheel mapping, pen-pressure mapping and default polygon/brush fading fall back to their defaults once, silently. That is the accepted trade for not carrying a compatibility shim to 1.0.

## One key under `spots/`, and why it had to move

`plugins/darkroom/spots/brush/hardness` → `…/fading`. That namespace is **not** the deprecated spots module's: `_get_mask_plugin()` selects it from the `DT_MASKS_CLONE` / `DT_MASKS_NON_CLONE` type bits, which **retouch** sets on all of its shapes too (`retouch.c:1039`, `retouch.c:4513`). It is retouch's live key, and retouch is not deprecated.

`plugins/darkroom/spots/ellipse/hardness` keeps its name — the ellipse asks for the `border` token and nothing has ever read that one.

## Checks

- Full clang build clean, `xmllint` included.
- `tools/check_module_boundaries.sh`: every masks counter at baseline.
- `pragma_once_to_guards.py --verify` OK; `include_graph.py`: `cycles 0`.
- Every `masks/*` key the code builds is declared in confgen. Five keys are still missing under `spots/` (`spots/ellipse/border`, `spots/gradient/{curvature,extent,rotation}`, `spots/polygon/fading`) — all pre-existing at `HEAD`, verified, and left alone since spots is deprecated.

## Not covered

Not yet exercised in the GUI. The thing worth a manual check before merge is that brush and polygon fading start from their default rather than 0 after the key rename.

`po/ansel.pot` still contains `Hardness` strings, but it is stale independently of this work (it references hints removed several commits ago) and regenerates separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)