### PR TITLE
masks: shape manager fixes -- leaks, an unlocked list write, multi-selection, and toolbar state

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1106,6 +1106,34 @@ ctrl+click only work once that node is *selected* (a mere hover gets the shorter
 `dt_hinter_set_message()` joins `\n` into `, `, so each line must read as a clause of one
 sentence.
 
+### A shape toolbar's pressed button is a view on the creation state, not a state of its own
+
+Which shape button looks armed is derived, never remembered. `dt_masks_creation_mode_enter()`
+(`masks/masks_gui.c`) ends by raising `DT_SIGNAL_MASK_SHAPE_BUTTONS_SYNC`
+(`dt_masks_shape_buttons_sync_all()`), and every toolbar built by `dt_masks_shape_buttons_create()`
+answers by recomputing each of its buttons from `_masks_shape_button_is_current_creation()` against
+`dev->form_gui`. `dt_masks_form_exit_creation()` is the symmetric half and raises
+`..._DEACTIVATE`. That is what lets creation be armed from places that own no button at all — the
+shape manager's "Add new shape ..." context menu (`libs/masks.c`), the keyboard shortcuts,
+`iop/spots.c` — without each of them having to find and press a widget.
+
+So a new way to arm a shape needs no toolbar code, and a toolbar must not track what was clicked.
+The buttons act on `button-press-event`, not `toggled`, which is why the sync may set them freely
+without re-entering the press handler; and the sync is raised *after* the whole creation state is
+written, so a handler that asks is told the truth.
+
+**A toolbar with a NULL `creation_module` is the shape manager's and belongs to no module**, so it
+reports any creation whose form is not a retouch/spot one (`DT_MASKS_IS_RETOUCHE`) — those never
+appear in its tree. Every other toolbar carries its owner in `creation_module` and lights up only
+for that module. The distinction matters because the manager's context menu arms creation with the
+*selected group's* module, not with the manager's own NULL: a strict identity test would leave the
+button that menu just chose unpressed.
+
+`_masks_shape_button_defs` is the one table naming a shape's icon and its two button tooltips
+(`label`, `ctrl_label`, phrased as actions) plus its bare `name`. Menu entries offering a shape are
+built from it through `dt_masks_shape_menu_item_new()`, so a menu and the button offering the same
+shape cannot drift apart — they did, as "add path" against "add polygon".
+
 ### Forms are refcounted, not deep-copied
 
 `dev->forms` (`dt_develop_t`) is the live, mutable `GList` of every mask shape and group

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1600,6 +1600,22 @@ The hint costs nothing for a panel shown and hidden repeatedly: GTK consults it 
 mapping only, so a window the user has dragged elsewhere keeps the place they gave it across
 later hide/show cycles.
 
+### A window a toggle button opens has exactly one state: the button's
+
+`gtk_widget_hide_on_delete()` is the usual answer to a window whose widgets and state must
+survive being closed, but it hides the window behind the back of whatever opened it. When the
+opener is a `GtkToggleButton` — the shape manager panel's toolbox button (`libs/masks.c`) — the
+button stays pressed after a window-manager close, and the next click reads that state as "the
+panel is open" and hides an already-hidden window: it takes two clicks to bring the panel back.
+
+So the button's `active` flag is the panel's only state. Visibility is driven from `toggled`,
+never from `clicked`, and the `delete-event` handler hides nothing itself — it un-presses the
+button and returns `TRUE`, leaving that same `toggled` handler to save the geometry and hide.
+The order matters: `gtk_toggle_button_set_active()` emits `clicked` as well as `toggled`, so a
+`clicked` handler flipping visibility would re-show the window it was just asked to close. The
+handler compares `active` against the window's actual visibility and returns when the two agree,
+which is what makes it safe to re-enter from the close path.
+
 ### Modal dialogs must explicitly refocus their parent on close
 
 `gtk_window_set_transient_for()` at dialog creation is not enough to guarantee focus returns to

--- a/src/control/signal.c
+++ b/src/control/signal.c
@@ -240,6 +240,8 @@ static dt_signal_description _signal_description[DT_SIGNAL_COUNT] = {
     FALSE }, //DT_SIGNAL_MASK_CHANGED
   { "dt-mask-shape-buttons-deactivate", NULL, NULL, G_TYPE_NONE, g_cclosure_marshal_generic, 1, pointer_arg, NULL,
     FALSE }, // DT_SIGNAL_MASK_SHAPE_BUTTONS_DEACTIVATE
+  { "dt-mask-shape-buttons-sync", NULL, NULL, G_TYPE_NONE, g_cclosure_marshal_VOID__VOID, 0, NULL, NULL,
+    FALSE }, // DT_SIGNAL_MASK_SHAPE_BUTTONS_SYNC
   { "dt-develop-masks-gui-changed", NULL, NULL, G_TYPE_NONE, g_cclosure_marshal_VOID__VOID, 0, NULL, NULL,
     FALSE }, // DT_SIGNAL_DEVELOP_MASKS_GUI_CHANGED
 

--- a/src/control/signal.h
+++ b/src/control/signal.h
@@ -315,6 +315,10 @@ typedef enum dt_signal_t
   DT_SIGNAL_MASK_CHANGED,
   DT_SIGNAL_MASK_SHAPE_BUTTONS_DEACTIVATE,
 
+  /* Raised when mask creation mode is entered, so every shape toolbar re-reads which shape is
+     being created and presses the matching button -- the toolbars are not the only way in. */
+  DT_SIGNAL_MASK_SHAPE_BUTTONS_SYNC,
+
   /* Raised when the focused darkroom module changes or its masks/blending GUI needs refresh */
   DT_SIGNAL_DEVELOP_MASKS_GUI_CHANGED,
 

--- a/src/develop/masks/masks_gui.c
+++ b/src/develop/masks/masks_gui.c
@@ -2155,6 +2155,26 @@ gboolean dt_masks_form_exit_creation(dt_iop_module_t *module, dt_masks_form_gui_
     }
 
     dt_masks_creation_mode_quit(mask_gui);
+
+    /* The user-facing ways to abandon a creation session all land here -- Esc, the right-click
+     * menu entry, backspace on a polygon with no node placed, the darkroom tearing down
+     * mid-creation -- and none of them told the shape toolbars, so a shape abandoned with Esc
+     * left its button pressed. Only the click-the-armed-button-again path deactivated, because
+     * it does so itself before calling us. Finishing a shape is NOT one of these: continuous
+     * creation deliberately keeps the tool armed for the next one.
+     *
+     * This is not the only place mask_gui->creation is cleared -- dt_masks_clear_form_gui()
+     * does it too, so entering edit mode leaves creation through dt_masks_change_form_gui()
+     * instead, and deactivates the toolbars on its own (develop/blend_gui.c). Neither that
+     * function nor dt_masks_creation_mode_quit() can carry this call, tempting as the latter
+     * looks: dt_masks_creation_mode_enter() reaches both while ARMING a tool, so deactivating
+     * there would switch off the button the same gesture just pressed.
+     *
+     * Raised after creation is cleared, so a handler that asks is told the truth; the buttons
+     * are on "button-press-event", not "toggled", so setting them inactive cannot re-enter
+     * this function. */
+    dt_masks_shape_buttons_deactivate_all(NULL);
+
     g_list_free(mask_gui->creation_formids);
     mask_gui->creation_formids = NULL;
     mask_gui->creation_last_formid = 0;

--- a/src/develop/masks/masks_gui.c
+++ b/src/develop/masks/masks_gui.c
@@ -59,8 +59,11 @@ typedef struct dt_masks_shape_button_def_t
   int index;
   guint flag;
   dt_masks_type_t type;
+  // label/ctrl_label are the button's two tooltips and read as actions ("add circle"); name is the
+  // shape itself, for a place that already says what it does -- an "Add new shape ..." submenu.
   const gchar *label;
   const gchar *ctrl_label;
+  const gchar *name;
   DTGTKCairoPaintIconFunc paint;
 } dt_masks_shape_button_def_t;
 
@@ -74,15 +77,15 @@ typedef struct dt_masks_shape_buttons_data_t
 
 static const dt_masks_shape_button_def_t _masks_shape_button_defs[] = {
   { DT_MASKS_SHAPE_INDEX_GRADIENT, DT_MASKS_SHAPE_BUTTONS_GRADIENT, DT_MASKS_GRADIENT,
-    N_("add gradient"), N_("add multiple gradients"), dtgtk_cairo_paint_masks_gradient },
+    N_("add gradient"), N_("add multiple gradients"), N_("Gradient"), dtgtk_cairo_paint_masks_gradient },
   { DT_MASKS_SHAPE_INDEX_BRUSH, DT_MASKS_SHAPE_BUTTONS_BRUSH, DT_MASKS_BRUSH,
-    N_("add brush"), N_("add multiple brush strokes"), dtgtk_cairo_paint_masks_brush },
+    N_("add brush"), N_("add multiple brush strokes"), N_("Brush"), dtgtk_cairo_paint_masks_brush },
   { DT_MASKS_SHAPE_INDEX_POLYGON, DT_MASKS_SHAPE_BUTTONS_POLYGON, DT_MASKS_POLYGON,
-    N_("add polygon"), N_("add multiple polygons"), dtgtk_cairo_paint_masks_polygon },
+    N_("add polygon"), N_("add multiple polygons"), N_("Polygon"), dtgtk_cairo_paint_masks_polygon },
   { DT_MASKS_SHAPE_INDEX_ELLIPSE, DT_MASKS_SHAPE_BUTTONS_ELLIPSE, DT_MASKS_ELLIPSE,
-    N_("add ellipse"), N_("add multiple ellipses"), dtgtk_cairo_paint_masks_ellipse },
+    N_("add ellipse"), N_("add multiple ellipses"), N_("Ellipse"), dtgtk_cairo_paint_masks_ellipse },
   { DT_MASKS_SHAPE_INDEX_CIRCLE, DT_MASKS_SHAPE_BUTTONS_CIRCLE, DT_MASKS_CIRCLE,
-    N_("add circle"), N_("add multiple circles"), dtgtk_cairo_paint_masks_circle },
+    N_("add circle"), N_("add multiple circles"), N_("Circle"), dtgtk_cairo_paint_masks_circle },
 };
 
 static void _masks_shape_buttons_deactivate(GtkWidget *active_button, dt_masks_shape_buttons_data_t *data)
@@ -127,10 +130,106 @@ static gboolean _masks_shape_button_is_current_creation(dt_develop_t *dev,
   dt_masks_form_gui_t *mask_gui = dev->form_gui;
   dt_masks_form_t *visible_form = dt_masks_get_visible_form(dev);
 
-  return !IS_NULL_PTR(mask_gui) && mask_gui->creation
-         && mask_gui->creation_module == data->config.creation_module
-         && !IS_NULL_PTR(visible_form)
-         && (visible_form->type & data->types[button_index]);
+  if(IS_NULL_PTR(mask_gui) || !mask_gui->creation || IS_NULL_PTR(visible_form)) return FALSE;
+  if(!(visible_form->type & data->types[button_index])) return FALSE;
+
+  /* A toolbar with no creation_module belongs to no module: it is the shape manager's, which lists
+   * every plain drawn shape whoever created it, so it reports any creation but a retouch/spot one,
+   * whose shapes it never shows. Every other toolbar is a module's own and speaks only for it. */
+  if(IS_NULL_PTR(data->config.creation_module))
+    return (visible_form->type & DT_MASKS_IS_RETOUCHE) == 0;
+
+  return mask_gui->creation_module == data->config.creation_module;
+}
+
+/* The pressed button is a view on dev->form_gui, not a state of its own: recompute it rather than
+ * remembering what was clicked, since creation is armed from places that have no button at all --
+ * the shape manager's "Add new shape ..." context menu, the keyboard shortcuts. */
+static void _masks_shape_buttons_sync(dt_masks_shape_buttons_data_t *data)
+{
+  if(IS_NULL_PTR(data)) return;
+
+  dt_develop_t *dev = !IS_NULL_PTR(data->config.creation_module) ? data->config.creation_module->dev
+                                                                : data->config.dev;
+  if(IS_NULL_PTR(dev)) return;
+
+  for(int i = 0; i < DT_MASKS_SHAPE_BUTTON_COUNT; i++)
+  {
+    GtkWidget *button = data->buttons[i];
+    if(!GTK_IS_TOGGLE_BUTTON(button)) continue;
+
+    const gboolean active = _masks_shape_button_is_current_creation(dev, data, i);
+    if(gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(button)) != active)
+      gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(button), active);
+  }
+}
+
+static void _masks_shape_buttons_sync_signal(gpointer instance, dt_masks_shape_buttons_data_t *data)
+{
+  _masks_shape_buttons_sync(data);
+}
+
+void dt_masks_shape_buttons_sync_all(void)
+{
+  DT_DEBUG_CONTROL_SIGNAL_RAISE(dt_control_signal_get_global(), DT_SIGNAL_MASK_SHAPE_BUTTONS_SYNC);
+}
+
+static const dt_masks_shape_button_def_t *_masks_shape_button_def(const dt_masks_type_t type)
+{
+  const size_t count = sizeof(_masks_shape_button_defs) / sizeof(_masks_shape_button_defs[0]);
+  for(size_t i = 0; i < count; i++)
+    if(_masks_shape_button_defs[i].type == type) return &_masks_shape_button_defs[i];
+
+  return NULL;
+}
+
+static gboolean _masks_shape_icon_draw(GtkWidget *widget, cairo_t *cr, gpointer user_data)
+{
+  DTGTKCairoPaintIconFunc paint = (DTGTKCairoPaintIconFunc)user_data;
+
+  // Follow the menu item's own foreground, so the icon dims and highlights with the row it is in.
+  GdkRGBA color;
+  gtk_style_context_get_color(gtk_widget_get_style_context(widget),
+                              gtk_widget_get_state_flags(widget), &color);
+  gdk_cairo_set_source_rgba(cr, &color);
+
+  GtkAllocation alloc;
+  gtk_widget_get_allocation(widget, &alloc);
+  // The shapes are drawn out to the edges of the square they are handed, so inset it: at this
+  // size the outermost stroke would otherwise be clipped by the allocation.
+  const gint pad = 1;
+  paint(cr, pad, pad, alloc.width - 2 * pad, alloc.height - 2 * pad, 0, NULL);
+
+  return FALSE;
+}
+
+GtkWidget *dt_masks_shape_menu_item_new(GtkWidget *menu, const dt_masks_type_t type,
+                                        GCallback activate_callback, gpointer user_data)
+{
+  const dt_masks_shape_button_def_t *def = _masks_shape_button_def(type);
+  if(IS_NULL_PTR(def) || !GTK_IS_MENU_SHELL(menu)) return NULL;
+
+  GtkWidget *menu_item = gtk_menu_item_new();
+  GtkWidget *box = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, DT_GUI_BOX_SPACING);
+  GtkWidget *icon = gtk_drawing_area_new();
+
+  // Square, and the height of a line of text, so the row keeps the height it would have had.
+  const gint size = DT_PIXEL_APPLY_DPI(12);
+  gtk_widget_set_size_request(icon, size, size);
+  gtk_widget_set_valign(icon, GTK_ALIGN_CENTER);
+  g_signal_connect(G_OBJECT(icon), "draw", G_CALLBACK(_masks_shape_icon_draw), def->paint);
+
+  GtkWidget *label = gtk_label_new(_(def->name));
+  gtk_label_set_xalign(GTK_LABEL(label), 0.0f);
+
+  gtk_box_pack_start(GTK_BOX(box), icon, FALSE, FALSE, 0);
+  gtk_box_pack_start(GTK_BOX(box), label, FALSE, FALSE, 0);
+  gtk_container_add(GTK_CONTAINER(menu_item), box);
+  gtk_menu_shell_append(GTK_MENU_SHELL(menu), menu_item);
+
+  if(activate_callback) g_signal_connect(G_OBJECT(menu_item), "activate", activate_callback, user_data);
+
+  return menu_item;
 }
 
 static gboolean _masks_shape_button_pressed(GtkWidget *button, GdkEventButton *event, gpointer user_data)
@@ -190,6 +289,7 @@ static gboolean _masks_shape_button_pressed(GtkWidget *button, GdkEventButton *e
 static void _masks_shape_buttons_destroy(GtkWidget *widget, dt_masks_shape_buttons_data_t *data)
 {
   DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(dt_control_signal_get_global(), G_CALLBACK(_masks_shape_buttons_deactivate_signal), data);
+  DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(dt_control_signal_get_global(), G_CALLBACK(_masks_shape_buttons_sync_signal), data);
   dt_free(data);
 }
 
@@ -259,6 +359,8 @@ GtkWidget *dt_masks_shape_buttons_create(const dt_masks_shape_buttons_config_t *
 
   DT_DEBUG_CONTROL_SIGNAL_CONNECT(dt_control_signal_get_global(), DT_SIGNAL_MASK_SHAPE_BUTTONS_DEACTIVATE,
                                   G_CALLBACK(_masks_shape_buttons_deactivate_signal), data);
+  DT_DEBUG_CONTROL_SIGNAL_CONNECT(dt_control_signal_get_global(), DT_SIGNAL_MASK_SHAPE_BUTTONS_SYNC,
+                                  G_CALLBACK(_masks_shape_buttons_sync_signal), data);
   g_signal_connect(G_OBJECT(data->box), "destroy", G_CALLBACK(_masks_shape_buttons_destroy), data);
 
   return data->box;
@@ -4940,6 +5042,12 @@ gboolean dt_masks_creation_mode_enter(dt_develop_t *dev, dt_iop_module_t *module
   dev->form_gui->creation_type = type;
   dev->form_gui->creation_formids = NULL;
   dev->form_gui->creation_last_formid = 0;
+
+  /* Whichever gesture armed the tool -- a toolbar button, the shape manager's "Add new shape ..."
+   * entry, a shortcut -- every toolbar now shows the shape being created. Raised after the whole
+   * creation state is written, so a handler asking is told the truth; the buttons act on
+   * "button-press-event", not "toggled", so pressing one here cannot re-enter this function. */
+  dt_masks_shape_buttons_sync_all();
 
   // Give focus to central view to allow using shortcuts for mask creation right after selecting a mask type in the manager
   gtk_widget_grab_focus(dt_gui_center_widget());

--- a/src/develop/masks/masks_gui.c
+++ b/src/develop/masks/masks_gui.c
@@ -164,7 +164,8 @@ static void _masks_shape_buttons_sync(dt_masks_shape_buttons_data_t *data)
   }
 }
 
-static void _masks_shape_buttons_sync_signal(gpointer instance, dt_masks_shape_buttons_data_t *data)
+static void _masks_shape_buttons_sync_signal(gpointer instance __attribute__((unused)),
+                                             dt_masks_shape_buttons_data_t *data)
 {
   _masks_shape_buttons_sync(data);
 }

--- a/src/develop/masks_gui.h
+++ b/src/develop/masks_gui.h
@@ -496,6 +496,20 @@ typedef struct dt_masks_shape_buttons_config_t
 } dt_masks_shape_buttons_config_t;GtkWidget *dt_masks_shape_buttons_create(const dt_masks_shape_buttons_config_t *config);
 void dt_masks_shape_buttons_deactivate_all(GtkWidget *active_button);
 
+/** @brief Make every shape toolbar show the shape currently being created, if any.
+ *
+ * The pressed button is a view on the creation state, so any code arming or re-arming a creation
+ * outside a toolbar button calls this. dt_masks_creation_mode_enter() already does. */
+void dt_masks_shape_buttons_sync_all(void);
+
+/** @brief Append a menu entry for one shape type: its toolbar icon, then its toolbar label.
+ *
+ * The icon and the name both come from the same table the shape toolbars are built from, so a
+ * menu offering a shape and the button offering it cannot drift apart. Returns the entry, or
+ * NULL for a type no toolbar knows. */
+GtkWidget *dt_masks_shape_menu_item_new(GtkWidget *menu, const dt_masks_type_t type,
+                                        GCallback activate_callback, gpointer user_data);
+
 int dt_masks_events_mouse_moved(dt_develop_t *dev, struct dt_iop_module_t *module, double x, double y, double pressure,
                                 int which);
 int dt_masks_events_button_released(dt_develop_t *dev, struct dt_iop_module_t *module, double x, double y, int which,

--- a/src/libs/masks.c
+++ b/src/libs/masks.c
@@ -1394,7 +1394,11 @@ static void _lib_masks_recreate_list(dt_lib_module_t *self)
       ids = g_list_next(ids);
 
       GtkTreeIter iter;
-      gtk_tree_model_get_iter_first(model, &iter);
+      // An empty store leaves iter untouched, and _find_mask_iter_by_values() then walks a
+      // stack-garbage iterator: gtk_tree_store_get_value() and gtk_tree_store_iter_next()
+      // assert on it, and the walk has no reason to terminate. Nothing later in this loop can
+      // make the store non-empty, so stop rather than skip.
+      if(!gtk_tree_model_get_iter_first(model, &iter)) break;
       // get formid in group for the given module
       const gboolean found = _find_mask_iter_by_values(model, &iter, mod, fid, 1);
 

--- a/src/libs/masks.c
+++ b/src/libs/masks.c
@@ -273,44 +273,25 @@ static void _lib_masks_blending_gui_changed_callback(gpointer instance, dt_lib_m
   dt_iop_gui_update_blending(module);
 }
 
-static void _tree_add_circle(GtkButton *button, dt_iop_module_t *module)
+/* The shape to create rides on the menu item, the way "masks-operation" already does below --
+ * one handler for the five entries, which is also what lets them be built from a loop. Arming the
+ * tool is dt_masks_creation_mode_enter()'s business alone, toolbars included: it tells every shape
+ * toolbar to press the matching button, so the entry and the button agree without either knowing
+ * about the other. */
+static void _tree_add_shape(GtkWidget *menu_item, dt_iop_module_t *module)
 {
-  // we create the new form
-  dt_masks_creation_mode_enter(dt_dev_get_global(), module, DT_MASKS_CIRCLE);
+  const dt_masks_type_t type
+      = (dt_masks_type_t)GPOINTER_TO_INT(g_object_get_data(G_OBJECT(menu_item), "masks-shape-type"));
+
+  dt_masks_creation_mode_enter(dt_dev_get_global(), module, type);
   dt_dev_get_global()->form_gui->group_selected = 0;
   dt_control_queue_redraw_center();
 }
 
-static void _tree_add_ellipse(GtkButton *button, dt_iop_module_t *module)
+static void _tree_add_shape_menu_item(GtkWidget *menu, const dt_masks_type_t type, dt_iop_module_t *module)
 {
-  // we create the new form
-  dt_masks_creation_mode_enter(dt_dev_get_global(), module, DT_MASKS_ELLIPSE);
-  dt_dev_get_global()->form_gui->group_selected = 0;
-  dt_control_queue_redraw_center();
-}
-
-static void _tree_add_polygon(GtkButton *button, dt_iop_module_t *module)
-{
-  // we create the new form
-  dt_masks_creation_mode_enter(dt_dev_get_global(), module, DT_MASKS_POLYGON);
-  dt_dev_get_global()->form_gui->group_selected = 0;
-  dt_control_queue_redraw_center();
-}
-
-static void _tree_add_gradient(GtkButton *button, dt_iop_module_t *module)
-{
-  // we create the new form
-  dt_masks_creation_mode_enter(dt_dev_get_global(), module, DT_MASKS_GRADIENT);
-  dt_dev_get_global()->form_gui->group_selected = 0;
-  dt_control_queue_redraw_center();
-}
-
-static void _tree_add_brush(GtkButton *button, dt_iop_module_t *module)
-{
-  // we create the new form
-  dt_masks_creation_mode_enter(dt_dev_get_global(), module, DT_MASKS_BRUSH);
-  dt_dev_get_global()->form_gui->group_selected = 0;
-  dt_control_queue_redraw_center();
+  GtkWidget *item = dt_masks_shape_menu_item_new(menu, type, G_CALLBACK(_tree_add_shape), module);
+  if(!IS_NULL_PTR(item)) g_object_set_data(G_OBJECT(item), "masks-shape-type", GINT_TO_POINTER(type));
 }
 
 static void _lib_masks_shape_button_started(GtkWidget *button, dt_iop_module_t *module,
@@ -849,21 +830,11 @@ static GtkWidget *_tree_context_menu(GtkTreeSelection *selection, GtkTreeModel *
     gtk_menu_item_set_submenu(GTK_MENU_ITEM(add_item), add_menu);
     gtk_menu_shell_append(menu, add_item);
 
-    item = gtk_menu_item_new_with_label(_("add circle"));
-    g_signal_connect(item, "activate", (GCallback)_tree_add_circle, module);
-    gtk_menu_shell_append(GTK_MENU_SHELL(add_menu), item);
-
-    item = gtk_menu_item_new_with_label(_("add ellipse"));
-    g_signal_connect(item, "activate", (GCallback)_tree_add_ellipse, module);
-    gtk_menu_shell_append(GTK_MENU_SHELL(add_menu), item);
-
-    item = gtk_menu_item_new_with_label(_("add path"));
-    g_signal_connect(item, "activate", (GCallback)_tree_add_polygon, module);
-    gtk_menu_shell_append(GTK_MENU_SHELL(add_menu), item);
-
-    item = gtk_menu_item_new_with_label(_("add gradient"));
-    g_signal_connect(item, "activate", (GCallback)_tree_add_gradient, module);
-    gtk_menu_shell_append(GTK_MENU_SHELL(add_menu), item);
+    _tree_add_shape_menu_item(add_menu, DT_MASKS_BRUSH, module);
+    _tree_add_shape_menu_item(add_menu, DT_MASKS_CIRCLE, module);
+    _tree_add_shape_menu_item(add_menu, DT_MASKS_ELLIPSE, module);
+    _tree_add_shape_menu_item(add_menu, DT_MASKS_POLYGON, module);
+    _tree_add_shape_menu_item(add_menu, DT_MASKS_GRADIENT, module);
 
     gtk_menu_shell_append(menu, gtk_separator_menu_item_new());
   }
@@ -878,25 +849,11 @@ static GtkWidget *_tree_context_menu(GtkTreeSelection *selection, GtkTreeModel *
       gtk_menu_item_set_submenu(GTK_MENU_ITEM(add_item), add_menu);
       gtk_menu_shell_append(menu, add_item);
 
-      item = gtk_menu_item_new_with_label(_("Add brush"));
-      g_signal_connect(item, "activate", (GCallback)_tree_add_brush, module);
-      gtk_menu_shell_append(GTK_MENU_SHELL(add_menu), item);
-
-      item = gtk_menu_item_new_with_label(_("Add circle"));
-      g_signal_connect(item, "activate", (GCallback)_tree_add_circle, module);
-      gtk_menu_shell_append(GTK_MENU_SHELL(add_menu), item);
-
-      item = gtk_menu_item_new_with_label(_("Add ellipse"));
-      g_signal_connect(item, "activate", (GCallback)_tree_add_ellipse, module);
-      gtk_menu_shell_append(GTK_MENU_SHELL(add_menu), item);
-
-      item = gtk_menu_item_new_with_label(_("Add polygon"));
-      g_signal_connect(item, "activate", (GCallback)_tree_add_polygon, module);
-      gtk_menu_shell_append(GTK_MENU_SHELL(add_menu), item);
-
-      item = gtk_menu_item_new_with_label(_("Add gradient"));
-      g_signal_connect(item, "activate", (GCallback)_tree_add_gradient, module);
-      gtk_menu_shell_append(GTK_MENU_SHELL(add_menu), item);
+      _tree_add_shape_menu_item(add_menu, DT_MASKS_BRUSH, module);
+      _tree_add_shape_menu_item(add_menu, DT_MASKS_CIRCLE, module);
+      _tree_add_shape_menu_item(add_menu, DT_MASKS_ELLIPSE, module);
+      _tree_add_shape_menu_item(add_menu, DT_MASKS_POLYGON, module);
+      _tree_add_shape_menu_item(add_menu, DT_MASKS_GRADIENT, module);
 
       // existing forms
       gboolean has_unused_shapes = FALSE;

--- a/src/libs/masks.c
+++ b/src/libs/masks.c
@@ -1057,14 +1057,13 @@ static int _tree_button_pressed(GtkWidget *treeview, GdkEventButton *event, dt_l
   dt_iop_module_t *module = NULL;
   int handled = 0;
   // mouse_path is non-NULL exactly when the pointer is over a row, so it answers "on a row?" too.
+  // The module is only wanted for the context menu below; a row that resolves to no iter simply
+  // leaves it NULL, which is what _tree_context_menu() already expects.
   if(gtk_tree_view_get_path_at_pos(GTK_TREE_VIEW(treeview), (gint)event->x, (gint)event->y, &mouse_path, NULL,
-                                   NULL, NULL))
+                                   NULL, NULL)
+     && gtk_tree_model_get_iter(model, &iter, mouse_path))
   {
-    // we retrieve the iter and module from path
-    if(gtk_tree_model_get_iter(model, &iter, mouse_path))
-    {
-      _lib_masks_get_values(model, &iter, &module, NULL, NULL);
-    }
+    _lib_masks_get_values(model, &iter, &module, NULL, NULL);
   }
   /* single click with the right mouse button? */
   if(event->type == GDK_BUTTON_PRESS && event->button == 1)

--- a/src/libs/masks.c
+++ b/src/libs/masks.c
@@ -998,6 +998,48 @@ static GtkWidget *_tree_context_menu(GtkTreeSelection *selection, GtkTreeModel *
   return GTK_WIDGET(menu);
 }
 
+/* The selection a left click asks for. Ctrl toggles the row, so a second one takes it back out
+ * rather than being a no-op; Shift extends from the cursor, which is the anchor GTK would have
+ * used, and rows the range picks up that _tree_restrict_select refuses -- a different parent, a
+ * different depth -- are dropped by it as usual. A click on blank space clears the selection.
+ *
+ * Returns whether the gesture was answered here, which is what the caller reports as handled:
+ * an unmodified click on a row is left to GtkTreeView, the one case it does act on. */
+static int _tree_apply_click_selection(GtkWidget *treeview, GtkTreeSelection *selection,
+                                       const GdkEventButton *event, GtkTreePath *mouse_path)
+{
+  if(IS_NULL_PTR(mouse_path))
+  {
+    gtk_tree_selection_unselect_all(selection);
+    return 0;
+  }
+
+  if(dt_modifier_is(event->state, DT_PRIMARY_MASK))
+  {
+    if(gtk_tree_selection_path_is_selected(selection, mouse_path))
+      gtk_tree_selection_unselect_path(selection, mouse_path);
+    else
+      gtk_tree_selection_select_path(selection, mouse_path);
+    return 1;
+  }
+
+  if(dt_modifier_is(event->state, GDK_SHIFT_MASK))
+  {
+    GtkTreePath *anchor = NULL;
+    gtk_tree_view_get_cursor(GTK_TREE_VIEW(treeview), &anchor, NULL);
+    if(anchor)
+    {
+      gtk_tree_selection_select_range(selection, anchor, mouse_path);
+      gtk_tree_path_free(anchor);
+    }
+    else
+      gtk_tree_selection_select_path(selection, mouse_path);
+    return 1;
+  }
+
+  return 0;
+}
+
 /* Ctrl+click toggles a row, Shift+click extends from the cursor. GtkTreeView's own handler does
  * neither on this tree: measured, the intent masks it derives are the expected ones (modify 0x4,
  * extend 0x1), the event carries them, the selection is GTK_SELECTION_MULTIPLE and the select
@@ -1013,12 +1055,11 @@ static int _tree_button_pressed(GtkWidget *treeview, GdkEventButton *event, dt_l
   GtkTreePath *mouse_path = NULL;
   GtkTreeIter iter;
   dt_iop_module_t *module = NULL;
-  int on_row = 0;
   int handled = 0;
+  // mouse_path is non-NULL exactly when the pointer is over a row, so it answers "on a row?" too.
   if(gtk_tree_view_get_path_at_pos(GTK_TREE_VIEW(treeview), (gint)event->x, (gint)event->y, &mouse_path, NULL,
                                    NULL, NULL))
   {
-    on_row = 1;
     // we retrieve the iter and module from path
     if(gtk_tree_model_get_iter(model, &iter, mouse_path))
     {
@@ -1028,41 +1069,12 @@ static int _tree_button_pressed(GtkWidget *treeview, GdkEventButton *event, dt_l
   /* single click with the right mouse button? */
   if(event->type == GDK_BUTTON_PRESS && event->button == 1)
   {
-    if(on_row && dt_modifier_is(event->state, DT_PRIMARY_MASK))
-    {
-      // Toggle, which is what this modifier means everywhere else: a second Ctrl+click on a row
-      // takes it back out of the selection rather than being a no-op.
-      if(gtk_tree_selection_path_is_selected(selection, mouse_path))
-        gtk_tree_selection_unselect_path(selection, mouse_path);
-      else
-        gtk_tree_selection_select_path(selection, mouse_path);
-      handled = 1;
-    }
-    else if(on_row && dt_modifier_is(event->state, GDK_SHIFT_MASK))
-    {
-      // The cursor is the anchor GTK would have used. Rows the range picks up that _tree_restrict_select
-      // refuses -- a different parent, a different depth -- are dropped by it as usual.
-      GtkTreePath *anchor = NULL;
-      gtk_tree_view_get_cursor(GTK_TREE_VIEW(treeview), &anchor, NULL);
-      if(anchor)
-      {
-        gtk_tree_selection_select_range(selection, anchor, mouse_path);
-        gtk_tree_path_free(anchor);
-      }
-      else
-        gtk_tree_selection_select_path(selection, mouse_path);
-      handled = 1;
-    }
-    // if click on a blank space, then deselect all
-    else if(!on_row)
-    {
-      gtk_tree_selection_unselect_all(selection);
-    }
+    handled = _tree_apply_click_selection(treeview, selection, event, mouse_path);
   }
   else if(event->type == GDK_BUTTON_PRESS && event->button == 3)
   {
     // if we are already inside the selection, no change
-    if(on_row && !gtk_tree_selection_path_is_selected(selection, mouse_path))
+    if(!IS_NULL_PTR(mouse_path) && !gtk_tree_selection_path_is_selected(selection, mouse_path))
     {
       if(!dt_modifier_is(event->state, DT_PRIMARY_MASK)) gtk_tree_selection_unselect_all(selection);
       gtk_tree_selection_select_path(selection, mouse_path);
@@ -1884,7 +1896,8 @@ static void _lib_masks_popup_button_toggled_cb(GtkWidget *button, gpointer user_
 /** @brief Closing from the window manager hides the panel, same as the toolbox button, so its
  * widgets and state survive. Un-pressing the button is what actually hides the window (and saves
  * the geometry before it goes), so the two ways of closing cannot disagree. */
-static gboolean _lib_masks_popup_delete_cb(GtkWidget *window, GdkEvent *event, gpointer user_data)
+static gboolean _lib_masks_popup_delete_cb(GtkWidget *window __attribute__((unused)),
+                                           GdkEvent *event __attribute__((unused)), gpointer user_data)
 {
   dt_lib_masks_t *d = (dt_lib_masks_t *)user_data;
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(d->popup_button), FALSE);

--- a/src/libs/masks.c
+++ b/src/libs/masks.c
@@ -1041,6 +1041,12 @@ static GtkWidget *_tree_context_menu(GtkTreeSelection *selection, GtkTreeModel *
   return GTK_WIDGET(menu);
 }
 
+/* Ctrl+click toggles a row, Shift+click extends from the cursor. GtkTreeView's own handler does
+ * neither on this tree: measured, the intent masks it derives are the expected ones (modify 0x4,
+ * extend 0x1), the event carries them, the selection is GTK_SELECTION_MULTIPLE and the select
+ * function allows the row -- yet no selection change follows a modified click, while a plain one
+ * works. Why it stays inert was not found; driving the two gestures here is not a workaround for
+ * that so much as the place this widget already adjusts its own selection. */
 static int _tree_button_pressed(GtkWidget *treeview, GdkEventButton *event, dt_lib_module_t *self)
 {
   // we first need to adjust selection
@@ -1051,6 +1057,7 @@ static int _tree_button_pressed(GtkWidget *treeview, GdkEventButton *event, dt_l
   GtkTreeIter iter;
   dt_iop_module_t *module = NULL;
   int on_row = 0;
+  int handled = 0;
   if(gtk_tree_view_get_path_at_pos(GTK_TREE_VIEW(treeview), (gint)event->x, (gint)event->y, &mouse_path, NULL,
                                    NULL, NULL))
   {
@@ -1064,8 +1071,33 @@ static int _tree_button_pressed(GtkWidget *treeview, GdkEventButton *event, dt_l
   /* single click with the right mouse button? */
   if(event->type == GDK_BUTTON_PRESS && event->button == 1)
   {
+    if(on_row && dt_modifier_is(event->state, DT_PRIMARY_MASK))
+    {
+      // Toggle, which is what this modifier means everywhere else: a second Ctrl+click on a row
+      // takes it back out of the selection rather than being a no-op.
+      if(gtk_tree_selection_path_is_selected(selection, mouse_path))
+        gtk_tree_selection_unselect_path(selection, mouse_path);
+      else
+        gtk_tree_selection_select_path(selection, mouse_path);
+      handled = 1;
+    }
+    else if(on_row && dt_modifier_is(event->state, GDK_SHIFT_MASK))
+    {
+      // The cursor is the anchor GTK would have used. Rows the range picks up that _tree_restrict_select
+      // refuses -- a different parent, a different depth -- are dropped by it as usual.
+      GtkTreePath *anchor = NULL;
+      gtk_tree_view_get_cursor(GTK_TREE_VIEW(treeview), &anchor, NULL);
+      if(anchor)
+      {
+        gtk_tree_selection_select_range(selection, anchor, mouse_path);
+        gtk_tree_path_free(anchor);
+      }
+      else
+        gtk_tree_selection_select_path(selection, mouse_path);
+      handled = 1;
+    }
     // if click on a blank space, then deselect all
-    if(!on_row)
+    else if(!on_row)
     {
       gtk_tree_selection_unselect_all(selection);
     }
@@ -1077,7 +1109,6 @@ static int _tree_button_pressed(GtkWidget *treeview, GdkEventButton *event, dt_l
     {
       if(!dt_modifier_is(event->state, DT_PRIMARY_MASK)) gtk_tree_selection_unselect_all(selection);
       gtk_tree_selection_select_path(selection, mouse_path);
-      gtk_tree_path_free(mouse_path);
     }
 
     // and we display the context-menu
@@ -1087,10 +1118,13 @@ static int _tree_button_pressed(GtkWidget *treeview, GdkEventButton *event, dt_l
 
     gtk_menu_popup_at_pointer(GTK_MENU(menu), (GdkEvent *)event);
 
-    return 1;
+    handled = 1;
   }
 
-  return 0;
+  // One exit for the path: it was leaked on every button-1 press before, and freed on only one
+  // of the two button-3 branches.
+  if(mouse_path) gtk_tree_path_free(mouse_path);
+  return handled;
 }
 
 static gboolean _tree_restrict_select(GtkTreeSelection *selection, GtkTreeModel *model, GtkTreePath *path,

--- a/src/libs/masks.c
+++ b/src/libs/masks.c
@@ -1862,30 +1862,38 @@ static void _lib_masks_popup_restore_geometry(dt_lib_masks_t *d)
   gtk_window_move(GTK_WINDOW(d->popup_window), clamped_x, clamped_y);
 }
 
-/** @brief Closing from the window manager hides the panel, same as the toolbox button, so its
- * widgets and state survive -- but the geometry has to be read before it goes. */
-static gboolean _lib_masks_popup_delete_cb(GtkWidget *window, GdkEvent *event, gpointer user_data)
-{
-  _lib_masks_popup_save_geometry((dt_lib_masks_t *)user_data);
-  return gtk_widget_hide_on_delete(window);
-}
-
-static void _lib_masks_popup_button_clicked_cb(GtkWidget *button, gpointer user_data)
+/** @brief The toolbox button is the panel's only state: showing and hiding both go through its
+ * active flag, so every way of closing the panel leaves the button un-pressed. Re-entrant by
+ * design -- the window-manager close path toggles the button, which comes back here. */
+static void _lib_masks_popup_button_toggled_cb(GtkWidget *button, gpointer user_data)
 {
   dt_lib_masks_t *d = (dt_lib_masks_t *)user_data;
-  if(!d->popup_window) return;
+  if(IS_NULL_PTR(d->popup_window)) return;
 
-  if(gtk_widget_get_visible(d->popup_window))
-  {
-    _lib_masks_popup_save_geometry(d);
-    gtk_widget_hide(d->popup_window);
-  }
-  else
+  const gboolean active = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(button));
+  if(active == gtk_widget_get_visible(d->popup_window)) return;
+
+  if(active)
   {
     // before mapping: a move applied to a mapped window makes it jump in view
     _lib_masks_popup_restore_geometry(d);
     gtk_widget_show_all(d->popup_window);
   }
+  else
+  {
+    _lib_masks_popup_save_geometry(d);
+    gtk_widget_hide(d->popup_window);
+  }
+}
+
+/** @brief Closing from the window manager hides the panel, same as the toolbox button, so its
+ * widgets and state survive. Un-pressing the button is what actually hides the window (and saves
+ * the geometry before it goes), so the two ways of closing cannot disagree. */
+static gboolean _lib_masks_popup_delete_cb(GtkWidget *window, GdkEvent *event, gpointer user_data)
+{
+  dt_lib_masks_t *d = (dt_lib_masks_t *)user_data;
+  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(d->popup_button), FALSE);
+  return TRUE;
 }
 
 /* Idle callback to add the popup button to the module toolbox once the
@@ -1967,7 +1975,7 @@ void gui_init(dt_lib_module_t *self)
    * other modules (including the module_toolbox) have had their gui_init
    * called. The callback will remove itself once it succeeds. */
   g_idle_add((GSourceFunc)_lib_masks_add_popup_button_idle, d);
-  g_signal_connect(G_OBJECT(d->popup_button), "clicked", G_CALLBACK(_lib_masks_popup_button_clicked_cb), d);
+  g_signal_connect(G_OBJECT(d->popup_button), "toggled", G_CALLBACK(_lib_masks_popup_button_toggled_cb), d);
 
   // From here, everything goes into the mask manager popup,
   // so there is no child added to self->widget from here.

--- a/src/libs/masks.c
+++ b/src/libs/masks.c
@@ -1958,6 +1958,10 @@ void gui_init(dt_lib_module_t *self)
 
   // 3. Create a clean box container inside the popup window to receive original shape elements
   GtkWidget *shape_manager_container = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_GUI_BOX_SPACING);
+  // The window is its own frame, so nothing would otherwise separate the content from its edges.
+  // DT_GUI_BOX_SPACING is the 0.625em the theme gives a module body (.dt_plugin_ui_main), so the
+  // panel breathes the same way a side-panel module does, at any font size.
+  gtk_container_set_border_width(GTK_CONTAINER(shape_manager_container), DT_GUI_BOX_SPACING);
   gtk_container_add(GTK_CONTAINER(d->popup_window), shape_manager_container);
 
   // The main container for module blending params.
@@ -1999,10 +2003,7 @@ void gui_init(dt_lib_module_t *self)
   GtkWidget *shape_buttons_box = dt_masks_shape_buttons_create(&shape_buttons_config);
   gtk_box_pack_start(GTK_BOX(hbox), shape_buttons_box, FALSE, FALSE, 0);
   // The button row keeps its natural height and stays at the top: expanding it would split the
-  // surplus with the shape list below and stretch the buttons vertically. It is the container's
-  // first child, so nothing separates it from the window edge -- give it the same gap the
-  // container puts between its children.
-  gtk_widget_set_margin_top(hbox, DT_GUI_BOX_SPACING);
+  // surplus with the shape list below and stretch the buttons vertically.
   gtk_box_pack_start(GTK_BOX(shape_manager_container), hbox, FALSE, FALSE, 0);
 
   d->treeview = gtk_tree_view_new();

--- a/src/libs/masks.c
+++ b/src/libs/masks.c
@@ -42,6 +42,7 @@
 #include "develop/masks.h"
 #include "develop/masks_group.h"   // dt_masks_group_set_member_operation()
 #include "develop/masks_gui.h"
+#include "develop/masks/masks_history.h"   // dt_masks_form_unref()
 #include "common/logging.h"
 #include "system/macros.h"
 #include "common/module_versioning.h"
@@ -79,8 +80,6 @@ static void _lib_masks_update_list(dt_lib_module_t *self);
 
 typedef struct dt_lib_masks_t
 {
-  GtkWidget *hbox;
-  GtkWidget *bt_circle, *bt_path, *bt_gradient, *bt_ellipse, *bt_brush;
   GtkWidget *treeview;
   dt_iop_module_t *active_module;
   dt_iop_module_t *hosted_module;
@@ -347,7 +346,11 @@ static void _tree_group(GtkButton *button, dt_lib_module_t *self)
 {
   dt_lib_masks_t *lm = (dt_lib_masks_t *)self->data;
   // we create the new group
-  dt_masks_form_t *mask = dt_masks_create(DT_MASKS_GROUP);
+  // create_ext registers the group in dev->allforms and dt_masks_append_form() below takes
+  // dev->forms's own reference, so both lists have a claim and teardown balances. Neither
+  // touches dev->forms outside masks_mutex, which a hand-rolled g_list_append does -- and the
+  // pipeline thread reads that list under the same lock.
+  dt_masks_form_t *mask = dt_masks_create_ext(dt_dev_get_global(), DT_MASKS_GROUP);
   g_snprintf(mask->name, sizeof(mask->name), _("Mask #%d"), g_list_length(dt_dev_get_global()->forms));
 
   // we add all selected forms to this group
@@ -377,7 +380,7 @@ static void _tree_group(GtkButton *button, dt_lib_module_t *self)
   items = NULL;
 
   // we add this group to the general list
-  dt_dev_get_global()->forms = g_list_append(dt_dev_get_global()->forms, mask);
+  dt_masks_append_form(dt_dev_get_global(), mask);
 
   // add we save
   dt_dev_add_history_item(dt_dev_get_global(), NULL, FALSE, TRUE);
@@ -794,6 +797,10 @@ static void _tree_selection_change(GtkTreeSelection *selection, dt_lib_masks_t *
   dt_masks_form_t *grp_dest = dt_masks_create(DT_MASKS_GROUP);
   grp_dest->formid = 0;
   dt_masks_group_ungroup(dev, grp_dest, grp);
+  // grp was a scratch group built to flatten the selection into grp_dest, which only reads it.
+  // It never joined dev->forms or dev->allforms, so this is the only reference there is --
+  // unlike grp_dest, whose reference passes to form_visible below.
+  dt_masks_form_unref(grp);
   dt_masks_change_form_gui(dev, grp_dest);
   dev->form_gui->edit_mode = DT_MASKS_EDIT_FULL;
   if(nb == 1 && !IS_NULL_PTR(selected_form))
@@ -1964,12 +1971,11 @@ void gui_init(dt_lib_module_t *self)
 
   // From here, everything goes into the mask manager popup,
   // so there is no child added to self->widget from here.
-  GtkWidget *shape_buttons[DEVELOP_MASKS_NB_SHAPES] = { 0 };
   const dt_masks_shape_buttons_config_t shape_buttons_config = {
     .dev = dt_dev_get_global(),
     .owner_module = NULL,
     .creation_module = NULL,
-    .buttons = shape_buttons,
+    .buttons = NULL,   // nothing here reads the individual buttons back
     .types = NULL,
     .action_section = NULL,
     .flags = DT_MASKS_SHAPE_BUTTONS_ALL,
@@ -1984,12 +1990,6 @@ void gui_init(dt_lib_module_t *self)
   GtkWidget *hbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, DT_GUI_BOX_SPACING);
   GtkWidget *shape_buttons_box = dt_masks_shape_buttons_create(&shape_buttons_config);
   gtk_box_pack_start(GTK_BOX(hbox), shape_buttons_box, FALSE, FALSE, 0);
-  d->bt_gradient = shape_buttons[DT_MASKS_SHAPE_INDEX_GRADIENT];
-  d->bt_path = shape_buttons[DT_MASKS_SHAPE_INDEX_POLYGON];
-  d->bt_ellipse = shape_buttons[DT_MASKS_SHAPE_INDEX_ELLIPSE];
-  d->bt_circle = shape_buttons[DT_MASKS_SHAPE_INDEX_CIRCLE];
-  d->bt_brush = shape_buttons[DT_MASKS_SHAPE_INDEX_BRUSH];
-
   // The button row keeps its natural height and stays at the top: expanding it would split the
   // surplus with the shape list below and stretch the buttons vertically. It is the container's
   // first child, so nothing separates it from the window edge -- give it the same gap the

--- a/tools/check_module_boundaries.sh
+++ b/tools/check_module_boundaries.sh
@@ -414,7 +414,7 @@ masks_gui_include_baseline=11
 masks_member_baseline=83
 masks_write_baseline=20
 masks_alloc_baseline=1
-masks_forms_baseline=76
+masks_forms_baseline=75
 masks_row_baseline=35
 
 # Members no other struct in the tree uses. Keep it that way: adding an ambiguous name here

--- a/tools/check_module_boundaries.sh
+++ b/tools/check_module_boundaries.sh
@@ -411,8 +411,8 @@ fi
 #                  are excluded; naming the type there is the design, not the leak.
 masks_include_baseline=19
 masks_gui_include_baseline=11
-masks_member_baseline=83
-masks_write_baseline=20
+masks_member_baseline=79
+masks_write_baseline=16
 masks_alloc_baseline=1
 masks_forms_baseline=75
 masks_row_baseline=35


### PR DESCRIPTION
Seven commits on the shape manager and the shape toolbars. Each defect below was established by measurement -- traces, database diffs, GTK-level probes -- rather than by reading, and several plausible readings were killed on the way; the commit messages say which.

## Deleting unused shapes deleted shapes that were in use

The sweep collected the ids that keep a form alive into a fixed table sized on the swept snapshot's form count. Those ids are not a subset of that snapshot: a module whose drawn mask was dropped keeps its old `mask_id` in every history entry it ever wrote, and no form answers to it. The table filled with ids that matched nothing and ran out before the live group's membership was walked, deleting shapes from the tail of that group inward. Measured on a 20-step history: four departed groups took four of the eight slots an 8-form snapshot allowed, and the group's last two shapes were swept while `exposure` was still using them.

The sweep also never reached the database -- `main.masks_history` is rewritten wholesale from `dev->history` by the write a commit triggers, and nothing on this path triggered one -- and its undo record was opened after the fact, so it captured the already-swept state as its "before". Measured round trip after the fix: 65 rows / 23 forms, 70 / 22 after the sweep, 65 / 23 after undo.

## A leaked scratch group and an unlocked `dev->forms` write

`_tree_selection_change()` built a scratch group to flatten the selection and never released it: one form plus one membership row per selected shape, on every click in the tree. `_tree_group()` appended to `dev->forms` with a bare `g_list_append()` while the pipeline thread reads that list under `masks_mutex`.

## Shape toolbars showed the wrong button

A shape abandoned with Esc left its button pressed -- only clicking the armed button again deactivated, because that path did it itself. And arming from the context menu left every toolbar showing nothing armed. The pressed button is now a view on `dev->form_gui` rather than state of its own, recomputed from the creation state on a signal raised where creation is entered and where it ends.

## Multi-selection

Selecting more than one shape was impossible: a modified click changed nothing while a plain one worked. Everything GTK needs is in place -- the intent masks it derives are the expected ones, the event carries them, the selection is `GTK_SELECTION_MULTIPLE`, and the select function allows the row when the selection is made programmatically. Why GtkTreeView stays inert was not found; disconnecting the select function changes nothing, and neither does dropping the `editable` attribute, both ruled out by bisection. The two gestures are driven in the handler this widget already uses to adjust its own selection.

That in turn reached a latent defect: the selection restore seeded an iterator with `gtk_tree_model_get_iter_first()` without testing the result, so an empty store left it holding stack garbage and the walk had no reason to terminate -- five GTK criticals and a frozen application.

## Verified

Build clean; `check_module_boundaries.sh`, `check_conditional_includes.sh`, `check_unused_includes.sh` and the include-cycle count all pass. Two masks baselines fall in the commit that took the ground.

Exercised in the running application: some thirty tree selection changes, the five shape buttons armed and abandoned by Esc and by the right-click entry, adding and removing rows with Ctrl and ranges with Shift, mixing depths so the filter prunes, and the grouping path -- create a group from several shapes, undo, redo, leave for the lighttable and back -- which had no way of being reached before multi-selection existed.

Two cmocka tests reproducing the measured used-set scenario were written and used to check that fix against the defect (they fail on the old code, one by assertion and one by stack overflow on a group cycle). They are not in this PR: `check_module_boundaries.sh` section 9 is a ratchet, and a test file outside `src/develop/masks/` raises five of the masks counters. Happy to land them alongside a baseline bump if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)