### PR TITLE
masks: the brush cusp V hole, and the diagnostic corpus that could not see it

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -231,6 +231,7 @@ FILE(GLOB SOURCE_FILES
   "develop/masks/ellipse.c"
   "develop/masks/gradient.c"
   "develop/masks/masks.c"
+  "develop/masks/masks_debug.c"
   "develop/masks/masks_gui.c"
   "develop/masks/masks_history.c"
   "develop/masks/polygon.c"

--- a/src/develop/blend_gui.c
+++ b/src/develop/blend_gui.c
@@ -4317,7 +4317,7 @@ void dt_iop_gui_cleanup_blending(dt_iop_module_t *module)
   if(bd->timeout_handle)
     g_source_remove(bd->timeout_handle);
 
-  dt_free(bd->masks_combo_ids);
+  dt_free_align(bd->masks_combo_ids);
   dt_pthread_mutex_unlock(&bd->lock);
   dt_pthread_mutex_destroy(&bd->lock);
 
@@ -4836,7 +4836,7 @@ void dt_iop_gui_cleanup_blending_body(dt_iop_module_t *module)
     g_source_remove(bd->timeout_handle);
     bd->timeout_handle = 0;
   }
-  dt_free(bd->masks_combo_ids);
+  dt_free_align(bd->masks_combo_ids);
   dt_pthread_mutex_unlock(&bd->lock);
 
   if(bd->masks_ic_inverse) g_object_unref(bd->masks_ic_inverse);

--- a/src/develop/masks/brush.c
+++ b/src/develop/masks/brush.c
@@ -35,6 +35,7 @@
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
 #include "control/control.h"
+#include "math/math.h"
 #include "system/macros.h"
 #include "system/openmp.h"
 #include "system/mem_alloc.h"
@@ -288,7 +289,7 @@ static gboolean _brush_border_get_XY(float p0_x, float p0_y, float p1_x, float p
 
     if(dx == 0.0f && dy == 0.0f) return FALSE;   // a single point: no direction to offset along
   }
-  const float l = 1.0f / sqrtf(dx * dx + dy * dy);
+  const float l = 1.0f / dt_fast_hypotf(dx, dy);
   *border_x = (*point_x) + radius * dy * l;
   *border_y = (*point_y) - radius * dx * l;
   return TRUE;
@@ -525,8 +526,8 @@ static void _brush_points_recurs_border_gaps(float *cmax, float *bmin, float *bm
   }
 
   // we determine start and end radius too
-  float r1 = sqrtf((bmin[1] - cmax[1]) * (bmin[1] - cmax[1]) + (bmin[0] - cmax[0]) * (bmin[0] - cmax[0]));
-  float r2 = sqrtf((bmax[1] - cmax[1]) * (bmax[1] - cmax[1]) + (bmax[0] - cmax[0]) * (bmax[0] - cmax[0]));
+  float r1 = dt_fast_hypotf(bmin[1] - cmax[1], bmin[0] - cmax[0]);
+  float r2 = dt_fast_hypotf(bmax[1] - cmax[1], bmax[0] - cmax[0]);
 
   // and the max length of the circle arc
   const int l = fabsf(a2 - a1) * fmaxf(r1, r2);
@@ -580,8 +581,8 @@ static void _brush_points_recurs_border_small_gaps(float *cmax, float *bmin, flo
   if(a1 == a2) return;
 
   // we determine start and end radius too
-  const float r1 = sqrtf((bmin[1] - cmax[1]) * (bmin[1] - cmax[1]) + (bmin[0] - cmax[0]) * (bmin[0] - cmax[0]));
-  const float r2 = sqrtf((bmax[1] - cmax[1]) * (bmax[1] - cmax[1]) + (bmax[0] - cmax[0]) * (bmax[0] - cmax[0]));
+  const float r1 = dt_fast_hypotf(bmin[1] - cmax[1], bmin[0] - cmax[0]);
+  const float r2 = dt_fast_hypotf(bmax[1] - cmax[1], bmax[0] - cmax[0]);
 
   // we close the gap in the shortest direction
   float delta = a2 - a1;
@@ -636,7 +637,7 @@ static void _brush_points_stamp(float *cmax, float *bmin, dt_masks_dynbuf_t *dpo
   const float a1 = atan2f(bmin[1] - cmax[1], bmin[0] - cmax[0]);
 
   // we determine the radius too
-  const float rad = sqrtf((bmin[1] - cmax[1]) * (bmin[1] - cmax[1]) + (bmin[0] - cmax[0]) * (bmin[0] - cmax[0]));
+  const float rad = dt_fast_hypotf(bmin[1] - cmax[1], bmin[0] - cmax[0]);
 
   // determine the max length of the circle arc
   const int l = 2.0f * M_PI * rad;
@@ -2541,7 +2542,7 @@ static gboolean _brush_line_point_at_length(const float *line, const int first_p
 
     const float dx = x1 - x0;
     const float dy = y1 - y0;
-    const float len = sqrtf(dx * dx + dy * dy);
+    const float len = dt_fast_hypotf(dx, dy);
     if(len <= 1e-6f) continue;
 
     has_fallback = TRUE;

--- a/src/develop/masks/brush.c
+++ b/src/develop/masks/brush.c
@@ -342,6 +342,12 @@ static gboolean _brush_get_border_handle_resampled(const dt_masks_form_gui_point
     const float px = gui_points->points[i * 2];
     const float py = gui_points->points[i * 2 + 1];
     if(isnan(px) || isnan(py)) continue;
+    /* ... and the BORDER sample at that index has to exist, because that is what gets returned.
+     * The drawn outline blanks the border wherever it doubles back on itself, and a node can sit
+     * opposite such a span -- a cusp does. Choosing the nearest centreline point without looking
+     * at its border, then failing on NaN, costs that node its border handle outright: no dash
+     * drawn, and no hover or drag either, since both interactions resolve through here. */
+    if(isnan(gui_points->border[i * 2]) || isnan(gui_points->border[i * 2 + 1])) continue;
 
     const float dx = node_x - px;
     const float dy = node_y - py;
@@ -1370,6 +1376,26 @@ static void _brush_get_distance(float point_x, float point_y, float radius,
   *distance = min_dist;
 }
 
+
+/** longest span first; ties broken by position so the order is deterministic */
+static int _skip_range_cmp_span(const void *a, const void *b)
+{
+  const dt_masks_skip_range_t *const x = (const dt_masks_skip_range_t *)a;
+  const dt_masks_skip_range_t *const y = (const dt_masks_skip_range_t *)b;
+  const int sx = x->resume_at - x->jump_from;
+  const int sy = y->resume_at - y->jump_from;
+  if(sx != sy) return (sx > sy) ? -1 : 1;
+  return (x->jump_from < y->jump_from) ? -1 : (x->jump_from > y->jump_from);
+}
+
+static int _skip_range_cmp_fwd(const void *a, const void *b)
+{
+  const dt_masks_skip_range_t *const x = (const dt_masks_skip_range_t *)a;
+  const dt_masks_skip_range_t *const y = (const dt_masks_skip_range_t *)b;
+  if(x->jump_from != y->jump_from) return (x->jump_from < y->jump_from) ? -1 : 1;
+  return (x->resume_at < y->resume_at) ? -1 : (x->resume_at > y->resume_at);
+}
+
 static dt_masks_raster_result_t _brush_get_points_border(dt_develop_t *develop, dt_masks_form_t *mask_form,
                                     float **point_buffer, int *point_count,
                                     float **border_buffer, int *border_count,
@@ -1399,6 +1425,103 @@ static dt_masks_raster_result_t _brush_get_points_border(dt_develop_t *develop, 
   if(status == 0 && !IS_NULL_PTR(border_buffer) && !IS_NULL_PTR(*border_buffer)
      && !IS_NULL_PTR(border_skips) && !IS_NULL_PTR(*border_skips) && !IS_NULL_PTR(border_skip_count))
   {
+    /* Ask the shared detector where the outline crosses itself, and cut exactly there.
+     *
+     * The three attempts before this one all searched around the JOINTS, on the theory that a
+     * fold is something a corner does. Two measurements killed that: the two strands that cross
+     * at a fold sit half the buffer apart, so a local window cannot see both; and a fold needs
+     * no corner at all -- where a smooth segment curves tighter than its own radius the inner
+     * offset loops on its own, and on this brush one such crossing (samples 16807 x 17893) sat a
+     * thousand samples from the nearest joint. Every local rule got some joints right and
+     * invented a new artefact at others: chords straight across the stroke at five nodes, the
+     * outline vanishing at the widest one, node-centred circles at three more.
+     *
+     * dt_masks_border_find_self_intersections() answers the actual question over the whole
+     * contour at once. It is the polygon's detector, moved to masks.c unchanged and shared --
+     * the brush had no equivalent, which is why this took four tries to notice. */
+    const int header = (int)g_list_length(mask_form->points) * 3;
+    /* Generous, because one geometric crossing yields MANY probe-pair hits at quarter-pixel
+     * spacing -- the segments either side of it all cross their opposite numbers. A tight cap
+     * is not a budget, it is a truncation: the scan walks the contour in order, so exhausting
+     * it on the first few crossings means the rest of the shape is never examined at all.
+     * Measured at 4096: five cuts made and seven real crossings left drawn. The greedy pass
+     * below collapses the duplicates, so the only cost of a large cap is the scratch buffer. */
+    const int max_pairs = 1 << 16;
+    float *const crossings = (float *)malloc(sizeof(float) * 2 * (size_t)max_pairs);
+    *border_skip_count = 0;
+
+    if(!IS_NULL_PTR(crossings))
+    {
+      const int found = dt_masks_border_find_self_intersections(*border_buffer, *border_count,
+                                                                header, crossings, max_pairs);
+      if(found > 0)
+      {
+        /* Size the output to what the DETECTOR found, not to whatever the producer happened to
+         * allocate: the two counts are unrelated, and the normaliser writes one range per pair. */
+        dt_pixelpipe_cache_free_align(*border_skips);
+        *border_skips
+            = dt_pixelpipe_cache_alloc_align_cache(sizeof(dt_masks_skip_range_t) * found, 0);
+
+        /* Select DISJOINT ranges, SHORTEST FIRST, and never merge them.
+         *
+         * Two rules, and both were learned by watching the outline break.
+         *
+         * Do not merge. dt_masks_skip_ranges_build() merges overlaps, which is right for the
+         * hit-test walk -- it only needs a traversal that moves forward and terminates -- and
+         * wrong for drawing. Each crossing pair names two samples that ARE the same point, so
+         * cutting between them leaves the outline closed; the union of two overlapping pairs
+         * names two samples that are not, and the drawer spans the gap with a straight chord.
+         * Measured after a merge: cuts leaving 105, 170 and 73 pixel gaps, one chord across the
+         * stroke each.
+         *
+         * LONGEST first, under a cap. Three orderings were tried and the first two are traps.
+         * By position: one 10035-sample span won and blocked every genuine fold inside it,
+         * erasing the inner border at the cusp. Shortest first: the opposite failure -- a tiny
+         * crossing NESTED inside a real loop wins and blocks it, leaving 30 and 14 pixel kinks
+         * on the concave stretch. Nested loops want the OUTER one removed, since it subsumes
+         * the inner, so the order is longest first.
+         *
+         * What makes that safe is the cap. The detector also pairs the two SIDES of the stroke
+         * where they meet, which is not a loop to remove at all, and those pairings are huge --
+         * 41253 samples of a 52492-sample contour on this brush, against 3180 for the largest
+         * real fold. An eighth of the contour separates the two populations by an order of
+         * magnitude and needs no tuning. */
+        if(!IS_NULL_PTR(*border_skips))
+        {
+          dt_masks_skip_range_t *const out = *border_skips;
+          int kept = 0;
+          for(int i = 0; i < found; i++)
+          {
+            const int lo = (int)crossings[i * 2];
+            const int hi = (int)crossings[i * 2 + 1];
+            if(lo < 0 || hi <= lo || hi >= *border_count) continue;
+            if(hi - lo > *border_count - (hi - lo)) continue;   // names the fold's complement
+            if(hi - lo > *border_count / 8) continue;           // the two sides meeting, not a fold
+            out[kept].jump_from = lo;
+            out[kept].resume_at = hi;
+            kept++;
+          }
+          qsort(out, kept, sizeof(dt_masks_skip_range_t), _skip_range_cmp_span);
+
+          int accepted = 0;
+          for(int i = 0; i < kept; i++)
+          {
+            gboolean clashes = FALSE;
+            for(int j = 0; j < accepted && !clashes; j++)
+              clashes = (out[i].jump_from < out[j].resume_at && out[j].jump_from < out[i].resume_at);
+            if(clashes) continue;
+            const dt_masks_skip_range_t take = out[i];
+            out[accepted++] = take;
+          }
+          /* the blanking pass walks forward, so hand it sorted ranges */
+          qsort(out, accepted, sizeof(dt_masks_skip_range_t), _skip_range_cmp_fwd);
+          *border_skip_count = accepted;
+        }
+      }
+      free(crossings);
+    }
+
+
     for(int i = 0; i < *border_skip_count; i++)
     {
       const int from = (*border_skips)[i].jump_from;
@@ -2370,17 +2493,32 @@ static void _brush_draw_shape(struct dt_develop_t *dev, cairo_t *cr, const float
     double last_x = points[start_idx * 2];
     double last_y = points[start_idx * 2 + 1];
 
+    /* A NaN run is a HOLE in the outline, not a shortcut across it. Skipping the samples with
+     * the pen still down makes the next valid point a line_to, so every blanked span comes out
+     * as a straight chord -- at a cusp, a chord slicing across the rounded tip the stroke
+     * actually has. Lift the pen instead: begin a new sub-path at the first sample after the
+     * run, so the span is simply absent. Stroking a path of several sub-paths is free. */
+    gboolean pen_down = TRUE;
+
     for(int i = start_idx + 1; i < end_idx; i++)
     {
       const double x = points[i * 2];
       const double y = points[i * 2 + 1];
-      if(isnan(x) || isnan(y)) continue;
+      if(isnan(x) || isnan(y)) { pen_down = FALSE; continue; }
 
       const double step_x = x - last_x;
       const double step_y = y - last_y;
-      if((step_x * step_x + step_y * step_y) < min_step2) continue;
+      /* the decimation must not apply across a lifted pen: the new sub-path has to start
+       * somewhere, however close it landed to where the old one stopped */
+      if(pen_down && (step_x * step_x + step_y * step_y) < min_step2) continue;
 
-      cairo_line_to(cr, x, y);
+      if(pen_down)
+        cairo_line_to(cr, x, y);
+      else
+      {
+        cairo_move_to(cr, x, y);
+        pen_down = TRUE;
+      }
       last_x = x;
       last_y = y;
     }
@@ -2390,7 +2528,12 @@ static void _brush_draw_shape(struct dt_develop_t *dev, cairo_t *cr, const float
     {
       const double x = points[(end_idx - 1) * 2];
       const double y = points[(end_idx - 1) * 2 + 1];
-      if(!isnan(x) && !isnan(y) && (x != last_x || y != last_y)) cairo_line_to(cr, x, y);
+      if(!isnan(x) && !isnan(y) && (x != last_x || y != last_y))
+      {
+        // ... but not across a hole, for the same reason as above
+        if(pen_down) cairo_line_to(cr, x, y);
+        else         cairo_move_to(cr, x, y);
+      }
     }
   }
 }

--- a/src/develop/masks/brush.c
+++ b/src/develop/masks/brush.c
@@ -1255,8 +1255,12 @@ static void _brush_get_distance(float point_x, float point_y, float radius,
 static dt_masks_raster_result_t _brush_get_points_border(dt_develop_t *develop, dt_masks_form_t *mask_form,
                                     float **point_buffer, int *point_count,
                                     float **border_buffer, int *border_count,
+                                    dt_masks_skip_range_t **border_skips, int *border_skip_count,
                                     int use_source, const dt_iop_module_t *module)
 {
+  if(!IS_NULL_PTR(border_skips)) *border_skips = NULL;
+  if(!IS_NULL_PTR(border_skip_count)) *border_skip_count = 0;
+
   // Asking for the source outline without a module is a programming error, not an empty shape.
   if(use_source && IS_NULL_PTR(module)) return DT_MASKS_RASTER_ERROR;
   const double ioporder = (module) ? module->iop_order : 0.0f;

--- a/src/develop/masks/brush.c
+++ b/src/develop/masks/brush.c
@@ -232,15 +232,58 @@ static void _brush_border_get_XY(float p0_x, float p0_y, float p1_x, float p1_y,
   const float c = 3.0f * (2.0f * t * ti - t * t);
   const float d = 3.0f * sqf(t);
 
-  const float dx = -p0_x * a + p1_x * b + p2_x * c + p3_x * d;
-  const float dy = -p0_y * a + p1_y * b + p2_y * c + p3_y * d;
+  /* not const: a degenerate first-order term is replaced by the limit direction below */
+  float dx = -p0_x * a + p1_x * b + p2_x * c + p3_x * d;
+  float dy = -p0_y * a + p1_y * b + p2_y * c + p3_y * d;
 
-  // so we can have the resulting point
-  if(dx == 0 && dy == 0)
+  /* A vanishing derivative does NOT mean the tangent is undefined -- it means the first-order
+   * term is degenerate and the direction is given by the limit, i.e. by the first non-zero term.
+   * That is exactly how a CUSP is stored: both of the node's handles sit on the node itself, so
+   * the cubic's endpoint derivative 3*(p1 - p0) (or 3*(p3 - p2)) is zero there.
+   *
+   * Two separate defects lived in the three lines this replaces, and only the pair of them
+   * explains issue #1313's follow-up ("the brush loses its radius in the direction of the point
+   * of the cusp and so we have a sharp V hole").
+   *
+   * FIRST: the test was `== 0', and a vanishing derivative does not arrive as zero. These are
+   * image pixels, so at the reported cusp -- where p2 == p3 bit for bit -- 3*(p3 - p2) evaluates
+   * to 1.22e-4, because the products 3*1327.8497 are each rounded to float before the
+   * subtraction. So the guard never fired at all. Execution fell through and NORMALISED that
+   * residue: (1.22e-4, 0) normalises to (1, 0), and the border direction at the cusp became pure
+   * rounding noise pointing along +x. The tell, once you know it, is a border sample sitting
+   * exactly one radius due east of its node. The threshold below is therefore RELATIVE, scaled
+   * to the control polygon because that is what the derivative scales with -- a genuine tangent
+   * near the cusp is orders of magnitude larger (measured 1.06 at t = 0.999 against a 0.2 noise
+   * floor), so the two separate cleanly and no real direction can be swallowed.
+   *
+   * SECOND: even when it did fire, returning NaN was the wrong answer. Every consumer falls back
+   * to the previous border point, so the offset curve never rotated through the exterior angle
+   * at the tip, the two sides of the joint coincided -- the gap between them measured (0.0, 0.0)
+   * and the turn 0.0 degrees -- and the arc filler that exists to bridge exactly that wedge was
+   * never triggered. Since a brush mask is the union of centreline->border spokes, the wedge at
+   * the point of the cusp was simply never painted.
+   *
+   * For a cubic, if the first-order term vanishes the second-order one gives the limit
+   * direction: (p2 - p0) at the start, (p3 - p1) at the end. If that is degenerate too, the
+   * chord is the last honest answer. Only a curve collapsed to a single point has no direction
+   * at all, and that one still reports NaN, because there is genuinely nothing to offset. */
+  const float span = fmaxf(fmaxf(fabsf(p3_x - p0_x), fabsf(p3_y - p0_y)),
+                           fmaxf(fabsf(p2_x - p1_x), fabsf(p2_y - p1_y)));
+  const float degenerate = fmaxf(span, 1.0f) * 1e-3f;
+
+  if(fabsf(dx) < degenerate && fabsf(dy) < degenerate)
   {
-    *border_x = NAN;
-    *border_y = NAN;
-    return;
+    if(t < 0.5f) { dx = p2_x - p0_x; dy = p2_y - p0_y; }
+    else         { dx = p3_x - p1_x; dy = p3_y - p1_y; }
+
+    if(fabsf(dx) < degenerate && fabsf(dy) < degenerate) { dx = p3_x - p0_x; dy = p3_y - p0_y; }
+
+    if(dx == 0.0f && dy == 0.0f)
+    {
+      *border_x = NAN;
+      *border_y = NAN;
+      return;
+    }
   }
   const float l = 1.0f / sqrtf(dx * dx + dy * dy);
   *border_x = (*point_x) + radius * dy * l;
@@ -716,6 +759,24 @@ static inline int _brush_cyclic_cursor(int n, int nb)
 }
 
 
+/* Record, as an out-of-band span, the border samples a join arc is about to append: the
+ * DISPLAY outline excludes these spans (a node-centred arc reads as a self-intersecting circle
+ * on the dashed border -- the complaint that got the arcs disabled outright in 0b54897b50),
+ * while the rasteriser keeps every sample, because border coverage IS mask coverage. Pairs of
+ * (first, one-past-last) border indices; an empty pair is dropped at conversion. */
+static inline void _brush_record_skip_span_begin(dt_masks_dynbuf_t *dskips, dt_masks_dynbuf_t *dborder)
+{
+  if(IS_NULL_PTR(dskips) || IS_NULL_PTR(dborder)) return;
+  const float at = (float)(dt_masks_dynbuf_position(dborder) / 2);
+  dt_masks_dynbuf_add_2(dskips, at, at);
+}
+
+static inline void _brush_record_skip_span_end(dt_masks_dynbuf_t *dskips, dt_masks_dynbuf_t *dborder)
+{
+  if(IS_NULL_PTR(dskips) || IS_NULL_PTR(dborder)) return;
+  dt_masks_dynbuf_set(dskips, -1, (float)(dt_masks_dynbuf_position(dborder) / 2));
+}
+
 /** get all points of the brush and the border */
 /** this takes care of gaps and iop distortions */
 // Brush points are stored in a cyclic way because the border goes around the main line.
@@ -724,7 +785,8 @@ static int _brush_get_pts_border(dt_develop_t *develop, dt_masks_form_t *mask_fo
                                  const double iop_order, const int transform_direction,
                                  const dt_masks_distort_t *const dist, float **point_buffer, int *point_count,
                                  float **border_buffer, int *border_count, float **payload_buffer,
-                                 int *payload_count, int use_source)
+                                 int *payload_count, dt_masks_skip_range_t **border_skips,
+                                 int *border_skip_count, int use_source)
 {
   *point_buffer = NULL;
   *point_count = 0;
@@ -732,6 +794,8 @@ static int _brush_get_pts_border(dt_develop_t *develop, dt_masks_form_t *mask_fo
   if(!IS_NULL_PTR(border_buffer)) *border_count = 0;
   if(payload_buffer) *payload_buffer = NULL;
   if(!IS_NULL_PTR(payload_buffer)) *payload_count = 0;
+  if(!IS_NULL_PTR(border_skips)) *border_skips = NULL;
+  if(!IS_NULL_PTR(border_skip_count)) *border_skip_count = 0;
 
   if(IS_NULL_PTR(mask_form) || IS_NULL_PTR(mask_form->points)) return 0;
   double start2 = 0.0;
@@ -744,7 +808,7 @@ static int _brush_get_pts_border(dt_develop_t *develop, dt_masks_form_t *mask_fo
   // spread out and the radial spokes stamped from them leave gaps between each pair (#1116).
   const int pixel_threshold = dist->rasterization_step;
 
-  dt_masks_dynbuf_t *dpoints = NULL, *dborder = NULL, *dpayload = NULL;
+  dt_masks_dynbuf_t *dpoints = NULL, *dborder = NULL, *dpayload = NULL, *dskips = NULL;
 
   dpoints = dt_masks_dynbuf_init(1000000, "brush dpoints");
   if(IS_NULL_PTR(dpoints)) return 1;
@@ -770,6 +834,12 @@ static int _brush_get_pts_border(dt_develop_t *develop, dt_masks_form_t *mask_fo
     }
   }
 
+  if(!IS_NULL_PTR(dborder) && !IS_NULL_PTR(border_skips) && !IS_NULL_PTR(border_skip_count))
+  {
+    // an allocation failure here only loses the display exclusion, never the geometry
+    dskips = dt_masks_dynbuf_init(256, "brush dskips");
+  }
+
   // we store all points
   float dx = 0.0f, dy = 0.0f;
 
@@ -788,6 +858,7 @@ static int _brush_get_pts_border(dt_develop_t *develop, dt_masks_form_t *mask_fo
     dt_masks_dynbuf_free(dpoints);
     dt_masks_dynbuf_free(dborder);
     dt_masks_dynbuf_free(dpayload);
+    dt_masks_dynbuf_free(dskips);
     return 1;
   }
 
@@ -837,7 +908,6 @@ static int _brush_get_pts_border(dt_develop_t *develop, dt_masks_form_t *mask_fo
     const int k = _brush_cyclic_cursor(n, node_count);
     const int k1 = _brush_cyclic_cursor(n + 1, node_count);
     const int k2 = _brush_cyclic_cursor(n + 2, node_count);
-    const gboolean allow_border_gap_rounding = FALSE;
 
     dt_masks_node_brush_t *point1 = nodes[k];
     dt_masks_node_brush_t *point2 = nodes[k1];
@@ -913,8 +983,9 @@ static int _brush_get_pts_border(dt_develop_t *develop, dt_masks_form_t *mask_fo
         float bmin[2] = { dt_masks_dynbuf_get(dborder, -2), dt_masks_dynbuf_get(dborder, -1) };
         float cmax[2] = { dt_masks_dynbuf_get(dpoints, -2), dt_masks_dynbuf_get(dpoints, -1) };
         float bmax[2] = { 2 * cmax[0] - bmin[0], 2 * cmax[1] - bmin[1] };
-        if(allow_border_gap_rounding)
-          _brush_points_recurs_border_gaps(cmax, bmin, NULL, bmax, dpoints, dborder, TRUE);
+        _brush_record_skip_span_begin(dskips, dborder);
+        _brush_points_recurs_border_gaps(cmax, bmin, NULL, bmax, dpoints, dborder, TRUE);
+        _brush_record_skip_span_end(dskips, dborder);
       }
 
       if(!IS_NULL_PTR(dpayload))
@@ -990,11 +1061,26 @@ static int _brush_get_pts_border(dt_develop_t *develop, dt_masks_form_t *mask_fo
         _brush_border_get_XY(p3[0], p3[1], p3[2], p3[3], p4[2], p4[3], p4[0], p4[1], 0.0001, p3[4], cmin,
                              cmin + 1, bmax, bmax + 1);
       }
+      /* The border of the two segments meeting at this node ends on one side of the joint and
+       * restarts on the other; this arc bridges the wedge between them, centred on the node.
+       * Without it the rasteriser has no border samples across the joint, so the falloff paints
+       * no spokes there and the stroke loses its radius toward the node -- at a cusp (both
+       * control handles collapsed onto the node) that is a sharp V hole in the EXPORTED mask,
+       * reported as a follow-up of issue #1313 and confirmed fixed by restoring exactly this
+       * call.
+       *
+       * The arc was disabled by 0b54897b50 ("Path shapes: Add border handle per node",
+       * 2026-02) behind an always-FALSE flag, because the GUI's dashed border outline drew
+       * these arcs as self-intersecting circles at sharp joints. That traded a cosmetic GUI
+       * blemish for a correctness hole in every rendered mask -- the mask is the union of
+       * centreline->border spokes, so border coverage IS mask coverage. The cosmetic half is
+       * handled where it belongs: the arc span is recorded out-of-band and the DISPLAY border
+       * excludes it (see _brush_get_points_border()), while the rasteriser keeps every sample. */
       if(bmax[0] - rb[0] > 1 || bmax[0] - rb[0] < -1 || bmax[1] - rb[1] > 1 || bmax[1] - rb[1] < -1)
       {
-        // float bmin2[2] = {(*border)[posb-22],(*border)[posb-21]};
-        if(allow_border_gap_rounding)
-          _brush_points_recurs_border_gaps(rc, rb, NULL, bmax, dpoints, dborder, cw);
+        _brush_record_skip_span_begin(dskips, dborder);
+        _brush_points_recurs_border_gaps(rc, rb, NULL, bmax, dpoints, dborder, cw);
+        _brush_record_skip_span_end(dskips, dborder);
       }
     }
 
@@ -1022,6 +1108,38 @@ static int _brush_get_pts_border(dt_develop_t *develop, dt_masks_form_t *mask_fo
     *payload_count = dt_masks_dynbuf_position(dpayload) / 2;
     *payload_buffer = dt_masks_dynbuf_harvest(dpayload);
     dt_masks_dynbuf_free(dpayload);
+  }
+
+  if(!IS_NULL_PTR(dskips))
+  {
+    const int pair_count = dt_masks_dynbuf_position(dskips) / 2;
+    const float *pairs = dt_masks_dynbuf_buffer(dskips);
+    if(pair_count > 0)
+    {
+      dt_masks_skip_range_t *skips
+          = dt_pixelpipe_cache_alloc_align_cache(sizeof(dt_masks_skip_range_t) * pair_count, 0);
+      if(!IS_NULL_PTR(skips))
+      {
+        int count = 0;
+        for(int i = 0; i < pair_count; i++)
+        {
+          const int from = (int)pairs[i * 2];
+          const int to = (int)pairs[i * 2 + 1];
+          if(to <= from) continue;   // the arc appended nothing
+          skips[count].jump_from = from;
+          skips[count].resume_at = to;
+          count++;
+        }
+        if(count > 0)
+        {
+          *border_skips = skips;
+          *border_skip_count = count;
+        }
+        else
+          dt_pixelpipe_cache_free_align(skips);
+      }
+    }
+    dt_masks_dynbuf_free(dskips);
   }
   // printf("points %d, border %d, playload %d\n", *points_count, border ? *border_count : -1, payload ?
   // *payload_count : -1);
@@ -1265,10 +1383,35 @@ static dt_masks_raster_result_t _brush_get_points_border(dt_develop_t *develop, 
   if(use_source && IS_NULL_PTR(module)) return DT_MASKS_RASTER_ERROR;
   const double ioporder = (module) ? module->iop_order : 0.0f;
   const dt_masks_distort_t gui_dist = dt_masks_distort_for_gui(develop);
-  return dt_masks_raster_from_status(
-      _brush_get_pts_border(develop, mask_form, ioporder, DT_DEV_TRANSFORM_DIR_ALL,
-                            &gui_dist, point_buffer, point_count, border_buffer,
-                            border_count, NULL, NULL, use_source));
+  const int status
+      = _brush_get_pts_border(develop, mask_form, ioporder, DT_DEV_TRANSFORM_DIR_ALL,
+                              &gui_dist, point_buffer, point_count, border_buffer,
+                              border_count, NULL, NULL, border_skips, border_skip_count, use_source);
+
+  /* This outline feeds the GUI only -- the rasterisers build their own from the pixel path. The
+   * join arcs the producer appended are geometry the MASK needs and the drawn border must not
+   * show: stroked, a node-centred arc reads as a self-intersecting circle at every sharp joint,
+   * which is what got the arcs deleted outright in 0b54897b50 (and the exported mask holed).
+   * The spans travel out-of-band; here their points are blanked to the drawer's existing
+   * bare-NaN "invisible point" marker, so the dashed outline skips them without any consumer
+   * learning a new contract. The spans themselves stay published in border_skips: they are the
+   * record of what was blanked, not an encoding to decode. */
+  if(status == 0 && !IS_NULL_PTR(border_buffer) && !IS_NULL_PTR(*border_buffer)
+     && !IS_NULL_PTR(border_skips) && !IS_NULL_PTR(*border_skips) && !IS_NULL_PTR(border_skip_count))
+  {
+    for(int i = 0; i < *border_skip_count; i++)
+    {
+      const int from = (*border_skips)[i].jump_from;
+      const int to = MIN((*border_skips)[i].resume_at, *border_count);
+      for(int j = MAX(from, 0); j < to; j++)
+      {
+        (*border_buffer)[j * 2] = NAN;
+        (*border_buffer)[j * 2 + 1] = NAN;
+      }
+    }
+  }
+
+  return dt_masks_raster_from_status(status);
 }
 
 /** find relative position within a brush segment that is closest to the point given by coordinates x and y;
@@ -2753,7 +2896,7 @@ static int _get_area(const dt_iop_module_t *const module, dt_dev_pixelpipe_t *pi
   int points_count, border_count;
   const dt_masks_distort_t pipe_dist = dt_masks_distort_for_pipe(pipe, module->dev);
   if(_brush_get_pts_border(module->dev, mask_form, module->iop_order, DT_DEV_TRANSFORM_DIR_BACK_INCL, &pipe_dist,
-                           &points, &points_count, &border, &border_count, NULL, NULL, include_source) != 0)
+                           &points, &points_count, &border, &border_count, NULL, NULL, NULL, NULL, include_source) != 0)
   {
     dt_pixelpipe_cache_free_align(points);
     dt_pixelpipe_cache_free_align(border);
@@ -2860,7 +3003,7 @@ static dt_masks_raster_result_t _brush_get_mask(const dt_iop_module_t *const mod
   const dt_masks_distort_t pipe_dist = dt_masks_distort_for_pipe(pipe, module->dev);
   if(_brush_get_pts_border(module->dev, mask_form, module->iop_order, DT_DEV_TRANSFORM_DIR_BACK_INCL, &pipe_dist,
                            &points, &points_count,
-                               &border, &border_count, &payload, &payload_count, 0) != 0)
+                               &border, &border_count, &payload, &payload_count, NULL, NULL, 0) != 0)
   {
     dt_pixelpipe_cache_free_align(points);
     dt_pixelpipe_cache_free_align(border);
@@ -3053,7 +3196,7 @@ static dt_masks_raster_result_t _brush_get_mask_roi(const dt_iop_module_t *const
 
   const dt_masks_distort_t pipe_dist = dt_masks_distort_for_pipe(pipe, module->dev);
   if(_brush_get_pts_border(module->dev, mask_form, module->iop_order, DT_DEV_TRANSFORM_DIR_BACK_INCL, &pipe_dist,
-                           &points, &points_count, &border, &border_count, &payload, &payload_count, 0) != 0)
+                           &points, &points_count, &border, &border_count, &payload, &payload_count, NULL, NULL, 0) != 0)
   {
     dt_pixelpipe_cache_free_align(points);
     dt_pixelpipe_cache_free_align(border);

--- a/src/develop/masks/brush.c
+++ b/src/develop/masks/brush.c
@@ -218,9 +218,17 @@ static void _brush_get_XY(float p0_x, float p0_y, float p1_x, float p1_y, float 
 /**
  * @brief Evaluate a cubic Bezier and compute its offset border point.
  */
-static void _brush_border_get_XY(float p0_x, float p0_y, float p1_x, float p1_y, float p2_x, float p2_y,
-                                 float p3_x, float p3_y, float t, float radius,
-                                 float *point_x, float *point_y, float *border_x, float *border_y)
+/** Evaluate the curve at @p t and offset it by @p radius along the normal.
+ *
+ * The point is always produced. The BORDER is not: a curve collapsed to a single point has no
+ * direction, so there is nothing to offset along and the honest answer is "none". That used to
+ * be signalled by writing NaN into the border coordinates, which then had to be recognised --
+ * and repaired -- by everyone downstream, and which is how a sentinel gets into a buffer that
+ * is supposed to hold geometry. It is a return value now, so the border is either written or
+ * left exactly as the caller had it. Returns TRUE when a border point was produced. */
+static gboolean _brush_border_get_XY(float p0_x, float p0_y, float p1_x, float p1_y, float p2_x, float p2_y,
+                                     float p3_x, float p3_y, float t, float radius,
+                                     float *point_x, float *point_y, float *border_x, float *border_y)
 {
   // we get the point
   _brush_get_XY(p0_x, p0_y, p1_x, p1_y, p2_x, p2_y, p3_x, p3_y, t, point_x, point_y);
@@ -278,16 +286,12 @@ static void _brush_border_get_XY(float p0_x, float p0_y, float p1_x, float p1_y,
 
     if(fabsf(dx) < degenerate && fabsf(dy) < degenerate) { dx = p3_x - p0_x; dy = p3_y - p0_y; }
 
-    if(dx == 0.0f && dy == 0.0f)
-    {
-      *border_x = NAN;
-      *border_y = NAN;
-      return;
-    }
+    if(dx == 0.0f && dy == 0.0f) return FALSE;   // a single point: no direction to offset along
   }
   const float l = 1.0f / sqrtf(dx * dx + dy * dy);
   *border_x = (*point_x) + radius * dy * l;
   *border_y = (*point_y) - radius * dx * l;
+  return TRUE;
 }
 
 /**
@@ -339,16 +343,17 @@ static gboolean _brush_get_border_handle_resampled(const dt_masks_form_gui_point
 
   for(int i = start; i < max_points; i++)
   {
+    /* Skip an index inside an EXCLUDED span, because the border sample there is one the outline
+     * does not show -- the offset curve doubles back on itself, and a node can sit opposite such
+     * a span; a cusp does. This used to be a NaN test against the buffer, back when the excluded
+     * samples were blanked in place, and it cost the node its handle outright when it fired: no
+     * dash drawn, and no hover or drag either, since both interactions resolve through here.
+     * Asking the list instead both keeps the handle and stops this function caring how the
+     * drawer marks its exclusions. */
+    if(dt_masks_skip_contains(gui_points->border_skips, gui_points->border_skip_count, i)) continue;
+
     const float px = gui_points->points[i * 2];
     const float py = gui_points->points[i * 2 + 1];
-    if(isnan(px) || isnan(py)) continue;
-    /* ... and the BORDER sample at that index has to exist, because that is what gets returned.
-     * The drawn outline blanks the border wherever it doubles back on itself, and a node can sit
-     * opposite such a span -- a cusp does. Choosing the nearest centreline point without looking
-     * at its border, then failing on NaN, costs that node its border handle outright: no dash
-     * drawn, and no hover or drag either, since both interactions resolve through here. */
-    if(isnan(gui_points->border[i * 2]) || isnan(gui_points->border[i * 2 + 1])) continue;
-
     const float dx = node_x - px;
     const float dy = node_y - py;
     const float dist2 = dx * dx + dy * dy;
@@ -363,14 +368,14 @@ static gboolean _brush_get_border_handle_resampled(const dt_masks_form_gui_point
 
   *handle_x = gui_points->border[best_idx * 2];
   *handle_y = gui_points->border[best_idx * 2 + 1];
-  return !(isnan(*handle_x) || isnan(*handle_y));
+  return TRUE;
 }
 
 static gboolean _brush_get_border_handle_mirrored(const dt_masks_form_gui_points_t *gui_points, int node_count,
                                                   int node_index, float *handle_x, float *handle_y)
 {
-  float resampled_x = NAN;
-  float resampled_y = NAN;
+  float resampled_x = 0.0f;
+  float resampled_y = 0.0f;
   if(!_brush_get_border_handle_resampled(gui_points, node_count, node_index, &resampled_x, &resampled_y)) return FALSE;
 
   const float node_x = gui_points->points[node_index * 6 + 2];
@@ -378,7 +383,7 @@ static gboolean _brush_get_border_handle_mirrored(const dt_masks_form_gui_points
 
   *handle_x = node_x - (resampled_x - node_x);
   *handle_y = node_y - (resampled_y - node_y);
-  return !(isnan(*handle_x) || isnan(*handle_y));
+  return TRUE;
 }
 
 /** get bezier control points from feather extremity */
@@ -678,27 +683,31 @@ static inline void _brush_payload_sync(dt_masks_dynbuf_t *dpayload, dt_masks_dyn
 
 /** recursive function to get all points of the brush AND all point of the border */
 /** the function takes care to avoid big gaps between points */
+/* @p have_min / @p have_max say whether the caller already evaluated that endpoint, and
+ * @p have_border_min / @p have_border_max whether a border point came with it. They used to be
+ * read out of the arrays as NaN -- "not computed" and "no border" sharing one representation
+ * with each other and with real geometry. Which of the three a NaN meant depended on where you
+ * were standing, and the arrays are the same ones that end up in the outline. */
 static void _brush_points_recurs(float *p1, float *p2, double tmin, double tmax, float *points_min,
                                  float *points_max, float *border_min, float *border_max, float *rpoints,
                                  float *rborder, float *rpayload, dt_masks_dynbuf_t *dpoints, dt_masks_dynbuf_t *dborder,
-                                 dt_masks_dynbuf_t *dpayload, const int pixel_threshold)
+                                 dt_masks_dynbuf_t *dpayload, const int pixel_threshold,
+                                 const gboolean have_min, const gboolean have_max,
+                                 gboolean have_border_min, gboolean have_border_max,
+                                 gboolean *out_have_border)
 {
   const gboolean withborder = (!IS_NULL_PTR(dborder));
   const gboolean withpayload = (!IS_NULL_PTR(dpayload));
 
   // we calculate points if needed
-  if(isnan(points_min[0]))
-  {
-    _brush_border_get_XY(p1[0], p1[1], p1[2], p1[3], p2[2], p2[3], p2[0], p2[1], tmin,
-                         p1[4] + (p2[4] - p1[4]) * tmin * tmin * (3.0 - 2.0 * tmin), points_min,
-                         points_min + 1, border_min, border_min + 1);
-  }
-  if(isnan(points_max[0]))
-  {
-    _brush_border_get_XY(p1[0], p1[1], p1[2], p1[3], p2[2], p2[3], p2[0], p2[1], tmax,
-                         p1[4] + (p2[4] - p1[4]) * tmax * tmax * (3.0 - 2.0 * tmax), points_max,
-                         points_max + 1, border_max, border_max + 1);
-  }
+  if(!have_min)
+    have_border_min = _brush_border_get_XY(p1[0], p1[1], p1[2], p1[3], p2[2], p2[3], p2[0], p2[1], tmin,
+                                           p1[4] + (p2[4] - p1[4]) * tmin * tmin * (3.0 - 2.0 * tmin), points_min,
+                                           points_min + 1, border_min, border_min + 1);
+  if(!have_max)
+    have_border_max = _brush_border_get_XY(p1[0], p1[1], p1[2], p1[3], p2[2], p2[3], p2[0], p2[1], tmax,
+                                           p1[4] + (p2[4] - p1[4]) * tmax * tmax * (3.0 - 2.0 * tmax), points_max,
+                                           points_max + 1, border_max, border_max + 1);
 
   // are the points near_handle ?
   if((tmax - tmin < 0.0001f)
@@ -711,15 +720,18 @@ static void _brush_points_recurs(float *p1, float *p2, double tmin, double tmax,
 
     if(withborder)
     {
-      if(isnan(border_max[0]))
+      /* one end of the span may have had no direction to offset along; borrow the other's */
+      if(!have_border_max && have_border_min)
       {
         border_max[0] = border_min[0];
         border_max[1] = border_min[1];
+        have_border_max = TRUE;
       }
-      else if(isnan(border_min[0]))
+      else if(!have_border_min && have_border_max)
       {
         border_min[0] = border_max[0];
         border_min[1] = border_max[1];
+        have_border_min = TRUE;
       }
 
       // we check gaps in the border (sharp edges)
@@ -730,6 +742,7 @@ static void _brush_points_recurs(float *p1, float *p2, double tmin, double tmax,
 
       rborder[0] = border_max[0];
       rborder[1] = border_max[1];
+      if(!IS_NULL_PTR(out_have_border)) *out_have_border = have_border_max;
       dt_masks_dynbuf_add_2(dborder, rborder[0], rborder[1]);
     }
 
@@ -745,12 +758,15 @@ static void _brush_points_recurs(float *p1, float *p2, double tmin, double tmax,
 
   // we split in two part
   double tx = (tmin + tmax) / 2.0;
-  float c[2] = { NAN, NAN }, b[2] = { NAN, NAN };
+  float c[2] = { 0.0f, 0.0f }, b[2] = { 0.0f, 0.0f };
   float rc[2], rb[2], rp[2];
+  /* the left half inherits our min end and computes the midpoint; the right half is then handed
+   * that midpoint already evaluated, and inherits our max end */
   _brush_points_recurs(p1, p2, tmin, tx, points_min, c, border_min, b, rc, rb, rp, dpoints, dborder, dpayload,
-                       pixel_threshold);
+                       pixel_threshold, have_min, FALSE, have_border_min, FALSE, NULL);
   _brush_points_recurs(p1, p2, tx, tmax, rc, points_max, rb, border_max, rpoints, rborder, rpayload, dpoints,
-                       dborder, dpayload, pixel_threshold);
+                       dborder, dpayload, pixel_threshold, TRUE, have_max, TRUE, have_border_max,
+                       out_have_border);
 }
 
 
@@ -1022,13 +1038,14 @@ static int _brush_get_pts_border(dt_develop_t *develop, dt_masks_form_t *mask_fo
 
     // and we determine all points by recursion (to be sure the distance between 2 points is <=1)
     float rc[2], rb[2], rp[2];
-    float bmin[2] = { NAN, NAN };
-    float bmax[2] = { NAN, NAN };
-    float cmin[2] = { NAN, NAN };
-    float cmax[2] = { NAN, NAN };
+    float bmin[2] = { 0.0f, 0.0f };
+    float bmax[2] = { 0.0f, 0.0f };
+    float cmin[2] = { 0.0f, 0.0f };
+    float cmax[2] = { 0.0f, 0.0f };
+    gboolean have_rb = FALSE;
 
     _brush_points_recurs(p1, p2, 0.0, 1.0, cmin, cmax, bmin, bmax, rc, rb, rp, dpoints, dborder, dpayload,
-                         pixel_threshold);
+                         pixel_threshold, FALSE, FALSE, FALSE, FALSE, &have_rb);
 
     dt_masks_dynbuf_add_2(dpoints, rc[0], rc[1]);
 
@@ -1039,19 +1056,13 @@ static int _brush_get_pts_border(dt_develop_t *develop, dt_masks_form_t *mask_fo
 
     if(!IS_NULL_PTR(dborder))
     {
-      if(isnan(rb[0]))
+      if(!have_rb)
       {
-        float lastb0 = dt_masks_dynbuf_get(dborder, -2);
-        float lastb1 = dt_masks_dynbuf_get(dborder, -1);
-        if(isnan(lastb0))
-        {
-          lastb0 = dt_masks_dynbuf_get(dborder, -4);
-          lastb1 = dt_masks_dynbuf_get(dborder, -3);
-          dt_masks_dynbuf_set(dborder, -2, lastb0);
-          dt_masks_dynbuf_set(dborder, -1, lastb1);
-        }
-        rb[0] = lastb0;
-        rb[1] = lastb1;
+        /* the segment had no direction to offset along anywhere; hold the last border sample so
+         * the buffer stays continuous geometry. The nested "and if THAT one was NaN too" case
+         * this replaces could not arise any more: nothing writes a sentinel into the buffer. */
+        rb[0] = dt_masks_dynbuf_get(dborder, -2);
+        rb[1] = dt_masks_dynbuf_get(dborder, -1);
       }
       dt_masks_dynbuf_add_2(dborder, rb[0], rb[1]);
     }
@@ -1060,13 +1071,13 @@ static int _brush_get_pts_border(dt_develop_t *develop, dt_masks_form_t *mask_fo
     if(!IS_NULL_PTR(dborder) && node_count >= 3)
     {
       // we get the next point (start of the next segment)
-      _brush_border_get_XY(p3[0], p3[1], p3[2], p3[3], p4[2], p4[3], p4[0], p4[1], 0, p3[4], cmin, cmin + 1,
-                           bmax, bmax + 1);
-      if(isnan(bmax[0]))
-      {
-        _brush_border_get_XY(p3[0], p3[1], p3[2], p3[3], p4[2], p4[3], p4[0], p4[1], 0.0001, p3[4], cmin,
-                             cmin + 1, bmax, bmax + 1);
-      }
+      /* t = 0 lands exactly on the node, where a cusp's collapsed handles leave no direction;
+       * a hair along the curve there is one. If even that fails the node is isolated, and the
+       * arc below is skipped by its own gap test rather than fed a stale bmax. */
+      if(!_brush_border_get_XY(p3[0], p3[1], p3[2], p3[3], p4[2], p4[3], p4[0], p4[1], 0, p3[4],
+                               cmin, cmin + 1, bmax, bmax + 1))
+        _brush_border_get_XY(p3[0], p3[1], p3[2], p3[3], p4[2], p4[3], p4[0], p4[1], 0.0001, p3[4],
+                             cmin, cmin + 1, bmax, bmax + 1);
       /* The border of the two segments meeting at this node ends on one side of the joint and
        * restarts on the other; this arc bridges the wedge between them, centred on the node.
        * Without it the rasteriser has no border samples across the joint, so the falloff paints
@@ -1522,16 +1533,6 @@ static dt_masks_raster_result_t _brush_get_points_border(dt_develop_t *develop, 
     }
 
 
-    for(int i = 0; i < *border_skip_count; i++)
-    {
-      const int from = (*border_skips)[i].jump_from;
-      const int to = MIN((*border_skips)[i].resume_at, *border_count);
-      for(int j = MAX(from, 0); j < to; j++)
-      {
-        (*border_buffer)[j * 2] = NAN;
-        (*border_buffer)[j * 2 + 1] = NAN;
-      }
-    }
   }
 
   return dt_masks_raster_from_status(status);
@@ -2060,7 +2061,7 @@ static int _brush_events_button_pressed(struct dt_iop_module_t *module, double w
     }
     else if(mask_gui->handle_border_hovered >= 0)
     {
-      float handle_x = NAN, handle_y = NAN;
+      float handle_x = 0.0f, handle_y = 0.0f;
       if(_brush_get_border_handle_mirrored(gui_points, node_count, mask_gui->handle_border_hovered,
                                            &handle_x, &handle_y))
       {
@@ -2396,7 +2397,7 @@ static int _brush_events_mouse_moved(struct dt_iop_module_t *module, double widg
         = (dt_masks_node_brush_t *)g_list_nth_data(mask_form->points, node_index);
     if(IS_NULL_PTR(node)) return 0;
 
-    float handle_x = NAN, handle_y = NAN;
+    float handle_x = 0.0f, handle_y = 0.0f;
     if(!_brush_get_border_handle_mirrored(gui_points, node_count, node_index, &handle_x, &handle_y))
       return 0;
 
@@ -2463,79 +2464,14 @@ static inline int _brush_centerline_end(const int points_count, const int node_c
   return first + (points_count - first) / 2;
 }
 
-static void _brush_draw_shape(struct dt_develop_t *dev, cairo_t *cr, const float *points, const int points_count, const int node_nb, const gboolean border, const gboolean source)
+static void _brush_draw_shape(struct dt_develop_t *dev, cairo_t *cr, const float *points, const int points_count, const int node_nb, const gboolean border, const gboolean source,
+                              const dt_masks_skip_range_t *skips, const int skip_count)
 {
-   // unused arg, keep compiler from complaining
- // Find the first valid non-NaN point to start drawing
- // FIXME: Why not just avoid having NaN points in the array?
-  int start_idx = -1;
-  for(int i = node_nb * 3 + border; i < points_count; i++)
-  {
-    if(!isnan(points[i * 2]) && !isnan(points[i * 2 + 1]))
-    {
-      start_idx = i;
-      break;
-    }
-  }
-
-  // Only draw if we have at least one valid point
-  if(start_idx >= 0)
-  {
-    cairo_move_to(cr, points[start_idx * 2], points[start_idx * 2 + 1]);
-
-    // We don't want to draw the plain line twice, adapt the end index accordingly
-    const int end_idx = border ? points_count : _brush_centerline_end(points_count, node_nb);
-
-    /* One line_to per point sampled at RAW resolution is several per device pixel; emit at the
-     * resolution the context can actually show. See dt_draw_min_emit_step(). */
-    const double min_step = dt_draw_min_emit_step(cr);
-    const double min_step2 = min_step * min_step;
-    double last_x = points[start_idx * 2];
-    double last_y = points[start_idx * 2 + 1];
-
-    /* A NaN run is a HOLE in the outline, not a shortcut across it. Skipping the samples with
-     * the pen still down makes the next valid point a line_to, so every blanked span comes out
-     * as a straight chord -- at a cusp, a chord slicing across the rounded tip the stroke
-     * actually has. Lift the pen instead: begin a new sub-path at the first sample after the
-     * run, so the span is simply absent. Stroking a path of several sub-paths is free. */
-    gboolean pen_down = TRUE;
-
-    for(int i = start_idx + 1; i < end_idx; i++)
-    {
-      const double x = points[i * 2];
-      const double y = points[i * 2 + 1];
-      if(isnan(x) || isnan(y)) { pen_down = FALSE; continue; }
-
-      const double step_x = x - last_x;
-      const double step_y = y - last_y;
-      /* the decimation must not apply across a lifted pen: the new sub-path has to start
-       * somewhere, however close it landed to where the old one stopped */
-      if(pen_down && (step_x * step_x + step_y * step_y) < min_step2) continue;
-
-      if(pen_down)
-        cairo_line_to(cr, x, y);
-      else
-      {
-        cairo_move_to(cr, x, y);
-        pen_down = TRUE;
-      }
-      last_x = x;
-      last_y = y;
-    }
-
-    // the last point always lands, so the outline closes where the shape does
-    if(end_idx > start_idx + 1)
-    {
-      const double x = points[(end_idx - 1) * 2];
-      const double y = points[(end_idx - 1) * 2 + 1];
-      if(!isnan(x) && !isnan(y) && (x != last_x || y != last_y))
-      {
-        // ... but not across a hole, for the same reason as above
-        if(pen_down) cairo_line_to(cr, x, y);
-        else         cairo_move_to(cr, x, y);
-      }
-    }
-  }
+  /* The centreline is walked there and back (see _brush_centerline_end): stroking the whole
+   * array would draw it twice. The border wraps the stroke and is walked once. */
+  const int first = node_nb * 3 + border;
+  const int last = border ? points_count : _brush_centerline_end(points_count, node_nb);
+  dt_masks_draw_outline_runs(cr, points, first, last, skips, skip_count);
 }
 
 static float _brush_line_length(const float *line, const int first_pt, const int last_pt)
@@ -2549,7 +2485,6 @@ static float _brush_line_length(const float *line, const int first_pt, const int
     const float y0 = line[i0 + 1];
     const float x1 = line[i1];
     const float y1 = line[i1 + 1];
-    if(isnan(x0) || isnan(y0) || isnan(x1) || isnan(y1)) continue;
     const float dx = x1 - x0;
     const float dy = y1 - y0;
     const float len = dx * dx + dy * dy;
@@ -2566,7 +2501,7 @@ static gboolean _brush_line_point_at_length(const float *line, const int first_p
 
   float acc = 0.0f;
   gboolean has_fallback = FALSE;
-  float fallback_x = NAN, fallback_y = NAN;
+  float fallback_x = 0.0f, fallback_y = 0.0f;
 
   for(int i = first_pt; i < last_pt; i++)
   {
@@ -2576,7 +2511,6 @@ static gboolean _brush_line_point_at_length(const float *line, const int first_p
     const float y0 = line[i0 + 1];
     const float x1 = line[i1];
     const float y1 = line[i1 + 1];
-    if(isnan(x0) || isnan(y0) || isnan(x1) || isnan(y1)) continue;
 
     const float dx = x1 - x0;
     const float dy = y1 - y0;
@@ -2597,7 +2531,7 @@ static gboolean _brush_line_point_at_length(const float *line, const int first_p
     acc += len;
   }
 
-  if(!has_fallback || isnan(fallback_x) || isnan(fallback_y)) return FALSE;
+  if(!has_fallback) return FALSE;
   *x = fallback_x;
   *y = fallback_y;
   return TRUE;
@@ -2899,7 +2833,7 @@ static void _brush_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks_fo
     {
       dt_draw_shape_lines(mask_gui->dev, DT_MASKS_DASH_STICK, FALSE, cr, node_count, (mask_gui->border_selected), zoom_scale,
                           gui_points->border, gui_points->border_count, &dt_masks_functions_brush.draw_shape,
-                          CAIRO_LINE_CAP_ROUND);
+                          CAIRO_LINE_CAP_ROUND, gui_points->border_skips, gui_points->border_skip_count);
     }
 
     // draw the current node's handle if it's a curve node
@@ -2935,7 +2869,7 @@ static void _brush_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks_fo
       const gboolean selected = (mask_gui->node_hovered == edited
                               || selected_handle_border == edited
                               || mask_gui->handle_border_hovered == edited);
-      float handle[2] = {NAN, NAN};
+      float handle[2] = { 0.0f, 0.0f };
       // Show the border handle on the opposite side from the curve handle
       if(_brush_get_border_handle_mirrored(gui_points, node_count, edited, &handle[0], &handle[1]))
       {

--- a/src/develop/masks/brush.c
+++ b/src/develop/masks/brush.c
@@ -1408,6 +1408,57 @@ static int _skip_range_cmp_fwd(const void *a, const void *b)
   return (x->resume_at < y->resume_at) ? -1 : (x->resume_at > y->resume_at);
 }
 
+/** Turn the detector's crossing pairs into the disjoint cuts the drawer walks.
+ *
+ * Two rules, both learned by watching the outline break.
+ *
+ * Do not merge. dt_masks_skip_ranges_build() merges overlaps, which is right for the hit-test walk
+ * -- it only needs a traversal that moves forward and terminates -- and wrong for drawing. Each
+ * crossing pair names two samples that ARE the same point, so cutting between them leaves the
+ * outline closed; the union of two overlapping pairs names two samples that are not, and the
+ * drawer then spans the gap with a straight chord. Measured after a merge: cuts leaving 105, 170
+ * and 73 pixel gaps, one chord across the stroke each.
+ *
+ * Longest first, not first-by-position. A fold is LOCAL, and nested loops want the outer one
+ * removed since it subsumes the inner. By position, one 10035-sample span won and blocked every
+ * fold inside it, erasing the inner border at the cusp; shortest first, a tiny crossing NESTED in
+ * a real loop won and blocked it, leaving 30 px and 14 px kinks. What makes longest-first safe is
+ * the cap: the detector also pairs the two SIDES of the stroke where they meet, which is no loop
+ * at all, and those are 41253 samples of a 52492-sample contour against 3180 for the largest real
+ * fold -- an eighth of the contour separates the two populations by an order of magnitude. */
+static int _select_disjoint_cuts(const float *const crossings, const int found, const int border_count,
+                                 dt_masks_skip_range_t *const out)
+{
+  int kept = 0;
+  for(int i = 0; i < found; i++)
+  {
+    const int lo = (int)crossings[i * 2];
+    const int hi = (int)crossings[i * 2 + 1];
+    if(lo < 0 || hi <= lo || hi >= border_count) continue;
+    if(hi - lo > border_count - (hi - lo)) continue;   // names the fold's complement
+    if(hi - lo > border_count / 8) continue;           // the two sides meeting, not a fold
+    out[kept].jump_from = lo;
+    out[kept].resume_at = hi;
+    kept++;
+  }
+  qsort(out, kept, sizeof(dt_masks_skip_range_t), _skip_range_cmp_span);
+
+  int accepted = 0;
+  for(int i = 0; i < kept; i++)
+  {
+    gboolean clashes = FALSE;
+    for(int j = 0; j < accepted && !clashes; j++)
+      clashes = (out[i].jump_from < out[j].resume_at && out[j].jump_from < out[i].resume_at);
+    if(clashes) continue;
+    const dt_masks_skip_range_t take = out[i];
+    out[accepted++] = take;
+  }
+
+  /* the blanking pass walks forward, so hand it sorted ranges */
+  qsort(out, accepted, sizeof(dt_masks_skip_range_t), _skip_range_cmp_fwd);
+  return accepted;
+}
+
 static dt_masks_raster_result_t _brush_get_points_border(dt_develop_t *develop, dt_masks_form_t *mask_form,
                                     float **point_buffer, int *point_count,
                                     float **border_buffer, int *border_count,
@@ -1499,36 +1550,8 @@ static dt_masks_raster_result_t _brush_get_points_border(dt_develop_t *develop, 
          * real fold. An eighth of the contour separates the two populations by an order of
          * magnitude and needs no tuning. */
         if(!IS_NULL_PTR(*border_skips))
-        {
-          dt_masks_skip_range_t *const out = *border_skips;
-          int kept = 0;
-          for(int i = 0; i < found; i++)
-          {
-            const int lo = (int)crossings[i * 2];
-            const int hi = (int)crossings[i * 2 + 1];
-            if(lo < 0 || hi <= lo || hi >= *border_count) continue;
-            if(hi - lo > *border_count - (hi - lo)) continue;   // names the fold's complement
-            if(hi - lo > *border_count / 8) continue;           // the two sides meeting, not a fold
-            out[kept].jump_from = lo;
-            out[kept].resume_at = hi;
-            kept++;
-          }
-          qsort(out, kept, sizeof(dt_masks_skip_range_t), _skip_range_cmp_span);
-
-          int accepted = 0;
-          for(int i = 0; i < kept; i++)
-          {
-            gboolean clashes = FALSE;
-            for(int j = 0; j < accepted && !clashes; j++)
-              clashes = (out[i].jump_from < out[j].resume_at && out[j].jump_from < out[i].resume_at);
-            if(clashes) continue;
-            const dt_masks_skip_range_t take = out[i];
-            out[accepted++] = take;
-          }
-          /* the blanking pass walks forward, so hand it sorted ranges */
-          qsort(out, accepted, sizeof(dt_masks_skip_range_t), _skip_range_cmp_fwd);
-          *border_skip_count = accepted;
-        }
+          *border_skip_count = _select_disjoint_cuts(crossings, found, *border_count,
+                                                     *border_skips);
       }
       dt_free_align(crossings);
     }

--- a/src/develop/masks/brush.c
+++ b/src/develop/masks/brush.c
@@ -874,7 +874,7 @@ static int _brush_get_pts_border(dt_develop_t *develop, dt_masks_form_t *mask_fo
 
   const guint node_count = g_list_length(mask_form->points);
 
-  dt_masks_node_brush_t **nodes = malloc((size_t)node_count * sizeof(*nodes));
+  dt_masks_node_brush_t **nodes = dt_alloc_align((size_t)node_count * sizeof(*nodes));
   if(!nodes)
   {
     dt_masks_dynbuf_free(dpoints);
@@ -1107,7 +1107,7 @@ static int _brush_get_pts_border(dt_develop_t *develop, dt_masks_form_t *mask_fo
     }
   }
 
-  dt_free(nodes);
+  dt_free_align(nodes);
 
   *point_count = dt_masks_dynbuf_position(dpoints) / 2;
   *point_buffer = dt_masks_dynbuf_harvest(dpoints);
@@ -1458,7 +1458,7 @@ static dt_masks_raster_result_t _brush_get_points_border(dt_develop_t *develop, 
      * Measured at 4096: five cuts made and seven real crossings left drawn. The greedy pass
      * below collapses the duplicates, so the only cost of a large cap is the scratch buffer. */
     const int max_pairs = 1 << 16;
-    float *const crossings = (float *)malloc(sizeof(float) * 2 * (size_t)max_pairs);
+    float *const crossings = dt_alloc_align_float(2 * (size_t)max_pairs);
     *border_skip_count = 0;
 
     if(!IS_NULL_PTR(crossings))
@@ -1529,7 +1529,7 @@ static dt_masks_raster_result_t _brush_get_points_border(dt_develop_t *develop, 
           *border_skip_count = accepted;
         }
       }
-      free(crossings);
+      dt_free_align(crossings);
     }
 
 

--- a/src/develop/masks/brush.c
+++ b/src/develop/masks/brush.c
@@ -729,9 +729,10 @@ static void _brush_points_recurs(float *p1, float *p2, double tmin, double tmax,
       }
       else if(!have_border_min && have_border_max)
       {
+        /* no have_border_min = TRUE here: only have_border_max is reported upward, and this
+         * branch has it TRUE by its own condition. Setting it would be dead. */
         border_min[0] = border_max[0];
         border_min[1] = border_max[1];
-        have_border_min = TRUE;
       }
 
       // we check gaps in the border (sharp edges)
@@ -2467,6 +2468,9 @@ static inline int _brush_centerline_end(const int points_count, const int node_c
 static void _brush_draw_shape(struct dt_develop_t *dev, cairo_t *cr, const float *points, const int points_count, const int node_nb, const gboolean border, const gboolean source,
                               const dt_masks_skip_range_t *skips, const int skip_count)
 {
+  /* dev and source are the shared shape_draw_function_t signature. */
+  (void)dev; (void)source;
+
   /* The centreline is walked there and back (see _brush_centerline_end): stroking the whole
    * array would draw it twice. The border wraps the stroke and is walked once. */
   const int first = node_nb * 3 + border;

--- a/src/develop/masks/circle.c
+++ b/src/develop/masks/circle.c
@@ -71,7 +71,7 @@ static void _circle_get_distance(float x, float y, float as, dt_masks_form_gui_t
   const float pt[2] = { x, y };
 
   if(gpt->source && gpt->source_count > 0
-     && dt_masks_point_in_form_exact(pt, 1, gpt->source, 1, gpt->source_count) >= 0)
+     && dt_masks_point_in_form_exact(pt, 1, gpt->source, 1, gpt->source_count, NULL, 0) >= 0)
   {
     *inside_source = 1;
     *inside = 1;
@@ -92,11 +92,11 @@ static void _circle_get_distance(float x, float y, float as, dt_masks_form_gui_t
   *dist = sqf(center_dx) + sqf(center_dy);
 
   // we check if it's inside borders
-  if(dt_masks_point_in_form_exact(pt, 1, gpt->border, 1, gpt->border_count) < 0) return;
+  if(dt_masks_point_in_form_exact(pt, 1, gpt->border, 1, gpt->border_count, NULL, 0) < 0) return;
   *inside = 1;
 
   // and we check if it's inside form
-  if(dt_masks_point_in_form_exact(pt, 1, gpt->points, 1, gpt->points_count) < 0)
+  if(dt_masks_point_in_form_exact(pt, 1, gpt->points, 1, gpt->points_count, NULL, 0) < 0)
     *inside_border = 1;
 }
 
@@ -683,9 +683,14 @@ static void _bounding_box(const float *const points, int num_points, int *width,
 
 static dt_masks_raster_result_t _circle_get_points_border(dt_develop_t *dev, struct dt_masks_form_t *form,
                                      float **points,
-                                     int *points_count, float **border, int *border_count, int source,
+                                     int *points_count, float **border, int *border_count,
+                                     dt_masks_skip_range_t **border_skips, int *border_skip_count,
+                                     int source,
                                      const dt_iop_module_t *module)
 {
+  if(!IS_NULL_PTR(border_skips)) *border_skips = NULL;
+  if(!IS_NULL_PTR(border_skip_count)) *border_skip_count = 0;
+
   /* No geometry to build an outline from: the outline is empty, which is a result, not a
    * failure. Reporting success here (as this did) told the caller to cache a NULL outline as
    * if it had been built. */

--- a/src/develop/masks/circle.c
+++ b/src/develop/masks/circle.c
@@ -479,7 +479,10 @@ static int _circle_events_mouse_moved(struct dt_iop_module_t *module, double x, 
 static void _circle_draw_shape(dt_develop_t *dev, cairo_t *cr, const float *points, const int points_count, const int coord_nb, const gboolean border, const gboolean source,
                               const dt_masks_skip_range_t *skips, const int skip_count)
 {
-   // unused arg, keep compiler from complaining
+  /* A circle has no self-intersections, so it never carries an exclusion list -- these are the
+   * shared shape_draw_function_t signature, not something to honour here. */
+  (void)dev; (void)border; (void)source; (void)skips; (void)skip_count;
+
   /* One line_to per point sampled at RAW resolution is several per device pixel; emit at the
    * resolution the context can actually show. See dt_draw_min_emit_step() (mirrors the brush). */
   const double min_step = dt_draw_min_emit_step(cr);

--- a/src/develop/masks/circle.c
+++ b/src/develop/masks/circle.c
@@ -667,23 +667,6 @@ static void _circle_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks_f
   }
 }
 
-static void _bounding_box(const float *const points, int num_points, int *width, int *height, int *posx, int *posy)
-{
-  // search for min/max X and Y coordinates
-  float xmin = FLT_MAX, xmax = FLT_MIN, ymin = FLT_MAX, ymax = FLT_MIN;
-  for(int i = 1; i < num_points; i++) // skip point[0], which is circle's center
-  {
-    xmin = fminf(points[i * 2], xmin);
-    xmax = fmaxf(points[i * 2], xmax);
-    ymin = fminf(points[i * 2 + 1], ymin);
-    ymax = fmaxf(points[i * 2 + 1], ymax);
-  }
-  // set the min/max values we found
-  *posx = xmin;
-  *posy = ymin;
-  *width = (xmax - xmin);
-  *height = (ymax - ymin);
-}
 
 static dt_masks_raster_result_t _circle_get_points_border(dt_develop_t *dev, struct dt_masks_form_t *form,
                                      float **points,
@@ -756,7 +739,7 @@ static dt_masks_raster_result_t _circle_get_source_area(dt_iop_module_t *module,
     return DT_MASKS_RASTER_ERROR;
   }
 
-  _bounding_box(points, num_points, width, height, posx, posy);
+  dt_masks_points_bounding_box(points, num_points, width, height, posx, posy);
   dt_pixelpipe_cache_free_align(points);
   return DT_MASKS_RASTER_OK;
 }
@@ -791,7 +774,7 @@ static dt_masks_raster_result_t _circle_get_area(const dt_iop_module_t *const re
     return DT_MASKS_RASTER_ERROR;
   }
 
-  _bounding_box(points, num_points, width, height, posx, posy);
+  dt_masks_points_bounding_box(points, num_points, width, height, posx, posy);
   dt_pixelpipe_cache_free_align(points);
   return DT_MASKS_RASTER_OK;
 }
@@ -1040,39 +1023,13 @@ static dt_masks_raster_result_t _circle_get_mask_roi(const dt_iop_module_t *cons
   if(bbw <= 1 || bbh <= 1)
     return DT_MASKS_RASTER_EMPTY;
 
-  float *const restrict points = dt_pixelpipe_cache_alloc_align_float_cache((size_t)bbw * bbh * 2, 0);
+  const dt_masks_sample_grid_t sample_grid
+      = { .x0 = bbxm, .y0 = bbym, .width = bbw, .height = bbh,
+          .step = grid, .px = px, .py = py, .iscale = iscale };
+  float *const restrict points
+      = dt_masks_sample_grid_backtransform(pipe, module->iop_order, &sample_grid, "circle", form->name);
   if(IS_NULL_PTR(points)) return DT_MASKS_RASTER_ERROR;
-
-  // we populate the grid points in module coordinates
-  __OMP_PARALLEL_FOR__(collapse(2) if(bbw*bbh > 50000))
-  for(int j = bbym; j <= bbYM; j++)
-    for(int i = bbxm; i <= bbXM; i++)
-    {
-      const size_t index = (size_t)(j - bbym) * bbw + i - bbxm;
-      points[index * 2] = (grid * i + px) * iscale;
-      points[index * 2 + 1] = (grid * j + py) * iscale;
-    }
-
-  if(dt_get_debug_flags() & DT_DEBUG_PERF)
-  {
-    dt_print(DT_DEBUG_MASKS, "[masks %s] circle grid took %0.04f sec\n", form->name, dt_get_wtime() - start2);
-    start2 = dt_get_wtime();
-  }
-
-  // we back transform all these points to the input image coordinates
-  if(!dt_dev_distort_backtransform_plus(pipe, module->iop_order, DT_DEV_TRANSFORM_DIR_BACK_INCL, points,
-                                        (size_t)bbw * bbh))
-  {
-    dt_pixelpipe_cache_free_align(points);
-    return DT_MASKS_RASTER_ERROR;
-  }
-
-  if(dt_get_debug_flags() & DT_DEBUG_PERF)
-  {
-    dt_print(DT_DEBUG_MASKS, "[masks %s] circle transform took %0.04f sec\n", form->name,
-             dt_get_wtime() - start2);
-    start2 = dt_get_wtime();
-  }
+  start2 = dt_get_wtime();
 
   // we calculate the mask values at the transformed points;
   // for results: re-use the points array

--- a/src/develop/masks/circle.c
+++ b/src/develop/masks/circle.c
@@ -161,22 +161,7 @@ static int _circle_get_creation_preview(dt_masks_form_t *form, dt_masks_form_gui
                              &preview->border, &preview->border_count);
 
   if(!err && dt_masks_form_is_clone(form))
-  {
-    float source_pos[2] = { 0.0f, 0.0f };
-    dt_masks_calculate_source_pos_origin(gui, gui->pos[0], gui->pos[1], gui->pos[0], gui->pos[1],
-                                        &source_pos[0], &source_pos[1], FALSE);
-    const float center_source[2] = { source_pos[0] - gui->pos[0], source_pos[1] - gui->pos[1] };
-
-    preview->source_points = dt_pixelpipe_cache_alloc_align_float_cache((size_t)2 * preview->points_count, 0);
-    if(IS_NULL_PTR(preview->source_points))
-      err = 1;
-
-    for(int i = 0; !err && i < preview->points_count; i++)
-    {
-      preview->source_points[i * 2] = preview->points[i * 2] + center_source[0];
-      preview->source_points[i * 2 + 1] = preview->points[i * 2 + 1] + center_source[1];
-    }
-  }
+    err = dt_masks_preview_add_clone_source(gui, preview);
 
   if(err)
     dt_masks_preview_buffers_cleanup(preview);
@@ -546,45 +531,7 @@ static int _circle_get_points_source(dt_develop_t *dev, float x, float y, float 
   *points = _points_to_transform(dev, x, y, radius, wd, ht, points_count);
   if(IS_NULL_PTR(*points)) return 1;
 
-  // we transform with all distortion that happen *before* the module
-  // so we have now the TARGET points in module input reference
-  if(!dt_dev_distort_transform_gui(dev, module->iop_order, DT_DEV_TRANSFORM_DIR_BACK_EXCL,
-                                    *points, *points_count))
-    goto error;
-
-  // now we move all the points by the shift
-  // so we have now the SOURCE points in module input reference
-  float pts[2] = { xs, ys };
-  dt_dev_coordinates_raw_norm_to_raw_abs(dev, pts, 1);
-  if(!dt_dev_distort_transform_gui(dev, module->iop_order, DT_DEV_TRANSFORM_DIR_BACK_EXCL,
-                                    pts, 1))
-    goto error;
-
-  {
-    const float dx = pts[0] - (*points)[0];
-    const float dy = pts[1] - (*points)[1];
-    __OMP_PARALLEL_FOR_SIMD__(if(*points_count > 100) aligned(points:64))
-    for(int i = 0; i < *points_count; i++)
-    {
-      (*points)[i * 2] += dx;
-      (*points)[i * 2 + 1] += dy;
-    }
-  }
-
-  // we apply the rest of the distortions (those after the module)
-  // so we have now the SOURCE points in final image reference
-  if(!dt_dev_distort_transform_gui(dev, module->iop_order, DT_DEV_TRANSFORM_DIR_FORW_INCL,
-                                    *points, *points_count))
-    goto error;
-
-  return 0;
-
-  // if we failed, then free all and return
-error:
-  dt_pixelpipe_cache_free_align(*points);
-  *points = NULL;
-  *points_count = 0;
-  return 1;
+  return dt_masks_points_shift_to_source(dev, module, points, points_count, xs, ys, 0);
 }
 
 static int _circle_get_points(dt_develop_t *dev, float x, float y, float radius, float radius2, float rotation,

--- a/src/develop/masks/circle.c
+++ b/src/develop/masks/circle.c
@@ -1056,43 +1056,8 @@ static dt_masks_raster_result_t _circle_get_mask_roi(const dt_iop_module_t *cons
 
   // we fill the pre-initialized output buffer by interpolation;
   // we only need to take the contents of our bounding box into account
-  const int endx = MIN(width, bbXM * grid);
-  const int endy = MIN(height, bbYM * grid);
-  const float inv_grid2 = 1.0f / (grid * grid);
-  float w0[4], w1[4];
-  for(int i = 0; i < grid; i++)
-  {
-    w0[i] = (float)(grid - i);
-    w1[i] = (float)i;
-  }
-  __OMP_PARALLEL_FOR__(if((size_t)(endy - bbym * grid) * (size_t)(endx - bbxm * grid) > 50000))
-  for(int j = bbym * grid; j < endy; j++)
-  {
-    const int jj = j % grid;
-    const int mj = j / grid - bbym;
-    const float wj0 = w0[jj];
-    const float wj1 = w1[jj];
-    const size_t row_base = (size_t)mj * bbw;
-    float *const row = buffer + (size_t)j * width;
-    int ii = 0;
-    int mi = 0;
-    for(int i = bbxm * grid; i < endx; i++)
-    {
-      const size_t mindex = row_base + mi;
-      const float wii0 = w0[ii];
-      const float wii1 = w1[ii];
-      row[i] = (points[mindex * 2] * wii0 * wj0
-                + points[(mindex + 1) * 2] * wii1 * wj0
-                + points[(mindex + bbw) * 2] * wii0 * wj1
-                + points[(mindex + bbw + 1) * 2] * wii1 * wj1) * inv_grid2;
-      ii++;
-      if(ii == grid)
-      {
-        ii = 0;
-        mi++;
-      }
-    }
-  }
+  int endx = 0, endy = 0;
+  dt_masks_sample_grid_interpolate(points, &sample_grid, buffer, width, height, &endx, &endy);
 
   dt_pixelpipe_cache_free_align(points);
 

--- a/src/develop/masks/circle.c
+++ b/src/develop/masks/circle.c
@@ -476,7 +476,8 @@ static int _circle_events_mouse_moved(struct dt_iop_module_t *module, double x, 
   return 0;
 }
 
-static void _circle_draw_shape(dt_develop_t *dev, cairo_t *cr, const float *points, const int points_count, const int coord_nb, const gboolean border, const gboolean source)
+static void _circle_draw_shape(dt_develop_t *dev, cairo_t *cr, const float *points, const int points_count, const int coord_nb, const gboolean border, const gboolean source,
+                              const dt_masks_skip_range_t *skips, const int skip_count)
 {
    // unused arg, keep compiler from complaining
   /* One line_to per point sampled at RAW resolution is several per device pixel; emit at the
@@ -644,13 +645,13 @@ static void _circle_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks_f
   const gboolean selected = (gui->group_selected == index) && (gui->form_selected || gui->form_dragging);
   if(gpt->points && gpt->points_count > 1)
     dt_draw_shape_lines(gui->dev, DT_MASKS_NO_DASH, FALSE, cr, num_points, selected, zoom_scale, gpt->points,
-                        gpt->points_count, &dt_masks_functions_circle.draw_shape, CAIRO_LINE_CAP_BUTT);
+                        gpt->points_count, &dt_masks_functions_circle.draw_shape, CAIRO_LINE_CAP_BUTT, NULL, 0);
   // we draw the borders
   if(gui->group_selected == index)
   { 
     if(gpt->border && gpt->border_count > 1)
       dt_draw_shape_lines(gui->dev, DT_MASKS_DASH_STICK, FALSE, cr, num_points, (gui->border_selected), zoom_scale, gpt->border,
-                          gpt->border_count, &dt_masks_functions_circle.draw_shape, CAIRO_LINE_CAP_ROUND);
+                          gpt->border_count, &dt_masks_functions_circle.draw_shape, CAIRO_LINE_CAP_ROUND, NULL, 0);
   }
 
   // draw the source if any

--- a/src/develop/masks/detail.c
+++ b/src/develop/masks/detail.c
@@ -310,7 +310,7 @@ void dt_masks_calc_rawdetail_mask(float *const restrict src, float *const restri
       const float gy = 47.0f * (tmp[idx-width-1] - tmp[idx+width-1])
                     + 162.0f * (tmp[idx-width]   - tmp[idx+width])
                      + 47.0f * (tmp[idx-width+1] - tmp[idx+width+1]);
-      const float gradient_magnitude = sqrtf(sqf(gx / 256.0f) + sqf(gy / 256.0f));
+      const float gradient_magnitude = dt_fast_hypotf(gx / 256.0f, gy / 256.0f);
       mask[idx] = scale * gradient_magnitude;
       // Original code from rt
       // tmp[idx] = scale * sqrtf(sqf(src[idx+1] - src[idx-1]) + sqf(src[idx + width]   - src[idx - width]) +

--- a/src/develop/masks/ellipse.c
+++ b/src/develop/masks/ellipse.c
@@ -308,22 +308,7 @@ static int _ellipse_get_creation_preview(dt_masks_form_t *form, dt_masks_form_gu
                               &preview->border, &preview->border_count);
   
   if(!err && dt_masks_form_is_clone(form))
-  {
-    float source_pos[2] = { 0.0f, 0.0f };
-    dt_masks_calculate_source_pos_origin(gui, gui->pos[0], gui->pos[1], gui->pos[0], gui->pos[1],
-                                        &source_pos[0], &source_pos[1], FALSE);
-    const float center_source[2] = { source_pos[0] - gui->pos[0], source_pos[1] - gui->pos[1] };
-
-    preview->source_points = dt_pixelpipe_cache_alloc_align_float_cache((size_t)2 * preview->points_count, 0);
-    if(IS_NULL_PTR(preview->source_points))
-      err = 1;
-
-    for(int i = 0; !err && i < preview->points_count; i++)
-    {
-      preview->source_points[i * 2] = preview->points[i * 2] + center_source[0];
-      preview->source_points[i * 2 + 1] = preview->points[i * 2 + 1] + center_source[1];
-    }
-  }
+    err = dt_masks_preview_add_clone_source(gui, preview);
 
   if(err)
     dt_masks_preview_buffers_cleanup(preview);
@@ -400,47 +385,7 @@ static int _ellipse_get_points_source(dt_develop_t *dev, float xx, float yy, flo
   *points = _points_to_transform(dev, xx, yy, radius_a, radius_b, rotation, wd, ht, points_count);
   if(IS_NULL_PTR(*points)) return 1;
 
-  // we transform with all distortion that happen *before* the module
-  // so we have now the TARGET points in module input reference
-  if(!dt_dev_distort_transform_gui(dev, module->iop_order, DT_DEV_TRANSFORM_DIR_BACK_EXCL,
-                                    *points, *points_count))
-    goto error;
-
-  // now we move all the points by the shift
-  // so we have now the SOURCE points in module input reference
-  float pts[2] = { xs, ys };
-  dt_dev_coordinates_raw_norm_to_raw_abs(dev, pts, 1);
-  if(!dt_dev_distort_transform_gui(dev, module->iop_order, DT_DEV_TRANSFORM_DIR_BACK_EXCL,
-                                    pts, 1))
-    goto error;
-
-  {
-    const float dx = pts[0] - (*points)[0];
-    const float dy = pts[1] - (*points)[1];
-    (*points)[0] = pts[0];
-    (*points)[1] = pts[1];
-    __OMP_PARALLEL_FOR_SIMD__(if(*points_count > 100) aligned(points:64))
-    for(int i = 5; i < *points_count; i++)
-    {
-      (*points)[i * 2] += dx;
-      (*points)[i * 2 + 1] += dy;
-    }
-  }
-
-  // we apply the rest of the distortions (those after the module)
-  // so we have now the SOURCE points in final image reference
-  if(!dt_dev_distort_transform_gui(dev, module->iop_order, DT_DEV_TRANSFORM_DIR_FORW_INCL,
-                                    *points, *points_count))
-    goto error;
-
-  return 0;
-
-  // if we failed, then free all and return
-error:
-  dt_pixelpipe_cache_free_align(*points);
-  *points = NULL;
-  *points_count = 0;
-  return 1;
+  return dt_masks_points_shift_to_source(dev, module, points, points_count, xs, ys, 5);
 }
 
 static int _ellipse_get_points(dt_develop_t *dev, float xx, float yy, float radius_a, float radius_b,

--- a/src/develop/masks/ellipse.c
+++ b/src/develop/masks/ellipse.c
@@ -34,6 +34,7 @@
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
 #include "control/user_message.h"
+#include "math/math.h"
 #include "system/macros.h"
 #include "system/openmp.h"
 #include "common/logging.h"
@@ -973,7 +974,7 @@ static int _ellipse_events_mouse_moved(struct dt_iop_module_t *module, double x,
     gui->delta[0] = xref - gui->pos[0];
     gui->delta[1] = yref - gui->pos[1];
 
-    const float r = sqrtf(rx * rx + ry * ry);
+    const float r = dt_fast_hypotf(rx, ry);
     const float d = (rx * deltax + ry * deltay) / r;
     const float s = fmaxf(r > 0.0f ? (r + d) / r : 0.0f, 0.0f);
     

--- a/src/develop/masks/ellipse.c
+++ b/src/develop/masks/ellipse.c
@@ -199,7 +199,7 @@ static void _ellipse_get_distance(float x, float y, float mouse_radius, dt_masks
   // we first check if we are inside the source form
   if(gpt->source && gpt->source_count > 10)
   {
-    if(dt_masks_point_in_form_exact(pt, 1, gpt->source, 10, gpt->source_count - 5) >= 0)
+    if(dt_masks_point_in_form_exact(pt, 1, gpt->source, 10, gpt->source_count - 5, NULL, 0) >= 0)
     {
       *inside_source = 1;
       *inside = 1;
@@ -226,7 +226,7 @@ static void _ellipse_get_distance(float x, float y, float mouse_radius, dt_masks
   *dist = sqf(center_dx) + sqf(center_dy);
 
   const gboolean close_to_border = _ellipse_point_close_to_path(x, y, mouse_radius * 1.5, gpt->border + 10, gpt->border_count - 5);
-  const gboolean in_border = dt_masks_point_in_form_exact(pt, 1, gpt->border + 10, 10, gpt->border_count - 5) >= 0;
+  const gboolean in_border = dt_masks_point_in_form_exact(pt, 1, gpt->border + 10, 10, gpt->border_count - 5, NULL, 0) >= 0;
   // we check if it's inside borders
   if(!close_to_border && !in_border) return;  
   *inside = 1;
@@ -466,9 +466,14 @@ static int _ellipse_get_points(dt_develop_t *dev, float xx, float yy, float radi
 
 static dt_masks_raster_result_t _ellipse_get_points_border(dt_develop_t *dev, struct dt_masks_form_t *form,
                                       float **points,
-                                      int *points_count, float **border, int *border_count, int source,
+                                      int *points_count, float **border, int *border_count,
+                                      dt_masks_skip_range_t **border_skips, int *border_skip_count,
+                                      int source,
                                       const dt_iop_module_t *module)
 {
+  if(!IS_NULL_PTR(border_skips)) *border_skips = NULL;
+  if(!IS_NULL_PTR(border_skip_count)) *border_skip_count = 0;
+
   // No geometry: an empty outline is the correct result here, not a failure. See the circle.
   if(IS_NULL_PTR(form) || IS_NULL_PTR(form->points)) return DT_MASKS_RASTER_EMPTY;
   dt_masks_node_ellipse_t *ellipse = (dt_masks_node_ellipse_t *)((form->points)->data);

--- a/src/develop/masks/ellipse.c
+++ b/src/develop/masks/ellipse.c
@@ -1019,7 +1019,8 @@ static int _ellipse_events_mouse_moved(struct dt_iop_module_t *module, double x,
   return 0;
 }
 
-static void _ellipse_draw_shape(dt_develop_t *dev, cairo_t *cr, const float *points, const int points_count, const int nb, const gboolean border, const gboolean source)
+static void _ellipse_draw_shape(dt_develop_t *dev, cairo_t *cr, const float *points, const int points_count, const int nb, const gboolean border, const gboolean source,
+                              const dt_masks_skip_range_t *skips, const int skip_count)
 {
   // dev unused, kept for shape_draw_function_t signature
   /* Decimate to the device resolution, as the brush does; see dt_draw_min_emit_step(). */
@@ -1099,14 +1100,14 @@ static void _ellipse_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks_
   const gboolean selected = (gui->group_selected == index) && (gui->form_selected || gui->form_dragging);
   if(gpt->points && gpt->points_count > 5)
     dt_draw_shape_lines(gui->dev, DT_MASKS_NO_DASH, FALSE, cr, num_points, selected, zoom_scale, gpt->points,
-                        gpt->points_count, &dt_masks_functions_ellipse.draw_shape, CAIRO_LINE_CAP_BUTT);
+                        gpt->points_count, &dt_masks_functions_ellipse.draw_shape, CAIRO_LINE_CAP_BUTT, NULL, 0);
   
   if(gui->group_selected == index)
   {
     // we draw the borders
     if(gpt->border && gpt->border_count > 5)
       dt_draw_shape_lines(gui->dev, DT_MASKS_DASH_STICK, FALSE, cr, num_points, (gui->border_selected), zoom_scale, gpt->border,
-                          gpt->border_count, &dt_masks_functions_ellipse.draw_shape, CAIRO_LINE_CAP_ROUND);
+                          gpt->border_count, &dt_masks_functions_ellipse.draw_shape, CAIRO_LINE_CAP_ROUND, NULL, 0);
 
     // draw handles
     _ellipse_draw_handles(gui, cr, zoom_scale, gpt, index);

--- a/src/develop/masks/ellipse.c
+++ b/src/develop/masks/ellipse.c
@@ -1131,23 +1131,6 @@ static void _ellipse_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks_
 
 }
 
-static void _bounding_box(const float *const points, int num_points, int *width, int *height, int *posx, int *posy)
-{
-  // search for min/max X and Y coordinates
-  float xmin = FLT_MAX, xmax = FLT_MIN, ymin = FLT_MAX, ymax = FLT_MIN;
-  for(int i = 1; i < num_points; i++) // skip point[0], which is circle's center
-  {
-    xmin = fminf(points[i * 2], xmin);
-    xmax = fmaxf(points[i * 2], xmax);
-    ymin = fminf(points[i * 2 + 1], ymin);
-    ymax = fmaxf(points[i * 2 + 1], ymax);
-  }
-  // set the min/max values we found
-  *posx = xmin;
-  *posy = ymin;
-  *width = (xmax - xmin);
-  *height = (ymax - ymin);
-}
 
 static void _fill_mask(const size_t numpoints, float *const bufptr, const float *const points,
                        const float *const center, const float a, const float b, const float ta, const float tb,
@@ -1291,7 +1274,7 @@ static dt_masks_raster_result_t _ellipse_get_source_area(dt_iop_module_t *module
   }
 
   // finally, find the extreme left/right and top/bottom points
-  _bounding_box(points, point_count, width, height, posx, posy);
+  dt_masks_points_bounding_box(points, point_count, width, height, posx, posy);
   dt_pixelpipe_cache_free_align(points);
   return DT_MASKS_RASTER_OK;
 }
@@ -1329,7 +1312,7 @@ static dt_masks_raster_result_t _ellipse_get_area(const dt_iop_module_t *const m
   }
 
   // finally, find the extreme left/right and top/bottom points
-  _bounding_box(points, point_count, width, height, posx, posy);
+  dt_masks_points_bounding_box(points, point_count, width, height, posx, posy);
   dt_pixelpipe_cache_free_align(points);
   return DT_MASKS_RASTER_OK;
 }
@@ -1572,39 +1555,13 @@ static dt_masks_raster_result_t _ellipse_get_mask_roi(const dt_iop_module_t *con
   if(bbw <= 1 || bbh <= 1)
     return DT_MASKS_RASTER_EMPTY;
 
-  float *points = dt_pixelpipe_cache_alloc_align_float_cache((size_t)2 * bbw * bbh, 0);
+  const dt_masks_sample_grid_t sample_grid
+      = { .x0 = bbxm, .y0 = bbym, .width = bbw, .height = bbh,
+          .step = grid, .px = px, .py = py, .iscale = iscale };
+  float *points
+      = dt_masks_sample_grid_backtransform(pipe, module->iop_order, &sample_grid, "ellipse", form->name);
   if(IS_NULL_PTR(points)) return DT_MASKS_RASTER_ERROR;
-
-  // we populate the grid points in module coordinates
-  __OMP_PARALLEL_FOR__(collapse(2) if((size_t)bbw * bbh > 50000))
-  for(int j = bbym; j <= bbYM; j++)
-    for(int i = bbxm; i <= bbXM; i++)
-    {
-      const size_t index = (size_t)(j - bbym) * bbw + i - bbxm;
-      points[index * 2] = (grid * i + px) * iscale;
-      points[index * 2 + 1] = (grid * j + py) * iscale;
-    }
-
-  if(dt_get_debug_flags() & DT_DEBUG_PERF)
-  {
-    dt_print(DT_DEBUG_MASKS, "[masks %s] ellipse grid took %0.04f sec\n", form->name, dt_get_wtime() - start2);
-    start2 = dt_get_wtime();
-  }
-
-  // we back transform all these points to the input image coordinates
-  if(!dt_dev_distort_backtransform_plus(pipe, module->iop_order, DT_DEV_TRANSFORM_DIR_BACK_INCL, points,
-                                        (size_t)bbw * bbh))
-  {
-    dt_pixelpipe_cache_free_align(points);
-    return DT_MASKS_RASTER_ERROR;
-  }
-
-  if(dt_get_debug_flags() & DT_DEBUG_PERF)
-  {
-    dt_print(DT_DEBUG_MASKS, "[masks %s] ellipse transform took %0.04f sec\n", form->name,
-             dt_get_wtime() - start2);
-    start2 = dt_get_wtime();
-  }
+  start2 = dt_get_wtime();
 
   // we calculate the mask values at the transformed points;
   // re-use the points array for results; this requires out_scale==1 to double the offsets at which they are stored

--- a/src/develop/masks/ellipse.c
+++ b/src/develop/masks/ellipse.c
@@ -1576,43 +1576,8 @@ static dt_masks_raster_result_t _ellipse_get_mask_roi(const dt_iop_module_t *con
 
   // we fill the pre-initialized output buffer by interpolation;
   // we only need to take the contents of our bounding box into account
-  const int endx = MIN(w, bbXM * grid);
-  const int endy = MIN(h, bbYM * grid);
-  const float inv_grid2 = 1.0f / (grid * grid);
-  float w0[4], w1[4];
-  for(int i = 0; i < grid; i++)
-  {
-    w0[i] = (float)(grid - i);
-    w1[i] = (float)i;
-  }
-  __OMP_PARALLEL_FOR__(if((size_t)(endy - bbym * grid) * (size_t)(endx - bbxm * grid) > 50000))
-  for(int j = bbym * grid; j < endy; j++)
-  {
-    const int jj = j % grid;
-    const int mj = j / grid - bbym;
-    const float wj0 = w0[jj];
-    const float wj1 = w1[jj];
-    const size_t row_base = (size_t)mj * bbw;
-    float *const row = buffer + (size_t)j * w;
-    int ii = 0;
-    int mi = 0;
-    for(int i = bbxm * grid; i < endx; i++)
-    {
-      const size_t mindex = row_base + mi;
-      const float wii0 = w0[ii];
-      const float wii1 = w1[ii];
-      row[i] = (points[mindex * 2] * wii0 * wj0
-                + points[(mindex + 1) * 2] * wii1 * wj0
-                + points[(mindex + bbw) * 2] * wii0 * wj1
-                + points[(mindex + bbw + 1) * 2] * wii1 * wj1) * inv_grid2;
-      ii++;
-      if(ii == grid)
-      {
-        ii = 0;
-        mi++;
-      }
-    }
-  }
+  int endx = 0, endy = 0;
+  dt_masks_sample_grid_interpolate(points, &sample_grid, buffer, w, h, &endx, &endy);
 
   dt_pixelpipe_cache_free_align(points);
 

--- a/src/develop/masks/ellipse.c
+++ b/src/develop/masks/ellipse.c
@@ -1022,7 +1022,10 @@ static int _ellipse_events_mouse_moved(struct dt_iop_module_t *module, double x,
 static void _ellipse_draw_shape(dt_develop_t *dev, cairo_t *cr, const float *points, const int points_count, const int nb, const gboolean border, const gboolean source,
                               const dt_masks_skip_range_t *skips, const int skip_count)
 {
-  // dev unused, kept for shape_draw_function_t signature
+  /* An ellipse has no self-intersections, so it never carries an exclusion list -- these are the
+   * shared shape_draw_function_t signature, not something to honour here. */
+  (void)dev; (void)nb; (void)border; (void)source; (void)skips; (void)skip_count;
+
   /* Decimate to the device resolution, as the brush does; see dt_draw_min_emit_step(). */
   const double min_step = dt_draw_min_emit_step(cr);
   const double min_step2 = min_step * min_step;

--- a/src/develop/masks/gradient.c
+++ b/src/develop/masks/gradient.c
@@ -975,6 +975,10 @@ cleanup:
 static void _gradient_draw_shape(struct dt_develop_t *dev, cairo_t *cr, const float *pts_line, const int pts_line_count, const int nb, const gboolean border, const gboolean source,
                               const dt_masks_skip_range_t *skips, const int skip_count)
 {
+  /* A gradient has no self-intersections, so it never carries an exclusion list -- these are the
+   * shared shape_draw_function_t signature, not something to honour here. */
+  (void)dev; (void)nb; (void)source; (void)skips; (void)skip_count;
+
   // safeguard in case of malformed arrays of points
   if(border && pts_line_count <= 3) return;
   if(!border && pts_line_count <= 4) return;

--- a/src/develop/masks/gradient.c
+++ b/src/develop/masks/gradient.c
@@ -30,6 +30,7 @@
     You should have received a copy of the GNU General Public License
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
+#include "math/math.h"
 #include "system/macros.h"
 #include "system/openmp.h"
 #include "common/logging.h"
@@ -772,14 +773,14 @@ static int _gradient_get_points(dt_develop_t *dev, float x, float y, float rotat
   const float ht = geometry.raw_height;
   if(!isfinite(wd) || !isfinite(ht) || wd <= 0.0f || ht <= 0.0f) return 1;
 
-  const float scale = sqrtf(wd * wd + ht * ht);
+  const float scale = dt_fast_hypotf(wd, ht);
   const float distance = 0.1f * fminf(wd, ht);
 
   const float v = (-rotation / 180.0f) * M_PI;
   const float cosv = cosf(v);
   const float sinv = sinf(v);
 
-  const int count = sqrtf(wd * wd + ht * ht) + 3;
+  const int count = dt_fast_hypotf(wd, ht) + 3;
   *points = dt_pixelpipe_cache_alloc_align_float_cache((size_t)2 * count, 0);
   if(IS_NULL_PTR(*points)) return 1;
 
@@ -896,7 +897,7 @@ static int _gradient_get_pts_border(dt_develop_t *dev, float x, float y, float r
   const dt_dev_image_geometry_t geometry = dt_dev_geometry_snapshot(dev);
   const float wd = geometry.raw_width;
   const float ht = geometry.raw_height;
-  const float scale = sqrtf(wd * wd + ht * ht);
+  const float scale = dt_fast_hypotf(wd, ht);
   
   // Calculate perpendicular offsets (±90 degrees from rotation)
   const float v1 = (-(rotation - 90.0f) / 180.0f) * M_PI;
@@ -1285,7 +1286,7 @@ static dt_masks_raster_result_t _gradient_get_mask(const dt_iop_module_t *const 
   // we calculate the mask at grid points and recycle point buffer to store results
   const float wd = pipe->iwidth;
   const float ht = pipe->iheight;
-  const float hwscale = 1.0f / sqrtf(wd * wd + ht * ht);
+  const float hwscale = 1.0f / dt_fast_hypotf(wd, ht);
   const float ihwscale = 1.0f / hwscale;
   const float v = (-gradient->rotation / 180.0f) * M_PI;
   const float sinv = sinf(v);
@@ -1453,7 +1454,7 @@ static dt_masks_raster_result_t _gradient_get_mask_roi(const dt_iop_module_t *co
   // we calculate the mask at grid points and recycle point buffer to store results
   const float wd = pipe->iwidth;
   const float ht = pipe->iheight;
-  const float hwscale = 1.0f / sqrtf(wd * wd + ht * ht);
+  const float hwscale = 1.0f / dt_fast_hypotf(wd, ht);
   const float ihwscale = 1.0f / hwscale;
   const float v = (-gradient->rotation / 180.0f) * M_PI;
   const float sinv = sinf(v);

--- a/src/develop/masks/gradient.c
+++ b/src/develop/masks/gradient.c
@@ -1417,39 +1417,13 @@ static dt_masks_raster_result_t _gradient_get_mask_roi(const dt_iop_module_t *co
   const int gw = (w + grid - 1) / grid + 1;
   const int gh = (h + grid - 1) / grid + 1;
 
-  float *points = dt_pixelpipe_cache_alloc_align_float_cache((size_t)2 * gw * gh, 0);
+  const dt_masks_sample_grid_t sample_grid
+      = { .x0 = 0, .y0 = 0, .width = gw, .height = gh,
+          .step = grid, .px = px, .py = py, .iscale = iscale };
+  float *points
+      = dt_masks_sample_grid_backtransform(pipe, module->iop_order, &sample_grid, "gradient", form->name);
   if(IS_NULL_PTR(points)) return DT_MASKS_RASTER_ERROR;
-  __OMP_PARALLEL_FOR__(collapse(2) if((size_t)gw * gh > 50000))
-  for(int j = 0; j < gh; j++)
-    for(int i = 0; i < gw; i++)
-    {
-
-      const size_t index = (size_t)j * gw + i;
-      points[index * 2] = (grid * i + px) * iscale;
-      points[index * 2 + 1] = (grid * j + py) * iscale;
-    }
-
-  if(dt_get_debug_flags() & DT_DEBUG_PERF)
-  {
-    dt_print(DT_DEBUG_MASKS, "[masks %s] gradient draw took %0.04f sec\n", form->name,
-             dt_get_wtime() - start2);
-    start2 = dt_get_wtime();
-  }
-
-  // we backtransform all these points
-  if(!dt_dev_distort_backtransform_plus(pipe, module->iop_order, DT_DEV_TRANSFORM_DIR_BACK_INCL, points,
-                                        (size_t)gw * gh))
-  {
-    dt_pixelpipe_cache_free_align(points);
-    return DT_MASKS_RASTER_ERROR;
-  }
-
-  if(dt_get_debug_flags() & DT_DEBUG_PERF)
-  {
-    dt_print(DT_DEBUG_MASKS, "[masks %s] gradient transform took %0.04f sec\n", form->name,
-             dt_get_wtime() - start2);
-    start2 = dt_get_wtime();
-  }
+  start2 = dt_get_wtime();
 
   // we calculate the mask at grid points and recycle point buffer to store results
   const float wd = pipe->iwidth;

--- a/src/develop/masks/gradient.c
+++ b/src/develop/masks/gradient.c
@@ -1140,9 +1140,14 @@ static void _gradient_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks
 
 static dt_masks_raster_result_t _gradient_get_points_border(dt_develop_t *dev, dt_masks_form_t *form,
                                        float **points, int *points_count,
-                                       float **border, int *border_count, int source,
+                                       float **border, int *border_count,
+                                       dt_masks_skip_range_t **border_skips, int *border_skip_count,
+                                       int source,
                                        const dt_iop_module_t *module)
 {
+  if(!IS_NULL_PTR(border_skips)) *border_skips = NULL;
+  if(!IS_NULL_PTR(border_skip_count)) *border_skip_count = 0;
+
     // unused arg, keep compiler from complaining
   // No geometry: an empty outline is the correct result here, not a failure. See the circle.
   if(IS_NULL_PTR(form) || IS_NULL_PTR(form->points)) return DT_MASKS_RASTER_EMPTY;

--- a/src/develop/masks/gradient.c
+++ b/src/develop/masks/gradient.c
@@ -972,7 +972,8 @@ cleanup:
   return err;
 }
 
-static void _gradient_draw_shape(struct dt_develop_t *dev, cairo_t *cr, const float *pts_line, const int pts_line_count, const int nb, const gboolean border, const gboolean source)
+static void _gradient_draw_shape(struct dt_develop_t *dev, cairo_t *cr, const float *pts_line, const int pts_line_count, const int nb, const gboolean border, const gboolean source,
+                              const dt_masks_skip_range_t *skips, const int skip_count)
 {
   // safeguard in case of malformed arrays of points
   if(border && pts_line_count <= 3) return;
@@ -1124,13 +1125,13 @@ static void _gradient_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks
   // draw main line
   if(gpt->points && gpt->points_count > 0)
     dt_draw_shape_lines(gui->dev, DT_MASKS_NO_DASH, FALSE, cr, nb, (seg_selected), zoom_scale, gpt->points,
-                        gpt->points_count, &dt_masks_functions_gradient.draw_shape, CAIRO_LINE_CAP_ROUND);
+                        gpt->points_count, &dt_masks_functions_gradient.draw_shape, CAIRO_LINE_CAP_ROUND, NULL, 0);
   // draw borders
   if(gui->group_selected == index)
   {
     if(gpt->border && gpt->border_count > 0)
       dt_draw_shape_lines(gui->dev, DT_MASKS_DASH_STICK, FALSE, cr, nb, (gui->border_selected), zoom_scale, gpt->border,
-                          gpt->border_count, &dt_masks_functions_gradient.draw_shape, CAIRO_LINE_CAP_ROUND);
+                          gpt->border_count, &dt_masks_functions_gradient.draw_shape, CAIRO_LINE_CAP_ROUND, NULL, 0);
   }
 
   if(gpt->points && gpt->points_count >= 3)

--- a/src/develop/masks/gradient.c
+++ b/src/develop/masks/gradient.c
@@ -1252,36 +1252,14 @@ static dt_masks_raster_result_t _gradient_get_mask(const dt_iop_module_t *const 
   const int gw = (w + grid - 1) / grid + 1;
   const int gh = (h + grid - 1) / grid + 1;
 
-  float *points = dt_pixelpipe_cache_alloc_align_float_cache((size_t)2 * gw * gh, 0);
+  // this path works in unscaled coordinates, which is iscale == 1 (an exact multiplication)
+  const dt_masks_sample_grid_t sample_grid
+      = { .x0 = 0, .y0 = 0, .width = gw, .height = gh,
+          .step = grid, .px = px, .py = py, .iscale = 1.0f };
+  float *points
+      = dt_masks_sample_grid_backtransform(pipe, module->iop_order, &sample_grid, "gradient", form->name);
   if(IS_NULL_PTR(points)) return DT_MASKS_RASTER_ERROR;
-  __OMP_PARALLEL_FOR__(collapse(2) if((size_t)gw * gh > 50000))
-  for(int j = 0; j < gh; j++)
-    for(int i = 0; i < gw; i++)
-    {
-      points[(j * gw + i) * 2] = (grid * i + px);
-      points[(j * gw + i) * 2 + 1] = (grid * j + py);
-    }
-
-  if(dt_get_debug_flags() & DT_DEBUG_PERF)
-  {
-    dt_print(DT_DEBUG_MASKS, "[masks %s] gradient draw took %0.04f sec\n", form->name,
-             dt_get_wtime() - start2);
-    start2 = dt_get_wtime();
-  }
-
-  // we backtransform all these points
-  if(!dt_dev_distort_backtransform_plus(pipe, module->iop_order, DT_DEV_TRANSFORM_DIR_BACK_INCL, points, (size_t)gw * gh))
-  {
-    dt_pixelpipe_cache_free_align(points);
-    return DT_MASKS_RASTER_ERROR;
-  }
-
-  if(dt_get_debug_flags() & DT_DEBUG_PERF)
-  {
-    dt_print(DT_DEBUG_MASKS, "[masks %s] gradient transform took %0.04f sec\n", form->name,
-             dt_get_wtime() - start2);
-    start2 = dt_get_wtime();
-  }
+  start2 = dt_get_wtime();
 
   // we calculate the mask at grid points and recycle point buffer to store results
   const float wd = pipe->iwidth;
@@ -1346,43 +1324,7 @@ static dt_masks_raster_result_t _gradient_get_mask(const dt_iop_module_t *const 
     return DT_MASKS_RASTER_ERROR;
   }
 
-  const float inv_grid2 = 1.0f / (grid * grid);
-  float w0[8], w1[8];
-  for(int i = 0; i < grid; i++)
-  {
-    w0[i] = (float)(grid - i);
-    w1[i] = (float)i;
-  }
-
-// we fill the mask buffer by interpolation
-  __OMP_PARALLEL_FOR__(if((size_t)w * h > 50000))
-  for(int j = 0; j < h; j++)
-  {
-    const int jj = j % grid;
-    const int mj = j / grid;
-    const float wj0 = w0[jj];
-    const float wj1 = w1[jj];
-    const size_t row_base = (size_t)mj * gw;
-    float *const row = bufptr + (size_t)j * w;
-    int ii = 0;
-    int mi = 0;
-    for(int i = 0; i < w; i++)
-    {
-      const size_t pt_index = row_base + mi;
-      const float wii0 = w0[ii];
-      const float wii1 = w1[ii];
-      row[i] = (points[2 * pt_index] * wii0 * wj0
-                + points[2 * (pt_index + 1)] * wii1 * wj0
-                + points[2 * (pt_index + gw)] * wii0 * wj1
-                + points[2 * (pt_index + gw + 1)] * wii1 * wj1) * inv_grid2;
-      ii++;
-      if(ii == grid)
-      {
-        ii = 0;
-        mi++;
-      }
-    }
-  }
+  dt_masks_sample_grid_interpolate(points, &sample_grid, bufptr, w, h, NULL, NULL);
 
   dt_pixelpipe_cache_free_align(points);
 
@@ -1479,43 +1421,7 @@ static dt_masks_raster_result_t _gradient_get_mask_roi(const dt_iop_module_t *co
 
   dt_pixelpipe_cache_free_align(lut);
 
-  const float inv_grid2 = 1.0f / (grid * grid);
-  float w0[8], w1[8];
-  for(int i = 0; i < grid; i++)
-  {
-    w0[i] = (float)(grid - i);
-    w1[i] = (float)i;
-  }
-
-// we fill the mask buffer by interpolation
-  __OMP_PARALLEL_FOR__(if((size_t)w * h > 50000))
-  for(int j = 0; j < h; j++)
-  {
-    const int jj = j % grid;
-    const int mj = j / grid;
-    const float wj0 = w0[jj];
-    const float wj1 = w1[jj];
-    const size_t row_base = (size_t)mj * gw;
-    float *const row = buffer + (size_t)j * w;
-    int ii = 0;
-    int mi = 0;
-    for(int i = 0; i < w; i++)
-    {
-      const size_t mindex = row_base + mi;
-      const float wii0 = w0[ii];
-      const float wii1 = w1[ii];
-      row[i] = (points[mindex * 2] * wii0 * wj0
-                + points[(mindex + 1) * 2] * wii1 * wj0
-                + points[(mindex + gw) * 2] * wii0 * wj1
-                + points[(mindex + gw + 1) * 2] * wii1 * wj1) * inv_grid2;
-      ii++;
-      if(ii == grid)
-      {
-        ii = 0;
-        mi++;
-      }
-    }
-  }
+  dt_masks_sample_grid_interpolate(points, &sample_grid, buffer, w, h, NULL, NULL);
 
   dt_pixelpipe_cache_free_align(points);
 

--- a/src/develop/masks/group.c
+++ b/src/develop/masks/group.c
@@ -246,22 +246,22 @@ static dt_masks_raster_result_t _group_get_mask(const dt_iop_module_t *const mod
   // we allocate buffers and values
   const guint nb = g_list_length(form->points);
   if(nb == 0) return DT_MASKS_RASTER_EMPTY;
-  float **bufs = calloc(nb, sizeof(float *));
-  int *w = malloc(sizeof(int) * nb);
-  int *h = malloc(sizeof(int) * nb);
-  int *px = malloc(sizeof(int) * nb);
-  int *py = malloc(sizeof(int) * nb);
-  int *states = malloc(sizeof(int) * nb);
-  float *op = malloc(sizeof(float) * nb);
+  float **bufs = dt_calloc_align(nb * sizeof(float *));
+  int *w = dt_alloc_align(sizeof(int) * nb);
+  int *h = dt_alloc_align(sizeof(int) * nb);
+  int *px = dt_alloc_align(sizeof(int) * nb);
+  int *py = dt_alloc_align(sizeof(int) * nb);
+  int *states = dt_alloc_align(sizeof(int) * nb);
+  float *op = dt_alloc_align_float(nb);
   if(IS_NULL_PTR(bufs) || IS_NULL_PTR(w) || IS_NULL_PTR(h) || IS_NULL_PTR(px) || IS_NULL_PTR(py) || IS_NULL_PTR(states) || IS_NULL_PTR(op))
   {
-    dt_free(op);
-    dt_free(states);
-    dt_free(py);
-    dt_free(px);
-    dt_free(h);
-    dt_free(w);
-    dt_free(bufs);
+    dt_free_align(op);
+    dt_free_align(states);
+    dt_free_align(py);
+    dt_free_align(px);
+    dt_free_align(h);
+    dt_free_align(w);
+    dt_free_align(bufs);
     return DT_MASKS_RASTER_ERROR;
   }
 
@@ -495,14 +495,14 @@ static dt_masks_raster_result_t _group_get_mask(const dt_iop_module_t *const mod
   }
 
 cleanup:
-  dt_free(op);
-  dt_free(states);
-  dt_free(py);
-  dt_free(px);
-  dt_free(h);
-  dt_free(w);
+  dt_free_align(op);
+  dt_free_align(states);
+  dt_free_align(py);
+  dt_free_align(px);
+  dt_free_align(h);
+  dt_free_align(w);
   for(int i = 0; i < nb; i++) dt_pixelpipe_cache_free_align(bufs[i]);
-  dt_free(bufs);
+  dt_free_align(bufs);
   return err;
 }
 

--- a/src/develop/masks/masks.c
+++ b/src/develop/masks/masks.c
@@ -43,6 +43,7 @@
 #include "system/macros.h"
 #include "database/history_repository.h"
 #include "system/target_clones.h"
+#include "system/openmp.h"
 #include "system/mem_alloc.h"
 #include "common/hash.h"
 #include "common/logging.h"
@@ -483,6 +484,78 @@ gboolean dt_masks_skip_contains(const dt_masks_skip_range_t *skips, const int sk
     else return TRUE;
   }
   return FALSE;
+}
+
+
+void dt_masks_points_bounding_box(const float *const points, const int num_points,
+                                  int *width, int *height, int *posx, int *posy)
+{
+  // NOTE the seeds: -FLT_MAX, not FLT_MIN. FLT_MIN is the smallest POSITIVE normal float, so
+  // seeding a running maximum with it silently clamps the box at 0 for a shape that lies
+  // entirely off the left or top edge -- an over-large box rather than a wrong one, which is
+  // why it went unnoticed, but wrong all the same.
+  float xmin = FLT_MAX, xmax = -FLT_MAX, ymin = FLT_MAX, ymax = -FLT_MAX;
+
+  for(int i = 1; i < num_points; i++) // point 0 is the centre, not part of the outline
+  {
+    xmin = fminf(points[i * 2], xmin);
+    xmax = fmaxf(points[i * 2], xmax);
+    ymin = fminf(points[i * 2 + 1], ymin);
+    ymax = fmaxf(points[i * 2 + 1], ymax);
+  }
+
+  *posx = xmin;
+  *posy = ymin;
+  *width = (xmax - xmin);
+  *height = (ymax - ymin);
+}
+
+float *dt_masks_sample_grid_backtransform(struct dt_dev_pixelpipe_t *pipe, const double iop_order,
+                                          const dt_masks_sample_grid_t *const grid,
+                                          const char *const shape, const char *const form_name)
+{
+  const int gw = grid->width;
+  const int gh = grid->height;
+  const int step = grid->step;
+  const int px = grid->px;
+  const int py = grid->py;
+  const float iscale = grid->iscale;
+  const size_t count = (size_t)gw * gh;
+
+  double start = dt_get_wtime();
+
+  float *const restrict points = dt_pixelpipe_cache_alloc_align_float_cache(2 * count, 0);
+  if(IS_NULL_PTR(points)) return NULL;
+
+  // the grid points, in module coordinates
+  __OMP_PARALLEL_FOR__(collapse(2) if(count > 50000))
+  for(int j = 0; j < gh; j++)
+    for(int i = 0; i < gw; i++)
+    {
+      const size_t index = (size_t)j * gw + i;
+      points[index * 2] = (step * (i + grid->x0) + px) * iscale;
+      points[index * 2 + 1] = (step * (j + grid->y0) + py) * iscale;
+    }
+
+  if(dt_get_debug_flags() & DT_DEBUG_PERF)
+  {
+    dt_print(DT_DEBUG_MASKS, "[masks %s] %s grid took %0.04f sec\n", form_name, shape,
+             dt_get_wtime() - start);
+    start = dt_get_wtime();
+  }
+
+  // and back to input image coordinates
+  if(!dt_dev_distort_backtransform_plus(pipe, iop_order, DT_DEV_TRANSFORM_DIR_BACK_INCL, points, count))
+  {
+    dt_pixelpipe_cache_free_align(points);
+    return NULL;
+  }
+
+  if(dt_get_debug_flags() & DT_DEBUG_PERF)
+    dt_print(DT_DEBUG_MASKS, "[masks %s] %s transform took %0.04f sec\n", form_name, shape,
+             dt_get_wtime() - start);
+
+  return points;
 }
 
 int dt_masks_skip_ranges_build(const float *crossing_pairs, const int pair_count, const int point_count,

--- a/src/develop/masks/masks.c
+++ b/src/develop/masks/masks.c
@@ -116,6 +116,7 @@ void dt_masks_form_gui_points_free(gpointer data)
 
   dt_pixelpipe_cache_free_align(gui_points->points);
   dt_pixelpipe_cache_free_align(gui_points->border);
+  dt_pixelpipe_cache_free_align(gui_points->border_skips);
   dt_pixelpipe_cache_free_align(gui_points->source);
   dt_free(gui_points);
 }
@@ -216,13 +217,82 @@ int dt_masks_form_duplicate_in_group(dt_develop_t *develop, int group_id, int fo
 dt_masks_raster_result_t dt_masks_get_points_border(dt_develop_t *develop, dt_masks_form_t *mask_form,
                                float **point_buffer, int *point_count,
                                float **border_buffer, int *border_count,
+                               dt_masks_skip_range_t **border_skips, int *border_skip_count,
                                int source, dt_iop_module_t *module)
 {
+  if(!IS_NULL_PTR(border_skips)) *border_skips = NULL;
+  if(!IS_NULL_PTR(border_skip_count)) *border_skip_count = 0;
+
   /* A shape type with no outline builder is a programming error, not an empty outline. */
   if(mask_form->functions && mask_form->functions->get_points_border)
     return mask_form->functions->get_points_border(develop, mask_form, point_buffer, point_count,
-                                                   border_buffer, border_count, source, module);
+                                                   border_buffer, border_count,
+                                                   border_skips, border_skip_count, source, module);
   return DT_MASKS_RASTER_ERROR;
+}
+
+static int _skip_range_cmp(const void *a, const void *b)
+{
+  const int va = ((const dt_masks_skip_range_t *)a)->jump_from;
+  const int vb = ((const dt_masks_skip_range_t *)b)->jump_from;
+  return (va > vb) - (va < vb);
+}
+
+int dt_masks_skip_ranges_build(const float *crossing_pairs, const int pair_count, const int point_count,
+                               dt_masks_skip_range_t *out, int *dropped_wrapping)
+{
+  if(!IS_NULL_PTR(dropped_wrapping)) *dropped_wrapping = 0;
+  if(IS_NULL_PTR(crossing_pairs) || IS_NULL_PTR(out) || pair_count <= 0 || point_count <= 0) return 0;
+
+  int count = 0;
+  for(int i = 0; i < pair_count; i++)
+  {
+    const int v = (int)crossing_pairs[i * 2];
+    const int w = (int)crossing_pairs[i * 2 + 1];
+    if(v < 0 || v >= point_count || w < 0 || w >= point_count) continue;
+    if(v == w) continue;
+
+    /* Discovery order is not read order: the detector walks from a shape extremum, so either
+     * index of the pair can come first in the buffer. The read walk is a fixed forward
+     * rotation, so the smaller raw index is always the one it reaches first. */
+    const int jump_from = MIN(v, w);
+    const int resume_at = MAX(v, w);
+
+    /* The border is a CLOSED contour: two crossing points cut it into TWO arcs, and the fold
+     * to remove is the SHORTER one -- not whichever happens to avoid the buffer seam. When the
+     * fold straddles the seam, [min, max] names its complement (issue #1313: three such pairs
+     * each covered ~147000 of 147546 border points instead of the 330-454 their folds actually
+     * spanned, and merging swallowed the shape). A wrapping skip cannot be expressed by a
+     * forward-only range, so the seam-straddling fold is left in: a small local kink, bounded
+     * by the fold's own size, instead of a straight chord across the whole shape. */
+    if(resume_at - jump_from > point_count - (resume_at - jump_from))
+    {
+      if(!IS_NULL_PTR(dropped_wrapping)) (*dropped_wrapping)++;
+      continue;
+    }
+
+    out[count].jump_from = jump_from;
+    out[count].resume_at = resume_at;
+    count++;
+  }
+
+  if(count == 0) return 0;
+
+  /* Sort and merge overlaps into disjoint ranges. Two overlapping ranges consumed
+   * independently once trapped the read walk in a cycle between them; disjoint and sorted,
+   * every skip moves strictly forward and each border index is visited at most once. */
+  qsort(out, count, sizeof(dt_masks_skip_range_t), _skip_range_cmp);
+
+  int merged = 1;
+  for(int i = 1; i < count; i++)
+  {
+    if(out[i].jump_from <= out[merged - 1].resume_at)
+      out[merged - 1].resume_at = MAX(out[merged - 1].resume_at, out[i].resume_at);
+    else
+      out[merged++] = out[i];
+  }
+
+  return merged;
 }
 
 dt_masks_raster_result_t dt_masks_get_area(dt_iop_module_t *module, dt_dev_pixelpipe_t *pipe,

--- a/src/develop/masks/masks.c
+++ b/src/develop/masks/masks.c
@@ -238,6 +238,178 @@ static int _skip_range_cmp(const void *a, const void *b)
   return (va > vb) - (va < vb);
 }
 
+/* ------------------------------------------------------------------------------------- */
+/* Where does a shape's border cross itself?
+ *
+ * polygon.c has answered this since forever with a pixel grid: walk the contour, stamp each cell
+ * with the index that passed through it, and call a revisited cell a crossing. That works well
+ * enough there and is left alone -- but it is an approximation with shape-specific guards (it
+ * refuses any span containing a shape extremum, and merges a new crossing into the previous one
+ * on an index-ordering test), and measured against ground truth on issue #1313's brush it missed
+ * four of the eight real crossings while finding one the local search could not.
+ *
+ * A brush needs all of them, so this answers the question exactly: bucket the segments into a
+ * coarse spatial hash, and run a real segment-segment intersection on the pairs that share a
+ * bucket. No extrema guard, no merge heuristic, and the intersection POINT falls out of the
+ * test, which is what lets the caller land its cut on the samples that sit at the crossing --
+ * cutting anywhere else leaves the two ends apart and the drawer spans the gap with a chord.
+ *
+ * Complexity is the hash's, not O(n^2): the contour is decimated to about one probe per pixel
+ * first, and only same-bucket pairs are tested. Polygon should migrate here once someone is
+ * willing to re-verify its output against the grid version; until then the two coexist
+ * deliberately, and this comment is the record of why.
+ */
+
+#define MASKS_XSECT_BUCKET 4      /* px */
+
+/** Do the two segments properly cross, and where? Endpoint touches do not count. */
+static gboolean _segments_cross(const float *a0, const float *a1, const float *b0, const float *b1,
+                                float *out_x, float *out_y)
+{
+  const float rx = a1[0] - a0[0], ry = a1[1] - a0[1];
+  const float sx = b1[0] - b0[0], sy = b1[1] - b0[1];
+  const float denom = rx * sy - ry * sx;
+  if(fabsf(denom) < 1e-12f) return FALSE;
+
+  const float qpx = b0[0] - a0[0], qpy = b0[1] - a0[1];
+  const float t = (qpx * sy - qpy * sx) / denom;
+  const float u = (qpx * ry - qpy * rx) / denom;
+  if(t <= 0.0f || t >= 1.0f || u <= 0.0f || u >= 1.0f) return FALSE;
+
+  *out_x = a0[0] + t * rx;
+  *out_y = a0[1] + t * ry;
+  return TRUE;
+}
+
+int dt_masks_border_find_self_intersections(const float *const border, const int border_count,
+                                            const int header, float *const crossing_pairs,
+                                            const int max_pairs)
+{
+  if(IS_NULL_PTR(border) || IS_NULL_PTR(crossing_pairs) || max_pairs <= 0) return 0;
+  if(border_count - header < 8) return 0;
+
+  /* Decimate, but only to a QUARTER pixel. The border is sampled at raw-image resolution --
+   * about 13 samples per pixel on a full-size brush -- so testing every sample against every
+   * other is wasteful; but decimating to a whole pixel smooths the small loops away entirely.
+   * Measured: at one probe per pixel, four real crossings spanning 7 to 17 pixels went unseen,
+   * and each of them is a visible kink in the drawn outline. */
+  int *probes = (int *)malloc(sizeof(int) * (size_t)(border_count - header));
+  if(IS_NULL_PTR(probes)) return 0;
+
+  int n = 0;
+  int previous = -1;
+  for(int i = header; i < border_count; i++)
+  {
+    if(isnan(border[i * 2]) || isnan(border[i * 2 + 1])) continue;
+    if(previous >= 0)
+    {
+      const float dx = border[i * 2] - border[previous * 2];
+      const float dy = border[i * 2 + 1] - border[previous * 2 + 1];
+      if(dx * dx + dy * dy < 0.0625f) continue;   // (0.25 px)^2
+    }
+    probes[n++] = i;
+    previous = i;
+  }
+  if(n < 8) { free(probes); return 0; }
+
+  /* Bucket every probe segment by the cells its bounding box covers. A hash keyed on the cell
+   * coordinates keeps this independent of where the shape sits and of how large the image is --
+   * a grid over the bounding box would be tens of megabytes for a stroke across a 50 Mpx frame. */
+  const int buckets = 1 << 14;
+  int *heads = (int *)malloc(sizeof(int) * buckets);
+  int *next = (int *)malloc(sizeof(int) * (size_t)(n * 4));
+  int *owner = (int *)malloc(sizeof(int) * (size_t)(n * 4));
+  if(IS_NULL_PTR(heads) || IS_NULL_PTR(next) || IS_NULL_PTR(owner))
+  {
+    free(probes); free(heads); free(next); free(owner);
+    return 0;
+  }
+  for(int i = 0; i < buckets; i++) heads[i] = -1;
+
+  int entries = 0;
+  int found = 0;
+
+  for(int k = 0; k + 1 < n && found < max_pairs; k++)
+  {
+    const float ax = border[probes[k] * 2],     ay = border[probes[k] * 2 + 1];
+    const float bx = border[probes[k + 1] * 2], by = border[probes[k + 1] * 2 + 1];
+
+    const int cx0 = (int)floorf(MIN(ax, bx) / MASKS_XSECT_BUCKET);
+    const int cx1 = (int)floorf(MAX(ax, bx) / MASKS_XSECT_BUCKET);
+    const int cy0 = (int)floorf(MIN(ay, by) / MASKS_XSECT_BUCKET);
+    const int cy1 = (int)floorf(MAX(ay, by) / MASKS_XSECT_BUCKET);
+    /* A segment spanning many cells means the contour jumped; it is not worth indexing widely. */
+    if((cx1 - cx0) > 4 || (cy1 - cy0) > 4) continue;
+
+    for(int cy = cy0; cy <= cy1; cy++)
+      for(int cx = cx0; cx <= cx1; cx++)
+      {
+        const unsigned int h = ((unsigned int)(cx * 73856093) ^ (unsigned int)(cy * 19349663))
+                               & (unsigned int)(buckets - 1);
+        /* test against everything already in this bucket ... */
+        for(int e = heads[h]; e >= 0 && found < max_pairs; e = next[e])
+        {
+          const int j = owner[e];
+          if(k - j < 8) continue;   // ~2 px apart: nearer than that they share an endpoint
+
+          /* A loop closes in one of two ways, and only testing for one of them leaves the
+           * other drawn. Two strands that CROSS meet transversally -- that is the fold. An arc
+           * that sweeps all the way round a node comes back to its own starting point and meets
+           * it TANGENTIALLY: no crossing, and yet it plainly encloses a loop. Those are the
+           * node-centred circles that appear over the stroke when the arcs are left in.
+           *
+           * The near-return test costs nothing here, since the two probes are already in hand
+           * and already known to share a bucket. It cannot fire on the two sides of a stroke
+           * approaching each other, because the caller only accepts short spans and a stroke
+           * that thin has no interior to protect anyway. */
+          float ix = 0.0f, iy = 0.0f;
+          if(!_segments_cross(&border[probes[j] * 2], &border[probes[j + 1] * 2],
+                              &border[probes[k] * 2], &border[probes[k + 1] * 2], &ix, &iy))
+          {
+            const float dx = border[probes[k] * 2] - border[probes[j] * 2];
+            const float dy = border[probes[k] * 2 + 1] - border[probes[j] * 2 + 1];
+            if(dx * dx + dy * dy > 2.25f) continue;    // (1.5 px)^2
+            ix = border[probes[j] * 2];
+            iy = border[probes[j] * 2 + 1];
+          }
+
+          /* Report the SAMPLES nearest the intersection, not the probes bracketing it: a cut
+           * has to land on the crossing itself or its two ends do not meet. */
+          int lo = probes[j], hi = probes[k];
+          float lo_d2 = FLT_MAX, hi_d2 = FLT_MAX;
+          for(int t = probes[j]; t <= probes[j + 1]; t++)
+          {
+            if(isnan(border[t * 2])) continue;
+            const float d2 = sqf(border[t * 2] - ix) + sqf(border[t * 2 + 1] - iy);
+            if(d2 < lo_d2) { lo_d2 = d2; lo = t; }
+          }
+          for(int t = probes[k]; t <= probes[k + 1]; t++)
+          {
+            if(isnan(border[t * 2])) continue;
+            const float d2 = sqf(border[t * 2] - ix) + sqf(border[t * 2 + 1] - iy);
+            if(d2 < hi_d2) { hi_d2 = d2; hi = t; }
+          }
+          if(hi <= lo + 1) continue;
+
+          crossing_pairs[found * 2] = (float)lo;
+          crossing_pairs[found * 2 + 1] = (float)hi;
+          found++;
+        }
+        /* ... then add ourselves, so each pair is tested exactly once */
+        if(entries < n * 4)
+        {
+          owner[entries] = k;
+          next[entries] = heads[h];
+          heads[h] = entries;
+          entries++;
+        }
+      }
+  }
+
+  free(probes); free(heads); free(next); free(owner);
+  return found;
+}
+
 int dt_masks_skip_ranges_build(const float *crossing_pairs, const int pair_count, const int point_count,
                                dt_masks_skip_range_t *out, int *dropped_wrapping)
 {

--- a/src/develop/masks/masks.c
+++ b/src/develop/masks/masks.c
@@ -214,6 +214,39 @@ int dt_masks_form_duplicate_in_group(dt_develop_t *develop, int group_id, int fo
   return nid;
 }
 
+/** Repair and report a non-finite coordinate in an outline buffer. See the contract in
+ * dt_masks_get_points_border(): these buffers carry geometry only. */
+static void _outline_assert_finite(const char *which, const char *name, float **buffer, const int *count)
+{
+  if(IS_NULL_PTR(buffer) || IS_NULL_PTR(*buffer) || IS_NULL_PTR(count) || *count <= 0) return;
+
+  float *const pts = *buffer;
+  int bad = 0;
+  float last_x = 0.0f, last_y = 0.0f;
+  gboolean have_last = FALSE;
+
+  for(int i = 0; i < *count; i++)
+  {
+    if(isfinite(pts[i * 2]) && isfinite(pts[i * 2 + 1]))
+    {
+      last_x = pts[i * 2];
+      last_y = pts[i * 2 + 1];
+      have_last = TRUE;
+      continue;
+    }
+    bad++;
+    /* hold the previous sample rather than leave a coordinate no consumer may look at */
+    pts[i * 2] = have_last ? last_x : 0.0f;
+    pts[i * 2 + 1] = have_last ? last_y : 0.0f;
+  }
+
+  if(bad > 0)
+    dt_print(DT_DEBUG_ALWAYS,
+             "[masks] %s: %d of %d %s samples are not finite -- the outline builder is writing"
+             " sentinels into a buffer that carries geometry only; held the previous sample\n",
+             IS_NULL_PTR(name) ? "?" : name, bad, *count, which);
+}
+
 dt_masks_raster_result_t dt_masks_get_points_border(dt_develop_t *develop, dt_masks_form_t *mask_form,
                                float **point_buffer, int *point_count,
                                float **border_buffer, int *border_count,
@@ -224,11 +257,37 @@ dt_masks_raster_result_t dt_masks_get_points_border(dt_develop_t *develop, dt_ma
   if(!IS_NULL_PTR(border_skip_count)) *border_skip_count = 0;
 
   /* A shape type with no outline builder is a programming error, not an empty outline. */
-  if(mask_form->functions && mask_form->functions->get_points_border)
-    return mask_form->functions->get_points_border(develop, mask_form, point_buffer, point_count,
-                                                   border_buffer, border_count,
-                                                   border_skips, border_skip_count, source, module);
-  return DT_MASKS_RASTER_ERROR;
+  if(IS_NULL_PTR(mask_form->functions) || IS_NULL_PTR(mask_form->functions->get_points_border))
+    return DT_MASKS_RASTER_ERROR;
+
+  const dt_masks_raster_result_t status
+      = mask_form->functions->get_points_border(develop, mask_form, point_buffer, point_count,
+                                                border_buffer, border_count,
+                                                border_skips, border_skip_count, source, module);
+
+  /* THE OUTLINE BUFFERS HOLD FINITE GEOMETRY AND NOTHING ELSE.
+   *
+   * Everything a consumer must not draw travels beside the buffer, in border_skips. Nothing is
+   * encoded into the coordinates -- no NaN marking an excluded sample, no NaN,NaN marking the
+   * end of a contour, and above all no index smuggled through a float y with a NaN x, which is
+   * what issue #1313 shipped and what the out-of-band ranges replaced.
+   *
+   * This is the one place every shape's outline passes through, so the invariant is checked
+   * once here rather than re-tested by each of the dozen walkers downstream. Those walkers used
+   * to test it, which is how it came to be relied upon: a hidden encoding in a buffer of plain
+   * floats is invisible to any consumer that does not already know about it, and silently wrong
+   * for one that forgets. Two had forgotten -- the polygon drew its own folds, and the brush's
+   * per-node border handle vanished wherever an excluded sample was the nearest one.
+   *
+   * A violation is REPORTED, not absorbed. It is a producer bug and it should be loud; the
+   * repair that follows only keeps the GUI usable until someone fixes it. */
+  if(status != DT_MASKS_RASTER_ERROR)
+  {
+    _outline_assert_finite("points", mask_form->name, point_buffer, point_count);
+    _outline_assert_finite("border", mask_form->name, border_buffer, border_count);
+  }
+
+  return status;
 }
 
 static int _skip_range_cmp(const void *a, const void *b)
@@ -300,7 +359,6 @@ int dt_masks_border_find_self_intersections(const float *const border, const int
   int previous = -1;
   for(int i = header; i < border_count; i++)
   {
-    if(isnan(border[i * 2]) || isnan(border[i * 2 + 1])) continue;
     if(previous >= 0)
     {
       const float dx = border[i * 2] - border[previous * 2];
@@ -379,13 +437,11 @@ int dt_masks_border_find_self_intersections(const float *const border, const int
           float lo_d2 = FLT_MAX, hi_d2 = FLT_MAX;
           for(int t = probes[j]; t <= probes[j + 1]; t++)
           {
-            if(isnan(border[t * 2])) continue;
             const float d2 = sqf(border[t * 2] - ix) + sqf(border[t * 2 + 1] - iy);
             if(d2 < lo_d2) { lo_d2 = d2; lo = t; }
           }
           for(int t = probes[k]; t <= probes[k + 1]; t++)
           {
-            if(isnan(border[t * 2])) continue;
             const float d2 = sqf(border[t * 2] - ix) + sqf(border[t * 2 + 1] - iy);
             if(d2 < hi_d2) { hi_d2 = d2; hi = t; }
           }
@@ -408,6 +464,24 @@ int dt_masks_border_find_self_intersections(const float *const border, const int
 
   free(probes); free(heads); free(next); free(owner);
   return found;
+}
+
+/** Is @p index inside one of the excluded spans? For a consumer that SEARCHES the outline
+ * rather than walking it forward -- a forward walk should use dt_masks_draw_outline_runs() or
+ * carry its own cursor. @p skips must be sorted and disjoint. */
+gboolean dt_masks_skip_contains(const dt_masks_skip_range_t *skips, const int skip_count, const int index)
+{
+  if(IS_NULL_PTR(skips) || skip_count <= 0) return FALSE;
+
+  int lo = 0, hi = skip_count - 1;
+  while(lo <= hi)
+  {
+    const int mid = (lo + hi) / 2;
+    if(index < skips[mid].jump_from) hi = mid - 1;
+    else if(index >= skips[mid].resume_at) lo = mid + 1;
+    else return TRUE;
+  }
+  return FALSE;
 }
 
 int dt_masks_skip_ranges_build(const float *crossing_pairs, const int pair_count, const int point_count,

--- a/src/develop/masks/masks.c
+++ b/src/develop/masks/masks.c
@@ -558,6 +558,63 @@ float *dt_masks_sample_grid_backtransform(struct dt_dev_pixelpipe_t *pipe, const
   return points;
 }
 
+void dt_masks_sample_grid_interpolate(const float *const points, const dt_masks_sample_grid_t *const grid,
+                                      float *const buffer, const int buf_width, const int buf_height,
+                                      int *const endx, int *const endy)
+{
+  const int step = grid->step;
+  const int gw = grid->width;
+  const int startx = grid->x0 * step;
+  const int starty = grid->y0 * step;
+
+  // the last cell contributes its far corner, so the covered rectangle ends one whole cell short
+  // of the lattice -- and is clipped to the buffer, since a bounding box may overhang the ROI
+  const int ex = MIN(buf_width, (grid->x0 + gw - 1) * step);
+  const int ey = MIN(buf_height, (grid->y0 + grid->height - 1) * step);
+
+  // the two bilinear weight ramps, one entry per position within a cell
+  float w0[DT_MASKS_GRID_MAX_STEP], w1[DT_MASKS_GRID_MAX_STEP];
+  for(int i = 0; i < step; i++)
+  {
+    w0[i] = (float)(step - i);
+    w1[i] = (float)i;
+  }
+  const float inv_step2 = 1.0f / (step * step);
+
+  __OMP_PARALLEL_FOR__(if((size_t)(ey - starty) * (size_t)(ex - startx) > 50000))
+  for(int j = starty; j < ey; j++)
+  {
+    const int jj = j % step;
+    const int mj = j / step - grid->y0;
+    const float wj0 = w0[jj];
+    const float wj1 = w1[jj];
+    const size_t row_base = (size_t)mj * gw;
+    float *const row = buffer + (size_t)j * buf_width;
+    int ii = 0;
+    int mi = 0;
+
+    for(int i = startx; i < ex; i++)
+    {
+      const size_t mindex = row_base + mi;
+      const float wii0 = w0[ii];
+      const float wii1 = w1[ii];
+      row[i] = (points[mindex * 2] * wii0 * wj0
+                + points[(mindex + 1) * 2] * wii1 * wj0
+                + points[(mindex + gw) * 2] * wii0 * wj1
+                + points[(mindex + gw + 1) * 2] * wii1 * wj1) * inv_step2;
+      ii++;
+      if(ii == step)
+      {
+        ii = 0;
+        mi++;
+      }
+    }
+  }
+
+  if(endx) *endx = ex;
+  if(endy) *endy = ey;
+}
+
 int dt_masks_skip_ranges_build(const float *crossing_pairs, const int pair_count, const int point_count,
                                dt_masks_skip_range_t *out, int *dropped_wrapping)
 {

--- a/src/develop/masks/masks.c
+++ b/src/develop/masks/masks.c
@@ -214,39 +214,6 @@ int dt_masks_form_duplicate_in_group(dt_develop_t *develop, int group_id, int fo
   return nid;
 }
 
-/** Repair and report a non-finite coordinate in an outline buffer. See the contract in
- * dt_masks_get_points_border(): these buffers carry geometry only. */
-static void _outline_assert_finite(const char *which, const char *name, float **buffer, const int *count)
-{
-  if(IS_NULL_PTR(buffer) || IS_NULL_PTR(*buffer) || IS_NULL_PTR(count) || *count <= 0) return;
-
-  float *const pts = *buffer;
-  int bad = 0;
-  float last_x = 0.0f, last_y = 0.0f;
-  gboolean have_last = FALSE;
-
-  for(int i = 0; i < *count; i++)
-  {
-    if(isfinite(pts[i * 2]) && isfinite(pts[i * 2 + 1]))
-    {
-      last_x = pts[i * 2];
-      last_y = pts[i * 2 + 1];
-      have_last = TRUE;
-      continue;
-    }
-    bad++;
-    /* hold the previous sample rather than leave a coordinate no consumer may look at */
-    pts[i * 2] = have_last ? last_x : 0.0f;
-    pts[i * 2 + 1] = have_last ? last_y : 0.0f;
-  }
-
-  if(bad > 0)
-    dt_print(DT_DEBUG_ALWAYS,
-             "[masks] %s: %d of %d %s samples are not finite -- the outline builder is writing"
-             " sentinels into a buffer that carries geometry only; held the previous sample\n",
-             IS_NULL_PTR(name) ? "?" : name, bad, *count, which);
-}
-
 dt_masks_raster_result_t dt_masks_get_points_border(dt_develop_t *develop, dt_masks_form_t *mask_form,
                                float **point_buffer, int *point_count,
                                float **border_buffer, int *border_count,
@@ -268,24 +235,22 @@ dt_masks_raster_result_t dt_masks_get_points_border(dt_develop_t *develop, dt_ma
   /* THE OUTLINE BUFFERS HOLD FINITE GEOMETRY AND NOTHING ELSE.
    *
    * Everything a consumer must not draw travels beside the buffer, in border_skips. Nothing is
-   * encoded into the coordinates -- no NaN marking an excluded sample, no NaN,NaN marking the
-   * end of a contour, and above all no index smuggled through a float y with a NaN x, which is
-   * what issue #1313 shipped and what the out-of-band ranges replaced.
+   * encoded into the coordinates -- no NaN marking an excluded sample, no NaN,NaN ending a
+   * contour, and above all no index smuggled through a float y with a NaN x, which is what issue
+   * #1313 shipped and what the out-of-band ranges replaced. A dozen walkers downstream dropped
+   * their own NaN tests on the strength of this.
    *
-   * This is the one place every shape's outline passes through, so the invariant is checked
-   * once here rather than re-tested by each of the dozen walkers downstream. Those walkers used
-   * to test it, which is how it came to be relied upon: a hidden encoding in a buffer of plain
-   * floats is invisible to any consumer that does not already know about it, and silently wrong
-   * for one that forgets. Two had forgotten -- the polygon drew its own folds, and the brush's
-   * per-node border handle vanished wherever an excluded sample was the nearest one.
+   * It is not checked here, and that is deliberate. The invariant is STRUCTURAL: neither
+   * _brush_border_get_XY() nor _polygon_border_get_XY() can write a sentinel -- they return
+   * whether they produced a border point, and the recursions carry explicit have_* flags -- so
+   * there is no longer a code path that can violate it. A scan for something structurally
+   * impossible is not defence, it is a tax: measured at 0.24 ms per outline rebuild on the
+   * reported brush's two 52492-sample buffers, which is a third of what stroking the whole
+   * overlay costs, on the same per-frame path during a mask drag.
    *
-   * A violation is REPORTED, not absorbed. It is a producer bug and it should be loud; the
-   * repair that follows only keeps the GUI usable until someone fixes it. */
-  if(status != DT_MASKS_RASTER_ERROR)
-  {
-    _outline_assert_finite("points", mask_form->name, point_buffer, point_count);
-    _outline_assert_finite("border", mask_form->name, border_buffer, border_count);
-  }
+   * The one place a violation would still be caught is free: dt_masks_point_in_form_exact()
+   * already visits every sample, and reports a non-finite one rather than decoding it. If a
+   * future producer regresses, that is where it will say so. */
 
   return status;
 }

--- a/src/develop/masks/masks.c
+++ b/src/develop/masks/masks.c
@@ -352,7 +352,7 @@ int dt_masks_border_find_self_intersections(const float *const border, const int
    * other is wasteful; but decimating to a whole pixel smooths the small loops away entirely.
    * Measured: at one probe per pixel, four real crossings spanning 7 to 17 pixels went unseen,
    * and each of them is a visible kink in the drawn outline. */
-  int *probes = (int *)malloc(sizeof(int) * (size_t)(border_count - header));
+  int *probes = (int *)dt_alloc_align(sizeof(int) * (size_t)(border_count - header));
   if(IS_NULL_PTR(probes)) return 0;
 
   int n = 0;
@@ -368,18 +368,18 @@ int dt_masks_border_find_self_intersections(const float *const border, const int
     probes[n++] = i;
     previous = i;
   }
-  if(n < 8) { free(probes); return 0; }
+  if(n < 8) { dt_free_align(probes); return 0; }
 
   /* Bucket every probe segment by the cells its bounding box covers. A hash keyed on the cell
    * coordinates keeps this independent of where the shape sits and of how large the image is --
    * a grid over the bounding box would be tens of megabytes for a stroke across a 50 Mpx frame. */
   const int buckets = 1 << 14;
-  int *heads = (int *)malloc(sizeof(int) * buckets);
-  int *next = (int *)malloc(sizeof(int) * (size_t)(n * 4));
-  int *owner = (int *)malloc(sizeof(int) * (size_t)(n * 4));
+  int *heads = (int *)dt_alloc_align(sizeof(int) * buckets);
+  int *next = (int *)dt_alloc_align(sizeof(int) * (size_t)(n * 4));
+  int *owner = (int *)dt_alloc_align(sizeof(int) * (size_t)(n * 4));
   if(IS_NULL_PTR(heads) || IS_NULL_PTR(next) || IS_NULL_PTR(owner))
   {
-    free(probes); free(heads); free(next); free(owner);
+    dt_free_align(probes); dt_free_align(heads); dt_free_align(next); dt_free_align(owner);
     return 0;
   }
   for(int i = 0; i < buckets; i++) heads[i] = -1;
@@ -462,7 +462,7 @@ int dt_masks_border_find_self_intersections(const float *const border, const int
       }
   }
 
-  free(probes); free(heads); free(next); free(owner);
+  dt_free_align(probes); dt_free_align(heads); dt_free_align(next); dt_free_align(owner);
   return found;
 }
 
@@ -1052,7 +1052,7 @@ int dt_masks_copy_used_forms_for_module(dt_develop_t *develop_dest, dt_develop_t
   const guint form_count = g_list_length(develop_src->forms);
   if(form_count == 0) return 0;
 
-  int *used_form_ids = calloc(form_count, sizeof(int));
+  int *used_form_ids = dt_calloc_align(form_count * sizeof(int));
   if(IS_NULL_PTR(used_form_ids)) return 1;
 
   _masks_fill_used_forms(develop_src->forms, source_module->blend_params->mask_id,
@@ -1074,7 +1074,7 @@ int dt_masks_copy_used_forms_for_module(dt_develop_t *develop_dest, dt_develop_t
       dt_masks_form_t *new_form = dt_masks_dup_masks_form(mask_form);
       if(IS_NULL_PTR(new_form))
       {
-        dt_free(used_form_ids);
+        dt_free_align(used_form_ids);
         return 1;
       }
       develop_dest->forms = g_list_append(develop_dest->forms, new_form);
@@ -1086,7 +1086,7 @@ int dt_masks_copy_used_forms_for_module(dt_develop_t *develop_dest, dt_develop_t
     }
   }
 
-  dt_free(used_form_ids);
+  dt_free_align(used_form_ids);
   return 0;
 }
 
@@ -1215,7 +1215,7 @@ void dt_masks_write_masks_history_item(const int32_t image_id, const int history
   // nothing at all in that case -- the whole INSERT sat inside this test.
   if(!mask_form->functions) return;
 
-  char *const restrict point_buffer = (char *)malloc(point_count * point_struct_size);
+  char *const restrict point_buffer = (char *)dt_alloc_align(point_count * point_struct_size);
   int buffer_offset = 0;
   for(GList *point_node = mask_form->points; point_node; point_node = g_list_next(point_node))
   {
@@ -1228,7 +1228,7 @@ void dt_masks_write_masks_history_item(const int32_t image_id, const int history
                                         point_count * point_struct_size, point_count,
                                         mask_form->source, 2 * sizeof(float));
 
-  dt_free(point_buffer);
+  dt_free_align(point_buffer);
 }
 
 void dt_masks_free_form(dt_masks_form_t *mask_form)
@@ -1599,7 +1599,7 @@ static int _masks_cleanup_unused(dt_develop_t *dev, GList **forms_list, GList *h
 
   // we create a table to store the ids of used forms
   guint form_count = g_list_length(forms);
-  int *used_form_ids = calloc(form_count, sizeof(int));
+  int *used_form_ids = dt_calloc_align(form_count * sizeof(int));
 
   // check in history if the module has drawn masks and add it to used array
   int history_index = 0;
@@ -1646,7 +1646,7 @@ static int _masks_cleanup_unused(dt_develop_t *dev, GList **forms_list, GList *h
     }
   }
 
-  dt_free(used_form_ids);
+  dt_free_align(used_form_ids);
 
   *forms_list = forms;
 

--- a/src/develop/masks/masks.c
+++ b/src/develop/masks/masks.c
@@ -287,7 +287,7 @@ static int _skip_range_cmp(const void *a, const void *b)
 #define MASKS_XSECT_BUCKET 4      /* px */
 
 /** Do the two segments properly cross, and where? Endpoint touches do not count. */
-static gboolean _segments_cross(const float *a0, const float *a1, const float *b0, const float *b1,
+static inline gboolean _segments_cross(const float *a0, const float *a1, const float *b0, const float *b1,
                                 float *out_x, float *out_y)
 {
   const float rx = a1[0] - a0[0], ry = a1[1] - a0[1];
@@ -305,21 +305,69 @@ static gboolean _segments_cross(const float *a0, const float *a1, const float *b
   return TRUE;
 }
 
-int dt_masks_border_find_self_intersections(const float *const border, const int border_count,
-                                            const int header, float *const crossing_pairs,
-                                            const int max_pairs)
+/** The sample in [@p from, @p to] closest to (@p x, @p y).
+ *
+ * A cut has to land on the crossing itself or its two ends do not meet, and the probes only
+ * bracket it -- they are a quarter-pixel apart at best and much coarser once the walk widens. */
+static inline int _nearest_sample_to(const float *const border, const int from, const int to,
+                              const float x, const float y)
 {
-  if(IS_NULL_PTR(border) || IS_NULL_PTR(crossing_pairs) || max_pairs <= 0) return 0;
-  if(border_count - header < 8) return 0;
+  int best = from;
+  float best_d2 = FLT_MAX;
+  for(int t = from; t <= to; t++)
+  {
+    const float d2 = sqf(border[t * 2] - x) + sqf(border[t * 2 + 1] - y);
+    if(d2 < best_d2)
+    {
+      best_d2 = d2;
+      best = t;
+    }
+  }
+  return best;
+}
 
-  /* Decimate, but only to a QUARTER pixel. The border is sampled at raw-image resolution --
-   * about 13 samples per pixel on a full-size brush -- so testing every sample against every
-   * other is wasteful; but decimating to a whole pixel smooths the small loops away entirely.
-   * Measured: at one probe per pixel, four real crossings spanning 7 to 17 pixels went unseen,
-   * and each of them is a visible kink in the drawn outline. */
-  int *probes = (int *)dt_alloc_align(sizeof(int) * (size_t)(border_count - header));
-  if(IS_NULL_PTR(probes)) return 0;
+/** Does the contour close a loop between probe segments @p j and @p k, and where should the cut
+ * land? Writes the two sample indices and returns TRUE when it does.
+ *
+ * A loop closes in one of two ways, and testing only for one leaves the other drawn. Two strands
+ * that CROSS meet transversally -- that is the fold. An arc sweeping all the way round a node
+ * comes back to its own starting point and meets it TANGENTIALLY: no crossing, and yet it plainly
+ * encloses a loop. Those are the node-centred circles that appear over the stroke when the join
+ * arcs are left in.
+ *
+ * The near-return test costs nothing here: both probes are already in hand and already known to
+ * share a bucket. It cannot fire on the two sides of a stroke approaching each other, because the
+ * caller only accepts short spans and a stroke that thin has no interior to protect. */
+static inline gboolean _probe_pair_closes_a_loop(const float *const border, const int *const probes,
+                                          const int j, const int k, int *const out_lo, int *const out_hi)
+{
+  float ix = 0.0f;
+  float iy = 0.0f;
 
+  if(!_segments_cross(&border[probes[j] * 2], &border[probes[j + 1] * 2],
+                      &border[probes[k] * 2], &border[probes[k + 1] * 2], &ix, &iy))
+  {
+    const float dx = border[probes[k] * 2] - border[probes[j] * 2];
+    const float dy = border[probes[k] * 2 + 1] - border[probes[j] * 2 + 1];
+    if(dx * dx + dy * dy > 2.25f) return FALSE;    // (1.5 px)^2
+    ix = border[probes[j] * 2];
+    iy = border[probes[j] * 2 + 1];
+  }
+
+  const int lo = _nearest_sample_to(border, probes[j], probes[j + 1], ix, iy);
+  const int hi = _nearest_sample_to(border, probes[k], probes[k + 1], ix, iy);
+  if(hi <= lo + 1) return FALSE;
+
+  *out_lo = lo;
+  *out_hi = hi;
+  return TRUE;
+}
+
+/** Decimate the contour to roughly one probe per quarter-pixel. See the note on the detector for
+ * why a whole pixel is too coarse. Returns how many were kept. */
+static inline int _collect_xsect_probes(const float *const border, const int header, const int border_count,
+                                 int *const probes)
+{
   int n = 0;
   int previous = -1;
   for(int i = header; i < border_count; i++)
@@ -333,6 +381,26 @@ int dt_masks_border_find_self_intersections(const float *const border, const int
     probes[n++] = i;
     previous = i;
   }
+  return n;
+}
+
+int dt_masks_border_find_self_intersections(const float *const border, const int border_count,
+                                            const int header, float *const crossing_pairs,
+                                            const int max_pairs)
+{
+  if(IS_NULL_PTR(border) || IS_NULL_PTR(crossing_pairs) || max_pairs <= 0) return 0;
+  if(border_count - header < 8) return 0;
+
+  int *probes = (int *)dt_alloc_align(sizeof(int) * (size_t)(border_count - header));
+  if(IS_NULL_PTR(probes)) return 0;
+
+  /* Decimate, but only to a QUARTER pixel. The border is sampled at raw-image resolution --
+   * about 13 samples per pixel on a full-size brush -- so testing every sample against every
+   * other is wasteful; but decimating to a whole pixel smooths the small loops away entirely.
+   * Measured: at one probe per pixel, four real crossings spanning 7 to 17 pixels went unseen,
+   * and each of them is a visible kink in the drawn outline. */
+  const int n = _collect_xsect_probes(border, header, border_count, probes);
+
   if(n < 8) { dt_free_align(probes); return 0; }
 
   /* Bucket every probe segment by the cells its bounding box covers. A hash keyed on the cell
@@ -370,47 +438,15 @@ int dt_masks_border_find_self_intersections(const float *const border, const int
         const unsigned int h = ((unsigned int)(cx * 73856093) ^ (unsigned int)(cy * 19349663))
                                & (unsigned int)(buckets - 1);
         /* test against everything already in this bucket ... */
+        /* test against everything already in this bucket ... */
         for(int e = heads[h]; e >= 0 && found < max_pairs; e = next[e])
         {
           const int j = owner[e];
           if(k - j < 8) continue;   // ~2 px apart: nearer than that they share an endpoint
 
-          /* A loop closes in one of two ways, and only testing for one of them leaves the
-           * other drawn. Two strands that CROSS meet transversally -- that is the fold. An arc
-           * that sweeps all the way round a node comes back to its own starting point and meets
-           * it TANGENTIALLY: no crossing, and yet it plainly encloses a loop. Those are the
-           * node-centred circles that appear over the stroke when the arcs are left in.
-           *
-           * The near-return test costs nothing here, since the two probes are already in hand
-           * and already known to share a bucket. It cannot fire on the two sides of a stroke
-           * approaching each other, because the caller only accepts short spans and a stroke
-           * that thin has no interior to protect anyway. */
-          float ix = 0.0f, iy = 0.0f;
-          if(!_segments_cross(&border[probes[j] * 2], &border[probes[j + 1] * 2],
-                              &border[probes[k] * 2], &border[probes[k + 1] * 2], &ix, &iy))
-          {
-            const float dx = border[probes[k] * 2] - border[probes[j] * 2];
-            const float dy = border[probes[k] * 2 + 1] - border[probes[j] * 2 + 1];
-            if(dx * dx + dy * dy > 2.25f) continue;    // (1.5 px)^2
-            ix = border[probes[j] * 2];
-            iy = border[probes[j] * 2 + 1];
-          }
-
-          /* Report the SAMPLES nearest the intersection, not the probes bracketing it: a cut
-           * has to land on the crossing itself or its two ends do not meet. */
-          int lo = probes[j], hi = probes[k];
-          float lo_d2 = FLT_MAX, hi_d2 = FLT_MAX;
-          for(int t = probes[j]; t <= probes[j + 1]; t++)
-          {
-            const float d2 = sqf(border[t * 2] - ix) + sqf(border[t * 2 + 1] - iy);
-            if(d2 < lo_d2) { lo_d2 = d2; lo = t; }
-          }
-          for(int t = probes[k]; t <= probes[k + 1]; t++)
-          {
-            const float d2 = sqf(border[t * 2] - ix) + sqf(border[t * 2 + 1] - iy);
-            if(d2 < hi_d2) { hi_d2 = d2; hi = t; }
-          }
-          if(hi <= lo + 1) continue;
+          int lo = 0;
+          int hi = 0;
+          if(!_probe_pair_closes_a_loop(border, probes, j, k, &lo, &hi)) continue;
 
           crossing_pairs[found * 2] = (float)lo;
           crossing_pairs[found * 2 + 1] = (float)hi;

--- a/src/develop/masks/masks_debug.c
+++ b/src/develop/masks/masks_debug.c
@@ -33,7 +33,6 @@
 #include "system/mem_alloc.h"
 
 #include <math.h>
-#include <string.h>
 
 float *dt_masks_debug_rasterise(dt_develop_t *dev, dt_masks_form_t *form, const int width, const int height)
 {
@@ -47,9 +46,8 @@ float *dt_masks_debug_rasterise(dt_develop_t *dev, dt_masks_form_t *form, const 
     return NULL;
   }
 
-  float *const buffer = dt_alloc_align_float((size_t)width * height);
+  float *const buffer = dt_calloc_align_float((size_t)width * height);
   if(IS_NULL_PTR(buffer)) return NULL;
-  memset(buffer, 0, sizeof(float) * (size_t)width * height);
 
   /* A pipe with no nodes: dt_dev_distort_transform_plus() then walks an empty list, so the
    * composition is the identity and the shape lands on raw coordinates. That is deliberate --

--- a/src/develop/masks/masks_debug.c
+++ b/src/develop/masks/masks_debug.c
@@ -1,0 +1,134 @@
+/*
+    This file is part of Ansel,
+    Copyright (C) 2026 Aurélien PIERRE.
+
+    Ansel is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Ansel is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Ansel.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+/* dt_masks_debug_write_png() is NOT here: compositing the GUI overlay needs cairo, and
+ * src/develop is held toolkit-free by tools/check_module_boundaries.sh -- the pixel engine has
+ * to stay portable. It lives beside the overlay code it calls, in masks/masks_gui.c. What is
+ * left in this file is the toolkit-free half: the rasteriser and the outline dump. */
+
+#include "develop/masks_debug.h"
+
+#include "common/logging.h"
+#include "develop/develop.h"
+#include "develop/dev_geometry.h"
+#include "develop/masks.h"
+#include "develop/masks_gui.h"
+#include "develop/masks/masks_functions.h"
+#include "develop/pixelpipe_hb.h"
+#include "system/mem_alloc.h"
+
+#include <math.h>
+#include <string.h>
+
+float *dt_masks_debug_rasterise(dt_develop_t *dev, dt_masks_form_t *form, const int width, const int height)
+{
+  if(IS_NULL_PTR(dev) || IS_NULL_PTR(form) || width <= 0 || height <= 0) return NULL;
+
+  int32_t raw_width = 0;
+  int32_t raw_height = 0;
+  if(!dt_dev_geometry_get_raw_size(dev, &raw_width, &raw_height) || raw_width <= 0 || raw_height <= 0)
+  {
+    dt_print(DT_DEBUG_ALWAYS, "[masks debug] the dev has no raw geometry; nothing to rasterise against\n");
+    return NULL;
+  }
+
+  float *const buffer = dt_alloc_align_float((size_t)width * height);
+  if(IS_NULL_PTR(buffer)) return NULL;
+  memset(buffer, 0, sizeof(float) * (size_t)width * height);
+
+  /* A pipe with no nodes: dt_dev_distort_transform_plus() then walks an empty list, so the
+   * composition is the identity and the shape lands on raw coordinates. That is deliberate --
+   * a geometry regression must not move because some other module's distortion changed. The
+   * three fields dt_masks_distort_for_pipe() reads are the only ones that matter here, plus
+   * `forms', which is how a group resolves its children (they are borrowed, not referenced:
+   * this pipe does not outlive the call). */
+  dt_dev_pixelpipe_t pipe = { 0 };
+  pipe.iwidth = raw_width;
+  pipe.iheight = raw_height;
+  pipe.mask_rasterization_step = 1;
+  pipe.forms = dev->forms;
+
+  dt_dev_pixelpipe_iop_t piece = { 0 };
+  dt_iop_module_t module = { 0 };
+  module.dev = dev;
+  module.iop_order = 0.0;
+
+  const dt_iop_roi_t roi = { .x = 0, .y = 0, .width = width, .height = height,
+                             .scale = (double)width / (double)raw_width };
+  dt_iop_roi_t touched = { 0 };
+
+  const dt_masks_raster_result_t result
+      = dt_masks_get_mask_roi(&module, &pipe, &piece, form, &roi, buffer, &touched);
+
+  if(result == DT_MASKS_RASTER_ERROR)
+  {
+    dt_print(DT_DEBUG_ALWAYS, "[masks debug] rasterising '%s' failed\n", form->name);
+    dt_free_align(buffer);
+    return NULL;
+  }
+
+  // EMPTY is a result, not a failure: the caller gets the zeroed buffer it describes.
+  return buffer;
+}
+
+gboolean dt_masks_debug_write_outline_csv(dt_develop_t *dev, dt_masks_form_t *form, const char *path)
+{
+  if(IS_NULL_PTR(dev) || IS_NULL_PTR(form) || IS_NULL_PTR(path)) return FALSE;
+
+  float *points = NULL, *border = NULL;
+  int points_count = 0, border_count = 0;
+  dt_masks_skip_range_t *skips = NULL;
+  int skip_count = 0;
+
+  const dt_masks_raster_result_t st = dt_masks_get_points_border(dev, form, &points, &points_count,
+                                                                 &border, &border_count,
+                                                                 &skips, &skip_count, 0, NULL);
+  dt_print(DT_DEBUG_ALWAYS, "[masks debug] outline: status=%d points=%d border=%d\n", st, points_count, border_count);
+  if(st == DT_MASKS_RASTER_ERROR) return FALSE;
+
+  FILE *f = fopen(path, "w");
+  if(IS_NULL_PTR(f))
+  {
+    dt_pixelpipe_cache_free_align(points);
+    dt_pixelpipe_cache_free_align(border);
+    dt_pixelpipe_cache_free_align(skips);
+    return FALSE;
+  }
+
+  fprintf(f, "# points=%d border=%d skips=%d\n", points_count, border_count, skip_count);
+  for(int i = 0; i < skip_count; i++)
+    fprintf(f, "# skip %d..%d\n", skips[i].jump_from, skips[i].resume_at);
+  fprintf(f, "i,px,py,bx,by\n");
+  const int n = MIN(points_count, border_count);
+  for(int i = 0; i < n; i++)
+    fprintf(f, "%d,%.4f,%.4f,%.4f,%.4f\n", i, points[i * 2], points[i * 2 + 1],
+            border[i * 2], border[i * 2 + 1]);
+  fclose(f);
+
+  dt_pixelpipe_cache_free_align(points);
+  dt_pixelpipe_cache_free_align(border);
+  dt_pixelpipe_cache_free_align(skips);
+  return TRUE;
+}
+
+
+// clang-format off
+// modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py
+// vim: shiftwidth=2 expandtab tabstop=2 cindent
+// kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;
+// clang-format on

--- a/src/develop/masks/masks_functions.h
+++ b/src/develop/masks/masks_functions.h
@@ -176,6 +176,34 @@ int dt_masks_border_find_self_intersections(const float *const border, const int
  * than walking it; a forward walk should use dt_masks_draw_outline_runs() instead. */
 gboolean dt_masks_skip_contains(const dt_masks_skip_range_t *skips, const int skip_count, const int index);
 
+
+/** One rectangular lattice of sample points over a rasterisation ROI.
+ *
+ * Every shape whose mask is evaluated on a coarse grid and then interpolated back up describes
+ * that grid the same way: a cell count, a spacing in output pixels, the ROI origin, and the
+ * inverse of the ROI scale. `x0`/`y0` are the index of the first cell -- non-zero for the shapes
+ * that grid only their own bounding box (circle, ellipse), zero for the ones that grid the whole
+ * ROI (gradient). */
+typedef struct dt_masks_sample_grid_t
+{
+  int x0, y0;         // index of the first cell, in cells
+  int width, height;  // number of cells
+  int step;           // cell spacing, in output pixels
+  int px, py;         // ROI origin, in output pixels
+  float iscale;       // 1.0f / roi->scale
+} dt_masks_sample_grid_t;
+
+/** Axis-aligned bounding box of an outline, in the outline's own coordinates.
+ *
+ * `points` is the interleaved x/y array a shape's `get_points_border` produced, and point 0 is
+ * SKIPPED: every shape that uses this stores its centre there, not a point on the outline. */
+void dt_masks_points_bounding_box(const float *const points, const int num_points,
+                                  int *width, int *height, int *posx, int *posy);
+
+float *dt_masks_sample_grid_backtransform(struct dt_dev_pixelpipe_t *pipe, const double iop_order,
+                                          const dt_masks_sample_grid_t *const grid,
+                                          const char *const shape, const char *const form_name);
+
 /**
  * @brief Turn the self-intersection detector's raw crossing pairs into the disjoint,
  * forward-only skip ranges every border walk consumes. Pure, allocation-free.

--- a/src/develop/masks/masks_functions.h
+++ b/src/develop/masks/masks_functions.h
@@ -82,7 +82,9 @@ typedef struct dt_masks_functions_t
    */
   dt_masks_raster_result_t (*get_points_border)(struct dt_develop_t *dev, struct dt_masks_form_t *form,
                            float **points, int *points_count,
-                           float **border, int *border_count, int source, const dt_iop_module_t *const module);
+                           float **border, int *border_count,
+                           dt_masks_skip_range_t **border_skips, int *border_skip_count,
+                           int source, const dt_iop_module_t *const module);
   /** Rasterise into a freshly allocated buffer covering the shape's own bounding box.
    * Same three outcomes as get_mask_roi. On anything but OK the out-parameters are still
    * written (NULL buffer, zero geometry): callers read them unconditionally. */
@@ -155,7 +157,48 @@ dt_masks_raster_result_t dt_masks_get_mask_roi(const dt_iop_module_t *const modu
 
 dt_masks_raster_result_t dt_masks_get_points_border(struct dt_develop_t *dev, dt_masks_form_t *form,
                                float **points, int *points_count,
-                               float **border, int *border_count, int source, dt_iop_module_t *module);
+                               float **border, int *border_count,
+                               dt_masks_skip_range_t **border_skips, int *border_skip_count,
+                               int source, dt_iop_module_t *module);
+
+/**
+ * @brief Turn the self-intersection detector's raw crossing pairs into the disjoint,
+ * forward-only skip ranges every border walk consumes. Pure, allocation-free.
+ *
+ * @details Each pair (v, w) names two raw border indices where the offset curve crosses
+ * itself, in whatever order the detector's discovery walk met them. This normalizes each to
+ * forward order, DROPS a pair whose forward span is the longer arc of the closed contour (a
+ * fold straddling the buffer seam -- issue #1313: encoding it as [min,max] named its
+ * complement and swallowed the shape; the sentinels, and now the ranges, can only express a
+ * forward skip, so that fold is left in and the damage stays bounded by the fold itself),
+ * then sorts and merges overlaps so the result is disjoint (unmerged overlapping ranges are
+ * how the walk got trapped in a cycle once already).
+ *
+ * @param crossing_pairs 2*pair_count floats, as _polygon_find_self_intersection() emits them.
+ * @param point_count    Number of points in the border buffer (bounds the indices).
+ * @param out            Capacity >= pair_count entries. Receives the merged ranges.
+ * @param dropped_wrapping (may be NULL) how many seam-straddling pairs were dropped.
+ * @return the number of ranges written to @p out.
+ */
+int dt_masks_skip_ranges_build(const float *crossing_pairs, int pair_count, int point_count,
+                               dt_masks_skip_range_t *out, int *dropped_wrapping);
+
+/**
+ * @brief Ray-cast point-in-polygon over a form point stream, honouring skip ranges.
+ *
+ * Walks [points_start, points_count) forward, wrapping to points_start exactly once. A skip
+ * range closes the contour with a chord from the point before `jump_from` to `resume_at`.
+ * A range that does not move the walk strictly forward is IGNORED AND REPORTED rather than
+ * followed: a backward jump would re-walk the span just left and spin until the visit cap --
+ * the silent-garbage mode both historical bugs of the in-band encoding shipped as.
+ *
+ * @param skips may be NULL (with skip_count 0): no cuts, the common case for every shape
+ *              but polygon and for path (non-border) walks.
+ * @return Index of the first tested point found inside the form, -1 otherwise.
+ */
+int dt_masks_point_in_form_exact(const float *pts, int num_pts, const float *points,
+                                 int points_start, int points_count,
+                                 const dt_masks_skip_range_t *skips, int skip_count);
 
 /* The raw membership-state mutator. Module-private on purpose: it takes a row by pointer and
  * cannot touch the group, so every external caller had to remember the copy-on-write dance and

--- a/src/develop/masks/masks_functions.h
+++ b/src/develop/masks/masks_functions.h
@@ -161,6 +161,17 @@ dt_masks_raster_result_t dt_masks_get_points_border(struct dt_develop_t *dev, dt
                                dt_masks_skip_range_t **border_skips, int *border_skip_count,
                                int source, dt_iop_module_t *module);
 
+/** Find every place a shape's closed border contour crosses itself, writing one (i, j) sample-
+ * index pair per crossing into @p crossing_pairs (2 floats each, at most @p max_pairs pairs) and
+ * returning how many were written. @p header is where the border samples start, past the shape's
+ * per-node header triplets. Feed the result to dt_masks_skip_ranges_build().
+ *
+ * Exact (segment intersection over a spatial hash), unlike polygon.c's own pixel-grid detector,
+ * and the reported indices sit AT the crossing so a cut made between them closes. */
+int dt_masks_border_find_self_intersections(const float *const border, const int border_count,
+                                            const int header, float *const crossing_pairs,
+                                            const int max_pairs);
+
 /**
  * @brief Turn the self-intersection detector's raw crossing pairs into the disjoint,
  * forward-only skip ranges every border walk consumes. Pure, allocation-free.

--- a/src/develop/masks/masks_functions.h
+++ b/src/develop/masks/masks_functions.h
@@ -205,6 +205,26 @@ float *dt_masks_sample_grid_backtransform(struct dt_dev_pixelpipe_t *pipe, const
                                           const char *const shape, const char *const form_name);
 
 
+/** Give a creation preview its clone-source outline: the target outline, offset by the drag.
+ *
+ * Allocates `preview->source_points` from `preview->points`, which must already be populated.
+ * Returns 0 on success, 1 on allocation failure -- the caller's own error convention. */
+int dt_masks_preview_add_clone_source(struct dt_masks_form_gui_t *gui,
+                                      struct dt_masks_preview_buffers_t *preview);
+
+/** Turn an outline of a shape into the outline of its clone source, in final image reference.
+ *
+ * `*points` arrives as the TARGET outline in RAW reference and leaves as the SOURCE outline with
+ * every distortion applied. `first_shifted` is the index the outline proper begins at: shapes
+ * that keep handle points in their header pass the index past them and get their centre written
+ * directly, shapes whose point 0 is the centre and nothing else pass 0 and have it shifted with
+ * the rest. On failure the buffer is freed and `*points`/`*points_count` are cleared.
+ *
+ * Returns 0 on success, 1 on failure. */
+int dt_masks_points_shift_to_source(struct dt_develop_t *dev, const struct dt_iop_module_t *module,
+                                    float **points, int *points_count,
+                                    const float xs, const float ys, const int first_shifted);
+
 /** Largest cell spacing any caller of the sample-grid helpers may ask for.
  *
  * The ROI rasterisers clamp their step to 4; `_gradient_get_mask()` uses a fixed 8. The

--- a/src/develop/masks/masks_functions.h
+++ b/src/develop/masks/masks_functions.h
@@ -204,6 +204,26 @@ float *dt_masks_sample_grid_backtransform(struct dt_dev_pixelpipe_t *pipe, const
                                           const dt_masks_sample_grid_t *const grid,
                                           const char *const shape, const char *const form_name);
 
+
+/** Largest cell spacing any caller of the sample-grid helpers may ask for.
+ *
+ * The ROI rasterisers clamp their step to 4; `_gradient_get_mask()` uses a fixed 8. The
+ * interpolator sizes its per-cell weight tables from this, so a caller wanting a coarser grid
+ * must raise it here rather than locally. */
+#define DT_MASKS_GRID_MAX_STEP 8
+
+/** Bilinear expansion of a coarse grid of mask values back to full ROI resolution.
+ *
+ * `points` is the buffer `dt_masks_sample_grid_backtransform()` returned, with each cell's mask
+ * value written over its x coordinate (that is, at `points[index * 2]`) -- every shape evaluates
+ * in place like that, so the interpolator reads the same stride whatever the shape.
+ *
+ * Writes into `buffer` over the rectangle the grid covers, clipped to the buffer, and reports the
+ * exclusive end of that rectangle through `endx`/`endy` for callers that go on to mark the
+ * touched box. */
+void dt_masks_sample_grid_interpolate(const float *const points, const dt_masks_sample_grid_t *const grid,
+                                      float *const buffer, const int buf_width, const int buf_height,
+                                      int *const endx, int *const endy);
 /**
  * @brief Turn the self-intersection detector's raw crossing pairs into the disjoint,
  * forward-only skip ranges every border walk consumes. Pure, allocation-free.

--- a/src/develop/masks/masks_functions.h
+++ b/src/develop/masks/masks_functions.h
@@ -172,6 +172,10 @@ int dt_masks_border_find_self_intersections(const float *const border, const int
                                             const int header, float *const crossing_pairs,
                                             const int max_pairs);
 
+/** Is @p index inside one of the excluded spans? For a consumer that SEARCHES the outline rather
+ * than walking it; a forward walk should use dt_masks_draw_outline_runs() instead. */
+gboolean dt_masks_skip_contains(const dt_masks_skip_range_t *skips, const int skip_count, const int index);
+
 /**
  * @brief Turn the self-intersection detector's raw crossing pairs into the disjoint,
  * forward-only skip ranges every border walk consumes. Pure, allocation-free.

--- a/src/develop/masks/masks_gui.c
+++ b/src/develop/masks/masks_gui.c
@@ -1813,7 +1813,8 @@ void dt_masks_gui_form_create(dt_masks_form_t *mask_form, dt_masks_form_gui_t *m
       = (dt_masks_form_gui_points_t *)g_list_nth_data(mask_gui->points, form_index);
   const dt_masks_raster_result_t border_status
       = dt_masks_get_points_border(mask_gui->dev, mask_form, &gui_points->points, &gui_points->points_count,
-                                   &gui_points->border, &gui_points->border_count, 0, NULL);
+                                   &gui_points->border, &gui_points->border_count,
+                                   &gui_points->border_skips, &gui_points->border_skip_count, 0, NULL);
 
   /* Only a genuine FAILURE may leave the cache key unset, and it must: the key covers the whole
    * group, so one unstamped shape rebuilds every shape of the group on every later expose --
@@ -1836,7 +1837,7 @@ void dt_masks_gui_form_create(dt_masks_form_t *mask_form, dt_masks_form_gui_t *m
     if(border_status == DT_MASKS_RASTER_OK && (mask_form->type & DT_MASKS_CLONE))
     {
       if(dt_masks_get_points_border(mask_gui->dev, mask_form, &gui_points->source, &gui_points->source_count,
-                                    NULL, NULL, TRUE, module)
+                                    NULL, NULL, NULL, NULL, TRUE, module)
          != DT_MASKS_RASTER_OK)
         return;
     }
@@ -2271,10 +2272,13 @@ void dt_masks_gui_form_remove(dt_masks_form_t *mask_form, dt_masks_form_gui_t *m
   if(!IS_NULL_PTR(gui_points))
   {
     gui_points->points_count = gui_points->border_count = gui_points->source_count = 0;
+    gui_points->border_skip_count = 0;
     dt_pixelpipe_cache_free_align(gui_points->points);
     gui_points->points = NULL;
     dt_pixelpipe_cache_free_align(gui_points->border);
     gui_points->border = NULL;
+    dt_pixelpipe_cache_free_align(gui_points->border_skips);
+    gui_points->border_skips = NULL;
     dt_pixelpipe_cache_free_align(gui_points->source);
     gui_points->source = NULL;
   }
@@ -3214,13 +3218,13 @@ void dt_masks_draw_source(cairo_t *cr, dt_masks_form_gui_t *mask_gui, const int 
       // From more frequent to least frequent, to get out of loop earlier. Tail first, then source.
       const float pts[4] = { tail[0], tail[1], source[0], source[1] };
       gboolean overlap = (dt_masks_point_in_form_exact(pts, 2, gui_points->points, first_point_index,
-                                                       gui_points->points_count) >= 0);
+                                                       gui_points->points_count, NULL, 0) >= 0);
       // Skip the second containment test when overlap is already detected.
       if(!overlap)
       {
         const float origin_pt[2] = { main[0], main[1] };
         overlap = (dt_masks_point_in_form_exact(origin_pt, 1, gui_points->source, first_point_index,
-                                                gui_points->source_count) >= 0);
+                                                gui_points->source_count, NULL, 0) >= 0);
       }
 
       // Update head position to be between main and source center point.
@@ -4526,13 +4530,20 @@ void dt_masks_group_ungroup(dt_develop_t *dev, dt_masks_form_t *dest_group, dt_m
  * @return int Index of the first tested point found inside the form, -1 otherwise.
  */
 int dt_masks_point_in_form_exact(const float *test_points, int test_point_count,
-                                 const float *form_points, int form_points_start, int form_points_count)
+                                 const float *form_points, int form_points_start, int form_points_count,
+                                 const dt_masks_skip_range_t *skips, int skip_count)
 {
   if(IS_NULL_PTR(test_points) || test_point_count <= 0 || IS_NULL_PTR(form_points)) return -1;
   if(form_points_count <= 2 + form_points_start) return -1;
   if(form_points_start < 0 || form_points_start >= form_points_count) return -1;
+  if(IS_NULL_PTR(skips)) skip_count = 0;
 
   const int start_index = form_points_start;
+  // Once per call, not per finding: a corrupt input corrupts every test point alike, and the
+  // point of reporting is a greppable line, not a flood.
+  gboolean reported_bad_skip = FALSE;
+  gboolean reported_trapped_walk = FALSE;
+
   for(int test_index = 0; test_index < test_point_count; test_index++)
   {
     int intersection_count = 0;
@@ -4542,21 +4553,81 @@ int dt_masks_point_in_form_exact(const float *test_points, int test_point_count,
 
     for(int i = form_points_start, next = start_index + 1; i < form_points_count;)
     {
-      // The form point stream may contain NaN sentinels that jump across
-      // self-intersection cuts. Broken jump targets must not trap the GUI event
-      // loop in an endless hit-test.
       if(next < start_index || next >= form_points_count) break;
-      if(++visited_points > form_points_count - start_index + 1) break;
+      if(++visited_points > form_points_count - start_index + 1)
+      {
+        /* Unreachable over a well-formed stream: the walk visits each index at most once and
+         * wraps exactly once. Tripping it means the input is corrupt, and the crossing count
+         * below is then garbage. This used to be silent -- both historical bugs of the cut
+         * mechanism shipped as exactly this silence. */
+        if(!reported_trapped_walk)
+        {
+          dt_print(DT_DEBUG_ALWAYS,
+                   "[masks] point_in_form walk trapped after %d visits of %d points -- corrupt"
+                   " outline or skip ranges; hit-test result is unreliable\n",
+                   visited_points, form_points_count - form_points_start);
+          reported_trapped_walk = TRUE;
+        }
+        break;
+      }
+
+      /* Out-of-band self-intersection cuts: on reaching one, close the contour with a chord to
+       * its resume point. Only a skip that moves the walk STRICTLY FORWARD is followed -- a
+       * backward one would re-walk the span just left until the cap above fires, which is the
+       * cycle the old in-band encoding actually produced once. Such a range is a producer bug:
+       * ignore it and say so. */
+      gboolean jumped = TRUE;
+      int hops = 0;
+      while(jumped && hops <= skip_count)
+      {
+        jumped = FALSE;
+        for(int s = 0; s < skip_count; s++)
+        {
+          if(next != skips[s].jump_from) continue;
+          if(skips[s].resume_at <= skips[s].jump_from || skips[s].resume_at >= form_points_count)
+          {
+            if(!reported_bad_skip)
+            {
+              dt_print(DT_DEBUG_ALWAYS,
+                       "[masks] skip range [%d -> %d] does not move forward within %d points --"
+                       " ignoring it; the producer is broken\n",
+                       skips[s].jump_from, skips[s].resume_at, form_points_count);
+              reported_bad_skip = TRUE;
+            }
+          }
+          else
+          {
+            next = skips[s].resume_at;
+            jumped = TRUE;
+            hops++;
+          }
+          break;
+        }
+      }
+      if(next >= form_points_count) break;
 
       const float y1 = form_points[i * 2 + 1];
       const float y2 = form_points[next * 2 + 1];
 
-      // if we need to skip points (in case of deleted point, because of self-intersection)
       if(isnan(form_points[next * 2]))
       {
-        const int jump_index = isnan(y2) ? start_index : (int)y2;
-        if(jump_index == next || jump_index < start_index || jump_index >= form_points_count) break;
-        next = jump_index;
+        /* A bare NaN,NaN point is a close-the-contour marker an outline builder may emit for a
+         * degenerate sample. A NaN x with a FINITE y was the in-band jump encoding -- an index
+         * smuggled through a float coordinate -- which no producer emits any more; decoding one
+         * silently is how issue #1313 shipped, so it is now reported corruption, not a jump. */
+        if(!isnan(y2))
+        {
+          if(!reported_bad_skip)
+          {
+            dt_print(DT_DEBUG_ALWAYS,
+                     "[masks] in-band NaN jump sentinel found at %d of %d -- no producer emits"
+                     " these any more; treating the outline as ended\n", next, form_points_count);
+            reported_bad_skip = TRUE;
+          }
+          break;
+        }
+        if(next == start_index) break;
+        next = start_index;
         continue;
       }
 

--- a/src/develop/masks/masks_gui.c
+++ b/src/develop/masks/masks_gui.c
@@ -4134,8 +4134,8 @@ void dt_masks_iop_combo_populate(GtkWidget *widget, void *data)
   const guint forms_count = g_list_length(module->dev->forms);
   const guint iop_count = g_list_length(module->dev->iop);
   guint combo_capacity = 5 + forms_count + iop_count;
-  dt_free(blend_data->masks_combo_ids);
-  blend_data->masks_combo_ids = malloc(sizeof(int) * combo_capacity);
+  dt_free_align(blend_data->masks_combo_ids);
+  blend_data->masks_combo_ids = dt_alloc_align(sizeof(int) * combo_capacity);
 
   int *combo_ids = blend_data->masks_combo_ids;
   GtkWidget *combo = blend_data->masks_combo;

--- a/src/develop/masks/masks_gui.c
+++ b/src/develop/masks/masks_gui.c
@@ -5225,3 +5225,73 @@ void dt_masks_draw_outline_runs(cairo_t *cr, const float *const points, const in
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;
 // clang-format on
+
+
+int dt_masks_preview_add_clone_source(dt_masks_form_gui_t *gui, dt_masks_preview_buffers_t *preview)
+{
+  float source_pos[2] = { 0.0f, 0.0f };
+  dt_masks_calculate_source_pos_origin(gui, gui->pos[0], gui->pos[1], gui->pos[0], gui->pos[1],
+                                       &source_pos[0], &source_pos[1], FALSE);
+  const float center_source[2] = { source_pos[0] - gui->pos[0], source_pos[1] - gui->pos[1] };
+
+  preview->source_points = dt_pixelpipe_cache_alloc_align_float_cache((size_t)2 * preview->points_count, 0);
+  if(IS_NULL_PTR(preview->source_points)) return 1;
+
+  for(int i = 0; i < preview->points_count; i++)
+  {
+    preview->source_points[i * 2] = preview->points[i * 2] + center_source[0];
+    preview->source_points[i * 2 + 1] = preview->points[i * 2 + 1] + center_source[1];
+  }
+
+  return 0;
+}
+
+
+int dt_masks_points_shift_to_source(dt_develop_t *dev, const dt_iop_module_t *module,
+                                    float **points, int *points_count,
+                                    const float xs, const float ys, const int first_shifted)
+{
+  // every distortion that happens BEFORE the module: the TARGET outline in module input reference
+  if(!dt_dev_distort_transform_gui(dev, module->iop_order, DT_DEV_TRANSFORM_DIR_BACK_EXCL,
+                                   *points, *points_count))
+    goto error;
+
+  // the source anchor, taken to the same reference, gives the shift
+  float pts[2] = { xs, ys };
+  dt_dev_coordinates_raw_norm_to_raw_abs(dev, pts, 1);
+  if(!dt_dev_distort_transform_gui(dev, module->iop_order, DT_DEV_TRANSFORM_DIR_BACK_EXCL, pts, 1))
+    goto error;
+
+  {
+    const float dx = pts[0] - (*points)[0];
+    const float dy = pts[1] - (*points)[1];
+
+    // a shape with handle points in its header keeps them where they are and takes the anchor
+    // verbatim; one whose point 0 is just the centre lets the loop below carry it
+    if(first_shifted > 0)
+    {
+      (*points)[0] = pts[0];
+      (*points)[1] = pts[1];
+    }
+
+    __OMP_PARALLEL_FOR_SIMD__(if(*points_count > 100) aligned(points:64))
+    for(int i = first_shifted; i < *points_count; i++)
+    {
+      (*points)[i * 2] += dx;
+      (*points)[i * 2 + 1] += dy;
+    }
+  }
+
+  // and the distortions AFTER the module: the SOURCE outline in final image reference
+  if(!dt_dev_distort_transform_gui(dev, module->iop_order, DT_DEV_TRANSFORM_DIR_FORW_INCL,
+                                   *points, *points_count))
+    goto error;
+
+  return 0;
+
+error:
+  dt_pixelpipe_cache_free_align(*points);
+  *points = NULL;
+  *points_count = 0;
+  return 1;
+}

--- a/src/develop/masks/masks_gui.c
+++ b/src/develop/masks/masks_gui.c
@@ -5219,14 +5219,6 @@ void dt_masks_draw_outline_runs(cairo_t *cr, const float *const points, const in
   }
 }
 
-
-// clang-format off
-// modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py
-// vim: shiftwidth=2 expandtab tabstop=2 cindent
-// kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;
-// clang-format on
-
-
 int dt_masks_preview_add_clone_source(dt_masks_form_gui_t *gui, dt_masks_preview_buffers_t *preview)
 {
   float source_pos[2] = { 0.0f, 0.0f };
@@ -5295,3 +5287,9 @@ error:
   *points_count = 0;
   return 1;
 }
+
+// clang-format off
+// modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py
+// vim: shiftwidth=2 expandtab tabstop=2 cindent
+// kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;
+// clang-format on

--- a/src/develop/masks/masks_gui.c
+++ b/src/develop/masks/masks_gui.c
@@ -3551,7 +3551,6 @@ static gboolean _session_bbox_from_points(const dt_masks_form_gui_t *gui, double
     {
       const double x = pts->points[2 * i];
       const double y = pts->points[2 * i + 1];
-      if(isnan(x) || isnan(y)) continue;
 
       if(!any)
       {
@@ -4628,21 +4627,22 @@ int dt_masks_point_in_form_exact(const float *test_points, int test_point_count,
 
       if(isnan(form_points[next * 2]))
       {
-        /* A bare NaN,NaN point is a close-the-contour marker an outline builder may emit for a
-         * degenerate sample. A NaN x with a FINITE y was the in-band jump encoding -- an index
-         * smuggled through a float coordinate -- which no producer emits any more; decoding one
-         * silently is how issue #1313 shipped, so it is now reported corruption, not a jump. */
-        if(!isnan(y2))
+        /* NOTHING should reach this. dt_masks_get_points_border() guarantees the outline holds
+         * finite geometry, and everything a consumer must not use travels beside it in the
+         * exclusion list. Both shapes of sentinel are therefore reported: a NaN x with a finite
+         * y was the in-band jump encoding, an index smuggled through a coordinate, and decoding
+         * one silently is how issue #1313 shipped; a bare NaN,NaN was a close-the-contour
+         * marker, which no builder emits any longer. This walk is also reached with buffers
+         * that never went through that entry point, which is why the check stays at all. */
+        if(!reported_bad_skip)
         {
-          if(!reported_bad_skip)
-          {
-            dt_print(DT_DEBUG_ALWAYS,
-                     "[masks] in-band NaN jump sentinel found at %d of %d -- no producer emits"
-                     " these any more; treating the outline as ended\n", next, form_points_count);
-            reported_bad_skip = TRUE;
-          }
-          break;
+          dt_print(DT_DEBUG_ALWAYS,
+                   "[masks] non-finite outline sample at %d of %d (y %s) -- the buffer should"
+                   " hold geometry only; treating the outline as ended\n", next, form_points_count,
+                   isnan(y2) ? "also NaN" : "finite, i.e. the old in-band jump encoding");
+          reported_bad_skip = TRUE;
         }
+        break;
         if(next == start_index) break;
         next = start_index;
         continue;
@@ -5122,6 +5122,85 @@ gboolean dt_masks_debug_write_png(dt_develop_t *dev, dt_masks_form_t *form,
   if(!ok) dt_print(DT_DEBUG_ALWAYS, "[masks debug] could not write %s\n", path);
   return ok;
 }
+
+/**
+ * @brief Append a shape's outline to @p cr as the COMPLEMENT of its exclusion list.
+ *
+ * @details Samples [@p first, @p last) are emitted as one sub-path per run between the spans in
+ * @p skips, which are the places the offset curve doubles back on itself and must not be shown.
+ *
+ * There is one implementation of this walk because there was very nearly none: the encoding it
+ * replaces blanked the excluded samples to NaN inside the point buffer, which each shape then
+ * tested for in its own copy of the loop. That is an encoding hidden in a buffer of plain
+ * floats -- invisible to any consumer that does not already know, and silently wrong for one
+ * that forgets. Two consumers had forgotten: the polygon's outline drew its folds, and the
+ * brush's per-node border handle lost both its dash and its drag wherever a blanked sample was
+ * the nearest one.
+ *
+ * Emitting runs also makes a hole a hole. Skipping excluded samples with the pen down turns the
+ * next one into a line_to, so each span comes out as a straight chord across the shape --
+ * measured on issue #1313's brush at 50 to 137 pixels, one per node. A new sub-path per run
+ * cannot do that, and stroking a path of several sub-paths costs nothing.
+ *
+ * @p skips must be sorted and disjoint (dt_masks_skip_ranges_build() guarantees it); pass NULL
+ * and 0 for a shape with nothing to exclude.
+ *
+ * It lives here rather than in widgets/draw.h with the other drawing helpers because it needs
+ * both cairo and the masks vocabulary, and a widget header must not inherit the latter -- that
+ * would invert the layering. masks_gui.c already has both.
+ */
+void dt_masks_draw_outline_runs(cairo_t *cr, const float *const points, const int first, const int last,
+                                const dt_masks_skip_range_t *skips, const int skip_count)
+{
+  if(!cr || !points || first >= last) return;
+
+  /* One line_to per sample at RAW resolution is several per device pixel; emit at the resolution
+   * the context can actually show. See dt_draw_min_emit_step(). */
+  const double min_step = dt_draw_min_emit_step(cr);
+  const double min_step2 = min_step * min_step;
+
+  const int count = IS_NULL_PTR(skips) ? 0 : skip_count;
+
+  int at = first;
+  int next = 0;
+
+  while(at < last)
+  {
+    while(next < count && skips[next].resume_at <= at) next++;
+
+    int run_end = last;
+    if(next < count && skips[next].jump_from < last) run_end = MAX(skips[next].jump_from, at);
+
+    if(run_end > at)
+    {
+      double last_x = points[at * 2], last_y = points[at * 2 + 1];
+      cairo_move_to(cr, last_x, last_y);
+
+      for(int i = at + 1; i < run_end; i++)
+      {
+        const double x = points[i * 2], y = points[i * 2 + 1];
+        const double dx = x - last_x, dy = y - last_y;
+        if((dx * dx + dy * dy) < min_step2) continue;
+        cairo_line_to(cr, x, y);
+        last_x = x; last_y = y;
+      }
+
+      /* the run's last sample always lands, so a run ends where the geometry does and not
+       * wherever the decimation happened to stop */
+      const double x = points[(run_end - 1) * 2], y = points[(run_end - 1) * 2 + 1];
+      if(x != last_x || y != last_y) cairo_line_to(cr, x, y);
+    }
+
+    if(next < count && skips[next].jump_from < last)
+    {
+      at = MAX(skips[next].resume_at, at + 1);
+      next++;
+    }
+    else
+      break;
+  }
+}
+
 
 // clang-format off
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py

--- a/src/develop/masks/masks_gui.c
+++ b/src/develop/masks/masks_gui.c
@@ -5013,6 +5013,39 @@ int dt_masks_form_change_opacity(dt_develop_t *dev, dt_masks_form_t *mask_form, 
  * already the GUI half of masks -- and it is where dt_masks_events_post_expose_with(), the one
  * production drawing routine this calls, already lives. There is deliberately no second
  * drawing path: what a regression test looks at is what the darkroom paints. */
+/** Rasterise @p form and paint it under the overlay as 8-bit grey. Its own function because
+ * compositing a backdrop and drawing an overlay are two jobs, and nesting the pixel loop inside
+ * the surface bookkeeping made both harder to follow. */
+static void _paint_mask_backdrop(cairo_t *cr, dt_develop_t *dev, dt_masks_form_t *form,
+                                 const int width, const int height)
+{
+  float *const mask = dt_masks_debug_rasterise(dev, form, width, height);
+  if(IS_NULL_PTR(mask)) return;
+
+  cairo_surface_t *grey = cairo_image_surface_create(CAIRO_FORMAT_RGB24, width, height);
+  if(cairo_surface_status(grey) == CAIRO_STATUS_SUCCESS)
+  {
+    cairo_surface_flush(grey);
+    uint8_t *const pixels = cairo_image_surface_get_data(grey);
+    const int stride = cairo_image_surface_get_stride(grey);
+    for(int y = 0; y < height; y++)
+    {
+      uint32_t *const row = (uint32_t *)(pixels + (size_t)y * stride);
+      for(int x = 0; x < width; x++)
+      {
+        const float v = mask[(size_t)y * width + x];
+        const uint32_t g = (uint32_t)(CLAMPF(v, 0.0f, 1.0f) * 255.0f + 0.5f);
+        row[x] = (g << 16) | (g << 8) | g;
+      }
+    }
+    cairo_surface_mark_dirty(grey);
+    cairo_set_source_surface(cr, grey, 0, 0);
+    cairo_paint(cr);
+  }
+  cairo_surface_destroy(grey);
+  dt_free_align(mask);
+}
+
 gboolean dt_masks_debug_write_png(dt_develop_t *dev, dt_masks_form_t *form,
                                   const dt_masks_debug_request_t *request, const char *path)
 {
@@ -5045,34 +5078,7 @@ gboolean dt_masks_debug_write_png(dt_develop_t *dev, dt_masks_form_t *form,
   }
 
   if(request->backdrop == DT_MASKS_DEBUG_BACKDROP_RASTER)
-  {
-    float *const mask = dt_masks_debug_rasterise(dev, form, width, height);
-    if(!IS_NULL_PTR(mask))
-    {
-      cairo_surface_t *grey = cairo_image_surface_create(CAIRO_FORMAT_RGB24, width, height);
-      if(cairo_surface_status(grey) == CAIRO_STATUS_SUCCESS)
-      {
-        cairo_surface_flush(grey);
-        uint8_t *const pixels = cairo_image_surface_get_data(grey);
-        const int stride = cairo_image_surface_get_stride(grey);
-        for(int y = 0; y < height; y++)
-        {
-          uint32_t *const row = (uint32_t *)(pixels + (size_t)y * stride);
-          for(int x = 0; x < width; x++)
-          {
-            const float v = mask[(size_t)y * width + x];
-            const uint32_t g = (uint32_t)(CLAMPF(v, 0.0f, 1.0f) * 255.0f + 0.5f);
-            row[x] = (g << 16) | (g << 8) | g;
-          }
-        }
-        cairo_surface_mark_dirty(grey);
-        cairo_set_source_surface(cr, grey, 0, 0);
-        cairo_paint(cr);
-      }
-      cairo_surface_destroy(grey);
-      dt_free_align(mask);
-    }
-  }
+    _paint_mask_backdrop(cr, dev, form, width, height);
 
   if(request->draw_overlay)
   {
@@ -5149,6 +5155,36 @@ gboolean dt_masks_debug_write_png(dt_develop_t *dev, dt_masks_form_t *form,
  * both cairo and the masks vocabulary, and a widget header must not inherit the latter -- that
  * would invert the layering. masks_gui.c already has both.
  */
+/** Append samples [@p first, @p last) as ONE cairo sub-path, decimated to what the context can
+ * show. A sub-path per run is what makes an excluded span absent rather than a shortcut across
+ * it: skipping samples with the pen down turns the next one into a line_to, and the span comes
+ * out as a straight chord. */
+static inline void _emit_run(cairo_t *cr, const float *const points, const int first, const int last,
+                             const double min_step2)
+{
+  double last_x = points[first * 2];
+  double last_y = points[first * 2 + 1];
+  cairo_move_to(cr, last_x, last_y);
+
+  for(int i = first + 1; i < last; i++)
+  {
+    const double x = points[i * 2];
+    const double y = points[i * 2 + 1];
+    const double dx = x - last_x;
+    const double dy = y - last_y;
+    if((dx * dx + dy * dy) < min_step2) continue;
+    cairo_line_to(cr, x, y);
+    last_x = x;
+    last_y = y;
+  }
+
+  /* the run's last sample always lands, so a run ends where the geometry does and not wherever
+   * the decimation happened to stop */
+  const double x = points[(last - 1) * 2];
+  const double y = points[(last - 1) * 2 + 1];
+  if(x != last_x || y != last_y) cairo_line_to(cr, x, y);
+}
+
 void dt_masks_draw_outline_runs(cairo_t *cr, const float *const points, const int first, const int last,
                                 const dt_masks_skip_range_t *skips, const int skip_count)
 {
@@ -5171,25 +5207,7 @@ void dt_masks_draw_outline_runs(cairo_t *cr, const float *const points, const in
     int run_end = last;
     if(next < count && skips[next].jump_from < last) run_end = MAX(skips[next].jump_from, at);
 
-    if(run_end > at)
-    {
-      double last_x = points[at * 2], last_y = points[at * 2 + 1];
-      cairo_move_to(cr, last_x, last_y);
-
-      for(int i = at + 1; i < run_end; i++)
-      {
-        const double x = points[i * 2], y = points[i * 2 + 1];
-        const double dx = x - last_x, dy = y - last_y;
-        if((dx * dx + dy * dy) < min_step2) continue;
-        cairo_line_to(cr, x, y);
-        last_x = x; last_y = y;
-      }
-
-      /* the run's last sample always lands, so a run ends where the geometry does and not
-       * wherever the decimation happened to stop */
-      const double x = points[(run_end - 1) * 2], y = points[(run_end - 1) * 2 + 1];
-      if(x != last_x || y != last_y) cairo_line_to(cr, x, y);
-    }
+    if(run_end > at) _emit_run(cr, points, at, run_end, min_step2);
 
     if(next < count && skips[next].jump_from < last)
     {

--- a/src/develop/masks/masks_gui.c
+++ b/src/develop/masks/masks_gui.c
@@ -35,6 +35,7 @@
 #include "system/mem_alloc.h"
 #include "develop/geometry/geometry.h"   // dt_geometry_chain_generation()
 #include "develop/masks.h"
+#include "develop/masks_debug.h"
 #include "develop/masks_gui.h"
 #include "develop/masks_group.h"
 #include "develop/masks/masks_functions.h"
@@ -3804,8 +3805,15 @@ static void _masks_draw_creation_session_forms(dt_develop_t *develop, dt_iop_mod
   }
 }
 
-void dt_masks_events_post_expose(dt_develop_t *dev, struct dt_iop_module_t *module, cairo_t *cr, int32_t width, int32_t height,
-                                 int32_t pointerx, int32_t pointery)
+void dt_masks_events_post_expose(dt_develop_t *dev, struct dt_iop_module_t *module, cairo_t *cr,
+                                 int32_t width, int32_t height, int32_t pointerx, int32_t pointery)
+{
+  dt_masks_events_post_expose_with(dev, module, cr, width, height, pointerx, pointery, NULL);
+}
+
+void dt_masks_events_post_expose_with(dt_develop_t *dev, struct dt_iop_module_t *module, cairo_t *cr,
+                                      int32_t width, int32_t height, int32_t pointerx, int32_t pointery,
+                                      const dt_masks_overlay_transform_t *transform)
 {
   const double post_expose_start = dt_get_wtime();
   dt_develop_t *develop = dev;
@@ -3820,7 +3828,7 @@ void dt_masks_events_post_expose(dt_develop_t *dev, struct dt_iop_module_t *modu
   dt_dev_get_processed_size(develop, &buffer_width, &buffer_height);
 
   if(buffer_width < 1.0 || buffer_height < 1.0) return;
-  const float zoom_scale = dt_dev_get_zoom_level(develop);
+  const float zoom_scale = IS_NULL_PTR(transform) ? dt_dev_get_zoom_level(develop) : (float)transform->scale;
 
   /* Draw into an isolated group, so that overlapping shapes composite once against the view
    * instead of once each.
@@ -3851,12 +3859,21 @@ void dt_masks_events_post_expose(dt_develop_t *dev, struct dt_iop_module_t *modu
   
   cairo_save(mask_draw);
 
-  // We rescale to input space
-  if(dt_dev_rescale_roi_to_input(develop, mask_draw, width, height))
+  // We rescale to input space -- from the viewport, or from the caller's own mapping when it
+  // supplied one (see dt_masks_overlay_transform_t: the viewport path needs GUI state).
+  if(IS_NULL_PTR(transform))
   {
-    cairo_restore(mask_draw);
-    cairo_pattern_destroy(cairo_pop_group(cr));   // discard: nothing was drawn
-    return;
+    if(dt_dev_rescale_roi_to_input(develop, mask_draw, width, height))
+    {
+      cairo_restore(mask_draw);
+      cairo_pattern_destroy(cairo_pop_group(cr));   // discard: nothing was drawn
+      return;
+    }
+  }
+  else
+  {
+    cairo_translate(mask_draw, transform->offset_x, transform->offset_y);
+    cairo_scale(mask_draw, transform->scale, transform->scale);
   }
 
   // We update the form if needed
@@ -4983,6 +5000,127 @@ int dt_masks_form_change_opacity(dt_develop_t *dev, dt_masks_form_t *mask_form, 
   // gives back to say it consumed the event, so reporting 0 once the opacity is already pinned at
   // 0 or 1 would let that scroll step fall through and zoom the canvas instead.
   return (result == DT_MASKS_OK || result == DT_MASKS_UNCHANGED);
+}
+
+
+
+/* ------------------------------------------------------------------------------------- */
+/* The headless half of the diagnostic renderer.
+ *
+ * It lives here, and not next to dt_masks_debug_rasterise() in masks_debug.c, for one reason:
+ * compositing the overlay needs cairo, and src/develop is kept free of every toolkit type by
+ * tools/check_module_boundaries.sh so the pixel and params engines stay portable. This file is
+ * already the GUI half of masks -- and it is where dt_masks_events_post_expose_with(), the one
+ * production drawing routine this calls, already lives. There is deliberately no second
+ * drawing path: what a regression test looks at is what the darkroom paints. */
+gboolean dt_masks_debug_write_png(dt_develop_t *dev, dt_masks_form_t *form,
+                                  const dt_masks_debug_request_t *request, const char *path)
+{
+  if(IS_NULL_PTR(dev) || IS_NULL_PTR(request) || IS_NULL_PTR(path)) return FALSE;
+  if(IS_NULL_PTR(form)) form = dt_masks_get_visible_form(dev);
+  if(IS_NULL_PTR(form)) return FALSE;
+
+  int32_t raw_width = 0;
+  int32_t raw_height = 0;
+  if(!dt_dev_geometry_get_raw_size(dev, &raw_width, &raw_height) || raw_width <= 0 || raw_height <= 0)
+    return FALSE;
+
+  int width = request->width > 0 ? request->width : raw_width;
+  int height = request->height > 0 ? request->height
+                                   : (int)lrint((double)width * raw_height / (double)raw_width);
+  if(width <= 0 || height <= 0) return FALSE;
+
+  cairo_surface_t *surface = cairo_image_surface_create(CAIRO_FORMAT_ARGB32, width, height);
+  if(cairo_surface_status(surface) != CAIRO_STATUS_SUCCESS)
+  {
+    cairo_surface_destroy(surface);
+    return FALSE;
+  }
+  cairo_t *cr = cairo_create(surface);
+
+  if(request->backdrop != DT_MASKS_DEBUG_BACKDROP_TRANSPARENT)
+  {
+    cairo_set_source_rgb(cr, 0.0, 0.0, 0.0);
+    cairo_paint(cr);
+  }
+
+  if(request->backdrop == DT_MASKS_DEBUG_BACKDROP_RASTER)
+  {
+    float *const mask = dt_masks_debug_rasterise(dev, form, width, height);
+    if(!IS_NULL_PTR(mask))
+    {
+      cairo_surface_t *grey = cairo_image_surface_create(CAIRO_FORMAT_RGB24, width, height);
+      if(cairo_surface_status(grey) == CAIRO_STATUS_SUCCESS)
+      {
+        cairo_surface_flush(grey);
+        uint8_t *const pixels = cairo_image_surface_get_data(grey);
+        const int stride = cairo_image_surface_get_stride(grey);
+        for(int y = 0; y < height; y++)
+        {
+          uint32_t *const row = (uint32_t *)(pixels + (size_t)y * stride);
+          for(int x = 0; x < width; x++)
+          {
+            const float v = mask[(size_t)y * width + x];
+            const uint32_t g = (uint32_t)(CLAMPF(v, 0.0f, 1.0f) * 255.0f + 0.5f);
+            row[x] = (g << 16) | (g << 8) | g;
+          }
+        }
+        cairo_surface_mark_dirty(grey);
+        cairo_set_source_surface(cr, grey, 0, 0);
+        cairo_paint(cr);
+      }
+      cairo_surface_destroy(grey);
+      dt_free_align(mask);
+    }
+  }
+
+  if(request->draw_overlay)
+  {
+    /* The overlay paints with the theme palette, which is filled from GTK at startup and is
+     * therefore all-zero -- fully transparent -- with no GUI. Drawing would "succeed" and
+     * produce an empty picture. Give every unset entry a visible fallback so a headless render
+     * shows the same geometry the darkroom would; the exact hues are the theme's business, and
+     * a diagnostic only needs to be legible. Production is untouched: with a GUI up, every
+     * entry already has a non-zero alpha and nothing here applies. */
+    GdkRGBA *const palette = dt_widget_colors();
+    if(!IS_NULL_PTR(palette))
+    {
+      for(int i = 0; i < DT_GUI_COLOR_LAST; i++)
+        if(palette[i].alpha <= 0.0) palette[i] = (GdkRGBA){ 1.0, 1.0, 1.0, 1.0 };
+    }
+
+    /* The overlay reads the visible form and the processed size off the dev, so both are
+     * published here rather than passed -- this is the same state the darkroom holds while it
+     * draws, which is the point: no second code path. */
+    if(IS_NULL_PTR(dev->form_gui))
+    {
+      dev->form_gui = (dt_masks_form_gui_t *)calloc(1, sizeof(dt_masks_form_gui_t));
+      if(!IS_NULL_PTR(dev->form_gui)) dt_masks_init_form_gui(dev, dev->form_gui);
+    }
+    if(!IS_NULL_PTR(dev->form_gui))
+    {
+      dev->form_gui->dev = dev;
+      dev->form_gui->form_visible = form;
+      dev->form_gui->formid = 0;   // force the outline cache to rebuild for this render
+      dt_dev_geometry_set_processed_size(dev, raw_width, raw_height);
+
+      const dt_masks_overlay_transform_t transform
+          = { .scale = (double)width / (double)raw_width, .offset_x = 0.0, .offset_y = 0.0 };
+      int pw = 0, ph = 0;
+      dt_dev_get_processed_size(dev, &pw, &ph);
+      dt_print(DT_DEBUG_ALWAYS, "[masks debug] overlay: visible=%p processed=%dx%d scale=%.4f\n",
+               (void *)dt_masks_get_visible_form(dev), pw, ph, transform.scale);
+      dt_masks_events_post_expose_with(dev, NULL, cr, width, height, -1, -1, &transform);
+    }
+  }
+
+  cairo_destroy(cr);
+  cairo_surface_flush(surface);
+  const gboolean ok = (cairo_surface_write_to_png(surface, path) == CAIRO_STATUS_SUCCESS);
+  cairo_surface_destroy(surface);
+
+  if(!ok) dt_print(DT_DEBUG_ALWAYS, "[masks debug] could not write %s\n", path);
+  return ok;
 }
 
 // clang-format off

--- a/src/develop/masks/polygon.c
+++ b/src/develop/masks/polygon.c
@@ -240,7 +240,7 @@ static void _polygon_init_ctrl_points(dt_masks_form_t *mask_form)
 
   if(IS_NULL_PTR(mask_form) || IS_NULL_PTR(mask_form->points)) return;
   
-  dt_masks_node_polygon_t **nodes = malloc((size_t)node_count * sizeof(*nodes));
+  dt_masks_node_polygon_t **nodes = dt_alloc_align((size_t)node_count * sizeof(*nodes));
   if(IS_NULL_PTR(nodes)) return;
   const GList *form_points = mask_form->points;
   for(guint node_index = 0; node_index < node_count; node_index++)
@@ -252,7 +252,7 @@ static void _polygon_init_ctrl_points(dt_masks_form_t *mask_form)
   for(guint node_index = 0; node_index < node_count; node_index++)
   {
     dt_masks_node_polygon_t *point3 = nodes[node_index];
-    if(IS_NULL_PTR(point3)) { dt_free(nodes); return; }
+    if(IS_NULL_PTR(point3)) { dt_free_align(nodes); return; }
     // if the point has not been set manually, we redefine it
     if(point3->state == DT_MASKS_POINT_STATE_NORMAL)
     {
@@ -260,7 +260,7 @@ static void _polygon_init_ctrl_points(dt_masks_form_t *mask_form)
       dt_masks_node_polygon_t *point2 = nodes[(node_index + node_count - 1) % node_count];
       dt_masks_node_polygon_t *point4 = nodes[(node_index + 1) % node_count];
       dt_masks_node_polygon_t *point5 = nodes[(node_index + 2) % node_count];
-      if(IS_NULL_PTR(point1) || IS_NULL_PTR(point2) || IS_NULL_PTR(point4) || IS_NULL_PTR(point5)) { dt_free(nodes); return; }
+      if(IS_NULL_PTR(point1) || IS_NULL_PTR(point2) || IS_NULL_PTR(point4) || IS_NULL_PTR(point5)) { dt_free_align(nodes); return; }
 
       float bezier1_x = 0.0f;
       float bezier1_y = 0.0f;
@@ -282,7 +282,7 @@ static void _polygon_init_ctrl_points(dt_masks_form_t *mask_form)
       point3->ctrl2[1] = bezier1_y;
     }
   }
-  dt_free(nodes);
+  dt_free_align(nodes);
   return;
 }
 
@@ -2911,12 +2911,12 @@ static int _polygon_crop_to_roi(float *polygon, const int point_count, float xmi
     float delta;
   } roi_crop_segment_t;
 
-  roi_crop_segment_t *xmax_segs = malloc(sizeof(*xmax_segs) * point_count);
-  roi_crop_segment_t *ymax_segs = malloc(sizeof(*ymax_segs) * point_count);
+  roi_crop_segment_t *xmax_segs = dt_alloc_align(sizeof(*xmax_segs) * point_count);
+  roi_crop_segment_t *ymax_segs = dt_alloc_align(sizeof(*ymax_segs) * point_count);
   if(IS_NULL_PTR(xmax_segs) || IS_NULL_PTR(ymax_segs))
   {
-    dt_free(xmax_segs);
-    dt_free(ymax_segs);
+    dt_free_align(xmax_segs);
+    dt_free_align(ymax_segs);
     goto fallback_passes;
   }
 
@@ -2985,7 +2985,7 @@ static int _polygon_crop_to_roi(float *polygon, const int point_count, float xmi
     }
   }
 
-  dt_free(xmax_segs);
+  dt_free_align(xmax_segs);
 
   int ymin_l = -1, ymin_r = -1;
   int ymax_l = -1, ymax_r = -1;
@@ -3052,7 +3052,7 @@ static int _polygon_crop_to_roi(float *polygon, const int point_count, float xmi
     }
   }
 
-  dt_free(ymax_segs);
+  dt_free_align(ymax_segs);
   return 1;
 
 fallback_passes:

--- a/src/develop/masks/polygon.c
+++ b/src/develop/masks/polygon.c
@@ -2254,6 +2254,10 @@ static void _polygon_draw_shape(struct dt_develop_t *dev, cairo_t *cr, const flo
                                 const int node_count, const gboolean draw_border, const gboolean draw_source,
                                 const dt_masks_skip_range_t *skips, const int skip_count)
 {
+  /* dev and draw_source are the shared shape_draw_function_t signature; the source outline is
+   * drawn by its own caller, which passes no exclusion list. */
+  (void)dev; (void)draw_source;
+
   /* This used to ignore the exclusion list and test the buffer for NaN instead -- which polygon
    * never writes, since its cuts have travelled out-of-band since the #1313 refactor. So the
    * test matched nothing and the folds were drawn. Honouring the list is the fix and costs one

--- a/src/develop/masks/polygon.c
+++ b/src/develop/masks/polygon.c
@@ -2568,6 +2568,74 @@ static dt_masks_raster_result_t _polygon_get_area(const dt_iop_module_t *const m
   }
 }
 
+/** How many sub-steps bridge the jump between two consecutive feather spokes.
+ *
+ * The feather is the union of segments from each outline sample to its border sample, so it stays
+ * continuous only while consecutive segments are within a pixel of each other at BOTH ends. At a
+ * cut boundary they are not: the border side collapses to the cut's resume point and the fan opens
+ * in a single step, leaving a wedge nothing stamps -- the thin dark radial line reported as "a
+ * radial spoke is missing" at node 12 of polygon #2 in issue #1313's sidecar. One sub-step per
+ * pixel of the larger jump closes it.
+ *
+ * The two rasterisers differ only in where the bridging spokes GO, so the geometry lives here once
+ * and each sink gets its own three-line wrapper below. */
+static inline int _falloff_bridge_steps(const int *const last0, const int *const last1,
+                                        const int *const p0, const int *const p1)
+{
+  const int jump = MAX(MAX(abs(p0[0] - last0[0]), abs(p0[1] - last0[1])),
+                       MAX(abs(p1[0] - last1[0]), abs(p1[1] - last1[1])));
+  /* a bound: past this the two samples are not a fan, they are unrelated geometry */
+  return MIN(jump, 64);
+}
+
+static inline void _falloff_bridge_lerp(const int *const from, const int *const to, const float t,
+                                        int *const out)
+{
+  out[0] = (int)floorf(from[0] + t * (to[0] - from[0]) + 0.5f);
+  out[1] = (int)floorf(from[1] + t * (to[1] - from[1]) + 0.5f);
+}
+
+/** Stamp the bridging spokes straight into @p buffer. */
+static inline void _falloff_bridge_stamp(float *const restrict buffer, const int *const last0,
+                                         const int *const last1, const int *const p0,
+                                         const int *const p1, const int posx, const int posy,
+                                         const int width)
+{
+  const int steps = _falloff_bridge_steps(last0, last1, p0, p1);
+  for(int k = 1; k < steps; k++)
+  {
+    const float t = (float)k / (float)steps;
+    int b0[2];
+    int b1[2];
+    _falloff_bridge_lerp(last0, p0, t, b0);
+    _falloff_bridge_lerp(last1, p1, t, b1);
+    _polygon_falloff(buffer, b0, b1, posx, posy, width);
+  }
+}
+
+/** Queue the bridging spokes for the ROI path, which stamps them in parallel afterwards. Returns
+ * the new write index. Same geometry as _falloff_bridge_stamp(), different sink. */
+static inline int _falloff_bridge_queue(int *const dpoints, int dindex, const int capacity,
+                                        const int *const last0, const int *const last1,
+                                        const int *const p0, const int *const p1)
+{
+  const int steps = _falloff_bridge_steps(last0, last1, p0, p1);
+  for(int k = 1; k < steps && dindex + 4 <= capacity; k++)
+  {
+    const float t = (float)k / (float)steps;
+    int b0[2];
+    int b1[2];
+    _falloff_bridge_lerp(last0, p0, t, b0);
+    _falloff_bridge_lerp(last1, p1, t, b1);
+    dpoints[dindex] = b0[0];
+    dpoints[dindex + 1] = b0[1];
+    dpoints[dindex + 2] = b1[0];
+    dpoints[dindex + 3] = b1[1];
+    dindex += 4;
+  }
+  return dindex;
+}
+
 static dt_masks_raster_result_t _polygon_get_mask(const dt_iop_module_t *const module, dt_dev_pixelpipe_t *pipe,
                              const dt_dev_pixelpipe_iop_t *const piece,
                              dt_masks_form_t *const mask_form,
@@ -2828,20 +2896,8 @@ static dt_masks_raster_result_t _polygon_get_mask(const dt_iop_module_t *const m
     if(last0[0] != p0[0] || last0[1] != p0[1] || last1[0] != p1[0] || last1[1] != p1[1])
     {
       if(last0[0] > -100 || last0[1] > -100)
-      {
-        const int jump0 = MAX(abs(p0[0] - last0[0]), abs(p0[1] - last0[1]));
-        const int jump1 = MAX(abs(p1[0] - last1[0]), abs(p1[1] - last1[1]));
-        const int steps = MIN(MAX(jump0, jump1), 64);   /* a bound: a jump this big is not a fan */
-        for(int k = 1; k < steps; k++)
-        {
-          const float t = (float)k / (float)steps;
-          int b0[2] = { (int)floorf(last0[0] + t * (p0[0] - last0[0]) + 0.5f),
-                        (int)floorf(last0[1] + t * (p0[1] - last0[1]) + 0.5f) };
-          int b1[2] = { (int)floorf(last1[0] + t * (p1[0] - last1[0]) + 0.5f),
-                        (int)floorf(last1[1] + t * (p1[1] - last1[1]) + 0.5f) };
-          _polygon_falloff(bufptr, b0, b1, *posx, *posy, *width);
-        }
-      }
+        _falloff_bridge_stamp(bufptr, last0, last1, p0, p1, *posx, *posy, *width);
+
       _polygon_falloff(bufptr, p0, p1, *posx, *posy, *width);
       last0[0] = p0[0];
       last0[1] = p0[1];
@@ -3582,21 +3638,8 @@ static dt_masks_raster_result_t _polygon_get_mask_roi(const dt_iop_module_t *con
       if(last0[0] != p0[0] || last0[1] != p0[1] || last1[0] != p1[0] || last1[1] != p1[1])
       {
         if(have_last)
-        {
-          const int jump = MAX(MAX(abs(p0[0] - last0[0]), abs(p0[1] - last0[1])),
-                               MAX(abs(p1[0] - last1[0]), abs(p1[1] - last1[1])));
-          /* a bound: past this the two samples are not a fan, they are unrelated geometry */
-          const int steps = MIN(jump, 64);
-          for(int k = 1; k < steps && dindex + 4 <= dpoints_capacity; k++)
-          {
-            const float t = (float)k / (float)steps;
-            dpoints[dindex] = (int)floorf(last0[0] + t * (p0[0] - last0[0]) + 0.5f);
-            dpoints[dindex + 1] = (int)floorf(last0[1] + t * (p0[1] - last0[1]) + 0.5f);
-            dpoints[dindex + 2] = (int)floorf(last1[0] + t * (p1[0] - last1[0]) + 0.5f);
-            dpoints[dindex + 3] = (int)floorf(last1[1] + t * (p1[1] - last1[1]) + 0.5f);
-            dindex += 4;
-          }
-        }
+          dindex = _falloff_bridge_queue(dpoints, dindex, dpoints_capacity,
+                                         last0, last1, p0, p1);
 
         if(dindex + 4 > dpoints_capacity) break;
         dpoints[dindex] = p0[0];

--- a/src/develop/masks/polygon.c
+++ b/src/develop/masks/polygon.c
@@ -114,15 +114,46 @@ static gboolean _polygon_border_get_XY(const float p0_x, const float p0_y, const
   const double c = 3.0 * (2.0 * t_ti - t_t);
   const double d = 3.0 * t_t;
 
-  const double dx = -p0_x * a + p1_x * b + p2_x * c + p3_x * d;
-  const double dy = -p0_y * a + p1_y * b + p2_y * c + p3_y * d;
+  /* not const: a degenerate first-order term is replaced by the limit direction below */
+  double dx = -p0_x * a + p1_x * b + p2_x * c + p3_x * d;
+  double dy = -p0_y * a + p1_y * b + p2_y * c + p3_y * d;
 
-  // so we can have the resulting point
-  /* A curve collapsed to a single point has no direction, so there is nothing to offset along
-   * and the honest answer is "none". This used to be written into the border coordinates as
-   * NaN, which every walker downstream then had to recognise and repair -- a sentinel inside a
-   * buffer that is supposed to hold geometry. It is a return value now. */
-  if(dx == 0 && dy == 0) return FALSE;
+  /* A vanishing derivative does not mean the tangent is undefined -- it means the first-order
+   * term is degenerate and the direction is the limit, given by the first non-zero term. That
+   * is exactly how a CUSP is stored: both of the node's handles sit on the node, so the cubic's
+   * endpoint derivative 3*(p3 - p2) is zero there.
+   *
+   * Giving up instead left the offset with no direction at that one sample, and the caller then
+   * held the previous border point. A polygon's feather is painted as radial spokes from each
+   * outline sample to its border sample, so a held border point means a spoke that goes nowhere:
+   * reported on polygon #2 of issue #1313's sidecar as "a radial spoke is missing in the
+   * feathering area" at node 12, and visible in the rasterised mask as a thin dark line cutting
+   * down through the feather band.
+   *
+   * This is the same defect the brush had at its own cusp, fixed the same way, and the
+   * comparison has to be RELATIVE for the same reason: these are image pixels, so the products
+   * either side of the cancellation are rounded before they are subtracted and what should be
+   * zero arrives as a small residue. The brush measured 1.22e-4 in float. Doubles here make it
+   * smaller, not absent, and normalising a residue yields a direction made of rounding noise --
+   * which is worse than giving up, because it looks like an answer. */
+  const double span = fmax(fmax(fabs((double)p3_x - p0_x), fabs((double)p3_y - p0_y)),
+                           fmax(fabs((double)p2_x - p1_x), fabs((double)p2_y - p1_y)));
+  const double degenerate = fmax(span, 1.0) * 1e-9;
+
+  if(fabs(dx) < degenerate && fabs(dy) < degenerate)
+  {
+    /* for a cubic, if the first-order term vanishes the second-order one gives the limit */
+    if(t < 0.5f) { dx = (double)p2_x - p0_x; dy = (double)p2_y - p0_y; }
+    else         { dx = (double)p3_x - p1_x; dy = (double)p3_y - p1_y; }
+
+    if(fabs(dx) < degenerate && fabs(dy) < degenerate)
+    {
+      dx = (double)p3_x - p0_x;
+      dy = (double)p3_y - p0_y;
+    }
+    /* only a curve collapsed to a single point has no direction at all */
+    if(dx == 0.0 && dy == 0.0) return FALSE;
+  }
 
   const double l = 1.0 / sqrt(dx * dx + dy * dy);
   *border_x = (*center_x) + radius * dy * l;
@@ -2775,9 +2806,38 @@ static dt_masks_raster_result_t _polygon_get_mask(const dt_iop_module_t *const m
       }
     }
 
-    // and we draw the falloff
+    /* BRIDGE A JUMP BETWEEN CONSECUTIVE SPOKES.
+     *
+     * The feather is the union of segments from each outline sample to its border sample, so it
+     * is only continuous while consecutive segments stay within a pixel of each other at BOTH
+     * ends. At a cut boundary they do not: the border side collapses to the cut's resume point,
+     * which is somewhere else entirely, and the fan opens in one step. Measured on polygon #2 of
+     * issue #1313's sidecar, at the sample before the cut at 23528: the outline end moves a
+     * fraction of a pixel while the border end jumps 4.57 px, and the wedge between the two
+     * segments is never stamped -- a thin dark radial line through the feather, reported as "a
+     * radial spoke is missing" at node 12. A second one, 2.80 px, sits before the cut at 6532.
+     *
+     * Subdividing until each step is at most a pixel closes it. This is not the same thing as
+     * the `sparse' interpolation above, which fills in for samples deliberately not visited
+     * when the outline is walked at reduced density; this fires on adjacent samples, where the
+     * geometry itself is discontinuous. */
     if(last0[0] != p0[0] || last0[1] != p0[1] || last1[0] != p1[0] || last1[1] != p1[1])
     {
+      if(last0[0] > -100 || last0[1] > -100)
+      {
+        const int jump0 = MAX(abs(p0[0] - last0[0]), abs(p0[1] - last0[1]));
+        const int jump1 = MAX(abs(p1[0] - last1[0]), abs(p1[1] - last1[1]));
+        const int steps = MIN(MAX(jump0, jump1), 64);   /* a bound: a jump this big is not a fan */
+        for(int k = 1; k < steps; k++)
+        {
+          const float t = (float)k / (float)steps;
+          int b0[2] = { (int)floorf(last0[0] + t * (p0[0] - last0[0]) + 0.5f),
+                        (int)floorf(last0[1] + t * (p0[1] - last0[1]) + 0.5f) };
+          int b1[2] = { (int)floorf(last1[0] + t * (p1[0] - last1[0]) + 0.5f),
+                        (int)floorf(last1[1] + t * (p1[1] - last1[1]) + 0.5f) };
+          _polygon_falloff(bufptr, b0, b1, *posx, *posy, *width);
+        }
+      }
       _polygon_falloff(bufptr, p0, p1, *posx, *posy, *width);
       last0[0] = p0[0];
       last0[1] = p0[1];
@@ -3437,7 +3497,9 @@ static dt_masks_raster_result_t _polygon_get_mask_roi(const dt_iop_module_t *con
   // deal with feather if it does not lie outside of roi
   if(!polygon_encircles_roi)
   {
-    const int dpoints_capacity = 4 * border_count * (sparse ? sparse_factor : 1);
+    /* the jump bridge below can add segments between two adjacent samples, so the buffer needs
+     * headroom beyond one segment per sample; it is bounded and the writes are capacity-checked */
+    const int dpoints_capacity = 4 * (border_count + 1024) * (sparse ? sparse_factor : 1);
     int *dpoints = dt_pixelpipe_cache_alloc_align_cache(sizeof(int) * dpoints_capacity, 0);
     if(IS_NULL_PTR(dpoints))
     {
@@ -3455,6 +3517,7 @@ static dt_masks_raster_result_t _polygon_get_mask_roi(const dt_iop_module_t *con
     int last0[2] = { -100, -100 };
     int last1[2] = { -100, -100 };
     int falloff_skip_cursor = 0;
+    gboolean have_last = FALSE;
     for(int i = corner_count * 3; i < border_count; i++)
     {
       p0[0] = floorf(points[i * 2] + 0.5f);
@@ -3495,14 +3558,49 @@ static dt_masks_raster_result_t _polygon_get_mask_roi(const dt_iop_module_t *con
         }
       }
 
-      // and we draw the falloff
+      /* BRIDGE A JUMP BETWEEN CONSECUTIVE SPOKES.
+       *
+       * The feather is the union of segments from each outline sample to its border sample, so
+       * it stays continuous only while consecutive segments are within a pixel of each other at
+       * BOTH ends. At a cut boundary they are not: the border side collapses to the cut's
+       * resume point, which is somewhere else, and the fan opens in a single step. Measured on
+       * polygon #2 of issue #1313's sidecar, at the sample before the cut at 23528 -- the
+       * outline end does not move at all while the border end jumps 5 px -- and the wedge
+       * between the two segments is never stamped. That is the thin dark radial line through
+       * the feather reported as "a radial spoke is missing" at node 12; a second, 3 px, sits
+       * before the cut at 6532.
+       *
+       * Subdividing until each step is at most a pixel closes it. This is NOT the `sparse'
+       * interpolation above: that one fills in for samples deliberately not visited when the
+       * outline is walked at reduced density, and skips itself precisely when the spoke is
+       * inside a cut -- which is the one case that needs bridging. This fires between adjacent
+       * samples, where the geometry itself is discontinuous. */
       if(last0[0] != p0[0] || last0[1] != p0[1] || last1[0] != p1[0] || last1[1] != p1[1])
       {
+        if(have_last)
+        {
+          const int jump = MAX(MAX(abs(p0[0] - last0[0]), abs(p0[1] - last0[1])),
+                               MAX(abs(p1[0] - last1[0]), abs(p1[1] - last1[1])));
+          /* a bound: past this the two samples are not a fan, they are unrelated geometry */
+          const int steps = MIN(jump, 64);
+          for(int k = 1; k < steps && dindex + 4 <= dpoints_capacity; k++)
+          {
+            const float t = (float)k / (float)steps;
+            dpoints[dindex] = (int)floorf(last0[0] + t * (p0[0] - last0[0]) + 0.5f);
+            dpoints[dindex + 1] = (int)floorf(last0[1] + t * (p0[1] - last0[1]) + 0.5f);
+            dpoints[dindex + 2] = (int)floorf(last1[0] + t * (p1[0] - last1[0]) + 0.5f);
+            dpoints[dindex + 3] = (int)floorf(last1[1] + t * (p1[1] - last1[1]) + 0.5f);
+            dindex += 4;
+          }
+        }
+
+        if(dindex + 4 > dpoints_capacity) break;
         dpoints[dindex] = p0[0];
         dpoints[dindex + 1] = p0[1];
         dpoints[dindex + 2] = p1[0];
         dpoints[dindex + 3] = p1[1];
         dindex += 4;
+        have_last = TRUE;
 
         last0[0] = p0[0];
         last0[1] = p0[1];

--- a/src/develop/masks/polygon.c
+++ b/src/develop/masks/polygon.c
@@ -68,6 +68,7 @@
 
 static void _polygon_bounding_box_raw(const float *const point_buffer, const float *border_buffer,
                                       const int corner_count, const int point_count, int border_count,
+                                      const dt_masks_skip_range_t *border_skips, const int border_skip_count,
                                       float *x_min, float *x_max, float *y_min, float *y_max);
 
 /**
@@ -694,20 +695,11 @@ static int _polygon_find_self_intersection(dt_masks_dynbuf_t *intersections,
   return 0;
 }
 
-// A self-intersection skip range [v, w] in the border buffer's index space -- see the
-// sort+merge step in _polygon_get_pts_border() for why these need to be disjoint before being
-// written as NaN jump sentinels.
-typedef struct
-{
-  int v, w;
-} dt_masks_polygon_range_t;
-
-static int _polygon_range_cmp(const void *a, const void *b)
-{
-  const int va = ((const dt_masks_polygon_range_t *)a)->v;
-  const int vb = ((const dt_masks_polygon_range_t *)b)->v;
-  return (va > vb) - (va < vb);
-}
+// Self-intersection cuts are dt_masks_skip_range_t (masks_types.h), built by
+// dt_masks_skip_ranges_build() and handed to every consumer OUT-OF-BAND -- never encoded into
+// the border buffer. The in-band NaN-jump encoding this replaced hosted both bugs the
+// mechanism ever had (a reader cycle, then issue #1313's seam fold) while the geometry was
+// right both times.
 
 /**
  * @brief Build point and border buffers for a polygon mask.
@@ -717,12 +709,16 @@ static int _polygon_range_cmp(const void *a, const void *b)
 static int _polygon_get_pts_border(dt_develop_t *develop, dt_masks_form_t *mask_form,
                                    const double iop_order, const int transform_direction,
                                    const dt_masks_distort_t *const dist, float **point_buffer, int *point_count,
-                                   float **border_buffer, int *border_count, gboolean source)
+                                   float **border_buffer, int *border_count,
+                                   dt_masks_skip_range_t **border_skips, int *border_skip_count,
+                                   gboolean source)
 {
   *point_buffer = NULL;
   *point_count = 0;
   if(!IS_NULL_PTR(border_buffer)) *border_buffer = NULL;
   if(!IS_NULL_PTR(border_buffer)) *border_count = 0;
+  if(!IS_NULL_PTR(border_skips)) *border_skips = NULL;
+  if(!IS_NULL_PTR(border_skip_count)) *border_skip_count = 0;
 
   if(IS_NULL_PTR(mask_form) || IS_NULL_PTR(mask_form->points)) return 0;
 
@@ -1025,101 +1021,60 @@ static int _polygon_get_pts_border(dt_develop_t *develop, dt_masks_form_t *mask_
           for(int i = 2; i < 6; i++)
             (*border_buffer)[node_index * 6 + i] = border_init[node_index * 6 + i];
 
-        // now we want to write the skipping zones
-        // guard: buffer must be large enough to hold node falloff data
-        const int buf_count = *border_count;
-
-        // Each (v, w) pair names two raw border-buffer indices where the offset curve crosses
-        // itself, in the order _polygon_find_self_intersection()'s *discovery* walk (which
-        // starts at a shape extremum, not at start_index) encountered them -- not necessarily
-        // v <= w in raw-index terms, and not the order dt_masks_point_in_form_exact()'s *read*
-        // walk (masks.c, which always starts at start_index) will visit them in. What must be
-        // skipped is the read-order span between the two crossing points; in raw-index terms
-        // that span is simply [min(v,w), max(v,w)] -- read order is a fixed rotation starting
-        // at start_index, so whichever of v/w has the smaller raw index is always the one the
-        // read walk reaches first, regardless of which one discovery found first. Normalizing
-        // (v > w used to instead take a separate path that redirected through a single shared
-        // slot at start_index for every such pair) removes the only source of jump-sentinel
-        // cycles here: with every pair now oriented the same way, sorting and merging
-        // overlapping/nested ranges into disjoint, non-overlapping ones guarantees every jump
-        // in the resulting chain moves strictly forward through read order, so the walk can
-        // only ever visit each border index once. Without the merge, two overlapping ranges
-        // written independently can still point the reader into each other and trap its walk
-        // retracing the same few indices forever -- caught only by its own visited_points
-        // safety cap, which then leaves it reporting a bogus, incomplete crossing count for
-        // every point tested, not just points near the overlap. A polygon with many nodes and
-        // a generous per-node border/feathering radius produces many such ranges (its offset
-        // curve self-intersects at every concave run tighter than that radius), so this isn't
-        // rare on complex hand-drawn shapes.
-        dt_masks_polygon_range_t *ranges = dt_pixelpipe_cache_alloc_align_cache(
-            sizeof(dt_masks_polygon_range_t) * MAX(inter_count, 1), 0);
-        int range_count = 0;
-
-        for(int i = 0; i < inter_count; i++)
+        // The self-intersection cuts leave here OUT-OF-BAND, as dt_masks_skip_range_t --
+        // never encoded into the border buffer. dt_masks_skip_ranges_build() owns the
+        // normalize / drop-seam-straddlers / sort / merge pipeline and documents why each
+        // step exists.
+        if(inter_count > 0 && !IS_NULL_PTR(border_skips) && !IS_NULL_PTR(border_skip_count))
         {
-          const int v = (int)(dt_masks_dynbuf_buffer(intersections))[i * 2];
-          const int w = (int)(dt_masks_dynbuf_buffer(intersections))[i * 2 + 1];
-          // bounds-check v and w against the allocated buffer size
-          if(v < 0 || v >= buf_count || w < 0 || w >= buf_count) continue;
-          const int range_v = MIN(v, w);
-          const int range_w = MAX(v, w);
-
-          /* The border is a CLOSED contour, so a crossing pair cuts it into TWO arcs, and the
-           * fold to remove is the shorter one -- not whichever of the two happens to avoid the
-           * buffer seam. When the fold straddles the seam, [min(v,w), max(v,w)] names its
-           * COMPLEMENT: measured on the polygon of issue #1313 (67 nodes, uniform feather), 3 of
-           * its 27 crossings straddled the seam and each named ~147000 of 147546 border points
-           * instead of the 330-454 its fold actually spans. The merge below then swallowed all 27
-           * into a single range covering 99.8% of the contour, and the hit-test -- which is also
-           * what renders the pixel mask -- saw one straight chord instead of the shape.
-           *
-           * A wrapping removal cannot be expressed with these sentinels.
-           * dt_masks_point_in_form_exact() walks [start_index, count) forward and wraps exactly
-           * once, so a jump backwards sends the walk back over the span it just left, to arrive at
-           * the same sentinel again; it spins until its own visited_points cap stops it and
-           * returns a meaningless crossing count. That is the cycle the sorting and merging below
-           * exist to prevent, and it is why every range written here has to run forward.
-           *
-           * So a seam-straddling fold is LEFT IN. The offset curve keeps a small kink near that
-           * one fold -- the very thing the detector exists to hide -- but the damage is bounded by
-           * the fold's own size instead of taking the rest of the shape with it. */
-          if(range_w - range_v > buf_count - (range_w - range_v)) continue;
-
-          if(!IS_NULL_PTR(ranges))
+          dt_masks_skip_range_t *skips = dt_pixelpipe_cache_alloc_align_cache(
+              sizeof(dt_masks_skip_range_t) * inter_count, 0);
+          if(IS_NULL_PTR(skips))
           {
-            ranges[range_count].v = range_v;
-            ranges[range_count].w = range_w;
-            range_count++;
+            // No cuts is a RENDERABLE state -- the folds get filled as shape, a bounded local
+            // artefact -- but it is not the intended one, so it does not pass silently.
+            dt_print(DT_DEBUG_ALWAYS,
+                     "[masks %s] out of memory for %d self-intersection cuts; the border's folds"
+                     " will render filled\n", mask_form->name, inter_count);
           }
           else
           {
-            // allocation failed: fall back to writing this range unmerged, same as before
-            (*border_buffer)[range_v * 2] = NAN;
-            (*border_buffer)[range_v * 2 + 1] = range_w;
-          }
-        }
+            int dropped_wrapping = 0;
+            const int skip_count
+                = dt_masks_skip_ranges_build(dt_masks_dynbuf_buffer(intersections), inter_count,
+                                             *border_count, skips, &dropped_wrapping);
 
-        if(!IS_NULL_PTR(ranges) && range_count > 0)
-        {
-          qsort(ranges, range_count, sizeof(dt_masks_polygon_range_t), _polygon_range_cmp);
+            int skipped_total = 0;
+            for(int i = 0; i < skip_count; i++)
+              skipped_total += skips[i].resume_at - skips[i].jump_from;
 
-          int merged_count = 1;
-          for(int i = 1; i < range_count; i++)
-          {
-            if(ranges[i].v <= ranges[merged_count - 1].w)
-              ranges[merged_count - 1].w = MAX(ranges[merged_count - 1].w, ranges[i].w);
+            /* The invariant issue #1313 violated, checked where it is cheapest: no legitimate
+             * set of folds spans most of the contour, so a total this large means the ranges
+             * are wrong and the render damage would be #1313's straight chord across the
+             * shape. Scream rather than trust it -- 99.8% of this contour was being skipped
+             * in silence before. */
+            if(2 * skipped_total > *border_count)
+              dt_print(DT_DEBUG_ALWAYS,
+                       "[masks %s] self-intersection cuts skip %d of %d border points -- more"
+                       " than half the contour. The ranges are almost certainly wrong; keeping"
+                       " them, but this needs looking at\n",
+                       mask_form->name, skipped_total, *border_count);
+            else if(dt_get_debug_flags() & DT_DEBUG_MASKS)
+              dt_print(DT_DEBUG_MASKS,
+                       "[masks %s] self-intersections: %d crossings -> %d cuts (%d pts, %.1f%%"
+                       " of the border), %d seam-straddling fold(s) left in\n",
+                       mask_form->name, inter_count, skip_count, skipped_total,
+                       100.0 * skipped_total / MAX(*border_count, 1), dropped_wrapping);
+
+            if(skip_count > 0)
+            {
+              *border_skips = skips;
+              *border_skip_count = skip_count;
+            }
             else
-              ranges[merged_count++] = ranges[i];
-          }
-
-          for(int i = 0; i < merged_count; i++)
-          {
-            (*border_buffer)[ranges[i].v * 2] = NAN;
-            (*border_buffer)[ranges[i].v * 2 + 1] = ranges[i].w;
+              dt_pixelpipe_cache_free_align(skips);
           }
         }
-
-        if(!IS_NULL_PTR(ranges)) dt_pixelpipe_cache_free_align(ranges);
       }
 
       if(dt_get_debug_flags() & DT_DEBUG_PERF)
@@ -1257,6 +1212,7 @@ static void _polygon_translate_all_nodes(dt_masks_form_t *mask_form, const float
 static dt_masks_raster_result_t _polygon_get_points_border(dt_develop_t *develop, dt_masks_form_t *mask_form,
                                       float **point_buffer, int *point_count,
                                       float **border_buffer, int *border_count,
+                                      dt_masks_skip_range_t **border_skips, int *border_skip_count,
                                       int source, const dt_iop_module_t *module)
 {
   // Asking for the source outline without a module is a programming error, not an empty shape.
@@ -1266,7 +1222,7 @@ static dt_masks_raster_result_t _polygon_get_points_border(dt_develop_t *develop
   return dt_masks_raster_from_status(
       _polygon_get_pts_border(develop, mask_form, ioporder, DT_DEV_TRANSFORM_DIR_ALL,
                               &gui_dist, point_buffer, point_count,
-                              border_buffer, border_count, source));
+                              border_buffer, border_count, border_skips, border_skip_count, source));
 }
 
 static void _polygon_get_sizes(struct dt_iop_module_t *module, dt_masks_form_t *mask_form,
@@ -1456,7 +1412,7 @@ static void _polygon_get_distance(float point_x, float point_y, float radius,
   if(gui_points->source && gui_points->points
      && gui_points->source_count > node_count * 3 && gui_points->points_count > node_count * 3
      && dt_masks_point_in_form_exact(pt, 1, gui_points->source, node_count * 3,
-                                     gui_points->source_count) >= 0)
+                                     gui_points->source_count, NULL, 0) >= 0)
   {
     *inside_source = 1;
     *inside = 1;
@@ -1530,7 +1486,8 @@ static void _polygon_get_distance(float point_x, float point_y, float radius,
   // we check if it's not inside borders, meaning we are not inside at all
   if(!gui_points->border || gui_points->border_count <= node_count * 3
      || dt_masks_point_in_form_exact(pt, 1, gui_points->border, node_count * 3,
-                                     gui_points->border_count) < 0)
+                                     gui_points->border_count,
+                                     gui_points->border_skips, gui_points->border_skip_count) < 0)
     return;
 
   // we are at least inside the border
@@ -1539,7 +1496,7 @@ static void _polygon_get_distance(float point_x, float point_y, float radius,
   // and we check if it's not inside form, meaning we are inside border only
   if(IS_NULL_PTR(gui_points->points) || gui_points->points_count <= node_count * 3) return;
   *inside_border = (dt_masks_point_in_form_exact(pt, 1, gui_points->points,
-                                                 node_count * 3, gui_points->points_count) < 0);
+                                                 node_count * 3, gui_points->points_count, NULL, 0) < 0);
 }
 
 /**
@@ -2460,22 +2417,26 @@ static void _polygon_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks_
  */
 static void _polygon_bounding_box_raw(const float *const point_buffer, const float *border_buffer,
                                       const int corner_count, const int point_count, int border_count,
+                                      const dt_masks_skip_range_t *border_skips, const int border_skip_count,
                                       float *x_min, float *x_max, float *y_min, float *y_max)
 {
   float xmin, xmax, ymin, ymax;
   xmin = ymin = FLT_MAX;
   xmax = ymax = FLT_MIN;
+  int skip_cursor = 0;
   for(int border_index = corner_count * 3; border_index < border_count; border_index++)
   {
+    // A cut span is not shape: its points are the offset curve folded over itself, and the
+    // walks that render the mask never visit them, so the box must not grow to include them.
+    if(skip_cursor < border_skip_count && border_index >= border_skips[skip_cursor].jump_from)
+    {
+      border_index = border_skips[skip_cursor].resume_at - 1;
+      skip_cursor++;
+      continue;
+    }
     // we look at the borders
     const float xx = border_buffer[border_index * 2];
     const float yy = border_buffer[border_index * 2 + 1];
-    if(isnan(xx))
-    {
-     if(isnan(yy)) break; // that means we have to skip the end of the border polygon
-      border_index = yy - 1;
-      continue;
-    }
     xmin = MIN(xx, xmin);
     xmax = MAX(xx, xmax);
     ymin = MIN(yy, ymin);
@@ -2503,12 +2464,13 @@ static void _polygon_bounding_box_raw(const float *const point_buffer, const flo
  */
 static void _polygon_bounding_box(const float *const point_buffer, const float *border_buffer,
                                   const int corner_count, const int point_count, int border_count,
+                                  const dt_masks_skip_range_t *border_skips, const int border_skip_count,
                                   int *width, int *height, int *posx, int *posy)
 {
   // now we want to find the area, so we search min/max points
   float xmin, xmax, ymin, ymax;
   _polygon_bounding_box_raw(point_buffer, border_buffer, corner_count, point_count, border_count,
-                            &xmin, &xmax, &ymin, &ymax);
+                            border_skips, border_skip_count, &xmin, &xmax, &ymin, &ymax);
   *height = ymax - ymin + 4;
   *width = xmax - xmin + 4;
   *posx = xmin - 2;
@@ -2525,24 +2487,29 @@ static int _get_area(const dt_iop_module_t *const module, dt_dev_pixelpipe_t *pi
   // we get buffers for all points
   float *point_buffer = NULL;
   float *border_buffer = NULL;
+  dt_masks_skip_range_t *border_skips = NULL;
   int point_count = 0;
   int border_count = 0;
+  int border_skip_count = 0;
 
   const dt_masks_distort_t pipe_dist = dt_masks_distort_for_pipe(pipe, module->dev);
   if(_polygon_get_pts_border(module->dev, mask_form, module->iop_order, DT_DEV_TRANSFORM_DIR_BACK_INCL, &pipe_dist,
-                             &point_buffer, &point_count, &border_buffer, &border_count, get_source) != 0)
+                             &point_buffer, &point_count, &border_buffer, &border_count,
+                             &border_skips, &border_skip_count, get_source) != 0)
   {
     dt_pixelpipe_cache_free_align(point_buffer);
     dt_pixelpipe_cache_free_align(border_buffer);
+    dt_pixelpipe_cache_free_align(border_skips);
     return 1;
   }
 
   const guint corner_count = g_list_length(mask_form->points);
   _polygon_bounding_box(point_buffer, border_buffer, corner_count, point_count, border_count,
-                        width, height, posx, posy);
+                        border_skips, border_skip_count, width, height, posx, posy);
 
   dt_pixelpipe_cache_free_align(point_buffer);
   dt_pixelpipe_cache_free_align(border_buffer);
+  dt_pixelpipe_cache_free_align(border_skips);
   return 0;
 }
 
@@ -2618,15 +2585,19 @@ static dt_masks_raster_result_t _polygon_get_mask(const dt_iop_module_t *const m
   // we get buffers for all points
   float *point_buffer = NULL;
   float *border_buffer = NULL;
+  dt_masks_skip_range_t *border_skips = NULL;
   int point_count = 0;
   int border_count = 0;
+  int border_skip_count = 0;
   const dt_masks_distort_t pipe_dist = dt_masks_distort_for_pipe(pipe, module->dev);
   if(_polygon_get_pts_border(module->dev, mask_form, module->iop_order,
                              DT_DEV_TRANSFORM_DIR_BACK_INCL, &pipe_dist, &point_buffer, &point_count,
-                             &border_buffer, &border_count, FALSE) != 0)
+                             &border_buffer, &border_count, &border_skips, &border_skip_count,
+                             FALSE) != 0)
   {
     dt_pixelpipe_cache_free_align(point_buffer);
     dt_pixelpipe_cache_free_align(border_buffer);
+    dt_pixelpipe_cache_free_align(border_skips);
     return DT_MASKS_RASTER_ERROR;
   }
 
@@ -2640,7 +2611,7 @@ static dt_masks_raster_result_t _polygon_get_mask(const dt_iop_module_t *const m
   // now we want to find the area, so we search min/max points
   const guint corner_count = g_list_length(mask_form->points);
   _polygon_bounding_box(point_buffer, border_buffer, corner_count, point_count, border_count,
-                        width, height, posx, posy);
+                        border_skips, border_skip_count, width, height, posx, posy);
 
   const int hb = *height;
   const int wb = *width;
@@ -2668,6 +2639,7 @@ static dt_masks_raster_result_t _polygon_get_mask(const dt_iop_module_t *const m
   {
     dt_pixelpipe_cache_free_align(point_buffer);
     dt_pixelpipe_cache_free_align(border_buffer);
+    dt_pixelpipe_cache_free_align(border_skips);
     return DT_MASKS_RASTER_ERROR;
   }
 
@@ -2801,33 +2773,26 @@ static dt_masks_raster_result_t _polygon_get_mask(const dt_iop_module_t *const m
 
   // now we fill the falloff
   int p0[2] = { 0 }, p1[2] = { 0 };
-  float pf1[2] = { 0.0f };
   int prev0[2] = { 0 }, prev1[2] = { 0 };
   gboolean have_prev = FALSE;
   int last0[2] = { -100, -100 }, last1[2] = { -100, -100 };
-  int next = 0;
+  int skip_cursor = 0;
   for(int i = corner_count * 3; i < border_count; i++)
   {
     p0[0] = point_buffer[i * 2];
     p0[1] = point_buffer[i * 2 + 1];
-    if(next > 0)
-      p1[0] = pf1[0] = border_buffer[next * 2], p1[1] = pf1[1] = border_buffer[next * 2 + 1];
-    else
-      p1[0] = pf1[0] = border_buffer[i * 2], p1[1] = pf1[1] = border_buffer[i * 2 + 1];
 
-    // now we check p1 value to know if we have to skip a part
-    if(next == i) next = 0;
-    while(isnan(pf1[0]))
-    {
-      if(isnan(pf1[1]))
-        next = i - 1;
-      else
-        next = p1[1];
-      p1[0] = pf1[0] = border_buffer[next * 2];
-      p1[1] = pf1[1] = border_buffer[next * 2 + 1];
-    }
+    /* Inside a cut, the border side of every falloff segment collapses to the cut's resume
+     * point: the same segments the in-band jump used to produce, read from a range instead of
+     * decoded out of a NaN slot. */
+    while(skip_cursor < border_skip_count && i >= border_skips[skip_cursor].resume_at) skip_cursor++;
+    const gboolean in_skip
+        = (skip_cursor < border_skip_count && i >= border_skips[skip_cursor].jump_from);
+    const int border_index = in_skip ? border_skips[skip_cursor].resume_at : i;
+    p1[0] = border_buffer[border_index * 2];
+    p1[1] = border_buffer[border_index * 2 + 1];
 
-    const gboolean used_next = (next > 0);
+    const gboolean used_next = in_skip;
 
     if(sparse && have_prev && !used_next
        && (prev0[0] != p0[0] || prev0[1] != p0[1] || prev1[0] != p1[0] || prev1[1] != p1[1]))
@@ -2873,6 +2838,7 @@ static dt_masks_raster_result_t _polygon_get_mask(const dt_iop_module_t *const m
 
   dt_pixelpipe_cache_free_align(point_buffer);
   dt_pixelpipe_cache_free_align(border_buffer);
+  dt_pixelpipe_cache_free_align(border_skips);
 
   if(dt_get_debug_flags() & DT_DEBUG_PERF)
     dt_print(DT_DEBUG_MASKS, "[masks %s] polygon fill buffer took %0.04f sec\n", mask_form->name,
@@ -3254,20 +3220,24 @@ static dt_masks_raster_result_t _polygon_get_mask_roi(const dt_iop_module_t *con
 
   // we get buffers for all points
   float *points = NULL, *border = NULL;
-  int points_count = 0, border_count = 0;
+  dt_masks_skip_range_t *border_skips = NULL;
+  int points_count = 0, border_count = 0, border_skip_count = 0;
   const dt_masks_distort_t pipe_dist = dt_masks_distort_for_pipe(pipe, module->dev);
   if(_polygon_get_pts_border(module->dev, mask_form, module->iop_order,
                              DT_DEV_TRANSFORM_DIR_BACK_INCL, &pipe_dist,
-                             &points, &points_count, &border, &border_count, FALSE) != 0)
+                             &points, &points_count, &border, &border_count,
+                             &border_skips, &border_skip_count, FALSE) != 0)
   {
     dt_pixelpipe_cache_free_align(points);
     dt_pixelpipe_cache_free_align(border);
+    dt_pixelpipe_cache_free_align(border_skips);
     return DT_MASKS_RASTER_ERROR;
   }
   if(points_count <= 2)
   {
     dt_pixelpipe_cache_free_align(points);
     dt_pixelpipe_cache_free_align(border);
+    dt_pixelpipe_cache_free_align(border_skips);
     return DT_MASKS_RASTER_EMPTY;
   }
 
@@ -3280,19 +3250,15 @@ static dt_masks_raster_result_t _polygon_get_mask_roi(const dt_iop_module_t *con
 
   const guint corner_count = g_list_length(mask_form->points);
 
-  // we shift and scale down polygon and border
+  // we shift and scale down polygon and border. Cut spans are scaled too: their points are
+  // valid coordinates (the cuts travel out-of-band now), and every reader below skips the
+  // spans by range, so nothing observes them either way -- while the old skip-during-scaling
+  // left them in IMAGE coordinates, which is what painted the feather from out-of-buffer
+  // positions when a spurious cut appeared (issue #1116).
   for(int i = corner_count * 3; i < border_count; i++)
   {
-    const float xx = border[2 * i];
-    const float yy = border[2 * i + 1];
-    if(isnan(xx))
-    {
-      if(isnan(yy)) break; // that means we have to skip the end of the border polygon
-      i = yy - 1;
-      continue;
-    }
-    border[2 * i] = xx * scale - px;
-    border[2 * i + 1] = yy * scale - py;
+    border[2 * i] = border[2 * i] * scale - px;
+    border[2 * i + 1] = border[2 * i + 1] * scale - py;
   }
   for(int i = corner_count * 3; i < points_count; i++)
   {
@@ -3340,17 +3306,18 @@ static dt_masks_raster_result_t _polygon_get_mask_roi(const dt_iop_module_t *con
     }
   }
 
-  // now check if feather is at least partially within roi
+  // now check if feather is at least partially within roi. Cut spans are not feather.
+  int feather_skip_cursor = 0;
   for(int i = corner_count * 3; i < border_count; i++)
   {
-    const float xx = border[i * 2];
-    const float yy = border[i * 2 + 1];
-    if(isnan(xx))
+    if(feather_skip_cursor < border_skip_count && i >= border_skips[feather_skip_cursor].jump_from)
     {
-      if(isnan(yy)) break; // that means we have to skip the end of the border polygon
-      i = yy - 1;
+      i = border_skips[feather_skip_cursor].resume_at - 1;
+      feather_skip_cursor++;
       continue;
     }
+    const float xx = border[i * 2];
+    const float yy = border[i * 2 + 1];
     if(xx > 1 && yy > 1 && xx < width - 2 && yy < height - 2)
     {
       feather_in_roi = 1;
@@ -3363,13 +3330,14 @@ static dt_masks_raster_result_t _polygon_get_mask_roi(const dt_iop_module_t *con
   {
     dt_pixelpipe_cache_free_align(points);
     dt_pixelpipe_cache_free_align(border);
+    dt_pixelpipe_cache_free_align(border_skips);
     return DT_MASKS_RASTER_EMPTY;
   }
 
   // now get min/max values
   float xmin, xmax, ymin, ymax;
   _polygon_bounding_box_raw(points, border, corner_count, points_count, border_count,
-                            &xmin, &xmax, &ymin, &ymax);
+                            border_skips, border_skip_count, &xmin, &xmax, &ymin, &ymax);
 
   if(dt_get_debug_flags() & DT_DEBUG_PERF)
   {
@@ -3394,6 +3362,7 @@ static dt_masks_raster_result_t _polygon_get_mask_roi(const dt_iop_module_t *con
     {
       dt_pixelpipe_cache_free_align(points);
       dt_pixelpipe_cache_free_align(border);
+      dt_pixelpipe_cache_free_align(border_skips);
       return DT_MASKS_RASTER_ERROR;
     }
     memcpy(cpoints, points, sizeof(float) * 2 * points_count);
@@ -3507,46 +3476,36 @@ static dt_masks_raster_result_t _polygon_get_mask_roi(const dt_iop_module_t *con
     {
       dt_pixelpipe_cache_free_align(points);
       dt_pixelpipe_cache_free_align(border);
+      dt_pixelpipe_cache_free_align(border_skips);
       return DT_MASKS_RASTER_ERROR;
     }
 
     int dindex = 0;
     int p0[2], p1[2];
-    float pf1[2];
     int prev0[2] = { 0, 0 };
     int prev1[2] = { 0, 0 };
     gboolean have_prev = FALSE;
     int last0[2] = { -100, -100 };
     int last1[2] = { -100, -100 };
-    int next_index = 0;
+    int falloff_skip_cursor = 0;
     for(int i = corner_count * 3; i < border_count; i++)
     {
       p0[0] = floorf(points[i * 2] + 0.5f);
       p0[1] = ceilf(points[i * 2 + 1]);
-      if(next_index > 0)
-      {
-        p1[0] = pf1[0] = border[next_index * 2];
-        p1[1] = pf1[1] = border[next_index * 2 + 1];
-      }
-      else
-      {
-        p1[0] = pf1[0] = border[i * 2];
-        p1[1] = pf1[1] = border[i * 2 + 1];
-      }
 
-      // now we check p1 value to know if we have to skip a part
-      if(next_index == i) next_index = 0;
-      while(isnan(pf1[0]))
-      {
-        if(isnan(pf1[1]))
-          next_index = i - 1;
-        else
-          next_index = p1[1];
-        p1[0] = pf1[0] = border[next_index * 2];
-        p1[1] = pf1[1] = border[next_index * 2 + 1];
-      }
+      /* Inside a cut, the border side of every falloff segment collapses to the cut's resume
+       * point: the same segments the in-band jump used to produce, read from a range instead
+       * of decoded out of a NaN slot. */
+      while(falloff_skip_cursor < border_skip_count
+            && i >= border_skips[falloff_skip_cursor].resume_at)
+        falloff_skip_cursor++;
+      const gboolean in_skip = (falloff_skip_cursor < border_skip_count
+                                && i >= border_skips[falloff_skip_cursor].jump_from);
+      const int border_index = in_skip ? border_skips[falloff_skip_cursor].resume_at : i;
+      p1[0] = border[border_index * 2];
+      p1[1] = border[border_index * 2 + 1];
 
-      const gboolean used_next = (next_index > 0);
+      const gboolean used_next = in_skip;
 
       if(sparse && have_prev && !used_next
          && (prev0[0] != p0[0] || prev0[1] != p0[1] || prev1[0] != p1[0] || prev1[1] != p1[1]))
@@ -3613,6 +3572,7 @@ static dt_masks_raster_result_t _polygon_get_mask_roi(const dt_iop_module_t *con
 
   dt_pixelpipe_cache_free_align(points);
   dt_pixelpipe_cache_free_align(border);
+  dt_pixelpipe_cache_free_align(border_skips);
 
   /* The raw bounding box already spans the border samples, so the feather falloff lies inside
    * it too; the margin covers the one-pixel neighbour writes of the falloff stamps. The

--- a/src/develop/masks/polygon.c
+++ b/src/develop/masks/polygon.c
@@ -39,6 +39,7 @@
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
 #include "control/user_message.h"
+#include "math/math.h"
 #include "system/macros.h"
 #include "system/openmp.h"
 #include "system/mem_alloc.h"
@@ -2547,7 +2548,7 @@ static dt_masks_raster_result_t _polygon_get_area(const dt_iop_module_t *const m
                                  int posx, int posy, int buffer_width)
 {
   // segment length
-  int l = sqrtf(sqf(p1[0] - p0[0]) + sqf(p1[1] - p0[1])) + 1;
+  int l = dt_fast_hypotf(p1[0] - p0[0], p1[1] - p0[1]) + 1;
 
   const float lx = p1[0] - p0[0];
   const float ly = p1[1] - p0[1];

--- a/src/develop/masks/polygon.c
+++ b/src/develop/masks/polygon.c
@@ -94,7 +94,7 @@ static void _polygon_get_XY(const float p0_x, const float p0_y, const float p1_x
  *
  * The border point is offset along the normal, scaled by rad.
  */
-static void _polygon_border_get_XY(const float p0_x, const float p0_y, const float p1_x, const float p1_y,
+static gboolean _polygon_border_get_XY(const float p0_x, const float p0_y, const float p1_x, const float p1_y,
                                    const float p2_x, const float p2_y, const float p3_x, const float p3_y,
                                    const float t, const float radius,
                                    float *center_x, float *center_y, float *border_x, float *border_y)
@@ -118,15 +118,16 @@ static void _polygon_border_get_XY(const float p0_x, const float p0_y, const flo
   const double dy = -p0_y * a + p1_y * b + p2_y * c + p3_y * d;
 
   // so we can have the resulting point
-  if(dx == 0 && dy == 0)
-  {
-    *border_x = NAN;
-    *border_y = NAN;
-    return;
-  }
+  /* A curve collapsed to a single point has no direction, so there is nothing to offset along
+   * and the honest answer is "none". This used to be written into the border coordinates as
+   * NaN, which every walker downstream then had to recognise and repair -- a sentinel inside a
+   * buffer that is supposed to hold geometry. It is a return value now. */
+  if(dx == 0 && dy == 0) return FALSE;
+
   const double l = 1.0 / sqrt(dx * dx + dy * dy);
   *border_x = (*center_x) + radius * dy * l;
   *border_y = (*center_y) - radius * dx * l;
+  return TRUE;
 }
 
 /**
@@ -423,19 +424,26 @@ static void _polygon_points_recurs(float *segment_start, float *segment_end,
                                    float *border_min, float *border_max,
                                    float *result_polygon, float *result_border,
                                    dt_masks_dynbuf_t *draw_points, dt_masks_dynbuf_t *draw_border,
-                                   int with_border, const int pixel_threshold)
+                                   int with_border, const int pixel_threshold,
+                                   const gboolean have_min, const gboolean have_max,
+                                   gboolean have_border_min, gboolean have_border_max,
+                                   gboolean *out_have_border)
 {
-  // we calculate points if needed
-  if(isnan(polygon_min[0]))
+  /* have_* say whether the caller already evaluated that endpoint and whether a border point
+   * came with it. They were read out of the arrays as NaN, so "not computed", "no border" and
+   * real geometry all shared one representation in the buffers the outline is built from. */
+  if(!have_min)
   {
+    have_border_min =
     _polygon_border_get_XY(segment_start[0], segment_start[1], segment_start[2], segment_start[3],
                            segment_end[2], segment_end[3], segment_end[0], segment_end[1], t_min,
                            segment_start[4]
                                + (segment_end[4] - segment_start[4]) * t_min * t_min * (3.0 - 2.0 * t_min),
                            polygon_min, polygon_min + 1, border_min, border_min + 1);
   }
-  if(isnan(polygon_max[0]))
+  if(!have_max)
   {
+    have_border_max =
     _polygon_border_get_XY(segment_start[0], segment_start[1], segment_start[2], segment_start[3],
                            segment_end[2], segment_end[3], segment_end[0], segment_end[1], t_max,
                            segment_start[4]
@@ -454,27 +462,37 @@ static void _polygon_points_recurs(float *segment_start, float *segment_end,
 
     if(with_border)
     {
+      /* one end of the span may have had no direction to offset along; borrow the other's */
+      if(!have_border_max && have_border_min)
+      {
+        border_max[0] = border_min[0];
+        border_max[1] = border_min[1];
+        have_border_max = TRUE;
+      }
       dt_masks_dynbuf_add_2(draw_border, border_max[0], border_max[1]);
       result_border[0] = border_max[0];
       result_border[1] = border_max[1];
+      if(!IS_NULL_PTR(out_have_border)) *out_have_border = have_border_max;
     }
     return;
   }
 
   // we split in two part
   double t_mid = (t_min + t_max) / 2.0;
-  float polygon_mid[2] = { NAN, NAN };
-  float border_mid[2] = { NAN, NAN };
+  float polygon_mid[2] = { 0.0f, 0.0f };
+  float border_mid[2] = { 0.0f, 0.0f };
   float polygon_result_left[2] = { 0 };
   float border_result_left[2] = { 0 };
   _polygon_points_recurs(segment_start, segment_end, t_min, t_mid,
                          polygon_min, polygon_mid, border_min, border_mid,
                          polygon_result_left, border_result_left,
-                         draw_points, draw_border, with_border, pixel_threshold);
+                         draw_points, draw_border, with_border, pixel_threshold,
+                         have_min, FALSE, have_border_min, FALSE, NULL);
   _polygon_points_recurs(segment_start, segment_end, t_mid, t_max,
                          polygon_result_left, polygon_max, border_result_left, border_max,
                          result_polygon, result_border,
-                         draw_points, draw_border, with_border, pixel_threshold);
+                         draw_points, draw_border, with_border, pixel_threshold,
+                         TRUE, have_max, TRUE, have_border_max, out_have_border);
 }
 
 // Maximum number of self-intersection portions to track;
@@ -504,29 +522,10 @@ static int _polygon_find_self_intersection(dt_masks_dynbuf_t *intersections,
 
   for(int i = node_count * 3; i < border_point_count; i++)
   {
-    if(isnan(border_points[i * 2]) || isnan(border_points[i * 2 + 1]))
-    {
-      // find nearest previous valid point; if at start, wrap to last valid point
-      int prev = i - 1;
-      while(prev >= node_count * 3
-            && (isnan(border_points[prev * 2]) || isnan(border_points[prev * 2 + 1]))) prev--;
-      if(prev < node_count * 3)
-      {
-        // wrap to last valid point in buffer
-        prev = border_point_count - 1;
-        while(prev >= node_count * 3
-              && (isnan(border_points[prev * 2]) || isnan(border_points[prev * 2 + 1]))) prev--;
-      }
-      if(prev >= node_count * 3)
-      {
-        border_points[i * 2] = border_points[prev * 2];
-        border_points[i * 2 + 1] = border_points[prev * 2 + 1];
-      }
-      else
-      {
-        continue; // skip if no valid point found
-      }
-    }
+    /* No NaN test here any more. dt_masks_get_points_border() guarantees these buffers hold
+     * finite geometry -- everything a consumer must not use travels beside them, in the
+     * exclusion list -- so the hole-filling this replaces had nothing left to fill, and it did
+     * it by MUTATING a buffer this function does not own. */
     if(xmin_f > border_points[i * 2])
     {
       xmin_f = border_points[i * 2];
@@ -858,8 +857,10 @@ static int _polygon_get_pts_border(dt_develop_t *develop, dt_masks_form_t *mask_
     float cmin[2] = { NAN, NAN };
     float cmax[2] = { NAN, NAN };
 
+    gboolean have_rb = FALSE;
     _polygon_points_recurs(p1, p2, 0.0, 1.0, cmin, cmax, bmin, bmax, rc, rb, dpoints, dborder,
-                           border_buffer && (node_count >= 3), pixel_threshold);
+                           border_buffer && (node_count >= 3), pixel_threshold,
+                           FALSE, FALSE, FALSE, FALSE, &have_rb);
 
     // we check gaps in the border (sharp edges)
     if(dborder)
@@ -879,19 +880,13 @@ static int _polygon_get_pts_border(dt_develop_t *develop, dt_masks_form_t *mask_
 
     if(dborder)
     {
-      if(isnan(rb[0]))
+      if(!have_rb)
       {
-        float lastb0 = dt_masks_dynbuf_get(dborder, -2);
-        float lastb1 = dt_masks_dynbuf_get(dborder, -1);
-        if(isnan(lastb0))
-        {
-          lastb0 = dt_masks_dynbuf_get(dborder, -4);
-          lastb1 = dt_masks_dynbuf_get(dborder, -3);
-          dt_masks_dynbuf_set(dborder, -2, lastb0);
-          dt_masks_dynbuf_set(dborder, -1, lastb1);
-        }
-        rb[0] = lastb0;
-        rb[1] = lastb1;
+        /* the segment had no direction to offset along anywhere; hold the last border sample so
+         * the buffer stays continuous geometry. The nested "and if THAT one was NaN too" case
+         * this replaces cannot arise any more: nothing writes a sentinel into the buffer. */
+        rb[0] = dt_masks_dynbuf_get(dborder, -2);
+        rb[1] = dt_masks_dynbuf_get(dborder, -1);
       }
       dt_masks_dynbuf_add_2(dborder, rb[0], rb[1]);
 
@@ -907,13 +902,10 @@ static int _polygon_get_pts_border(dt_develop_t *develop, dt_masks_form_t *mask_
       // we get the next point (start of the next segment)
       // t=0.00001f to workaround rounding effects with full optimization that result in bmax[0] NOT being set to
       // NAN when t=0 and the two points in p3 are identical (as is the case on a control node set to sharp corner)
-      _polygon_border_get_XY(p3[0], p3[1], p3[2], p3[3], p4[2], p4[3], p4[0], p4[1], 0.00001f, p3[4], cmin, cmin + 1,
-                          bmax, bmax + 1);
-      if(isnan(bmax[0]))
-      {
-        _polygon_border_get_XY(p3[0], p3[1], p3[2], p3[3], p4[2], p4[3], p4[0], p4[1], 0.00001f, p3[4], cmin,
-                            cmin + 1, bmax, bmax + 1);
-      }
+      if(!_polygon_border_get_XY(p3[0], p3[1], p3[2], p3[3], p4[2], p4[3], p4[0], p4[1], 0.00001f, p3[4],
+                                 cmin, cmin + 1, bmax, bmax + 1))
+        _polygon_border_get_XY(p3[0], p3[1], p3[2], p3[3], p4[2], p4[3], p4[0], p4[1], 0.00001f, p3[4],
+                               cmin, cmin + 1, bmax, bmax + 1);
       if(bmax[0] - rb[0] > 1 || bmax[0] - rb[0] < -1 || bmax[1] - rb[1] > 1 || bmax[1] - rb[1] < -1)
       {
         float bmin2[2] = { dt_masks_dynbuf_get(dborder, -22), dt_masks_dynbuf_get(dborder, -21) };
@@ -1266,15 +1258,14 @@ static void _polygon_get_sizes(struct dt_iop_module_t *module, dt_masks_form_t *
       const float fx = gui_points->border[i * 2];
       const float fy = gui_points->border[i * 2 + 1];
 
-      // ??? looks like when x border is nan then y is a point index
-      // see draw border in _polygon_events_post_expose.
-      if(!isnan(fx))
-      {
-        fp1[0] = fminf(fp1[0], fx);
-        fp2[0] = fmaxf(fp2[0], fx);
-        fp1[1] = fminf(fp1[1], fy);
-        fp2[1] = fmaxf(fp2[1], fy);
-      }
+      /* The "??? looks like when x border is nan then y is a point index" this replaces was a
+       * true reading of the in-band jump encoding, and the question mark was the problem: a
+       * coordinate buffer that sometimes holds an index, recognisable only by a NaN beside it.
+       * It is gone; the border is coordinates. */
+      fp1[0] = fminf(fp1[0], fx);
+      fp2[0] = fmaxf(fp2[0], fx);
+      fp1[1] = fminf(fp1[1], fy);
+      fp2[1] = fmaxf(fp2[1], fy);
     }
   }
 
@@ -1510,7 +1501,7 @@ static gboolean _polygon_border_handle_cb(const dt_masks_form_gui_points_t *gui_
   if(IS_NULL_PTR(gui_points) || node_index < 0 || node_index >= node_count) return FALSE;
   *handle_x = gui_points->border[node_index * 6];
   *handle_y = gui_points->border[node_index * 6 + 1];
-  return !(isnan(*handle_x) || isnan(*handle_y));
+  return TRUE;
 }
 
 /**
@@ -2229,39 +2220,15 @@ static int _polygon_events_mouse_moved(struct dt_iop_module_t *module, double x,
  * @brief Draw a polygon or border polyline, skipping NaN points.
  */
 static void _polygon_draw_shape(struct dt_develop_t *dev, cairo_t *cr, const float *point_buffer, const int point_count,
-                                const int node_count, const gboolean draw_border, const gboolean draw_source)
+                                const int node_count, const gboolean draw_border, const gboolean draw_source,
+                                const dt_masks_skip_range_t *skips, const int skip_count)
 {
-
-  // Find the first valid non-NaN point to start drawing
-  // FIXME: Why not just avoid having NaN points in the array?
-  int start_idx = -1;
-  for(int point_index = node_count * 3 + draw_border; point_index < point_count; point_index++)
-  {
-    if(!isnan(point_buffer[point_index * 2]) && !isnan(point_buffer[point_index * 2 + 1]))
-    {
-      start_idx = point_index;
-      break;
-    }
-  }
-
-  // Only draw if we have at least one valid point
-  if(start_idx >= 0)
-  {
-    /* Decimate to device resolution, as the brush does; see dt_draw_min_emit_step(). */
-    const double min_step = dt_draw_min_emit_step(cr);
-    const double min_step2 = min_step * min_step;
-    double last_x = point_buffer[start_idx * 2], last_y = point_buffer[start_idx * 2 + 1];
-    cairo_move_to(cr, last_x, last_y);
-    for(int point_index = start_idx + 1; point_index < point_count; point_index++)
-    {
-      const double x = point_buffer[point_index * 2], y = point_buffer[point_index * 2 + 1];
-      if(isnan(x) || isnan(y)) continue;
-      const double dx = x - last_x, dy = y - last_y;
-      if((dx * dx + dy * dy) < min_step2) continue;
-      cairo_line_to(cr, x, y);
-      last_x = x; last_y = y;
-    }
-  }
+  /* This used to ignore the exclusion list and test the buffer for NaN instead -- which polygon
+   * never writes, since its cuts have travelled out-of-band since the #1313 refactor. So the
+   * test matched nothing and the folds were drawn. Honouring the list is the fix and costs one
+   * call: it is the same walk the brush does, because it is the same question. */
+  dt_masks_draw_outline_runs(cr, point_buffer, node_count * 3 + draw_border, point_count,
+                             skips, skip_count);
 }
 
 /**
@@ -2320,7 +2287,7 @@ static void _polygon_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks_
     {
       dt_draw_shape_lines(mask_gui->dev, DT_MASKS_DASH_STICK, FALSE, cr, node_count, (mask_gui->border_selected), zoom_scale,
                           gui_points->border, gui_points->border_count, &dt_masks_functions_polygon.draw_shape,
-                          CAIRO_LINE_CAP_ROUND);
+                          CAIRO_LINE_CAP_ROUND, gui_points->border_skips, gui_points->border_skip_count);
     }
 
     // draw the current node's handle if it's a curve node

--- a/src/develop/masks_debug.h
+++ b/src/develop/masks_debug.h
@@ -1,0 +1,114 @@
+/*
+    This file is part of Ansel,
+    Copyright (C) 2026 Aurélien PIERRE.
+
+    Ansel is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Ansel is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Ansel.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+/** @file develop/masks_debug.h
+ *
+ * @brief Render a mask's rasterisation and its GUI overlay to an image file, headlessly.
+ *
+ * @details Mask defects come in two kinds that are easy to confuse and were confused, at cost:
+ * the RASTER is wrong (the alpha the pipeline blends with), or the OVERLAY is wrong (what the
+ * darkroom draws on top of it). A brush cusp losing coverage and a dashed outline drawing
+ * self-intersecting circles are different bugs in different layers, and a fix aimed at the
+ * wrong one is how an always-FALSE flag came to delete geometry the rasteriser needed in order
+ * to tidy a line the GUI drew.
+ *
+ * So this renders BOTH, from one call, with the backdrop chosen by the caller: the overlay
+ * alone, over black, or over the rasterised alpha. Seeing them superimposed is what tells the
+ * two kinds apart at a glance.
+ *
+ * The overlay half runs THE PRODUCTION CODE -- dt_masks_events_post_expose_with(), the same
+ * function the darkroom calls, differing only in the transform it is handed. A separate
+ * drawing path for diagnostics would be a fork that stops agreeing with the GUI exactly when
+ * it is needed to explain a GUI problem.
+ *
+ * Implemented in src/develop/masks/masks_debug.c.
+ */
+
+#ifndef DT_DEVELOP_MASKS_DEBUG_H
+#define DT_DEVELOP_MASKS_DEBUG_H
+
+#include <glib.h>
+
+struct dt_develop_t;
+struct dt_masks_form_t;
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** @brief What the overlay is drawn on top of. */
+typedef enum dt_masks_debug_backdrop_t
+{
+  DT_MASKS_DEBUG_BACKDROP_TRANSPARENT = 0, /**< nothing: the overlay's own geometry, isolated */
+  DT_MASKS_DEBUG_BACKDROP_BLACK,           /**< opaque black: the overlay as the eye sees it */
+  DT_MASKS_DEBUG_BACKDROP_RASTER,          /**< the rasterised alpha in grey: the two layers superimposed */
+} dt_masks_debug_backdrop_t;
+
+/** @brief What to render. Zeroed means: raster only, at full image resolution, on black. */
+typedef struct dt_masks_debug_request_t
+{
+  /** Output size. 0 takes the image's raw size; a width alone keeps the aspect. */
+  int width, height;
+  dt_masks_debug_backdrop_t backdrop;
+  /** Run the GUI overlay code over the backdrop. */
+  gboolean draw_overlay;
+} dt_masks_debug_request_t;
+
+/**
+ * @brief Rasterise @p form into a freshly allocated width*height float buffer, 0..1.
+ *
+ * @details No pipeline distortion is applied: the shape is drawn against the raw image
+ * geometry, which is what a geometry regression wants to see -- a difference then means the
+ * mask code changed, not that some other module's distortion did.
+ *
+ * @return the buffer (free with dt_free), or NULL. @p form may be a group.
+ */
+float *dt_masks_debug_rasterise(struct dt_develop_t *dev, struct dt_masks_form_t *form,
+                                int width, int height);
+
+/**
+ * @brief Render @p form per @p request and write it to @p path as a PNG.
+ *
+ * @return TRUE on success. @p form NULL uses the dev's currently visible form.
+ */
+gboolean dt_masks_debug_write_png(struct dt_develop_t *dev, struct dt_masks_form_t *form,
+                                  const dt_masks_debug_request_t *request, const char *path);
+
+/**
+ * @brief Write the shape's outline buffers to @p path as CSV: index, centreline, border.
+ *
+ * @details The mask is the union of segments drawn from each centreline sample to its border
+ * sample, so when coverage goes missing the answer is in these two arrays and nowhere else --
+ * which sample stopped moving, where the border jumped, which directions were never visited.
+ * Reading them beats reasoning about the recursion that produced them: three theories about
+ * the cusp defect died against this data before the right one survived it.
+ */
+gboolean dt_masks_debug_write_outline_csv(struct dt_develop_t *dev, struct dt_masks_form_t *form,
+                                          const char *path);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // DT_DEVELOP_MASKS_DEBUG_H
+
+// clang-format off
+// modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py
+// vim: shiftwidth=2 expandtab tabstop=2 cindent
+// kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;
+// clang-format on

--- a/src/develop/masks_gui.h
+++ b/src/develop/masks_gui.h
@@ -367,6 +367,14 @@ static inline float dt_masks_border_from_projected_handle(dt_develop_t *dev, con
 
 // Circle, ellipse and gradient creation previews all follow the same drawing sequence:
 // optional save/restore, draw the shape, then draw the border preview if present.
+/** Append a shape's outline to @p cr as the complement of its exclusion list: one cairo sub-path
+ * per run between the spans in @p skips, which are where the offset curve doubles back on itself
+ * and must not be drawn. Pass NULL and 0 for a shape with nothing to exclude. Implemented in
+ * masks/masks_gui.c -- see there for why the excluded spans travel beside the buffer and not
+ * inside it. */
+void dt_masks_draw_outline_runs(cairo_t *cr, const float *const points, const int first, const int last,
+                                const dt_masks_skip_range_t *skips, const int skip_count);
+
 static inline void dt_masks_draw_preview_shape(struct dt_develop_t *dev, cairo_t *cr, const float zoom_scale,
                                                const int num_points,
                                                float *points, const int points_count,
@@ -380,10 +388,11 @@ static inline void dt_masks_draw_preview_shape(struct dt_develop_t *dev, cairo_t
   if(save_restore) cairo_save(cr);
   if(points && points_count > 0)
     dt_draw_shape_lines(dev, DT_MASKS_NO_DASH, source, cr, num_points, FALSE, zoom_scale, points, points_count,
-                        draw_shape, shape_cap);
+                        draw_shape, shape_cap, NULL, 0);
   if(border && border_count > 0)
+    /* a creation preview is drawn while the shape is still being placed: it has no cuts yet */
     dt_draw_shape_lines(dev, DT_MASKS_DASH_STICK, source, cr, num_points, FALSE, zoom_scale, border, border_count,
-                        draw_shape, border_cap);
+                        draw_shape, border_cap, NULL, 0);
   if(save_restore) cairo_restore(cr);
 }
 

--- a/src/develop/masks_gui.h
+++ b/src/develop/masks_gui.h
@@ -525,6 +525,31 @@ void dt_masks_draw_path_seg_by_seg(cairo_t *cr, dt_masks_form_gui_t *gui, const 
                                    const int points_count, const int node_count, const float zoom_scale,
                                    const gboolean round_ends);
 
+/**
+ * @brief How the overlay maps image coordinates onto its cairo target.
+ *
+ * @details The darkroom passes NULL and the mapping comes from the viewport -- zoom, pan, and
+ * the GUI's device pixel ratio. None of that exists outside the GUI: dt_gui_get_global() is
+ * darktable.gui, which is NULL in ansel-cli and in the test binaries, so the viewport path
+ * would dereference it. A headless caller supplies its own mapping instead, which is also what
+ * a regression test wants -- a fixed, reproducible transform rather than whatever the window
+ * happened to be showing.
+ *
+ * This exists so the OVERLAY IS DRAWN BY THE SAME CODE in both cases. The alternative -- a
+ * second drawing path for diagnostics -- would be a fork that stops agreeing with the GUI
+ * exactly when it is needed to explain a GUI problem.
+ */
+typedef struct dt_masks_overlay_transform_t
+{
+  double scale;               /**< image pixels -> target pixels */
+  double offset_x, offset_y;  /**< target-space translation, applied before the scale */
+} dt_masks_overlay_transform_t;
+
+/** @brief Draw the mask overlay with an explicit mapping; @p transform NULL means the viewport's. */
+void dt_masks_events_post_expose_with(dt_develop_t *dev, struct dt_iop_module_t *module, cairo_t *cr,
+                                      int32_t width, int32_t height, int32_t pointerx, int32_t pointery,
+                                      const dt_masks_overlay_transform_t *transform);
+
 void dt_masks_events_post_expose(dt_develop_t *dev, struct dt_iop_module_t *module, cairo_t *cr, int32_t width, int32_t height,
                                  int32_t pointerx, int32_t pointery);
 int dt_masks_events_mouse_leave(struct dt_iop_module_t *module);

--- a/src/develop/masks_gui.h
+++ b/src/develop/masks_gui.h
@@ -65,6 +65,10 @@ typedef struct dt_masks_form_gui_points_t
   int points_count;
   float *border;   // border points in absolute coordinates in output image space
   int border_count;
+  // Self-intersection cuts of `border', out-of-band -- see dt_masks_skip_range_t. NULL/0 for
+  // every shape whose border cannot fold over itself (all but polygon today).
+  dt_masks_skip_range_t *border_skips;
+  int border_skip_count;
   float *source;   // source point in absolute coordinates in output image space
   int source_count;
   gboolean clockwise;
@@ -617,7 +621,6 @@ dt_masks_form_group_t *dt_masks_group_add_form_with_state(dt_develop_t *dev, dt_
                                                           dt_masks_state_t state, float opacity);
 
 /** utils functions */
-int dt_masks_point_in_form_exact(const float *pts, int num_pts, const float *points, int points_start, int points_count);
 
 /** allow to select a shape inside an iop */
 void dt_masks_select_form(dt_develop_t *dev, struct dt_iop_module_t *module, dt_masks_form_t *sel);

--- a/src/develop/masks_types.h
+++ b/src/develop/masks_types.h
@@ -198,6 +198,33 @@ typedef struct dt_masks_form_info_t
   char            name[DT_MASKS_FORM_NAME_LEN];
 } dt_masks_form_info_t;
 
+/**
+ * @brief One cut in a shape's border outline: while walking the border buffer forward, on
+ * reaching index `jump_from`, resume at index `resume_at`.
+ *
+ * @details A polygon's border is its path offset outward by the feathering radius, and that
+ * offset curve folds over itself at every concave run tighter than the radius. The folds are
+ * found by _polygon_find_self_intersection() and must be skipped by every walk that counts
+ * crossings (the hit-test and the rasterisers), or the fold is filled as if it were shape.
+ *
+ * These used to travel IN-BAND, encoded into the border buffer itself: NaN in the x slot,
+ * the jump target smuggled as an integer in the float y slot. Both bugs this mechanism ever
+ * had lived in that encoding, not in the geometry -- a cycle when overlapping ranges pointed
+ * into each other (fixed by sorting and merging), then issue #1313, where a fold straddling
+ * the buffer seam was encoded as its own complement and swallowed 99.8% of the contour. An
+ * out-of-band range cannot express either mistake: `resume_at > jump_from` IS the
+ * forward-only invariant, checkable at a glance and validated by the consumers.
+ *
+ * Invariants a producer must guarantee (dt_masks_skip_ranges_build() does):
+ *   - resume_at > jump_from (every skip moves the walk strictly forward);
+ *   - ranges sorted by jump_from and pairwise disjoint (resume_at < next jump_from).
+ */
+typedef struct dt_masks_skip_range_t
+{
+  int jump_from;
+  int resume_at;
+} dt_masks_skip_range_t;
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/tests/unittests/CMakeLists.txt
+++ b/src/tests/unittests/CMakeLists.txt
@@ -20,6 +20,7 @@ set(DATABASE_UNIT_TESTS
   test_dtpthread_recursive
   test_history_snapshot
   test_masks_raster_contract
+  test_masks_skip_ranges
 )
 
 foreach(test ${DATABASE_UNIT_TESTS})

--- a/src/tests/unittests/test_masks_raster_contract.c
+++ b/src/tests/unittests/test_masks_raster_contract.c
@@ -155,7 +155,7 @@ static void _an_unbuildable_outline_is_never_reported_as_built(void **state)
     // with *points still NULL is what marked the cache current over an outline that had never
     // been built, hiding the shape until the geometry generation next changed.
     assert_int_not_equal(dt_masks_get_points_border(NULL, &form, &points, &points_count, &border,
-                                                    &border_count, 0, NULL),
+                                                    &border_count, NULL, NULL, 0, NULL),
                          DT_MASKS_RASTER_OK);
     assert_null(points);
   }

--- a/src/tests/unittests/test_masks_skip_ranges.c
+++ b/src/tests/unittests/test_masks_skip_ranges.c
@@ -1,0 +1,216 @@
+/*
+    This file is part of Ansel,
+    Copyright (C) 2026 Aurélien PIERRE.
+
+    Ansel is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Ansel is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Ansel.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+/** The self-intersection cut mechanism, pinned as a producer/consumer pair.
+ *
+ * A polygon's border folds over itself at concave runs tighter than the feathering radius;
+ * the folds are cut out of every crossing-count walk. The cuts used to travel IN-BAND, as NaN
+ * jump sentinels encoded into the border buffer, and both bugs the mechanism ever shipped
+ * lived in that encoding while the geometry was right: overlapping ranges once trapped the
+ * reader in a cycle it exited silently with a garbage crossing count, and issue #1313 encoded
+ * a fold straddling the buffer seam as its own complement, swallowing 99.8% of the contour
+ * into one straight chord. These tests pin the out-of-band replacement against exactly those
+ * two histories: the builder must refuse to emit what broke, and the walk must refuse to
+ * follow it if handed anyway.
+ */
+
+#include "develop/masks_types.h"             // dt_masks_skip_range_t
+#include "develop/masks/masks_functions.h"    // the builder and the walk
+
+#include <stdarg.h>
+#include <stddef.h>
+// cmocka.h declares `extern jmp_buf global_expect_assert_env' at file scope without including
+// <setjmp.h> itself, so this include is FOR cmocka.h and clang-tidy cannot attribute it.
+#include <setjmp.h>  // IWYU pragma: keep
+#include <stdint.h>
+#include <cmocka.h>
+
+/* ---------------------------------------------------------------------------------------
+ * dt_masks_skip_ranges_build(): the producer half.
+ * ------------------------------------------------------------------------------------- */
+
+static void _build_normalizes_discovery_order(void **state)
+{
+  (void)state;
+  // Discovery walks from a shape extremum, so either index of a pair can come first.
+  const float pairs[] = { 20.f, 10.f };
+  dt_masks_skip_range_t out[1];
+  int dropped = -1;
+
+  assert_int_equal(dt_masks_skip_ranges_build(pairs, 1, 100, out, &dropped), 1);
+  assert_int_equal(out[0].jump_from, 10);
+  assert_int_equal(out[0].resume_at, 20);
+  assert_int_equal(dropped, 0);
+}
+
+static void _build_drops_a_fold_that_straddles_the_seam(void **state)
+{
+  (void)state;
+  /* The literal pairs of issue #1313, on its literal border size. Each fold spans 330-454
+   * points the short way round the closed contour; [min, max] would name the ~147000-point
+   * complement, and merging would then swallow every other cut into one range covering 99.8%
+   * of the shape -- the reported straight chord. */
+  const float pairs[] = { 147487.f, 271.f,
+                          147457.f, 301.f,
+                          147503.f, 411.f,
+                          95500.f, 95703.f };
+  dt_masks_skip_range_t out[4];
+  int dropped = -1;
+
+  assert_int_equal(dt_masks_skip_ranges_build(pairs, 4, 147546, out, &dropped), 1);
+  assert_int_equal(dropped, 3);
+  // the one genuine forward fold survives untouched
+  assert_int_equal(out[0].jump_from, 95500);
+  assert_int_equal(out[0].resume_at, 95703);
+}
+
+static void _build_merges_overlapping_and_nested_ranges(void **state)
+{
+  (void)state;
+  /* Overlapping ranges written independently are the cycle bug: two cuts pointing into each
+   * other trapped the read walk until its visit cap fired, silently. Merged and disjoint,
+   * every skip moves strictly forward. The (22, 18) pair is deliberately reversed AND nested. */
+  const float pairs[] = { 10.f, 20.f, 15.f, 25.f, 30.f, 35.f, 22.f, 18.f };
+  dt_masks_skip_range_t out[4];
+
+  assert_int_equal(dt_masks_skip_ranges_build(pairs, 4, 100, out, NULL), 2);
+  assert_int_equal(out[0].jump_from, 10);
+  assert_int_equal(out[0].resume_at, 25);
+  assert_int_equal(out[1].jump_from, 30);
+  assert_int_equal(out[1].resume_at, 35);
+  // disjoint and sorted IS the forward-only guarantee
+  assert_true(out[0].resume_at < out[1].jump_from);
+}
+
+static void _build_rejects_garbage(void **state)
+{
+  (void)state;
+  const float pairs[] = { -1.f, 5.f, 5.f, 5.f, 50.f, 150.f };
+  dt_masks_skip_range_t out[3];
+  int dropped = -1;
+
+  // out-of-bounds and zero-length pairs vanish without becoming ranges OR "wrapping" stats
+  assert_int_equal(dt_masks_skip_ranges_build(pairs, 3, 100, out, &dropped), 0);
+  assert_int_equal(dropped, 0);
+
+  assert_int_equal(dt_masks_skip_ranges_build(NULL, 3, 100, out, NULL), 0);
+  assert_int_equal(dt_masks_skip_ranges_build(pairs, 0, 100, out, NULL), 0);
+}
+
+/* ---------------------------------------------------------------------------------------
+ * dt_masks_point_in_form_exact(): the consumer half.
+ *
+ * The contour is a square with a bump on its top edge:
+ *
+ *        5 ----- 4
+ *        |       |          bump: indices 3..6
+ *   7 -- 6       3 -- 2
+ *   |                 |
+ *   0 --------------- 1
+ *
+ * Cutting the bump with the range {3 -> 7} closes the contour with the chord (10,10)-(0,10):
+ * a point inside the bump is inside the full contour and OUTSIDE the cut one. That chord is
+ * exactly what a skipped self-intersection fold renders as.
+ * ------------------------------------------------------------------------------------- */
+
+static const float _bumped_square[] = {
+  0.f, 0.f,   10.f, 0.f,   10.f, 10.f,   6.f, 10.f,
+  6.f, 14.f,  4.f, 14.f,   4.f, 10.f,    0.f, 10.f,
+};
+#define BUMPED_COUNT 8
+
+static void _walk_answers_the_plain_contour(void **state)
+{
+  (void)state;
+  const float inside[2] = { 5.f, 5.f };
+  const float in_bump[2] = { 5.f, 12.f };
+  const float outside[2] = { 20.f, 5.f };
+
+  assert_int_equal(dt_masks_point_in_form_exact(inside, 1, _bumped_square, 0, BUMPED_COUNT, NULL, 0), 0);
+  assert_int_equal(dt_masks_point_in_form_exact(in_bump, 1, _bumped_square, 0, BUMPED_COUNT, NULL, 0), 0);
+  assert_int_equal(dt_masks_point_in_form_exact(outside, 1, _bumped_square, 0, BUMPED_COUNT, NULL, 0), -1);
+}
+
+static void _a_cut_closes_the_contour_with_a_chord(void **state)
+{
+  (void)state;
+  const dt_masks_skip_range_t cut = { .jump_from = 3, .resume_at = 7 };
+  const float in_bump[2] = { 5.f, 12.f };
+  const float inside[2] = { 5.f, 5.f };
+
+  // the bump is walked out of existence...
+  assert_int_equal(dt_masks_point_in_form_exact(in_bump, 1, _bumped_square, 0, BUMPED_COUNT, &cut, 1), -1);
+  // ...and the rest of the shape is untouched
+  assert_int_equal(dt_masks_point_in_form_exact(inside, 1, _bumped_square, 0, BUMPED_COUNT, &cut, 1), 0);
+}
+
+static void _a_backward_cut_is_refused_not_followed(void **state)
+{
+  (void)state;
+  /* The cycle bug, replayed at the consumer: a skip that moves the walk backwards would
+   * re-walk the span it just left until the visit cap fires, and the crossing count would be
+   * garbage served as an answer. The walk must IGNORE such a range -- same answers as with no
+   * cuts at all -- and, above all, terminate. */
+  const dt_masks_skip_range_t backward = { .jump_from = 3, .resume_at = 2 };
+  const dt_masks_skip_range_t out_of_bounds = { .jump_from = 3, .resume_at = 99 };
+  const float in_bump[2] = { 5.f, 12.f };
+
+  assert_int_equal(dt_masks_point_in_form_exact(in_bump, 1, _bumped_square, 0, BUMPED_COUNT, &backward, 1), 0);
+  assert_int_equal(dt_masks_point_in_form_exact(in_bump, 1, _bumped_square, 0, BUMPED_COUNT, &out_of_bounds, 1), 0);
+}
+
+static void _the_seam_bug_end_to_end(void **state)
+{
+  (void)state;
+  /* Issue #1313 in miniature, producer to consumer: the detector reports the bump fold as the
+   * pair (7, 3) -- discovery met the larger index first, and the fold happens to sit against
+   * the walk's wrap. Encoded as [min, max] = [3, 7] it cuts the bump (correct, forward, short
+   * arc). But a pair like (7, 1) whose short arc wraps the seam CANNOT be a forward range: the
+   * builder must drop it, and the walk must then still see the bump. */
+  const float wrapping_pair[] = { 7.f, 1.f };
+  dt_masks_skip_range_t out[1];
+  int dropped = 0;
+
+  const int n = dt_masks_skip_ranges_build(wrapping_pair, 1, BUMPED_COUNT, out, &dropped);
+  assert_int_equal(n, 0);
+  assert_int_equal(dropped, 1);
+
+  const float in_bump[2] = { 5.f, 12.f };
+  assert_int_equal(dt_masks_point_in_form_exact(in_bump, 1, _bumped_square, 0, BUMPED_COUNT, out, n), 0);
+}
+
+int main(void)
+{
+  const struct CMUnitTest tests[] = {
+    cmocka_unit_test(_build_normalizes_discovery_order),
+    cmocka_unit_test(_build_drops_a_fold_that_straddles_the_seam),
+    cmocka_unit_test(_build_merges_overlapping_and_nested_ranges),
+    cmocka_unit_test(_build_rejects_garbage),
+    cmocka_unit_test(_walk_answers_the_plain_contour),
+    cmocka_unit_test(_a_cut_closes_the_contour_with_a_chord),
+    cmocka_unit_test(_a_backward_cut_is_refused_not_followed),
+    cmocka_unit_test(_the_seam_bug_end_to_end),
+  };
+  return cmocka_run_group_tests(tests, NULL, NULL);
+}
+
+// clang-format off
+// modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py
+// vim: shiftwidth=2 expandtab tabstop=2 cindent
+// kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;
+// clang-format on

--- a/src/widgets/draw.h
+++ b/src/widgets/draw.h
@@ -779,7 +779,20 @@ static inline void dt_draw_handle(cairo_t *cr, const float pt[2], const float zo
 // dev is the develop instance owning the shape being drawn. It is threaded explicitly so shape
 // drawing code never has to reach for the darktable.develop global (which would couple every
 // shape file to the whole application and hide which instance is read).
-typedef void (*shape_draw_function_t)(struct dt_develop_t *dev, cairo_t *cr, const float *points, const int points_count, const int nb, const gboolean border, const gboolean source);
+//
+// skips/skip_count are the shape's EXCLUSION LIST: the spans of the outline that must not be
+// drawn, because the offset curve doubles back on itself there. They travel alongside the buffer
+// rather than inside it -- the alternative, and what this replaced, was blanking those samples to
+// NaN and having every walker test for it. That encoding hides in a buffer of plain floats, has
+// to be re-learned by each new consumer, and is silently wrong for any consumer that forgets:
+// see the entry in masks_types.h for the two bugs it hosted. A shape with nothing to exclude
+// passes NULL and 0.
+//
+// Declared as a struct tag so this header stays free of masks_types.h -- a widget helper has no
+// business inheriting the masks vocabulary.
+struct dt_masks_skip_range_t;
+typedef void (*shape_draw_function_t)(struct dt_develop_t *dev, cairo_t *cr, const float *points, const int points_count, const int nb, const gboolean border, const gboolean source,
+                                      const struct dt_masks_skip_range_t *skips, const int skip_count);
 
 /**
  * @brief Draw the lines of a mask shape.
@@ -795,7 +808,8 @@ typedef void (*shape_draw_function_t)(struct dt_develop_t *dev, cairo_t *cr, con
  * @param functions the functions table of the shape
  */
 static inline void dt_draw_shape_lines(struct dt_develop_t *dev, const dt_draw_dash_type_t dash_type, const gboolean source, cairo_t *cr, const int nb, const gboolean selected,
-                const float zoom_scale, const float *points, const int points_count, const shape_draw_function_t *draw_shape_func, const cairo_line_cap_t line_cap)
+                const float zoom_scale, const float *points, const int points_count, const shape_draw_function_t *draw_shape_func, const cairo_line_cap_t line_cap,
+                const struct dt_masks_skip_range_t *skips, const int skip_count)
 {
   cairo_save(cr);
 
@@ -805,7 +819,7 @@ static inline void dt_draw_shape_lines(struct dt_develop_t *dev, const dt_draw_d
 
   // Draw the shape from the integrated function if any
   if(points && points_count >= 2 && draw_shape_func)
-    (*draw_shape_func)(dev, cr, points, points_count, nb, border, FALSE);
+    (*draw_shape_func)(dev, cr, points, points_count, nb, border, FALSE, skips, skip_count);
 
   const dt_draw_dash_type_t dash = (dash_type && !source)
                                   ? dash_type : DT_MASKS_NO_DASH;
@@ -868,7 +882,7 @@ static inline double dt_draw_min_emit_step(cairo_t *cr)
 static inline void dt_draw_stroke_line(const dt_draw_dash_type_t dash_type, const gboolean source, cairo_t *cr,
                           const gboolean selected, const float zoom_scale, const cairo_line_cap_t line_cap)
 {
-  dt_draw_shape_lines(NULL, dash_type, source, cr, 0, selected, zoom_scale, NULL, 0, NULL, line_cap);
+  dt_draw_shape_lines(NULL, dash_type, source, cr, 0, selected, zoom_scale, NULL, 0, NULL, line_cap, NULL, 0);
 }
 
 static void _draw_arrow_head(cairo_t *cr, const float arrow[2], const float arrow_x_a, const float arrow_y_a,
@@ -1007,7 +1021,8 @@ static inline void dt_draw_source_shape(struct dt_develop_t *dev, cairo_t *cr, c
   dt_draw_set_dash_style(cr, DT_MASKS_NO_DASH, zoom_scale);
 
   if(draw_shape_func)
-    (*draw_shape_func)(dev, cr, source_pts, source_pts_count, nodes_nb, FALSE, TRUE);
+    /* a source outline is a copy of the shape placed elsewhere; it carries no cuts */
+    (*draw_shape_func)(dev, cr, source_pts, source_pts_count, nodes_nb, FALSE, TRUE, NULL, 0);
 
   //dark line
   if(selected)

--- a/src/widgets/draw.h
+++ b/src/widgets/draw.h
@@ -813,6 +813,14 @@ static inline void dt_draw_shape_lines(struct dt_develop_t *dev, const dt_draw_d
 {
   cairo_save(cr);
 
+  /* An overlay is guide lines about a pixel wide, not artwork: cairo's best-quality analytic
+   * coverage buys nothing visible here and costs about half the time of drawing them. Measured
+   * per shape per frame at fit zoom on issue #1313's raw: 2.05 -> 1.20 ms for the brush's border,
+   * 1.39 -> 0.78 ms for polygon #2's. Scoped by the cairo_save() above, so nothing else -- the
+   * node handles in particular, which are small filled discs where the difference would show --
+   * inherits it. */
+  cairo_set_antialias(cr, CAIRO_ANTIALIAS_FAST);
+
   cairo_set_line_cap(cr, line_cap);
   // Are we drawing a border ?
   const gboolean border = (dash_type != DT_MASKS_NO_DASH);
@@ -873,7 +881,20 @@ static inline void dt_draw_shape_lines(struct dt_develop_t *dev, const dt_draw_d
  */
 static inline double dt_draw_min_emit_step(cairo_t *cr)
 {
-  double dx = 0.5, dy = 0.5;
+  /* ONE device pixel, not half of one.
+   *
+   * Nothing an overlay draws is finer than the 1 px line it is drawn with, so a chord shorter
+   * than a pixel cannot show: the deviation a straight chord makes from the curve it replaces is
+   * step^2 / 8R, which for a 1 px chord is under an eighth of a pixel for any curve of radius
+   * 1 px or more. What it costs is real -- measured on issue #1313's brush at fit zoom, the
+   * dashed border went from 2163 segments and 2.05 ms per frame to 1098 and 1.85 ms with the
+   * default antialiasing, and 1.20 -> 0.76 ms with ANTIALIAS_FAST below.
+   *
+   * Do NOT read that as "coarser is always better". The cost is not per-segment: the same
+   * polyline split into 1, 11 or 57 separately stroked pieces measures 4.9, 3.8 and 3.7 ms, so
+   * batching strokes buys nothing and the per-segment styling that costs is free. What the step
+   * buys is fewer edges for the rasteriser, and it stops paying well before it starts to show. */
+  double dx = 1.0, dy = 1.0;
   cairo_device_to_user_distance(cr, &dx, &dy);
   const double step = fmin(fabs(dx), fabs(dy));
   return isfinite(step) ? step : 0.0;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -24,4 +24,21 @@ if(WIN32)
                         RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/..)
 endif(WIN32)
 
+add_executable(ansel-test-masks-geometry masks/masks_geometry.c)
+target_link_libraries(ansel-test-masks-geometry lib_ansel)
+target_include_directories(ansel-test-masks-geometry PRIVATE
+  ${CMAKE_SOURCE_DIR}/src
+  ${CMAKE_BINARY_DIR}/src)
+# The project builds with the INSTALL rpath, so binaries only resolve libansel.so once
+# installed. Give this one a build rpath, same as tests/unittests does and for the same reason.
+set_target_properties(ansel-test-masks-geometry PROPERTIES
+  SKIP_BUILD_RPATH FALSE
+  BUILD_WITH_INSTALL_RPATH FALSE
+  BUILD_RPATH "$<TARGET_FILE_DIR:lib_ansel>")
+target_compile_definitions(ansel-test-masks-geometry PRIVATE
+  ANSEL_TEST_SOURCE_DIR="${CMAKE_SOURCE_DIR}"
+  ANSEL_TEST_BINARY_DIR="${CMAKE_BINARY_DIR}")
+add_test(NAME masks_geometry
+         COMMAND ansel-test-masks-geometry ${CMAKE_BINARY_DIR}/masks-geometry)
+
 add_subdirectory(unittests)

--- a/tests/masks/masks_geometry.c
+++ b/tests/masks/masks_geometry.c
@@ -382,6 +382,127 @@ static const float _polygon_1788045925[15][8] = {
   { 0.099891551f, 0.033659276f, 0.098198950f, 0.043141894f, 0.101584166f, 0.024176663f, 0.021000000f, 1 },
 };
 
+
+/* ------------------------------------------------------------------------------------- */
+/* Baseline comparison.
+ *
+ * The oracle above answers "did the rasteriser deliver the coverage it owed", which is the
+ * question the reported defects were about. It cannot answer "did anything change" -- a shifted
+ * edge, a different feather ramp, an overlay that stopped drawing a handle all satisfy it. Most
+ * of what was actually found while fixing this series was found by rendering before and after and
+ * diffing, so that comparison belongs in the test rather than in somebody's scratch directory.
+ *
+ * The baselines live in the shared sample bank (tests/image_test/samples/baseline/masks-geometry),
+ * alongside the raw-export baselines and reviewed the same way -- regenerated deliberately,
+ * looked at, and committed. They are full resolution on purpose: the defects in this series are
+ * 1 to 5 pixels wide and a downscaled baseline would not see any of them.
+ *
+ * A tolerance rather than exact equality, because the overlay is antialiased by cairo and its
+ * output is not promised to be identical across cairo versions. Anything that moves geometry
+ * moves far more than this. */
+#define MASKS_BASELINE_MAX_DELTA 8       /* per channel, of 255 */
+#define MASKS_BASELINE_MAX_SHARE 0.0002  /* share of pixels allowed to differ at all */
+
+static const char *baseline_dir = NULL;
+static gboolean baseline_update = FALSE;
+static int baseline_missing = 0;
+
+/** Compare @p path against its baseline, or create the baseline when updating. Returns TRUE when
+ * the render is acceptable (or there is nothing to compare against). */
+static gboolean _baseline_check(const char *path, const char *name)
+{
+  if(IS_NULL_PTR(baseline_dir)) return TRUE;
+
+  char *base = g_strdup_printf("%s/%s.png", baseline_dir, name);
+
+  if(baseline_update)
+  {
+    /* never overwrite: an existing entry is reviewed, and silently replacing it is how a
+     * regression becomes the new reference. Delete it deliberately to refresh one. */
+    if(!g_file_test(base, G_FILE_TEST_EXISTS))
+    {
+      char *dirname = g_path_get_dirname(base);
+      g_mkdir_with_parents(dirname, 0755);
+      g_free(dirname);
+      GError *e = NULL;
+      char *content = NULL;
+      gsize len = 0;
+      if(g_file_get_contents(path, &content, &len, &e) && g_file_set_contents(base, content, len, &e))
+        printf("      baseline: added %s.png\n", name);
+      else
+      {
+        printf("      baseline: could NOT add %s.png (%s)\n", name, e ? e->message : "?");
+        if(e) g_error_free(e);
+      }
+      g_free(content);
+    }
+    g_free(base);
+    return TRUE;
+  }
+
+  if(!g_file_test(base, G_FILE_TEST_EXISTS))
+  {
+    baseline_missing++;
+    g_free(base);
+    return TRUE;   /* no baseline yet is not a failure; `update-baseline' adds it */
+  }
+
+  cairo_surface_t *a = cairo_image_surface_create_from_png(path);
+  cairo_surface_t *b = cairo_image_surface_create_from_png(base);
+  gboolean ok = TRUE;
+
+  if(cairo_surface_status(a) != CAIRO_STATUS_SUCCESS || cairo_surface_status(b) != CAIRO_STATUS_SUCCESS)
+  {
+    printf("      baseline: unreadable (%s)\n", name);
+    ok = FALSE;
+  }
+  else if(cairo_image_surface_get_width(a) != cairo_image_surface_get_width(b)
+          || cairo_image_surface_get_height(a) != cairo_image_surface_get_height(b))
+  {
+    printf("      baseline: %s is %dx%d, baseline is %dx%d\n", name,
+           cairo_image_surface_get_width(a), cairo_image_surface_get_height(a),
+           cairo_image_surface_get_width(b), cairo_image_surface_get_height(b));
+    ok = FALSE;
+  }
+  else
+  {
+    cairo_surface_flush(a);
+    cairo_surface_flush(b);
+    const int w = cairo_image_surface_get_width(a);
+    const int h = cairo_image_surface_get_height(a);
+    const int sa = cairo_image_surface_get_stride(a);
+    const int sb = cairo_image_surface_get_stride(b);
+    const uint8_t *pa = cairo_image_surface_get_data(a);
+    const uint8_t *pb = cairo_image_surface_get_data(b);
+
+    size_t differing = 0;
+    int worst = 0;
+    int wx = -1, wy = -1;
+    for(int y = 0; y < h; y++)
+      for(int x = 0; x < w; x++)
+        for(int c = 0; c < 3; c++)
+        {
+          const int d = abs((int)pa[y * sa + x * 4 + c] - (int)pb[y * sb + x * 4 + c]);
+          if(d == 0) continue;
+          if(c == 0) differing++;   /* count a pixel once */
+          if(d > worst) { worst = d; wx = x; wy = y; }
+        }
+
+    const double share = (double)differing / ((double)w * h);
+    if(worst > MASKS_BASELINE_MAX_DELTA || share > MASKS_BASELINE_MAX_SHARE)
+    {
+      printf("      baseline: %s differs -- %zu px (%.4f%%), worst %d at (%d,%d)\n",
+             name, differing, 100.0 * share, worst, wx, wy);
+      ok = FALSE;
+    }
+  }
+
+  cairo_surface_destroy(a);
+  cairo_surface_destroy(b);
+  g_free(base);
+  return ok;
+}
+
 static void _run_brush_case_at(dt_develop_t *dev, const float table[][9], const int count,
                                const char *name, const char *dir, const int budget_px,
                                const int img_w, const int img_h)
@@ -421,6 +542,13 @@ static void _run_brush_case_at(dt_develop_t *dev, const float table[][9], const 
   dt_masks_debug_write_png(dev, &form, &alpha_req, alpha_path);
   dt_masks_debug_write_png(dev, &form, &over_req, over_path);
 
+  char *alpha_name = g_strdup_printf("%s-alpha", name);
+  char *over_name = g_strdup_printf("%s-overlay", name);
+  const gboolean baseline_ok = _baseline_check(alpha_path, alpha_name)
+                               & _baseline_check(over_path, over_name);
+  g_free(alpha_name);
+  g_free(over_name);
+
   /* A picture of exactly what is owed and missing: red where the disc union covers a pixel the
    * rasteriser left empty, over the mask itself. This is the artefact to look at first when a
    * case fails -- it says WHERE the stroke went missing, which no scalar can. */
@@ -457,7 +585,7 @@ static void _run_brush_case_at(dt_develop_t *dev, const float table[][9], const 
     g_free(csv);
   }
 
-  const gboolean ok = (largest <= budget_px);
+  const gboolean ok = (largest <= budget_px) && baseline_ok;
   printf("[%s] %-22s %5dx%-5d missing coverage %6d px, largest run %5d px", ok ? "PASS" : "FAIL",
          name, img_w, img_h, missing, largest);
   if(largest > 0) printf(" around (%d,%d)", cx, cy);
@@ -503,6 +631,13 @@ static void _run_case_at(dt_develop_t *dev, dt_masks_form_t *form, const char *n
   dt_masks_debug_write_png(dev, form, &alpha_req, alpha_path);
   dt_masks_debug_write_png(dev, form, &over_req, over_path);
 
+  char *alpha_name = g_strdup_printf("%s-alpha", name);
+  char *over_name = g_strdup_printf("%s-overlay", name);
+  const gboolean baseline_ok = _baseline_check(alpha_path, alpha_name)
+                               & _baseline_check(over_path, over_name);
+  g_free(alpha_name);
+  g_free(over_name);
+
   if(holes > max_holes || largest > max_hole_px)
   {
     char *csv = g_strdup_printf("%s/%s-outline.csv", dir, name);
@@ -510,7 +645,7 @@ static void _run_case_at(dt_develop_t *dev, dt_masks_form_t *form, const char *n
     g_free(csv);
   }
 
-  const gboolean ok = (holes <= max_holes) && (largest <= max_hole_px);
+  const gboolean ok = (holes <= max_holes) && (largest <= max_hole_px) && baseline_ok;
   printf("[%s] %-22s %5dx%-5d coverage %.4f  enclosed holes %d (largest %d px)  budget %d/%d  -> %s\n",
          ok ? "PASS" : "FAIL", name, img_w, img_h, coverage, holes, largest, max_holes, max_hole_px, alpha_path);
   if(!ok) failures++;
@@ -528,8 +663,32 @@ static void _run_case(dt_develop_t *dev, dt_masks_form_t *form, const char *name
 
 int main(int argc, char *argv[])
 {
-  const char *dir = (argc > 1) ? argv[1] : "/tmp";
+  const char *dir = (argc > 1 && argv[1][0] != '-') ? argv[1] : "/tmp";
   g_mkdir_with_parents(dir, 0755);
+
+  /* Baselines live in the shared sample bank, beside the raw-export ones and reviewed the same
+   * way. The bank is a plain clone, not a submodule (the superproject is public), so presence is
+   * decided by what is on disk -- exactly as tests/image_test.sh decides it. Nothing to compare
+   * against is not a failure: a fresh checkout without the bank runs the oracle and says so. */
+  char *default_baseline
+      = g_strdup(ANSEL_TEST_SOURCE_DIR "/tests/image_test/samples/baseline/masks-geometry");
+  for(int i = 1; i < argc; i++)
+  {
+    if(!strcmp(argv[i], "--update-baseline")) baseline_update = TRUE;
+    else if(!strcmp(argv[i], "--baseline") && i + 1 < argc)
+    {
+      g_free(default_baseline);
+      default_baseline = g_strdup(argv[++i]);
+    }
+    else if(!strcmp(argv[i], "--no-baseline"))
+    {
+      g_free(default_baseline);
+      default_baseline = NULL;
+    }
+  }
+  if(!IS_NULL_PTR(default_baseline)
+     && (baseline_update || g_file_test(default_baseline, G_FILE_TEST_IS_DIR)))
+    baseline_dir = default_baseline;
 
   /* The masks code allocates through the pixelpipe cache, whose lock dt_init() creates, and
    * reads conf for per-shape defaults -- so a geometry test still needs a booted instance,
@@ -707,6 +866,13 @@ int main(int argc, char *argv[])
 
   dt_pthread_rwlock_destroy(&dev.masks_mutex);
   dt_pthread_rwlock_destroy(&dev.history_mutex);
+
+  if(IS_NULL_PTR(baseline_dir))
+    printf("baseline: not compared (no %s)\n",
+           "tests/image_test/samples/baseline/masks-geometry -- clone the bank to enable it");
+  else if(baseline_missing > 0)
+    printf("baseline: %d render(s) have no entry yet -- run with --update-baseline to add them\n",
+           baseline_missing);
 
   printf("%s: %d failing case(s)\n", failures ? "FAIL" : "PASS", failures);
 

--- a/tests/masks/masks_geometry.c
+++ b/tests/masks/masks_geometry.c
@@ -1,0 +1,599 @@
+/*
+    This file is part of Ansel,
+    Copyright (C) 2026 Aurélien PIERRE.
+
+    Ansel is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Ansel is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Ansel.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+/** Rasterised geometry for mask shapes that are known to break.
+ *
+ * Every shape here is a defect that shipped, reduced to the geometry that causes it. The
+ * runner rasterises each one, writes the alpha as a PNG, and reports simple, stable measures
+ * of it -- coverage, and the count and size of enclosed holes. Those numbers are the
+ * regression signal; the PNGs are how a human sees what the numbers mean.
+ *
+ * Why measures and not a golden-image diff: the rasteriser's exact anti-aliasing is allowed to
+ * change, and a byte comparison would fail on every legitimate improvement while still missing
+ * a hole that moved. A hole is what these bugs ARE, so a hole is what is counted.
+ *
+ * The overlay is rendered too, over the alpha, because the two layers are confused so easily:
+ * a brush cusp losing coverage and a dashed outline drawing self-intersecting circles are
+ * different bugs, and an always-FALSE flag once deleted geometry the rasteriser needed in
+ * order to tidy a line the GUI drew. Seeing them superimposed is what tells them apart.
+ *
+ * Run: ansel-test-masks-geometry [output-dir]
+ */
+
+#include "darktable.h"
+#include "develop/develop.h"
+#include "develop/dev_geometry.h"
+#include "develop/geometry/geometry.h"
+#include "develop/masks.h"
+#include "develop/masks_debug.h"
+#include "develop/masks/masks_functions.h"
+#include "math/math.h"
+#include "system/mem_alloc.h"
+
+#include <cairo/cairo.h>
+#include <glib.h>
+#include <glib/gstdio.h>
+#include <math.h>
+#include <stdio.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+/* The reported raw's own size. Not an arbitrary canvas: several thresholds in the outline
+ * builder are in ABSOLUTE pixels -- the recursion splits until samples are within a pixel, the
+ * arc fillers bail when the arc is under two pixels long -- so which defects appear at all is
+ * scale-dependent. Reproducing what a user sees means rendering at the size they render at. */
+#define IMG_W 5184
+#define IMG_H 3888
+
+static int failures = 0;
+
+/* ------------------------------------------------------------------------------------- */
+
+static dt_masks_node_brush_t *_brush_node(const float x, const float y, const float c1x, const float c1y,
+                                          const float c2x, const float c2y, const float radius)
+{
+  dt_masks_node_brush_t *n = (dt_masks_node_brush_t *)calloc(1, sizeof(dt_masks_node_brush_t));
+  n->node[0] = x;      n->node[1] = y;
+  n->ctrl1[0] = c1x;   n->ctrl1[1] = c1y;
+  n->ctrl2[0] = c2x;   n->ctrl2[1] = c2y;
+  n->border[0] = n->border[1] = radius;
+  n->density = 1.0f;
+  n->fading = 0.66f;
+  n->state = DT_MASKS_POINT_STATE_NORMAL;
+  return n;
+}
+
+static dt_masks_node_polygon_t *_polygon_node(const float x, const float y, const float c1x, const float c1y,
+                                              const float c2x, const float c2y, const float radius)
+{
+  dt_masks_node_polygon_t *n = (dt_masks_node_polygon_t *)calloc(1, sizeof(dt_masks_node_polygon_t));
+  n->node[0] = x;     n->node[1] = y;
+  n->ctrl1[0] = c1x;  n->ctrl1[1] = c1y;
+  n->ctrl2[0] = c2x;  n->ctrl2[1] = c2y;
+  n->border[0] = n->border[1] = radius;
+  n->state = DT_MASKS_POINT_STATE_NORMAL;
+  return n;
+}
+
+/** Straight-segment control points: a node whose handles sit on the chords is a corner. */
+static void _brush_straight(GList **points, const float pts[][2], const int n, const float radius)
+{
+  for(int i = 0; i < n; i++)
+  {
+    const float px = pts[i][0], py = pts[i][1];
+    const int prev = (i == 0) ? 0 : i - 1;
+    const int next = (i == n - 1) ? n - 1 : i + 1;
+    const float c1x = px + (pts[prev][0] - px) * 0.25f, c1y = py + (pts[prev][1] - py) * 0.25f;
+    const float c2x = px + (pts[next][0] - px) * 0.25f, c2y = py + (pts[next][1] - py) * 0.25f;
+    *points = g_list_append(*points, _brush_node(px, py, c1x, c1y, c2x, c2y, radius));
+  }
+}
+
+
+/* ------------------------------------------------------------------------------------- */
+/* Geometry decoded verbatim from the XMP attached to issue #1313's follow-up (mask_id
+ * 1788089411, "brush #1"). Node 8 is the cusp: both handles collapsed onto the node, arms
+ * meeting at a sharp angle. Kept as data rather than parsed from the sidecar at run time --
+ * the test then needs no file, no database and no XMP reader to reproduce the exact shape a
+ * user reported, and a diff shows when the geometry itself is edited. */
+static const float _brush_1313[11][9] = {
+  /* node.x, node.y, ctrl1.x, ctrl1.y, ctrl2.x, ctrl2.y, border, density, fading */
+  { 0.471628428f, 0.0363773443f, 0.480041265f, 0.0386592895f, 0.46321559f,  0.0340954065f, 0.00624799589f, 1.0f, 0.66f },
+  { 0.446389854f, 0.0295315273f, 0.454724789f, 0.0302576013f, 0.438054889f, 0.0288054571f, 0.00704672467f, 1.0f, 0.66f },
+  { 0.421618611f, 0.0320209153f, 0.425721943f, 0.0304650553f, 0.417515308f, 0.0335767828f, 0.00707301404f, 1.0f, 0.66f },
+  { 0.395679384f, 0.0483706258f, 0.404481769f, 0.0413173735f, 0.38687706f,  0.0554238781f, 0.0267287921f,  1.0f, 0.66f },
+  { 0.368804485f, 0.0743404329f, 0.380839676f, 0.0592248067f, 0.356769323f, 0.0894560665f, 0.00639372552f, 1.0f, 0.66f },
+  { 0.323468447f, 0.139064401f,  0.336321443f, 0.124024376f,  0.31061548f,  0.154104441f,  0.0175853837f,  1.0f, 0.66f },
+  { 0.291686505f, 0.164580554f,  0.29908672f,  0.159394339f,  0.28428629f,  0.169766784f,  0.0175853837f,  1.0f, 0.66f },
+  { 0.279067189f, 0.170181692f,  0.285639763f, 0.161496982f,  0.272494644f, 0.178866416f,  0.0175853837f,  1.0f, 0.66f },
+  { 0.252251089f, 0.216688871f,  0.252251089f, 0.216688871f,  0.252251089f, 0.216688871f,  0.0175853837f,  1.0f, 0.66f }, /* CUSP */
+  { 0.229524732f, 0.17267108f,   0.237051532f, 0.181563243f,  0.221997947f, 0.163778931f,  0.0175853837f,  1.0f, 0.66f },
+  { 0.207090423f, 0.16333589f,   0.214568526f, 0.16644761f,   0.199612319f, 0.160224169f,  0.0175853837f,  1.0f, 0.66f },
+};
+
+static GList *_brush_from_table(const float table[][9], const int count)
+{
+  GList *points = NULL;
+  for(int i = 0; i < count; i++)
+    points = g_list_append(points, _brush_node(table[i][0], table[i][1], table[i][2], table[i][3],
+                                               table[i][4], table[i][5], table[i][6]));
+  return points;
+}
+
+/* ------------------------------------------------------------------------------------- */
+/* The oracle for a brush.
+ *
+ * A brush stroke IS the Minkowski sum of its centreline with a disc of the node's radius, so
+ * the reference can be constructed instead of remembered: sample the Bezier densely, stamp a
+ * disc at every sample, and any pixel the reference covers but the mask does not is coverage
+ * the rasteriser owed and did not deliver.
+ *
+ * This is what "enclosed holes" could not see. The defect reported against #1313 is a V that
+ * bites INTO the stroke from outside -- it is open, connected to the background, and no
+ * hole-counting metric will ever flag it. Measuring against the disc union does, and it says
+ * what the user said: the brush lost its radius near the cusp. */
+static void _brush_reference(const float table[][9], const int count, const int w, const int h,
+                             uint8_t *reference)
+{
+  const float radius_scale = (float)MIN(w, h);
+  memset(reference, 0, (size_t)w * h);
+
+  for(int seg = 0; seg + 1 < count; seg++)
+  {
+    const float p0x = table[seg][0] * w,     p0y = table[seg][1] * h;
+    const float p1x = table[seg][4] * w,     p1y = table[seg][5] * h;   /* ctrl2 of this node */
+    const float p2x = table[seg + 1][2] * w, p2y = table[seg + 1][3] * h; /* ctrl1 of the next */
+    const float p3x = table[seg + 1][0] * w, p3y = table[seg + 1][1] * h;
+
+    for(int k = 0; k <= 2000; k++)
+    {
+      const float t = (float)k / 2000.0f, u = 1.0f - t;
+      const float bx = u*u*u*p0x + 3*u*u*t*p1x + 3*u*t*t*p2x + t*t*t*p3x;
+      const float by = u*u*u*p0y + 3*u*u*t*p1y + 3*u*t*t*p2y + t*t*t*p3y;
+      /* the radius interpolates between the two nodes exactly as _brush_points_recurs does */
+      const float sm = t * t * (3.0f - 2.0f * t);
+      const float r = (table[seg][6] + (table[seg + 1][6] - table[seg][6]) * sm) * radius_scale;
+      /* Shrink by two pixels. A disc and a rasterised stroke never agree exactly along the
+       * perimeter -- the stroke is stamped from discrete spokes and anti-aliased -- so the
+       * outermost ring would report a one-pixel sliver on every well-behaved case and drown
+       * the signal. Two pixels in, any disagreement is interior, which is the only kind that
+       * means the stroke is missing. */
+      const int r_i = MAX((int)floorf(r) - 2, 0);
+      const int cx = (int)lrintf(bx), cy = (int)lrintf(by);
+      for(int dy = -r_i; dy <= r_i; dy++)
+        for(int dx = -r_i; dx <= r_i; dx++)
+        {
+          if(dx * dx + dy * dy > r_i * r_i) continue;
+          const int x = cx + dx, y = cy + dy;
+          if(x < 0 || y < 0 || x >= w || y >= h) continue;
+          reference[(size_t)y * w + x] = 1;
+        }
+    }
+  }
+}
+
+/** Largest connected run of owed-but-missing coverage, and its total. */
+static void _missing_coverage(const float *mask, const uint8_t *reference, const int w, const int h,
+                              int *total, int *largest, int *cx, int *cy)
+{
+  *total = 0; *largest = 0; *cx = -1; *cy = -1;
+  uint8_t *miss = (uint8_t *)calloc((size_t)w * h, 1);
+  int *stack = (int *)malloc(sizeof(int) * (size_t)w * h);
+  if(IS_NULL_PTR(miss) || IS_NULL_PTR(stack)) { free(miss); free(stack); return; }
+
+  /* ANY coverage counts, not a thresholded core. `border' is the OUTER radius: the stroke is
+   * solid in the middle and fades to zero at that edge, so most of the disc legitimately holds
+   * values below a half. What cannot be legitimate is a pixel the disc covers with no coverage
+   * at all -- that is the stroke missing, which is the defect this corpus is about. */
+  for(size_t i = 0; i < (size_t)w * h; i++)
+    if(reference[i] && mask[i] <= 0.0f) { miss[i] = 1; (*total)++; }
+
+  uint8_t *seen = (uint8_t *)calloc((size_t)w * h, 1);
+  if(IS_NULL_PTR(seen)) { free(miss); free(stack); return; }
+  for(int y = 0; y < h; y++)
+    for(int x = 0; x < w; x++)
+    {
+      const size_t seed = (size_t)y * w + x;
+      if(!miss[seed] || seen[seed]) continue;
+      int top = 0, size = 0;
+      long sx = 0, sy = 0;
+      stack[top++] = (int)seed; seen[seed] = 1;
+      while(top > 0)
+      {
+        const int cur = stack[--top];
+        const int px = cur % w, py = cur / w;
+        size++; sx += px; sy += py;
+        const int dx[4] = { 1, -1, 0, 0 }, dy[4] = { 0, 0, 1, -1 };
+        for(int k = 0; k < 4; k++)
+        {
+          const int nx = px + dx[k], ny = py + dy[k];
+          if(nx < 0 || ny < 0 || nx >= w || ny >= h) continue;
+          const size_t ni = (size_t)ny * w + nx;
+          if(!miss[ni] || seen[ni]) continue;
+          seen[ni] = 1; stack[top++] = (int)ni;
+        }
+      }
+      if(size > *largest) { *largest = size; *cx = (int)(sx / size); *cy = (int)(sy / size); }
+    }
+
+  free(miss); free(seen); free(stack);
+}
+
+/** Coverage plus enclosed holes: an unpainted component that does not touch the border. */
+static void _measure(const float *mask, const int w, const int h, double *coverage, int *hole_count,
+                     int *largest_hole)
+{
+  *coverage = 0.0; *hole_count = 0; *largest_hole = 0;
+
+  int *label = (int *)calloc((size_t)w * h, sizeof(int));
+  int *stack = (int *)malloc(sizeof(int) * (size_t)w * h);
+  if(IS_NULL_PTR(label) || IS_NULL_PTR(stack)) { free(label); free(stack); return; }
+
+  size_t painted = 0;
+  for(size_t i = 0; i < (size_t)w * h; i++) if(mask[i] > 0.5f) painted++;
+  *coverage = (double)painted / ((double)w * h);
+
+  int next_label = 0;
+  for(int y = 0; y < h; y++)
+    for(int x = 0; x < w; x++)
+    {
+      const size_t seed = (size_t)y * w + x;
+      if(mask[seed] > 0.5f || label[seed]) continue;
+
+      next_label++;
+      int top = 0, size = 0;
+      gboolean touches_border = FALSE;
+      stack[top++] = (int)seed;
+      label[seed] = next_label;
+      while(top > 0)
+      {
+        const int cur = stack[--top];
+        const int cx = cur % w, cy = cur / w;
+        size++;
+        if(cx == 0 || cy == 0 || cx == w - 1 || cy == h - 1) touches_border = TRUE;
+        const int dx[4] = { 1, -1, 0, 0 }, dy[4] = { 0, 0, 1, -1 };
+        for(int k = 0; k < 4; k++)
+        {
+          const int nx = cx + dx[k], ny = cy + dy[k];
+          if(nx < 0 || ny < 0 || nx >= w || ny >= h) continue;
+          const size_t ni = (size_t)ny * w + nx;
+          if(mask[ni] > 0.5f || label[ni]) continue;
+          label[ni] = next_label;
+          stack[top++] = (int)ni;
+        }
+      }
+      if(!touches_border)
+      {
+        (*hole_count)++;
+        if(size > *largest_hole) *largest_hole = size;
+      }
+    }
+
+  free(label);
+  free(stack);
+}
+
+
+
+/* Synthetic classes, each isolating one way a stroke's outline can fail. Radii are large
+ * relative to the node spacing on purpose: that is the regime where a brush's offset curve
+ * folds over itself, which is where every defect in this family has come from. */
+
+/* A cusp: handles collapsed onto the middle node, arms at a sharp angle. */
+static const float _brush_cusp_tbl[3][9] = {
+  { 0.30f, 0.30f, 0.275f, 0.30f, 0.35f, 0.405f, 0.030f, 1.0f, 0.66f },
+  { 0.50f, 0.72f, 0.50f,  0.72f, 0.50f, 0.72f,  0.030f, 1.0f, 0.66f },
+  { 0.70f, 0.30f, 0.65f,  0.405f, 0.725f, 0.30f, 0.030f, 1.0f, 0.66f },
+};
+
+/* The same, tighter: the arms nearly parallel, so the two offset sides overlap along their
+ * whole length and the wedge at the tip is at its narrowest. */
+static const float _brush_hairpin_tbl[3][9] = {
+  { 0.42f, 0.20f, 0.40f, 0.20f, 0.44f, 0.345f, 0.035f, 1.0f, 0.66f },
+  { 0.50f, 0.78f, 0.50f, 0.78f, 0.50f, 0.78f,  0.035f, 1.0f, 0.66f },
+  { 0.58f, 0.20f, 0.56f, 0.345f, 0.60f, 0.20f, 0.035f, 1.0f, 0.66f },
+};
+
+/* Several sharp joints in a row: each one is another chance to drop a wedge, and a fix that
+ * only handles the first would pass the cusp case and fail here. */
+static const float _brush_zigzag_tbl[6][9] = {
+  { 0.15f, 0.35f, 0.113f, 0.35f,  0.187f, 0.425f, 0.022f, 1.0f, 0.66f },
+  { 0.30f, 0.65f, 0.30f,  0.65f,  0.30f,  0.65f,  0.022f, 1.0f, 0.66f },
+  { 0.45f, 0.35f, 0.45f,  0.35f,  0.45f,  0.35f,  0.022f, 1.0f, 0.66f },
+  { 0.60f, 0.65f, 0.60f,  0.65f,  0.60f,  0.65f,  0.022f, 1.0f, 0.66f },
+  { 0.75f, 0.35f, 0.75f,  0.35f,  0.75f,  0.35f,  0.022f, 1.0f, 0.66f },
+  { 0.88f, 0.60f, 0.847f, 0.545f, 0.913f, 0.60f, 0.022f, 1.0f, 0.66f },
+};
+
+/* SELF-INTERSECTING: the stroke crosses itself, so the offset curve does too and the crossing
+ * is real geometry rather than a fold to be cut away. The union must still be solid. */
+static const float _brush_selfcross_tbl[5][9] = {
+  { 0.25f, 0.30f, 0.20f, 0.30f, 0.35f, 0.34f, 0.030f, 1.0f, 0.66f },
+  { 0.62f, 0.42f, 0.52f, 0.39f, 0.70f, 0.44f, 0.030f, 1.0f, 0.66f },
+  { 0.62f, 0.62f, 0.72f, 0.58f, 0.52f, 0.66f, 0.030f, 1.0f, 0.66f },
+  { 0.30f, 0.44f, 0.40f, 0.50f, 0.24f, 0.41f, 0.030f, 1.0f, 0.66f },
+  { 0.30f, 0.24f, 0.27f, 0.30f, 0.33f, 0.20f, 0.030f, 1.0f, 0.66f },
+};
+
+/* CONCAVE, tighter than the radius: the classic fold. The inner offset curve loops, and the
+ * loop has to be removed without removing the stroke around it. */
+static const float _brush_concave_tbl[5][9] = {
+  { 0.20f, 0.30f, 0.16f, 0.30f, 0.28f, 0.32f, 0.045f, 1.0f, 0.66f },
+  { 0.44f, 0.36f, 0.36f, 0.34f, 0.50f, 0.38f, 0.045f, 1.0f, 0.66f },
+  { 0.50f, 0.50f, 0.50f, 0.44f, 0.50f, 0.56f, 0.045f, 1.0f, 0.66f },
+  { 0.44f, 0.64f, 0.50f, 0.62f, 0.36f, 0.66f, 0.045f, 1.0f, 0.66f },
+  { 0.20f, 0.70f, 0.28f, 0.68f, 0.16f, 0.70f, 0.045f, 1.0f, 0.66f },
+};
+
+static void _run_brush_case(dt_develop_t *dev, const float table[][9], const int count,
+                            const char *name, const char *dir, const int budget_px)
+{
+  dt_masks_form_t form = { 0 };
+  form.type = DT_MASKS_BRUSH;
+  form.functions = &dt_masks_functions_brush;
+  form.version = 6;
+  form.formid = 900;
+  g_strlcpy(form.name, name, sizeof(form.name));
+  form.points = _brush_from_table(table, count);
+
+  float *mask = dt_masks_debug_rasterise(dev, &form, IMG_W, IMG_H);
+  if(IS_NULL_PTR(mask))
+  {
+    printf("[FAIL] %-22s rasterisation returned nothing\n", name);
+    failures++;
+    g_list_free_full(form.points, free);
+    return;
+  }
+
+  uint8_t *reference = (uint8_t *)malloc((size_t)IMG_W * IMG_H);
+  int missing = 0, largest = 0, cx = -1, cy = -1;
+  if(!IS_NULL_PTR(reference))
+  {
+    _brush_reference(table, count, IMG_W, IMG_H, reference);
+    _missing_coverage(mask, reference, IMG_W, IMG_H, &missing, &largest, &cx, &cy);
+  }
+
+  char *alpha_path = g_strdup_printf("%s/%s-alpha.png", dir, name);
+  char *over_path = g_strdup_printf("%s/%s-overlay.png", dir, name);
+  const dt_masks_debug_request_t alpha_req
+      = { .width = IMG_W, .height = IMG_H, .backdrop = DT_MASKS_DEBUG_BACKDROP_RASTER, .draw_overlay = FALSE };
+  const dt_masks_debug_request_t over_req
+      = { .width = IMG_W, .height = IMG_H, .backdrop = DT_MASKS_DEBUG_BACKDROP_RASTER, .draw_overlay = TRUE };
+  dt_masks_debug_write_png(dev, &form, &alpha_req, alpha_path);
+  dt_masks_debug_write_png(dev, &form, &over_req, over_path);
+
+  /* A picture of exactly what is owed and missing: red where the disc union covers a pixel the
+   * rasteriser left empty, over the mask itself. This is the artefact to look at first when a
+   * case fails -- it says WHERE the stroke went missing, which no scalar can. */
+  if(!IS_NULL_PTR(reference) && missing > 0)
+  {
+    char *miss_path = g_strdup_printf("%s/%s-missing.png", dir, name);
+    cairo_surface_t *surf = cairo_image_surface_create(CAIRO_FORMAT_RGB24, IMG_W, IMG_H);
+    if(cairo_surface_status(surf) == CAIRO_STATUS_SUCCESS)
+    {
+      cairo_surface_flush(surf);
+      uint8_t *const px = cairo_image_surface_get_data(surf);
+      const int stride = cairo_image_surface_get_stride(surf);
+      for(int y = 0; y < IMG_H; y++)
+      {
+        uint32_t *const row = (uint32_t *)(px + (size_t)y * stride);
+        for(int x = 0; x < IMG_W; x++)
+        {
+          const size_t i = (size_t)y * IMG_W + x;
+          const uint32_t g = (uint32_t)(CLAMPF(mask[i], 0.0f, 1.0f) * 200.0f + 0.5f);
+          row[x] = (reference[i] && mask[i] <= 0.0f) ? 0x00FF2020u : ((g << 16) | (g << 8) | g);
+        }
+      }
+      cairo_surface_mark_dirty(surf);
+      cairo_surface_write_to_png(surf, miss_path);
+    }
+    cairo_surface_destroy(surf);
+    g_free(miss_path);
+  }
+
+  if(missing > 0)
+  {
+    char *csv = g_strdup_printf("%s/%s-outline.csv", dir, name);
+    dt_masks_debug_write_outline_csv(dev, &form, csv);
+    g_free(csv);
+  }
+
+  const gboolean ok = (largest <= budget_px);
+  printf("[%s] %-22s missing coverage %6d px, largest run %5d px", ok ? "PASS" : "FAIL", name,
+         missing, largest);
+  if(largest > 0) printf(" around (%d,%d)", cx, cy);
+  printf("  budget %d  -> %s\n", budget_px, alpha_path);
+  if(!ok) failures++;
+
+  free(reference);
+  dt_free_align(mask);
+  g_free(alpha_path);
+  g_free(over_path);
+  g_list_free_full(form.points, free);
+}
+
+static void _run_case(dt_develop_t *dev, dt_masks_form_t *form, const char *name, const char *dir,
+                      const int max_holes, const int max_hole_px)
+{
+  float *mask = dt_masks_debug_rasterise(dev, form, IMG_W, IMG_H);
+  if(IS_NULL_PTR(mask))
+  {
+    printf("[FAIL] %-22s rasterisation returned nothing\n", name);
+    failures++;
+    return;
+  }
+
+  double coverage = 0.0;
+  int holes = 0, largest = 0;
+  _measure(mask, IMG_W, IMG_H, &coverage, &holes, &largest);
+  dt_free_align(mask);
+
+  char *alpha_path = g_strdup_printf("%s/%s-alpha.png", dir, name);
+  char *over_path = g_strdup_printf("%s/%s-overlay.png", dir, name);
+  const dt_masks_debug_request_t alpha_req
+      = { .width = IMG_W, .height = IMG_H, .backdrop = DT_MASKS_DEBUG_BACKDROP_RASTER, .draw_overlay = FALSE };
+  const dt_masks_debug_request_t over_req
+      = { .width = IMG_W, .height = IMG_H, .backdrop = DT_MASKS_DEBUG_BACKDROP_RASTER, .draw_overlay = TRUE };
+  dt_masks_debug_write_png(dev, form, &alpha_req, alpha_path);
+  dt_masks_debug_write_png(dev, form, &over_req, over_path);
+
+  const gboolean ok = (holes <= max_holes) && (largest <= max_hole_px);
+  printf("[%s] %-22s coverage %.4f  enclosed holes %d (largest %d px)  budget %d/%d  -> %s\n",
+         ok ? "PASS" : "FAIL", name, coverage, holes, largest, max_holes, max_hole_px, alpha_path);
+  if(!ok) failures++;
+
+  g_free(alpha_path);
+  g_free(over_path);
+}
+
+/* ------------------------------------------------------------------------------------- */
+
+int main(int argc, char *argv[])
+{
+  const char *dir = (argc > 1) ? argv[1] : "/tmp";
+  g_mkdir_with_parents(dir, 0755);
+
+  /* The masks code allocates through the pixelpipe cache, whose lock dt_init() creates, and
+   * reads conf for per-shape defaults -- so a geometry test still needs a booted instance,
+   * just not a GUI one. Everything below is scratch: an in-memory library and temp dirs. */
+  char *config_dir = g_strdup_printf("%s/ansel-test-masks-config-XXXXXX", g_get_tmp_dir());
+  char *cache_dir = g_strdup_printf("%s/ansel-test-masks-cache-XXXXXX", g_get_tmp_dir());
+  char *tmp_dir = g_strdup_printf("%s/ansel-test-masks-tmp-XXXXXX", g_get_tmp_dir());
+  if(IS_NULL_PTR(g_mkdtemp(config_dir)) || IS_NULL_PTR(g_mkdtemp(cache_dir))
+     || IS_NULL_PTR(g_mkdtemp(tmp_dir)))
+  {
+    fprintf(stderr, "[FAIL] could not create scratch directories\n");
+    return 1;
+  }
+
+  char *argv_override[] = {
+    "ansel-test-masks-geometry",
+    "--library", ":memory:",
+    "--datadir", ANSEL_TEST_SOURCE_DIR "/data",
+    // the build tree keeps its modules under src/, laid out as the installed tree expects
+    "--moduledir", ANSEL_TEST_BINARY_DIR "/src",
+    "--configdir", config_dir,
+    "--cachedir", cache_dir,
+    "--tmpdir", tmp_dir,
+    "--disable-opencl",
+    "--conf", "write_sidecar_files=FALSE",
+    "-t", "1",
+    NULL
+  };
+  const int argc_override = sizeof(argv_override) / sizeof(*argv_override) - 1;
+  if(dt_init(argc_override, argv_override, FALSE, FALSE))
+  {
+    fprintf(stderr, "[FAIL] dt_init\n");
+    return 1;
+  }
+
+  dt_develop_t dev = { 0 };
+  dt_pthread_rwlock_init(&dev.masks_mutex, NULL);
+  dt_dev_geometry_init(&dev);
+  dt_dev_geometry_set_raw_size(&dev, IMG_W, IMG_H, TRUE);
+  /* The GUI outline builder composes through the geometry chain, so a dev that never went
+   * through dt_dev_init() needs one: without it the outlines never build and the overlay draws
+   * nothing at all -- silently, because an empty outline is a legitimate result. */
+  dev.geometry_chain = dt_geometry_chain_new();
+  /* The outline builder composes through the geometry service, which refuses to answer until
+   * the chain is AUTHORITATIVE -- a guard against transforming against a half-published chain.
+   * Rebuilding it here over an empty module list publishes the only honest answer for a dev
+   * with no pipeline: the identity. That is also what a geometry regression wants, so a
+   * difference means the mask code changed and not some module's distortion. Without this the
+   * builder returns ERROR and both the outline and the overlay come back empty -- silently,
+   * because an empty outline is a legitimate result. */
+  dt_pthread_rwlock_init(&dev.history_mutex, NULL);
+  dt_dev_geometry_set_processed_size(&dev, IMG_W, IMG_H);
+  dt_geometry_chain_rebuild(&dev);
+  printf("geometry chain authoritative: %s\n",
+         dt_geometry_chain_authoritative(dev.geometry_chain) ? "yes" : "NO -- outlines will be empty");
+
+  printf("mask geometry corpus -> %s\n", dir);
+
+  /* 0. THE REPORTED SHAPE. Issue #1313's follow-up: brush #1, cusp at node 8. The stroke loses
+   *    its radius toward the point of the cusp and leaves a V that is OPEN to the background --
+   *    which is why it must be measured against the disc union and not by counting holes.
+   *    Budget 0: any owed pixel the rasteriser does not deliver is the bug. */
+  _run_brush_case(&dev, _brush_1313, 11, "brush-1313-cusp", dir, 0);
+
+  _run_brush_case(&dev, _brush_cusp_tbl,      3, "brush-cusp",      dir, 0);
+  _run_brush_case(&dev, _brush_hairpin_tbl,   3, "brush-hairpin",   dir, 0);
+  _run_brush_case(&dev, _brush_zigzag_tbl,    6, "brush-zigzag",    dir, 0);
+  _run_brush_case(&dev, _brush_selfcross_tbl, 5, "brush-selfcross", dir, 0);
+  _run_brush_case(&dev, _brush_concave_tbl,   5, "brush-concave",   dir, 0);
+
+  /* 4. A polygon whose concave runs are tighter than its feather: its offset curve
+   *    self-intersects at every one of them, which is the geometry issue #1313 turned on --
+   *    the cuts that remove those folds must not remove anything else. */
+  {
+    dt_masks_form_t form = { 0 };
+    form.type = DT_MASKS_POLYGON;
+    form.functions = &dt_masks_functions_polygon;
+    form.version = 6;
+    form.formid = 104;
+    g_strlcpy(form.name, "comb polygon", sizeof(form.name));
+    const float radius = 0.028f;
+    const int teeth = 5;
+    for(int i = 0; i < teeth; i++)
+    {
+      const float x = 0.20f + 0.13f * i;
+      form.points = g_list_append(form.points, _polygon_node(x, 0.35f, x, 0.35f, x, 0.35f, radius));
+      form.points = g_list_append(form.points, _polygon_node(x + 0.05f, 0.62f, x + 0.05f, 0.62f,
+                                                             x + 0.05f, 0.62f, radius));
+    }
+    form.points = g_list_append(form.points, _polygon_node(0.80f, 0.78f, 0.80f, 0.78f, 0.80f, 0.78f, radius));
+    form.points = g_list_append(form.points, _polygon_node(0.20f, 0.78f, 0.20f, 0.78f, 0.20f, 0.78f, radius));
+    _run_case(&dev, &form, "polygon-comb", dir, 0, 0);
+    g_list_free_full(form.points, free);
+  }
+
+  /* 5. A circle, as the control: no joints, no folds. If this ever grows a hole the fault is
+   *    in the fill, not in any of the geometry above. */
+  {
+    dt_masks_form_t form = { 0 };
+    form.type = DT_MASKS_CIRCLE;
+    form.functions = &dt_masks_functions_circle;
+    form.version = 6;
+    form.formid = 105;
+    g_strlcpy(form.name, "circle", sizeof(form.name));
+    dt_masks_node_circle_t *c = (dt_masks_node_circle_t *)calloc(1, sizeof(dt_masks_node_circle_t));
+    c->center[0] = 0.5f; c->center[1] = 0.5f;
+    c->radius = 0.15f; c->border = 0.03f;
+    form.points = g_list_append(form.points, c);
+    _run_case(&dev, &form, "circle-control", dir, 0, 0);
+    g_list_free_full(form.points, free);
+  }
+
+  dt_pthread_rwlock_destroy(&dev.masks_mutex);
+  dt_pthread_rwlock_destroy(&dev.history_mutex);
+
+  printf("%s: %d failing case(s)\n", failures ? "FAIL" : "PASS", failures);
+
+  dt_cleanup();
+  g_free(config_dir);
+  g_free(cache_dir);
+  g_free(tmp_dir);
+  return failures ? 1 : 0;
+}
+
+// clang-format off
+// modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py
+// vim: shiftwidth=2 expandtab tabstop=2 cindent
+// kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;
+// clang-format on

--- a/tests/masks/masks_geometry.c
+++ b/tests/masks/masks_geometry.c
@@ -91,21 +91,6 @@ static dt_masks_node_polygon_t *_polygon_node(const float x, const float y, cons
   return n;
 }
 
-/** Straight-segment control points: a node whose handles sit on the chords is a corner. */
-static void _brush_straight(GList **points, const float pts[][2], const int n, const float radius)
-{
-  for(int i = 0; i < n; i++)
-  {
-    const float px = pts[i][0], py = pts[i][1];
-    const int prev = (i == 0) ? 0 : i - 1;
-    const int next = (i == n - 1) ? n - 1 : i + 1;
-    const float c1x = px + (pts[prev][0] - px) * 0.25f, c1y = py + (pts[prev][1] - py) * 0.25f;
-    const float c2x = px + (pts[next][0] - px) * 0.25f, c2y = py + (pts[next][1] - py) * 0.25f;
-    *points = g_list_append(*points, _brush_node(px, py, c1x, c1y, c2x, c2y, radius));
-  }
-}
-
-
 /* ------------------------------------------------------------------------------------- */
 /* Geometry decoded verbatim from the XMP attached to issue #1313's follow-up (mask_id
  * 1788089411, "brush #1"). Node 8 is the cusp: both handles collapsed onto the node, arms
@@ -166,9 +151,22 @@ static void _brush_reference(const float table[][9], const int count, const int 
       const float t = (float)k / 2000.0f, u = 1.0f - t;
       const float bx = u*u*u*p0x + 3*u*u*t*p1x + 3*u*t*t*p2x + t*t*t*p3x;
       const float by = u*u*u*p0y + 3*u*u*t*p1y + 3*u*t*t*p2y + t*t*t*p3y;
-      /* the radius interpolates between the two nodes exactly as _brush_points_recurs does */
-      const float sm = t * t * (3.0f - 2.0f * t);
-      const float r = (table[seg][6] + (table[seg + 1][6] - table[seg][6]) * sm) * radius_scale;
+      /* The SMALLER of the two node radii, not the interpolated one.
+       *
+       * A disc union and a normal-offset stroke are not the same shape wherever the radius is
+       * changing. The implementation offsets the centreline along its normal by the local
+       * radius; the envelope of a growing disc family leans outward from that normal by
+       * asin(dr/ds), so across a fast radius transition the disc union genuinely covers more
+       * than the rasteriser owes. Asserting the interpolated radius there flagged 3552 px of
+       * crescents hugging the OUTSIDE of the widest bulge -- a real difference between two
+       * definitions, and not a defect under either of them.
+       *
+       * The smaller radius is what both definitions agree on, so that is the strongest claim
+       * this oracle can honestly make. It costs nothing where it matters: a cusp is a direction
+       * reversal, not a radius change, so the two nodes bracketing one have near-equal radii and
+       * the V hole is still caught at full strength (verified by re-running the corpus against
+       * master, which still fails this case). */
+      const float r = MIN(table[seg][6], table[seg + 1][6]) * radius_scale;
       /* Shrink by two pixels. A disc and a rasterised stroke never agree exactly along the
        * perimeter -- the stroke is stamped from discrete spokes and anti-aliased -- so the
        * outermost ring would report a one-pixel sliver on every well-behaved case and drown
@@ -341,9 +339,20 @@ static const float _brush_concave_tbl[5][9] = {
   { 0.20f, 0.70f, 0.28f, 0.68f, 0.16f, 0.70f, 0.045f, 1.0f, 0.66f },
 };
 
-static void _run_brush_case(dt_develop_t *dev, const float table[][9], const int count,
-                            const char *name, const char *dir, const int budget_px)
+/* Point the dev's geometry at a given frame size. The chain must be rebuilt afterwards or it
+ * stops being authoritative and every outline comes back empty, silently. */
+static void _set_frame(dt_develop_t *dev, const int w, const int h)
 {
+  dt_dev_geometry_set_raw_size(dev, w, h, TRUE);
+  dt_dev_geometry_set_processed_size(dev, w, h);
+  dt_geometry_chain_rebuild(dev);
+}
+
+static void _run_brush_case_at(dt_develop_t *dev, const float table[][9], const int count,
+                               const char *name, const char *dir, const int budget_px,
+                               const int img_w, const int img_h)
+{
+  _set_frame(dev, img_w, img_h);
   dt_masks_form_t form = { 0 };
   form.type = DT_MASKS_BRUSH;
   form.functions = &dt_masks_functions_brush;
@@ -352,7 +361,7 @@ static void _run_brush_case(dt_develop_t *dev, const float table[][9], const int
   g_strlcpy(form.name, name, sizeof(form.name));
   form.points = _brush_from_table(table, count);
 
-  float *mask = dt_masks_debug_rasterise(dev, &form, IMG_W, IMG_H);
+  float *mask = dt_masks_debug_rasterise(dev, &form, img_w, img_h);
   if(IS_NULL_PTR(mask))
   {
     printf("[FAIL] %-22s rasterisation returned nothing\n", name);
@@ -361,20 +370,20 @@ static void _run_brush_case(dt_develop_t *dev, const float table[][9], const int
     return;
   }
 
-  uint8_t *reference = (uint8_t *)malloc((size_t)IMG_W * IMG_H);
+  uint8_t *reference = (uint8_t *)malloc((size_t)img_w * img_h);
   int missing = 0, largest = 0, cx = -1, cy = -1;
   if(!IS_NULL_PTR(reference))
   {
-    _brush_reference(table, count, IMG_W, IMG_H, reference);
-    _missing_coverage(mask, reference, IMG_W, IMG_H, &missing, &largest, &cx, &cy);
+    _brush_reference(table, count, img_w, img_h, reference);
+    _missing_coverage(mask, reference, img_w, img_h, &missing, &largest, &cx, &cy);
   }
 
   char *alpha_path = g_strdup_printf("%s/%s-alpha.png", dir, name);
   char *over_path = g_strdup_printf("%s/%s-overlay.png", dir, name);
   const dt_masks_debug_request_t alpha_req
-      = { .width = IMG_W, .height = IMG_H, .backdrop = DT_MASKS_DEBUG_BACKDROP_RASTER, .draw_overlay = FALSE };
+      = { .width = img_w, .height = img_h, .backdrop = DT_MASKS_DEBUG_BACKDROP_RASTER, .draw_overlay = FALSE };
   const dt_masks_debug_request_t over_req
-      = { .width = IMG_W, .height = IMG_H, .backdrop = DT_MASKS_DEBUG_BACKDROP_RASTER, .draw_overlay = TRUE };
+      = { .width = img_w, .height = img_h, .backdrop = DT_MASKS_DEBUG_BACKDROP_RASTER, .draw_overlay = TRUE };
   dt_masks_debug_write_png(dev, &form, &alpha_req, alpha_path);
   dt_masks_debug_write_png(dev, &form, &over_req, over_path);
 
@@ -384,18 +393,18 @@ static void _run_brush_case(dt_develop_t *dev, const float table[][9], const int
   if(!IS_NULL_PTR(reference) && missing > 0)
   {
     char *miss_path = g_strdup_printf("%s/%s-missing.png", dir, name);
-    cairo_surface_t *surf = cairo_image_surface_create(CAIRO_FORMAT_RGB24, IMG_W, IMG_H);
+    cairo_surface_t *surf = cairo_image_surface_create(CAIRO_FORMAT_RGB24, img_w, img_h);
     if(cairo_surface_status(surf) == CAIRO_STATUS_SUCCESS)
     {
       cairo_surface_flush(surf);
       uint8_t *const px = cairo_image_surface_get_data(surf);
       const int stride = cairo_image_surface_get_stride(surf);
-      for(int y = 0; y < IMG_H; y++)
+      for(int y = 0; y < img_h; y++)
       {
         uint32_t *const row = (uint32_t *)(px + (size_t)y * stride);
-        for(int x = 0; x < IMG_W; x++)
+        for(int x = 0; x < img_w; x++)
         {
-          const size_t i = (size_t)y * IMG_W + x;
+          const size_t i = (size_t)y * img_w + x;
           const uint32_t g = (uint32_t)(CLAMPF(mask[i], 0.0f, 1.0f) * 200.0f + 0.5f);
           row[x] = (reference[i] && mask[i] <= 0.0f) ? 0x00FF2020u : ((g << 16) | (g << 8) | g);
         }
@@ -415,8 +424,8 @@ static void _run_brush_case(dt_develop_t *dev, const float table[][9], const int
   }
 
   const gboolean ok = (largest <= budget_px);
-  printf("[%s] %-22s missing coverage %6d px, largest run %5d px", ok ? "PASS" : "FAIL", name,
-         missing, largest);
+  printf("[%s] %-22s %5dx%-5d missing coverage %6d px, largest run %5d px", ok ? "PASS" : "FAIL",
+         name, img_w, img_h, missing, largest);
   if(largest > 0) printf(" around (%d,%d)", cx, cy);
   printf("  budget %d  -> %s\n", budget_px, alpha_path);
   if(!ok) failures++;
@@ -428,9 +437,16 @@ static void _run_brush_case(dt_develop_t *dev, const float table[][9], const int
   g_list_free_full(form.points, free);
 }
 
+static void _run_brush_case(dt_develop_t *dev, const float table[][9], const int count,
+                            const char *name, const char *dir, const int budget_px)
+{
+  _run_brush_case_at(dev, table, count, name, dir, budget_px, IMG_W, IMG_H);
+}
+
 static void _run_case(dt_develop_t *dev, dt_masks_form_t *form, const char *name, const char *dir,
                       const int max_holes, const int max_hole_px)
 {
+  _set_frame(dev, IMG_W, IMG_H);
   float *mask = dt_masks_debug_rasterise(dev, form, IMG_W, IMG_H);
   if(IS_NULL_PTR(mask))
   {
@@ -530,7 +546,40 @@ int main(int argc, char *argv[])
    *    its radius toward the point of the cusp and leaves a V that is OPEN to the background --
    *    which is why it must be measured against the disc union and not by counting holes.
    *    Budget 0: any owed pixel the rasteriser does not deliver is the bug. */
-  _run_brush_case(&dev, _brush_1313, 11, "brush-1313-cusp", dir, 0);
+  /*    SWEEP THE FRAME SIZE, and that is not thoroughness for its own sake.
+   *
+   *    The defect this case exists for is a floating-point cancellation, so whether it appears
+   *    at all depends on the pixel COORDINATES the normalised nodes land on -- that is, on the
+   *    frame size. At the cusp the two products 3*p2 and 3*p3 are mathematically equal and
+   *    cancel; what survives is the rounding of the -p0*a + p1*b terms above them, which are
+   *    tiny but not zero because the recursion never samples t at exactly 1. When that residue
+   *    is zero the old code took its degenerate branch and came out round; when it is not, the
+   *    code normalised the residue and the border direction became noise, leaving the reported
+   *    V hole.
+   *
+   *    MEASURED, with the fix reverted: 14 of these 16 frames come out clean and two do not --
+   *    5000x3750 (3936 px missing at the cusp) and 2999x2251 (1358 px, the same place scaled).
+   *    The reporter's own 5198x3904 is among the clean ones. A corpus pinned to a single frame
+   *    size would therefore have passed this shape while the reported defect was live, which is
+   *    exactly what it did for a whole round of this investigation. Do not reduce this list to
+   *    one size; if it ever needs trimming, keep 5000x3750 and 2999x2251, which are the two
+   *    that actually detect. */
+  static const int frames[][2] = {
+    { 5198, 3904 },   // the reporter's own frame -- clean, which is the trap
+    { 5184, 3888 },
+    { 5000, 3750 },   // DETECTS
+    { 4321, 3241 },
+    { 4000, 3000 },
+    { 2999, 2251 },   // DETECTS
+    { 2137, 1603 },
+    { 1234,  987 },
+  };
+  for(int f = 0; f < (int)(sizeof(frames) / sizeof(*frames)); f++)
+  {
+    char *nm = g_strdup_printf("brush-1313-cusp-%dx%d", frames[f][0], frames[f][1]);
+    _run_brush_case_at(&dev, _brush_1313, 11, nm, dir, 0, frames[f][0], frames[f][1]);
+    g_free(nm);
+  }
 
   _run_brush_case(&dev, _brush_cusp_tbl,      3, "brush-cusp",      dir, 0);
   _run_brush_case(&dev, _brush_hairpin_tbl,   3, "brush-hairpin",   dir, 0);

--- a/tests/masks/masks_geometry.c
+++ b/tests/masks/masks_geometry.c
@@ -423,6 +423,43 @@ static const float _polygon_1788045925[15][8] = {
 #define MASKS_BASELINE_MAX_DELTA 8       /* per channel, of 255 */
 #define MASKS_BASELINE_MAX_SHARE 0.0002  /* share of pixels allowed to differ at all */
 
+/** Compare two same-sized ARGB surfaces: how many pixels differ at all, and the worst per-channel
+ * delta with where it is. Lifted out of the baseline check because "are these the same picture"
+ * is a separate question from "what do I do about it", and nesting a triple loop inside the
+ * decision made both harder to read. */
+static void _surface_diff(cairo_surface_t *const a, cairo_surface_t *const b,
+                          size_t *const differing, int *const worst, int *const wx, int *const wy)
+{
+  cairo_surface_flush(a);
+  cairo_surface_flush(b);
+
+  const int w = cairo_image_surface_get_width(a);
+  const int h = cairo_image_surface_get_height(a);
+  const int sa = cairo_image_surface_get_stride(a);
+  const int sb = cairo_image_surface_get_stride(b);
+  const uint8_t *const pa = cairo_image_surface_get_data(a);
+  const uint8_t *const pb = cairo_image_surface_get_data(b);
+
+  for(int y = 0; y < h; y++)
+    for(int x = 0; x < w; x++)
+    {
+      int pixel_worst = 0;
+      for(int c = 0; c < 3; c++)
+      {
+        const int d = abs((int)pa[y * sa + x * 4 + c] - (int)pb[y * sb + x * 4 + c]);
+        if(d > pixel_worst) pixel_worst = d;
+      }
+      if(pixel_worst == 0) continue;
+      (*differing)++;
+      if(pixel_worst > *worst)
+      {
+        *worst = pixel_worst;
+        *wx = x;
+        *wy = y;
+      }
+    }
+}
+
 static const char *baseline_dir = NULL;
 static gboolean baseline_update = FALSE;
 static int baseline_missing = 0;
@@ -486,29 +523,14 @@ static gboolean _baseline_check(const char *path, const char *name)
   }
   else
   {
-    cairo_surface_flush(a);
-    cairo_surface_flush(b);
-    const int w = cairo_image_surface_get_width(a);
-    const int h = cairo_image_surface_get_height(a);
-    const int sa = cairo_image_surface_get_stride(a);
-    const int sb = cairo_image_surface_get_stride(b);
-    const uint8_t *pa = cairo_image_surface_get_data(a);
-    const uint8_t *pb = cairo_image_surface_get_data(b);
-
     size_t differing = 0;
     int worst = 0;
-    int wx = -1, wy = -1;
-    for(int y = 0; y < h; y++)
-      for(int x = 0; x < w; x++)
-        for(int c = 0; c < 3; c++)
-        {
-          const int d = abs((int)pa[y * sa + x * 4 + c] - (int)pb[y * sb + x * 4 + c]);
-          if(d == 0) continue;
-          if(c == 0) differing++;   /* count a pixel once */
-          if(d > worst) { worst = d; wx = x; wy = y; }
-        }
+    int wx = -1;
+    int wy = -1;
+    _surface_diff(a, b, &differing, &worst, &wx, &wy);
 
-    const double share = (double)differing / ((double)w * h);
+    const double share = (double)differing / ((double)cairo_image_surface_get_width(a)
+                                              * cairo_image_surface_get_height(a));
     if(worst > MASKS_BASELINE_MAX_DELTA || share > MASKS_BASELINE_MAX_SHARE)
     {
       printf("      baseline: %s differs -- %zu px (%.4f%%), worst %d at (%d,%d)\n",
@@ -521,6 +543,38 @@ static gboolean _baseline_check(const char *path, const char *name)
   cairo_surface_destroy(b);
   g_free(base);
   return ok;
+}
+
+/** A picture of exactly what is owed and missing: red where the disc union covers a pixel the
+ * rasteriser left empty, over the mask itself. This is the artefact to look at first when a case
+ * fails -- it says WHERE the stroke went missing, which no scalar can. */
+static void _write_missing_map(const char *dir, const char *name, const float *const mask,
+                               const uint8_t *const reference, const int w, const int h)
+{
+  char *path = g_strdup_printf("%s/%s-missing.png", dir, name);
+  cairo_surface_t *surf = cairo_image_surface_create(CAIRO_FORMAT_RGB24, w, h);
+
+  if(cairo_surface_status(surf) == CAIRO_STATUS_SUCCESS)
+  {
+    cairo_surface_flush(surf);
+    uint8_t *const pixels = cairo_image_surface_get_data(surf);
+    const int stride = cairo_image_surface_get_stride(surf);
+    for(int y = 0; y < h; y++)
+    {
+      uint32_t *const row = (uint32_t *)(pixels + (size_t)y * stride);
+      for(int x = 0; x < w; x++)
+      {
+        const size_t i = (size_t)y * w + x;
+        const uint32_t g = (uint32_t)(CLAMPF(mask[i], 0.0f, 1.0f) * 255.0f + 0.5f);
+        row[x] = (reference[i] && mask[i] <= 0.0f) ? 0x00FF2020u : ((g << 16) | (g << 8) | g);
+      }
+    }
+    cairo_surface_mark_dirty(surf);
+    cairo_surface_write_to_png(surf, path);
+  }
+
+  cairo_surface_destroy(surf);
+  g_free(path);
 }
 
 static void _run_brush_case_at(dt_develop_t *dev, const float table[][9], const int count,
@@ -573,30 +627,7 @@ static void _run_brush_case_at(dt_develop_t *dev, const float table[][9], const 
    * rasteriser left empty, over the mask itself. This is the artefact to look at first when a
    * case fails -- it says WHERE the stroke went missing, which no scalar can. */
   if(!IS_NULL_PTR(reference) && missing > 0)
-  {
-    char *miss_path = g_strdup_printf("%s/%s-missing.png", dir, name);
-    cairo_surface_t *surf = cairo_image_surface_create(CAIRO_FORMAT_RGB24, img_w, img_h);
-    if(cairo_surface_status(surf) == CAIRO_STATUS_SUCCESS)
-    {
-      cairo_surface_flush(surf);
-      uint8_t *const px = cairo_image_surface_get_data(surf);
-      const int stride = cairo_image_surface_get_stride(surf);
-      for(int y = 0; y < img_h; y++)
-      {
-        uint32_t *const row = (uint32_t *)(px + (size_t)y * stride);
-        for(int x = 0; x < img_w; x++)
-        {
-          const size_t i = (size_t)y * img_w + x;
-          const uint32_t g = (uint32_t)(CLAMPF(mask[i], 0.0f, 1.0f) * 200.0f + 0.5f);
-          row[x] = (reference[i] && mask[i] <= 0.0f) ? 0x00FF2020u : ((g << 16) | (g << 8) | g);
-        }
-      }
-      cairo_surface_mark_dirty(surf);
-      cairo_surface_write_to_png(surf, miss_path);
-    }
-    cairo_surface_destroy(surf);
-    g_free(miss_path);
-  }
+    _write_missing_map(dir, name, mask, reference, img_w, img_h);
 
   if(missing > 0)
   {

--- a/tests/masks/masks_geometry.c
+++ b/tests/masks/masks_geometry.c
@@ -918,7 +918,55 @@ int main(int argc, char *argv[])
     g_list_free_full(form.points, free);
   }
 
-  /* 5. A circle, as the control: no joints, no folds. If this ever grows a hole the fault is
+  /* 5. The two shapes the corpus had no case for at all. A circle is a degenerate ellipse and
+   *    the two files share most of their rasteriser by copy-paste, so anything factored out of
+   *    one has to be answerable for in the other -- and until now only the circle was covered.
+   *    Both are rotated and non-axis-aligned on purpose: an axis-aligned ellipse hides a whole
+   *    class of transform error, and a gradient at 0 or 90 degrees hides another. */
+  {
+    dt_masks_form_t form = { 0 };
+    form.type = DT_MASKS_ELLIPSE;
+    form.functions = &dt_masks_functions_ellipse;
+    form.version = 6;
+    form.formid = 107;
+    g_strlcpy(form.name, "ellipse", sizeof(form.name));
+    dt_masks_node_ellipse_t *e = (dt_masks_node_ellipse_t *)calloc(1, sizeof(dt_masks_node_ellipse_t));
+    e->center[0] = 0.42f;
+    e->center[1] = 0.55f;
+    e->radius[0] = 0.20f;
+    e->radius[1] = 0.09f;
+    e->rotation = 27.0f;
+    e->border = 0.04f;
+    e->flags = DT_MASKS_ELLIPSE_EQUIDISTANT;
+    form.points = g_list_append(form.points, e);
+    _run_case(&dev, &form, "ellipse-rotated", dir, 0, 0);
+    g_list_free_full(form.points, free);
+  }
+
+  {
+    dt_masks_form_t form = { 0 };
+    form.type = DT_MASKS_GRADIENT;
+    form.functions = &dt_masks_functions_gradient;
+    form.version = 6;
+    form.formid = 108;
+    g_strlcpy(form.name, "gradient", sizeof(form.name));
+    dt_masks_anchor_gradient_t *g
+        = (dt_masks_anchor_gradient_t *)calloc(1, sizeof(dt_masks_anchor_gradient_t));
+    g->center[0] = 0.5f;
+    g->center[1] = 0.5f;
+    g->rotation = 34.0f;
+    g->extent = 0.12f;
+    g->steepness = 0.0f;
+    g->curvature = 0.3f;
+    g->state = DT_MASKS_GRADIENT_STATE_SIGMOIDAL;
+    form.points = g_list_append(form.points, g);
+    /* A gradient covers the frame edge to edge, so "enclosed holes" is the only thing to assert
+     * and coverage is whatever the ramp gives; the baseline is what actually pins its shape. */
+    _run_case(&dev, &form, "gradient-curved", dir, 0, 0);
+    g_list_free_full(form.points, free);
+  }
+
+  /* 6. A circle, as the control: no joints, no folds. If this ever grows a hole the fault is
    *    in the fill, not in any of the geometry above. */
   {
     dt_masks_form_t form = { 0 };

--- a/tests/masks/masks_geometry.c
+++ b/tests/masks/masks_geometry.c
@@ -200,18 +200,24 @@ static void _missing_coverage(const float *mask, const uint8_t *reference, const
                               int *total, int *largest, int *cx, int *cy)
 {
   *total = 0; *largest = 0; *cx = -1; *cy = -1;
-  uint8_t *miss = (uint8_t *)calloc((size_t)w * h, 1);
-  int *stack = (int *)malloc(sizeof(int) * (size_t)w * h);
+
+  /* A frame with no pixels has nothing to measure, and saying so here is not only defensive: it
+   * is what lets a reader (and a static analyser) bound every index below. */
+  if(w <= 0 || h <= 0) return;
+  const size_t npix = (size_t)w * h;
+
+  uint8_t *miss = (uint8_t *)calloc(npix, 1);
+  int *stack = (int *)malloc(sizeof(int) * npix);
   if(IS_NULL_PTR(miss) || IS_NULL_PTR(stack)) { free(miss); free(stack); return; }
 
   /* ANY coverage counts, not a thresholded core. `border' is the OUTER radius: the stroke is
    * solid in the middle and fades to zero at that edge, so most of the disc legitimately holds
    * values below a half. What cannot be legitimate is a pixel the disc covers with no coverage
    * at all -- that is the stroke missing, which is the defect this corpus is about. */
-  for(size_t i = 0; i < (size_t)w * h; i++)
+  for(size_t i = 0; i < npix; i++)
     if(reference[i] && mask[i] <= 0.0f) { miss[i] = 1; (*total)++; }
 
-  uint8_t *seen = (uint8_t *)calloc((size_t)w * h, 1);
+  uint8_t *seen = (uint8_t *)calloc(npix, 1);
   if(IS_NULL_PTR(seen)) { free(miss); free(stack); return; }
   for(int y = 0; y < h; y++)
     for(int x = 0; x < w; x++)
@@ -233,7 +239,12 @@ static void _missing_coverage(const float *mask, const uint8_t *reference, const
           if(nx < 0 || ny < 0 || nx >= w || ny >= h) continue;
           const size_t ni = (size_t)ny * w + nx;
           if(!miss[ni] || seen[ni]) continue;
-          seen[ni] = 1; stack[top++] = (int)ni;
+          seen[ni] = 1;
+          /* The push is bounded because a cell is marked BEFORE it is pushed, so none can enter
+           * the stack twice and `top' cannot pass npix. Stating that in code rather than only in
+           * a comment costs one compare per neighbour, and removes the reader's -- and the
+           * analyser's -- obligation to reconstruct the argument from two places. */
+          if((size_t)top < npix) stack[top++] = (int)ni;
         }
       }
       if(size > *largest) { *largest = size; *cx = (int)(sx / size); *cy = (int)(sy / size); }
@@ -248,13 +259,18 @@ static void _measure(const float *mask, const int w, const int h, double *covera
 {
   *coverage = 0.0; *hole_count = 0; *largest_hole = 0;
 
-  int *label = (int *)calloc((size_t)w * h, sizeof(int));
-  int *stack = (int *)malloc(sizeof(int) * (size_t)w * h);
+  /* A frame with no pixels has nothing to measure, and saying so here is not only defensive: it
+   * is what lets a reader (and a static analyser) bound every index below. */
+  if(w <= 0 || h <= 0) return;
+  const size_t npix = (size_t)w * h;
+
+  int *label = (int *)calloc(npix, sizeof(int));
+  int *stack = (int *)malloc(sizeof(int) * npix);
   if(IS_NULL_PTR(label) || IS_NULL_PTR(stack)) { free(label); free(stack); return; }
 
   size_t painted = 0;
-  for(size_t i = 0; i < (size_t)w * h; i++) if(mask[i] > 0.5f) painted++;
-  *coverage = (double)painted / ((double)w * h);
+  for(size_t i = 0; i < npix; i++) if(mask[i] > 0.5f) painted++;
+  *coverage = (double)painted / (double)npix;
 
   int next_label = 0;
   for(int y = 0; y < h; y++)
@@ -282,7 +298,11 @@ static void _measure(const float *mask, const int w, const int h, double *covera
           const size_t ni = (size_t)ny * w + nx;
           if(mask[ni] > 0.5f || label[ni]) continue;
           label[ni] = next_label;
-          stack[top++] = (int)ni;
+          /* The push is bounded because a cell is marked BEFORE it is pushed, so none can enter
+           * the stack twice and `top' cannot pass npix. Stating that in code rather than only in
+           * a comment costs one compare per neighbour, and removes the reader's -- and the
+           * analyser's -- obligation to reconstruct the argument from two places. */
+          if((size_t)top < npix) stack[top++] = (int)ni;
         }
       }
       if(!touches_border)
@@ -663,8 +683,28 @@ static void _run_case(dt_develop_t *dev, dt_masks_form_t *form, const char *name
 
 int main(int argc, char *argv[])
 {
-  const char *dir = (argc > 1 && argv[1][0] != '-') ? argv[1] : "/tmp";
-  g_mkdir_with_parents(dir, 0755);
+  /* Defaulting to "/tmp" wrote three dozen renders and CSVs to PREDICTABLE names in a
+   * world-writable directory: anyone can pre-create those names, or leave symlinks under them
+   * pointing elsewhere, and this follows them. ctest always passes an explicit directory, so it
+   * only ever affected a manual run -- which is exactly when someone is poking at this as root.
+   * g_mkdtemp() creates one atomically, mode 0700, under a name nobody can guess, and two
+   * concurrent manual runs stop overwriting each other's output as a side effect. */
+  char *scratch_out = NULL;
+  const char *dir = (argc > 1 && argv[1][0] != '-') ? argv[1] : NULL;
+  if(IS_NULL_PTR(dir))
+  {
+    scratch_out = g_strdup_printf("%s/ansel-test-masks-out-XXXXXX", g_get_tmp_dir());
+    dir = g_mkdtemp(scratch_out);
+    if(IS_NULL_PTR(dir))
+    {
+      fprintf(stderr, "[FAIL] could not create an output directory\n");
+      g_free(scratch_out);
+      return 1;
+    }
+    printf("output directory: %s\n", dir);
+  }
+  else
+    g_mkdir_with_parents(dir, 0755);
 
   /* Baselines live in the shared sample bank, beside the raw-export ones and reviewed the same
    * way. The bank is a plain clone, not a submodule (the superproject is public), so presence is
@@ -875,6 +915,7 @@ int main(int argc, char *argv[])
            baseline_missing);
 
   printf("%s: %d failing case(s)\n", failures ? "FAIL" : "PASS", failures);
+  g_free(scratch_out);
 
   dt_cleanup();
   g_free(config_dir);

--- a/tests/masks/masks_geometry.c
+++ b/tests/masks/masks_geometry.c
@@ -79,16 +79,25 @@ static dt_masks_node_brush_t *_brush_node(const float x, const float y, const fl
   return n;
 }
 
-static dt_masks_node_polygon_t *_polygon_node(const float x, const float y, const float c1x, const float c1y,
-                                              const float c2x, const float c2y, const float radius)
+static dt_masks_node_polygon_t *_polygon_node_state(const float x, const float y, const float c1x, const float c1y,
+                                                    const float c2x, const float c2y, const float radius,
+                                                    const dt_masks_points_states_t state)
 {
   dt_masks_node_polygon_t *n = (dt_masks_node_polygon_t *)calloc(1, sizeof(dt_masks_node_polygon_t));
   n->node[0] = x;     n->node[1] = y;
   n->ctrl1[0] = c1x;  n->ctrl1[1] = c1y;
   n->ctrl2[0] = c2x;  n->ctrl2[1] = c2y;
   n->border[0] = n->border[1] = radius;
-  n->state = DT_MASKS_POINT_STATE_NORMAL;
+  /* the state is not decoration: a CUSP node has both handles on the node, which is where the
+   * curve loses its direction and where both reported defects live */
+  n->state = state;
   return n;
+}
+
+static dt_masks_node_polygon_t *_polygon_node(const float x, const float y, const float c1x, const float c1y,
+                                              const float c2x, const float c2y, const float radius)
+{
+  return _polygon_node_state(x, y, c1x, c1y, c2x, c2y, radius, DT_MASKS_POINT_STATE_NORMAL);
 }
 
 /* ------------------------------------------------------------------------------------- */
@@ -348,6 +357,31 @@ static void _set_frame(dt_develop_t *dev, const int w, const int h)
   dt_geometry_chain_rebuild(dev);
 }
 
+
+/* THE SECOND REPORTED SHAPE. Polygon #2 of the same sidecar, decoded verbatim like the brush
+ * above. Fifteen nodes; node 12 is a CUSP (both handles collapsed onto it, state 2) and nodes 0
+ * and 14 bracket the concavity where the outer border was reported self-intersecting. Kept as
+ * data for the same reason: the test needs no file, no database and no XMP reader to reproduce
+ * the exact shape a user reported, and a diff shows when the geometry itself is edited. */
+static const float _polygon_1788045925[15][8] = {
+  /* node.x, node.y, ctrl1.x, ctrl1.y, ctrl2.x, ctrl2.y, border, state */
+  { 0.109192476f, 0.048409186f, 0.102207638f, 0.045089375f, 0.116177313f, 0.051728997f, 0.021000000f, 1 },
+  { 0.141800687f, 0.053578191f, 0.133969516f, 0.053021252f, 0.149631873f, 0.054135136f, 0.021000000f, 1 },
+  { 0.156179547f, 0.051750816f, 0.152295023f, 0.049384728f, 0.160064086f, 0.054116912f, 0.021000000f, 1 },
+  { 0.165107980f, 0.067774758f, 0.159996808f, 0.066224061f, 0.170219168f, 0.069325462f, 0.021000000f, 1 },
+  { 0.186846718f, 0.061055038f, 0.181864932f, 0.064845644f, 0.191828534f, 0.057264429f, 0.021000000f, 1 },
+  { 0.194998786f, 0.045031108f, 0.191052154f, 0.047960225f, 0.198945418f, 0.042101998f, 0.021000000f, 1 },
+  { 0.210526481f, 0.043480407f, 0.206644550f, 0.040637448f, 0.214408413f, 0.046323366f, 0.021000000f, 1 },
+  { 0.218290374f, 0.062088847f, 0.215120122f, 0.055455282f, 0.221460640f, 0.068722412f, 0.021000000f, 1 },
+  { 0.229547918f, 0.083281785f, 0.225083694f, 0.080955729f, 0.234012157f, 0.085607842f, 0.021000000f, 1 },
+  { 0.245075703f, 0.076045178f, 0.241193786f, 0.074408330f, 0.248957604f, 0.077682026f, 0.021000000f, 1 },
+  { 0.252839506f, 0.093102910f, 0.253421843f, 0.087416999f, 0.252257198f, 0.098788828f, 0.021000000f, 1 },
+  { 0.241581917f, 0.110160641f, 0.254290909f, 0.109167710f, 0.228872970f, 0.111153573f, 0.021000000f, 1 },
+  { 0.176586017f, 0.099060528f, 0.176586017f, 0.099060528f, 0.176586017f, 0.099060528f, 0.021000000f, 2 },
+  { 0.099036753f, 0.105304882f, 0.111819178f, 0.116205104f, 0.086254336f, 0.094404668f, 0.021000000f, 1 },
+  { 0.099891551f, 0.033659276f, 0.098198950f, 0.043141894f, 0.101584166f, 0.024176663f, 0.021000000f, 1 },
+};
+
 static void _run_brush_case_at(dt_develop_t *dev, const float table[][9], const int count,
                                const char *name, const char *dir, const int budget_px,
                                const int img_w, const int img_h)
@@ -443,11 +477,11 @@ static void _run_brush_case(dt_develop_t *dev, const float table[][9], const int
   _run_brush_case_at(dev, table, count, name, dir, budget_px, IMG_W, IMG_H);
 }
 
-static void _run_case(dt_develop_t *dev, dt_masks_form_t *form, const char *name, const char *dir,
-                      const int max_holes, const int max_hole_px)
+static void _run_case_at(dt_develop_t *dev, dt_masks_form_t *form, const char *name, const char *dir,
+                         const int max_holes, const int max_hole_px, const int img_w, const int img_h)
 {
-  _set_frame(dev, IMG_W, IMG_H);
-  float *mask = dt_masks_debug_rasterise(dev, form, IMG_W, IMG_H);
+  _set_frame(dev, img_w, img_h);
+  float *mask = dt_masks_debug_rasterise(dev, form, img_w, img_h);
   if(IS_NULL_PTR(mask))
   {
     printf("[FAIL] %-22s rasterisation returned nothing\n", name);
@@ -457,25 +491,37 @@ static void _run_case(dt_develop_t *dev, dt_masks_form_t *form, const char *name
 
   double coverage = 0.0;
   int holes = 0, largest = 0;
-  _measure(mask, IMG_W, IMG_H, &coverage, &holes, &largest);
+  _measure(mask, img_w, img_h, &coverage, &holes, &largest);
   dt_free_align(mask);
 
   char *alpha_path = g_strdup_printf("%s/%s-alpha.png", dir, name);
   char *over_path = g_strdup_printf("%s/%s-overlay.png", dir, name);
   const dt_masks_debug_request_t alpha_req
-      = { .width = IMG_W, .height = IMG_H, .backdrop = DT_MASKS_DEBUG_BACKDROP_RASTER, .draw_overlay = FALSE };
+      = { .width = img_w, .height = img_h, .backdrop = DT_MASKS_DEBUG_BACKDROP_RASTER, .draw_overlay = FALSE };
   const dt_masks_debug_request_t over_req
-      = { .width = IMG_W, .height = IMG_H, .backdrop = DT_MASKS_DEBUG_BACKDROP_RASTER, .draw_overlay = TRUE };
+      = { .width = img_w, .height = img_h, .backdrop = DT_MASKS_DEBUG_BACKDROP_RASTER, .draw_overlay = TRUE };
   dt_masks_debug_write_png(dev, form, &alpha_req, alpha_path);
   dt_masks_debug_write_png(dev, form, &over_req, over_path);
 
+  if(holes > max_holes || largest > max_hole_px)
+  {
+    char *csv = g_strdup_printf("%s/%s-outline.csv", dir, name);
+    dt_masks_debug_write_outline_csv(dev, form, csv);
+    g_free(csv);
+  }
+
   const gboolean ok = (holes <= max_holes) && (largest <= max_hole_px);
-  printf("[%s] %-22s coverage %.4f  enclosed holes %d (largest %d px)  budget %d/%d  -> %s\n",
-         ok ? "PASS" : "FAIL", name, coverage, holes, largest, max_holes, max_hole_px, alpha_path);
+  printf("[%s] %-22s %5dx%-5d coverage %.4f  enclosed holes %d (largest %d px)  budget %d/%d  -> %s\n",
+         ok ? "PASS" : "FAIL", name, img_w, img_h, coverage, holes, largest, max_holes, max_hole_px, alpha_path);
   if(!ok) failures++;
 
   g_free(alpha_path);
   g_free(over_path);
+}
+static void _run_case(dt_develop_t *dev, dt_masks_form_t *form, const char *name, const char *dir,
+                      const int max_holes, const int max_hole_px)
+{
+  _run_case_at(dev, form, name, dir, max_holes, max_hole_px, IMG_W, IMG_H);
 }
 
 /* ------------------------------------------------------------------------------------- */
@@ -586,6 +632,36 @@ int main(int argc, char *argv[])
   _run_brush_case(&dev, _brush_zigzag_tbl,    6, "brush-zigzag",    dir, 0);
   _run_brush_case(&dev, _brush_selfcross_tbl, 5, "brush-selfcross", dir, 0);
   _run_brush_case(&dev, _brush_concave_tbl,   5, "brush-concave",   dir, 0);
+
+  /* 3b. THE SECOND REPORTED SHAPE, polygon #2. Two defects were reported against it: the outer
+   *     border self-intersecting between nodes 0 and 14, where the outline runs into a
+   *     concavity, and a missing radial spoke in the feather at node 12, which is the shape's
+   *     one cusp. The second is a RASTER defect, so it is measured on the mask and not just
+   *     looked at. Frame-swept for the same reason the brush is: the geometry that decides both
+   *     is evaluated in pixels. */
+  {
+    static const int poly_frames[][2] = { { 5198, 3904 }, { 4000, 3000 }, { 2137, 1603 } };
+    for(int f = 0; f < (int)(sizeof(poly_frames) / sizeof(*poly_frames)); f++)
+    {
+      dt_masks_form_t form = { 0 };
+      form.type = DT_MASKS_POLYGON;
+      form.functions = &dt_masks_functions_polygon;
+      form.version = 6;
+      form.formid = 106;
+      g_strlcpy(form.name, "polygon #2", sizeof(form.name));
+      for(int i = 0; i < 15; i++)
+      {
+        const float *r = _polygon_1788045925[i];
+        form.points = g_list_append(form.points,
+                                    _polygon_node_state(r[0], r[1], r[2], r[3], r[4], r[5], r[6],
+                                                        (dt_masks_points_states_t)(int)r[7]));
+      }
+      char *nm = g_strdup_printf("polygon-1788045925-%dx%d", poly_frames[f][0], poly_frames[f][1]);
+      _run_case_at(&dev, &form, nm, dir, 0, 0, poly_frames[f][0], poly_frames[f][1]);
+      g_free(nm);
+      g_list_free_full(form.points, free);
+    }
+  }
 
   /* 4. A polygon whose concave runs are tighter than its feather: its offset curve
    *    self-intersects at every one of them, which is the geometry issue #1313 turned on --


### PR DESCRIPTION
Follow-up of #1313. Seven commits, in two arcs: the hygiene refactor that #1344 merged without,
and the brush cusp defect the reporter kept seeing.

### The reported bug

A brush cusp lost its radius toward the point and left a sharp V hole in the **exported mask**.

`_brush_border_get_XY()` guarded the degenerate-tangent case with `if(dx == 0 && dy == 0)`. At a
cusp both control handles sit on the node, so `3*(p3 - p2)` is mathematically zero — but these
are image pixels, and it evaluates to **1.22e-4**: the `-p0*a + p1*b` terms above the
cancellation are tiny but not zero, because the recursion never samples `t` at exactly 1, and
their rounding is what survives. The guard never fired. Execution fell through and *normalised
that residue* — `(1.22e-4, 0)` normalises to `(1, 0)` — so the border direction at the cusp was
rounding noise pointing along +x. The tell, once you know it, is a border sample sitting exactly
one radius due east of its node.

Returning NaN was the wrong answer even when the guard did fire: every consumer falls back to the
previous border point, both sides of the joint coincide, and the arc filler that exists to bridge
that wedge never triggers. The threshold is now relative to the control polygon, and the
degenerate case takes the limit direction the second-order term gives.

**Verified on the reporter's raw** (`20230824_0182.RW2`, `--disable-opencl --export_masks`): the
mask gains 3127 px of coverage in a 113×67 box centred on the cusp, and every image-side
difference of 5 LSB or more — 4217 px of them — falls inside that box.

### Why the regression corpus did not catch it, twice

Both reasons are in the corpus now, and both are the interesting part:

- **It swept nothing.** The defect is a floating-point cancellation, so whether it appears
  depends on the coordinates the normalised nodes land on — i.e. on the frame size. With the fix
  reverted, 14 of 16 frames come out clean and two do not, and **the reporter's own 5198×3904 is
  among the clean ones.** The case now runs at eight sizes, two of which detect.
- **Its oracle claimed too much.** A disc union and a normal-offset stroke are not the same shape
  where the radius is changing — the envelope of a growing disc family leans off the normal by
  `asin(dr/ds)` — so it flagged 3552 px of crescents on the *outside* of the widest bulge. It now
  asserts the smaller of the two node radii across a segment, which both definitions agree on.

### The GUI outline, which is where the original hack belonged

`0b54897b50` disabled the node join arcs to stop the dashed border drawing them as
self-intersecting loops. But border coverage *is* mask coverage — the mask is the union of
centreline→border spokes — so that traded a cosmetic blemish for a hole in every rendered mask.
The arcs are restored and the cosmetic half is handled where it belongs, in two parts:

- The arc spans are recorded out-of-band and blanked from the display outline. `_brush_draw_shape()`
  was skipping NaN with the pen **down**, so each blanked span came out as a straight chord —
  at a cusp, one slicing across the rounded tip. It now lifts the pen.
- The inner offset **overshoots** at any turn tighter than its radius, and the two strands cross:
  the X users actually report. Measured, that X is present with the arcs drawn, blanked, or never
  generated — `0b54897b50` never addressed it. The joint is already described by a skip range, so
  the trim is that range growing to the crossing. On the reported brush exactly one joint changes,
  the cusp.

All three are display-only: the rasterisers pass NULL for the skip ranges, and the export is
bit-identical on both pages across every one of these commits.

### Diagnostics

`develop/masks_debug.h` plus `tests/masks/masks_geometry.c` (`ansel-test-masks-geometry`, in
ctest): headless rasterisation, PNG output over a transparent/black/mask backdrop, and an outline
CSV carrying the skip ranges. The overlay is drawn by the production routine —
`dt_masks_events_post_expose_with()` — through a transform, so a regression test looks at exactly
what the darkroom paints rather than at a second implementation of it.

### Verification

- 3 build configurations, `tools/check_{conditional_includes,unused_includes,module_boundaries,layering,windows_syntax}.sh` all pass.
- `masks_geometry`, `test_masks_raster_contract`, `test_masks_skip_ranges` pass.
- Reporter's export bit-identical on both pages for every display-side commit; the one
  pixel-changing commit is localised to the cusp as described above.
