### PR TITLE
masks: delete unused shapes, really and reversibly

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1138,6 +1138,62 @@ are now refcounted (`dt_masks_form_t.refcount`, `src/develop/masks/masks_history
   already guarantees a GUI-side edit clones instead of mutating a form an in-flight pipeline run
   is holding.
 
+### The unused-shape sweep's used-set is not a subset of the snapshot it sweeps
+
+"Delete unused shapes" in the shape manager (`libs/masks.c`, `dt_masks_cleanup_unused()`) keeps a
+form when some history entry's `blend_params->mask_id` names it, or names a group that
+transitively contains it. Those ids are collected by walking history from the bottom up, and they
+are **not** a subset of the `hist->forms` snapshot being swept: a module whose drawn mask was
+since dropped keeps its old `mask_id` in every history entry it ever wrote, and no form in a
+later snapshot answers to it. The set is therefore unbounded with respect to the snapshot, and
+must live in a hash set — `_cleanup_unused_recurs()` sizing a table on `g_list_length(forms)`
+filled it with ids that match nothing and ran out of slots before the one live group's membership
+was walked, deleting shapes from the tail of that group inward while the module was still using
+them. Measured on a 20-step history: four departed groups (`colorbalancergb`, two `toneequal`, an
+older `exposure`) took four of the eight slots an 8-form snapshot allowed, the live group and its
+first three members took the rest, and the group's last two shapes were swept.
+
+Marking an id and recursing into it are now the same step, which also bounds a group that
+contains itself through a chain of member groups — the old code broke out of its scan on an
+already-seen id but recursed regardless, so such a cycle did not terminate.
+
+A swept form's snapshot reference is **handed to `dev->allforms`**, not released: a form read back
+from `masks_history` is built by `dt_masks_create()` and its snapshot membership is its only
+claim, so unref-ing at that point would free an object `dev->forms` may still hold by address. One
+`allforms` entry per transferred claim is what keeps teardown balanced; do not "fix" the missing
+unref.
+
+The sweep is history-wide by necessity: `main.masks_history` stores one row per (history step,
+form), so a shape only really leaves the database once **every** snapshot has stopped naming it —
+hence the rewrite of every `hist->forms` in place, after which `dev->forms` is re-pointed at the
+topmost surviving snapshot.
+
+That is still undoable, and the menu handler opens the undo record itself, **before** the sweep.
+`dt_dev_add_history_item()` opens one of its own, but by then every snapshot has been rewritten
+and the "before" state it would capture is the swept one; `dt_dev_history_undo_start_record()`'s
+depth counter makes the inner pair a no-op, so the recorded pair spans the whole operation. What
+makes the restore work is that `dt_history_duplicate()` copies each item's forms **list**
+(`g_list_copy` plus one reference per form) instead of aliasing it: the record owns its own
+cells, the sweep's `g_list_remove()` on the live items cannot reach them, and every swept shape
+stays alive as long as the record holds it. `_pop_undo()` rewrites the database from the restored
+history, so the `masks_history` rows come back too. Measured round trip on one image:
+65 rows / 23 forms → 70 / 22 after the sweep → 65 / 23 after undo, the swept shape restored and
+nothing else moved.
+
+That rewrite is in-memory only. `main.history` and `main.masks_history` are deleted and
+re-inserted wholesale from `dev->history` by `_write_history_from_state()`, and nothing on this
+path triggers it — so the menu handler commits a mask-manager history entry
+(`dt_dev_add_history_item(dev, NULL, FALSE, TRUE)`) after the sweep, the way every other forms
+mutation in `libs/masks.c` must. Without it the swept shapes stay in the database and come back
+on the next read, and the pipeline never resyncs. Measured on a 20-step history: 60 rows / 24
+forms before, 58 / 22 after, with exactly the two orphans gone and one extra history step.
+
+The sweep also takes `dev->history_mutex` as **writer** for its whole span. The async DB write
+job walks `hist->forms` with the lock released; its snapshot references keep each history *item*
+alive but say nothing about the list cells `g_list_remove()` frees under it. Order is
+`history_mutex` outer, `masks_mutex` (taken by `dt_masks_replace_current_forms()`) inner — the
+same way a history commit takes them.
+
 ### A form mutation that never reaches a history commit is invisible to undo/redo
 
 `dt_dev_add_history_item_ext()` (`dev_history.c`) is the only place that turns the current

--- a/src/develop/masks/masks.c
+++ b/src/develop/masks/masks.c
@@ -1694,21 +1694,22 @@ uint64_t dt_masks_form_get_own_hash(uint64_t hash, GList *masks, const dt_masks_
   return hash;
 }
 
-// adds formid to used array
-// if formid is a group it adds all the forms that belongs to that group
-static void _cleanup_unused_recurs(GList *form_list, int form_id, int *used_form_ids, int used_count)
+/* Marks form_id as used, and every form a group transitively contains.
+ *
+ * The set is unbounded on purpose. Its members are not a subset of form_list: every
+ * blend_params->mask_id ever recorded in history is fed in, groups of modules whose mask was
+ * since dropped included, and those ids have no form to match in the snapshot being cleaned.
+ * A fixed table sized on the snapshot's form count therefore fills up on ids that answer
+ * nothing, and the members discovered last -- the tail of the one group that IS live -- find no
+ * slot left and are silently taken for unused. Measured on a 20-step history: four departed
+ * groups ate the eight slots an 8-form snapshot allowed, and the two last shapes of the module's
+ * own mask group were deleted while the module was still using them.
+ *
+ * Re-entering an already-marked id also stops the walk here rather than after it: a group that
+ * contains itself through some chain of member groups would otherwise not terminate. */
+static void _cleanup_unused_recurs(GList *form_list, int form_id, GHashTable *used_form_ids)
 {
-  // first, we search for the formid in used table
-  for(int used_index = 0; used_index < used_count; used_index++)
-  {
-    if(used_form_ids[used_index] == 0)
-    {
-      // we store the formid
-      used_form_ids[used_index] = form_id;
-      break;
-    }
-    if(used_form_ids[used_index] == form_id) break;
-  }
+  if(!g_hash_table_add(used_form_ids, GINT_TO_POINTER(form_id))) return;
 
   // if the form is a group, we iterate through the sub-forms
   dt_masks_form_t *mask_form = dt_masks_get_from_id_ext(form_list, form_id);
@@ -1717,7 +1718,7 @@ static void _cleanup_unused_recurs(GList *form_list, int form_id, int *used_form
     for(GList *group_node = mask_form->points; group_node; group_node = g_list_next(group_node))
     {
       dt_masks_form_group_t *group_entry = (dt_masks_form_group_t *)group_node->data;
-      _cleanup_unused_recurs(form_list, group_entry->formid, used_form_ids, used_count);
+      _cleanup_unused_recurs(form_list, group_entry->formid, used_form_ids);
     }
   }
 }
@@ -1728,9 +1729,8 @@ static int _masks_cleanup_unused(dt_develop_t *dev, GList **forms_list, GList *h
   int masks_removed = 0;
   GList *forms = *forms_list;
 
-  // we create a table to store the ids of used forms
-  guint form_count = g_list_length(forms);
-  int *used_form_ids = dt_calloc_align(form_count * sizeof(int));
+  // the set of ids used by the history entries we are about to walk
+  GHashTable *used_form_ids = g_hash_table_new(g_direct_hash, g_direct_equal);
 
   // check in history if the module has drawn masks and add it to used array
   int history_index = 0;
@@ -1745,7 +1745,7 @@ static int _masks_cleanup_unused(dt_develop_t *dev, GList **forms_list, GList *h
     if(blend_params)
     {
       if(blend_params->mask_id > 0)
-        _cleanup_unused_recurs(forms, blend_params->mask_id, used_form_ids, form_count);
+        _cleanup_unused_recurs(forms, blend_params->mask_id, used_form_ids);
     }
     history_index++;
   }
@@ -1755,29 +1755,23 @@ static int _masks_cleanup_unused(dt_develop_t *dev, GList **forms_list, GList *h
   while(shape_node)
   {
     dt_masks_form_t *mask_form = (dt_masks_form_t *)shape_node->data;
-    int is_used = 0;
-    for(int used_index = 0; used_index < form_count; used_index++)
-    {
-      if(used_form_ids[used_index] == mask_form->formid)
-      {
-        is_used = 1;
-        break;
-      }
-      if(used_form_ids[used_index] == 0) break;
-    }
+    const gboolean is_used = g_hash_table_contains(used_form_ids, GINT_TO_POINTER(mask_form->formid));
 
     shape_node = g_list_next(shape_node); // need to get 'next' now, because we may be removing the current node
 
-    if(is_used == 0)
+    if(!is_used)
     {
       forms = g_list_remove(forms, mask_form);
-      // and add it to allforms for cleanup
+      // This list's reference is handed over to dev->allforms rather than released: a form read
+      // from masks_history is created by dt_masks_create() and its snapshot membership is its
+      // only claim, so unref-ing here would free an object dev->forms may still be holding by
+      // address. One allforms entry per transferred claim keeps the teardown balanced.
       dev->allforms = g_list_append(dev->allforms, mask_form);
       masks_removed = 1;
     }
   }
 
-  dt_free_align(used_form_ids);
+  g_hash_table_destroy(used_form_ids);
 
   *forms_list = forms;
 
@@ -1791,7 +1785,7 @@ static int _masks_cleanup_unused(dt_develop_t *dev, GList **forms_list, GList *h
  * Caveat: if multiple history entries reference masks, some unused masks may remain.
  *         This is intentional so users can still jump back in history.
  */
-void dt_masks_cleanup_unused_from_list(dt_develop_t *dev, GList *history_list)
+static void _masks_cleanup_unused_from_list(dt_develop_t *dev, GList *history_list)
 {
   // a mask is used in a given hist->forms entry if it is used up to the next hist->forms
   // so we are going to remove for each hist->forms from the top
@@ -1819,8 +1813,17 @@ void dt_masks_cleanup_unused(dt_develop_t *develop)
 {
   dt_masks_change_form_gui(develop, NULL);
 
+  /* The sweep rewrites every hist->forms in place, and the async DB write job walks those same
+   * lists with history_mutex released. Its snapshot holds a reference on each history ITEM,
+   * which keeps the item alive but says nothing about the list cells g_list_remove() frees
+   * under it. Hold the writer across the sweep and the re-point that reads its result, so the
+   * job sees the image either fully swept or untouched. Order is history_mutex outer,
+   * masks_mutex (taken by dt_masks_replace_current_forms) inner -- the same way a history
+   * commit takes them. */
+  dt_pthread_rwlock_wrlock(&develop->history_mutex);
+
   // we remove the forms from history
-  dt_masks_cleanup_unused_from_list(develop, develop->history);
+  _masks_cleanup_unused_from_list(develop, develop->history);
 
   // and we save all that
   GList *forms = NULL;
@@ -1836,6 +1839,8 @@ void dt_masks_cleanup_unused(dt_develop_t *develop)
   }
 
   dt_masks_replace_current_forms(develop, forms);
+
+  dt_pthread_rwlock_unlock(&develop->history_mutex);
 }
 
 #include "detail.c"

--- a/src/libs/masks.c
+++ b/src/libs/masks.c
@@ -454,10 +454,33 @@ static void _set_iter_name(dt_lib_masks_t *lm, dt_masks_form_t *form, int state,
                      (!IS_NULL_PTR(icop)), TREE_IC_INVERSE, icinv, TREE_IC_INVERSE_VISIBLE, (!IS_NULL_PTR(icinv)), -1);
 }
 
-static void _tree_cleanup(GtkButton *button, dt_lib_module_t *self)
+static void _tree_delete_unused(GtkButton *button, dt_lib_module_t *self)
 {
-  dt_masks_cleanup_unused(dt_dev_get_global());
+  dt_develop_t *dev = dt_dev_get_global();
+
+  /* The undo record has to be opened HERE, before the sweep. dt_dev_add_history_item() below
+   * opens one of its own, but by then every hist->forms has been rewritten in place and the
+   * "before" state it captures is the swept one. dt_dev_history_undo_start_record()'s depth
+   * counter makes that inner pair a no-op, so the recorded before/after spans the whole
+   * operation.
+   *
+   * What makes the restore work is that dt_history_duplicate() copies each item's forms LIST
+   * (g_list_copy plus one reference per form) rather than aliasing it: the snapshot owns its
+   * own cells, the sweep's g_list_remove() on the live items cannot reach them, and every
+   * swept shape stays alive as long as the record holds it. _pop_undo() rewrites the database
+   * from the restored history, so undoing puts the masks_history rows back too. */
+  dt_dev_undo_start_record(dev);
+
+  dt_masks_cleanup_unused(dev);
   _lib_masks_recreate_list(self);
+
+  // The sweep only rewrote the in-memory snapshots. main.history and main.masks_history are
+  // rewritten wholesale from dev->history by the write a commit triggers, so without one the
+  // deleted shapes stay in the database and come back on the next read -- and, like every other
+  // forms mutation here, the deletion is never recorded as its own history step.
+  dt_dev_add_history_item(dev, NULL, FALSE, TRUE);
+
+  dt_dev_undo_end_record(dev);
 }
 
 static void _add_masks_history_item(dt_lib_masks_t *lm)
@@ -1000,8 +1023,8 @@ static GtkWidget *_tree_context_menu(GtkTreeSelection *selection, GtkTreeModel *
     gtk_menu_shell_append(menu, item);
   }
 
-  item = gtk_menu_item_new_with_label(_("Cleanup unused shapes"));
-  g_signal_connect(item, "activate", (GCallback)_tree_cleanup, self);
+  item = gtk_menu_item_new_with_label(_("Delete unused shapes"));
+  g_signal_connect(item, "activate", (GCallback)_tree_delete_unused, self);
   gtk_menu_shell_append(menu, item);
   
   return GTK_WIDGET(menu);


### PR DESCRIPTION
The shape manager's "Cleanup unused shapes" deleted shapes a module was still using, left the ones it did delete in the database, and could not be undone. Three separate defects, each established by measurement on a real 20-step history rather than from reading the source.

## The used-set was bounded by the wrong thing

A form survives the sweep if some history entry's `blend_params->mask_id` names it, or names a group that transitively contains it. Those ids were collected into a fixed table sized on the swept snapshot's form count — but they are **not** a subset of that snapshot. A module whose drawn mask was since dropped keeps its old `mask_id` in every history entry it ever wrote, and no form in a later snapshot answers to it.

So the table filled up on ids that matched nothing and ran out before the one live group's membership was walked, deleting shapes from the tail of that group inward. Measured, on a snapshot of 8 forms:

```
used 1784689597  Mask Color balance    <- departed
used 1787932453  Mask Tone equalizer   <- departed
used 1787932501  Mask Exposure (old)   <- departed
used 1788014035  Mask Tone equalizer   <- departed
used 1788023345  Mask Exposure         <- live group
used 1788023340  circle #1
used 1788023349  ellipse #1
used 1788045925  polygon #2            <- 8/8, table full
```

`brush #1` and `brush #2`, the group's remaining members, found no slot and were swept while `exposure` was still using them. The set now lives in a `GHashTable`, where nothing bounds it.

Marking an id and recursing into it also become the same step, which terminates a group that contains itself through a chain of member groups — the old code broke out of its scan on an already-seen id but recursed regardless.

## Nothing reached the database

`main.history` and `main.masks_history` are deleted and re-inserted wholesale from `dev->history` by the write a history commit triggers. The sweep rewrote the in-memory snapshots and triggered nothing, so the deleted shapes stayed in the database and came back on the next read. The handler now commits a mask-manager entry, the way every other forms mutation in `libs/masks.c` must.

## Undo recorded the wrong "before"

`dt_dev_add_history_item()` opens an undo record of its own, but by then every `hist->forms` has been rewritten and the state it captures is the swept one. The handler opens the record itself, before the sweep; `dt_dev_history_undo_start_record()`'s depth counter makes the inner pair a no-op, so the recorded pair spans the whole operation.

That is all it needed: `dt_history_duplicate()` copies each item's forms **list** (`g_list_copy` plus one reference per form) rather than aliasing it, so the record owns its own cells, the sweep's `g_list_remove()` on the live items cannot reach them, and every swept shape stays alive as long as the record holds it. `_pop_undo()` rewrites the database from the restored history, so the `masks_history` rows come back too.

## Locking

The sweep takes `history_mutex` as writer for its whole span. The async DB write job walks `hist->forms` with the lock released; its snapshot references keep each history *item* alive but say nothing about the list cells `g_list_remove()` frees under it. Order is `history_mutex` outer, `masks_mutex` inner, the same way a history commit takes them.

## Verification

Measured against `main.masks_history` on one image, at each step:

| | rows | forms | steps |
|---|---|---|---|
| after creating an orphan shape | 65 | 23 | 11 |
| after "Delete unused shapes" | 70 | 22 | 12 |
| after Ctrl+Z | 65 | 23 | 11 |

The orphan leaves every step, and undo brings it back with nothing else moved. An earlier run on the same image removed exactly the two genuine orphans and kept `brush #1` / `brush #2`, which the buggy version deleted.

Two cmocka tests reproducing the measured scenario were written and used to check the fix against the defect — they fail on the old code (assertion, then a stack overflow on the group cycle) and pass on the new. They are **not** in this PR: `tools/check_module_boundaries.sh` section 9 is a ratchet, and a test file outside `src/develop/masks/` raises five of the masks counters. Happy to land them alongside a baseline bump if that is wanted.

The menu entry now reads "Delete unused shapes", which is what it does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)