### PR TITLE
Fix #1313: a polygon fold that straddles the buffer seam took the whole shape with it

### DIFF
--- a/src/develop/masks/polygon.c
+++ b/src/develop/masks/polygon.c
@@ -1063,6 +1063,28 @@ static int _polygon_get_pts_border(dt_develop_t *develop, dt_masks_form_t *mask_
           if(v < 0 || v >= buf_count || w < 0 || w >= buf_count) continue;
           const int range_v = MIN(v, w);
           const int range_w = MAX(v, w);
+
+          /* The border is a CLOSED contour, so a crossing pair cuts it into TWO arcs, and the
+           * fold to remove is the shorter one -- not whichever of the two happens to avoid the
+           * buffer seam. When the fold straddles the seam, [min(v,w), max(v,w)] names its
+           * COMPLEMENT: measured on the polygon of issue #1313 (67 nodes, uniform feather), 3 of
+           * its 27 crossings straddled the seam and each named ~147000 of 147546 border points
+           * instead of the 330-454 its fold actually spans. The merge below then swallowed all 27
+           * into a single range covering 99.8% of the contour, and the hit-test -- which is also
+           * what renders the pixel mask -- saw one straight chord instead of the shape.
+           *
+           * A wrapping removal cannot be expressed with these sentinels.
+           * dt_masks_point_in_form_exact() walks [start_index, count) forward and wraps exactly
+           * once, so a jump backwards sends the walk back over the span it just left, to arrive at
+           * the same sentinel again; it spins until its own visited_points cap stops it and
+           * returns a meaningless crossing count. That is the cycle the sorting and merging below
+           * exist to prevent, and it is why every range written here has to run forward.
+           *
+           * So a seam-straddling fold is LEFT IN. The offset curve keeps a small kink near that
+           * one fold -- the very thing the detector exists to hide -- but the damage is bounded by
+           * the fold's own size instead of taking the rest of the shape with it. */
+          if(range_w - range_v > buf_count - (range_w - range_v)) continue;
+
           if(!IS_NULL_PTR(ranges))
           {
             ranges[range_count].v = range_v;


### PR DESCRIPTION
Fixes #1313 — "Mask displayed is not consistent with the path". **Two commits: the fix, then the hygiene work so this class of bug cannot recur.**

## Commit 1 — the fix

A polygon's border is its path offset outward by the feathering radius, and that offset curve **folds over itself at any concave run tighter than the radius**. The folds are found by `_polygon_find_self_intersection()` and cut out of every crossing-count walk — the hit-test *and* the pixel mask.

Each crossing arrives as a pair of border indices `(v, w)`, and the span to cut was taken to be `[min(v,w), max(v,w)]`. But the border is a **closed** contour: two crossing points cut it into **two** arcs, and the fold is the **shorter** one — not whichever happens to avoid the buffer seam. Instrumented on the reported polygon (67 nodes, 147,546 border points):

```
raw 27 crossings -> merged 1 range, skipped 147277 (99.8%)
pair 20: v=147487 w=271 -> [271..147487] len 147216   (its fold spans 330)
```

Three seam-straddling folds each named ~147k points instead of their real 330–454, and the merge swallowed the other 24 cuts into one range — rendered as the straight chord in the report. A wrapping skip cannot be expressed by a forward-only cut, so it is **dropped**: a small local kink, bounded by the fold's own size, instead of a chord across the shape.

Verified against the reporter's own XMP on a same-geometry raw: IoU vs the node path 0.898 → **0.936**, missing pixels 210 → **0**, wedge gone.

## Commit 2 — remove the place such bugs live

The cuts were encoded **into the border buffer**: NaN in a point's x slot, the jump target smuggled as an integer through the float y slot. Every bug this mechanism ever shipped — the reader cycle on complex shapes, then this seam fold — was a bug of that *encoding*, with the geometry right both times. And both shipped **silently**, because the walk's defensive visit cap turned a corrupt buffer into a plausible-but-wrong crossing count.

Now:

- **Cuts travel out-of-band** as `dt_masks_skip_range_t` — plain index pairs handed to every consumer alongside the buffer, never through it. The producer no longer destroys a border point's coordinate to mark a cut.
- **`dt_masks_skip_ranges_build()`** (pure, allocation-free, unit-testable) owns normalize / drop-seam-straddlers / sort / merge. Its output is disjoint and strictly forward *by construction*.
- **The walks scream instead of guessing.** A skip that doesn't move the walk strictly forward is ignored **and reported**; the visit cap reports when it trips instead of returning garbage; a leftover in-band sentinel is reported corruption. The producer validates the invariant this bug violated — cuts spanning more than half the contour — where it's cheapest.
- **New CMocka suite** (`test_masks_skip_ranges`, 8 cases) pins **both historical bugs at both ends**: the builder drops this issue's literal seam pairs on its literal border size and merges the cycle bug's overlapping ranges; the walk closes a cut with the chord, refuses backward/out-of-bounds ranges while still answering correctly, and terminates. The "producer is broken" lines in the test log are the mechanism working.

## Verification

- Commit 2 is **bit-identical** to commit 1 at export, image and `--export_masks` pages alike: the #1313 polygon (27 crossings, 3 seam folds — 0 of 4,414,200 differing) and a 26-shape image with three ordinary polygons (0 of 5,126,400).
- 8/8 new tests, 19/19 existing masks tests, full local suite unchanged.
- Boundary ratchet, pragma, cycles, unused/conditional includes: clean. The ratchet counters do not move.
- *Repro caveat from commit 1:* the reporter's raw isn't public; their XMP was applied to a same-sensor-geometry raw (5184×3888). A first attempt on an EXIF-orientation-8 raw produces a much more violent, different artefact — worth knowing if anyone re-runs this.
- `nofeatures` config is left to CI (that local build dir was removed in a disk cleanup).

🤖 Generated with [Claude Code](https://claude.com/claude-code)