### PR TITLE
widgets: count the CSS border in a size request, not just the padding

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1503,6 +1503,27 @@ Verify this class of layout by measuring, not by looking: build the widget in a
 `gtk_widget_get_allocation()` for the cells. It answers in seconds what several rebuild-and-look
 round trips do not.
 
+### A height/width request must cover the CSS border, not just the padding
+
+A widget's size request is its whole CSS box: padding *and* border come out of the allocation
+before the content sees any of it. Code that sizes an area to fit its content therefore has to
+add both back, and `gtk_style_context_get_padding()` without the matching
+`gtk_style_context_get_border()` leaves the content short by exactly one border.
+
+Two pixels is enough to be visible, because the widgets that care answer a shortfall with a
+whole scrollbar rather than a clipped pixel. `dt_ui_scroll_wrap()` (`widgets/scroll_wrap.c`)
+sizes every list and textview in the application to `clamp(min(content, cap), min_size, 75%
+window)`, snapped to whole rows so it never shows a half-row — no slack anywhere — and its
+`GtkScrolledWindow` carries `.dt_recessed_scroll`, which the theme gives `padding: 2px` over a
+`border: 1px`. Counting the padding alone handed the viewport 123 px for 125 px of content, and
+`GTK_POLICY_AUTOMATIC` did the rest. Measured, same rows and same CSS, border omitted then
+counted: `page=123 < upper=125, scrollbar` → `page=125 = upper=125, none`.
+
+Reproduce this class of bug offscreen in seconds: build the widget with the theme's CSS on it,
+pump the main loop, then compare the scrolled window's vadjustment `page_size` against `upper`.
+A scrollbar that appears for a couple of pixels looks like a content-height miscount and is
+usually a frame the request forgot.
+
 ### Modal dialogs must explicitly refocus their parent on close
 
 `gtk_window_set_transient_for()` at dialog creation is not enough to guarantee focus returns to

--- a/src/develop/imageop_gui.c
+++ b/src/develop/imageop_gui.c
@@ -737,12 +737,17 @@ static gboolean _rename_module_resize(GtkWidget *entry, GdkEventKey *event, dt_i
 {
   int width = 0;
   GtkBorder padding;
+  GtkBorder border;
 
   pango_layout_get_pixel_size(gtk_entry_get_layout(GTK_ENTRY(entry)), &width, NULL);
-  gtk_style_context_get_padding(gtk_widget_get_style_context (entry),
-                                gtk_widget_get_state_flags (entry),
-                                &padding);
-  gtk_widget_set_size_request(entry, width + padding.left + padding.right + 1, -1);
+  // The entry's frame eats into its allocation before the text gets any room, so the request has
+  // to carry the border as well as the padding -- the theme gives every entry a 1px one.
+  GtkStyleContext *context = gtk_widget_get_style_context(entry);
+  const GtkStateFlags state = gtk_widget_get_state_flags(entry);
+  gtk_style_context_get_padding(context, state, &padding);
+  gtk_style_context_get_border(context, state, &border);
+  gtk_widget_set_size_request(entry, width + padding.left + padding.right
+                                     + border.left + border.right + 1, -1);
 
   return TRUE;
 }

--- a/src/widgets/scroll_wrap.c
+++ b/src/widgets/scroll_wrap.c
@@ -206,7 +206,8 @@ static gint _resizable_scroll_max_height(void)
  * persisted height when set, otherwise the window ceiling so the area auto-grows to its content.
  * This makes small content shrink to fit, lets nested lists grow and have their parent panel scroll
  * until the user drags the handle to cap them, and snaps lists/textviews to whole rows to avoid
- * clipped half-rows. The computed bare (pre-padding) height is cached for the drag handle.
+ * clipped half-rows. The computed bare height -- before the scrolled window's own padding and
+ * border are added back -- is cached for the drag handle.
  */
 static void _resizable_scroll_apply(GtkWidget *w)
 {
@@ -264,13 +265,23 @@ static void _resizable_scroll_apply(GtkWidget *w)
   }
   state->last_height = height;
 
+  // The request covers the scrolled window's whole CSS box, and the viewport only gets what is
+  // left of it: padding AND border are both taken out first. Counting one and not the other
+  // leaves the content exactly that many pixels short of fitting, and an AUTOMATIC policy
+  // answers a two-pixel shortfall with a full scrollbar -- on an area whose whole purpose is to
+  // be sized to fit its content. The .dt_recessed_scroll treeviews carry both (2px padding over
+  // a 1px border), so this is not a hypothetical.
+  GtkStyleContext *sw_context = gtk_widget_get_style_context(sw);
+  const GtkStateFlags sw_state = gtk_widget_get_state_flags(sw);
   GtkBorder padding;
-  gtk_style_context_get_padding(gtk_widget_get_style_context(sw),
-                                gtk_widget_get_state_flags(sw), &padding);
+  GtkBorder border;
+  gtk_style_context_get_padding(sw_context, sw_state, &padding);
+  gtk_style_context_get_border(sw_context, sw_state, &border);
 
   gint old_height = 0;
   gtk_widget_get_size_request(sw, NULL, &old_height);
-  const gint new_height = height + padding.top + padding.bottom + (GTK_IS_TEXT_VIEW(w) ? 2 : 0);
+  const gint new_height = height + padding.top + padding.bottom + border.top + border.bottom
+                          + (GTK_IS_TEXT_VIEW(w) ? 2 : 0);
   if(new_height != old_height)
     gtk_widget_set_size_request(sw, -1, new_height);
 }


### PR DESCRIPTION
A widget's size request covers its whole CSS box: padding and border are both taken out of the allocation before the content gets any of it. `_resizable_scroll_apply()` added the padding back and not the border, so every area sized to fit its content came out exactly one border short — and since the rule snaps lists to whole rows, there was no slack anywhere to absorb it.

The `.dt_recessed_scroll` class every scroll-wrapped treeview carries declares both, `padding: 2px` over a `border: 1px`, so the viewport received 123 px for 125 px of content and `GTK_POLICY_AUTOMATIC` answered those two pixels with a full scrollbar — on an area whose entire purpose is to be sized to fit. This affects every list and textview going through `dt_ui_scroll_wrap()`, not one panel.

Measured on the same rows and the same CSS, border omitted then counted:

```
border counted=False  row=25  content=125  request=129  alloc_tv=123  page=123 < upper=125  scrollbar=True
border counted=True   row=25  content=125  request=131  alloc_tv=125  page=125 = upper=125  scrollbar=False
```

The same omission was in `_rename_module_resize()`, which sized a module's rename entry from its text width plus padding while the theme gives every `entry` a 1px border and `#iop-panel-label` overrides only the padding — the field was systematically 2 px too narrow for its text.

Left alone deliberately: `thumbnail_btn.c` reads the padding without the border because it insets the icon it draws rather than requesting a size; the border there is painted by CSS itself.

The trap is documented in the GTK/UI section of `CLAUDE.md`, with the offscreen measurement (compare the vadjustment's `page_size` against `upper`) that settles this class of bug in seconds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
