### PR TITLE
libs: split the masks module into a blending panel and a shape manager

### DIFF
--- a/src/common/usermanual_url.c
+++ b/src/common/usermanual_url.c
@@ -122,7 +122,7 @@ dt_help_url urls_db[] =
   {"modulegroups",               "modules/utility-modules/darkroom/manage-module-layouts/"},
   {"history",                    "modules/utility-modules/darkroom/history-stack/"},
   {"colorpicker",                "modules/utility-modules/darkroom/global-color-picker/"},
-  {"masks",                      "modules/utility-modules/darkroom/mask-manager/"},
+  {"shape_manager",              "modules/utility-modules/darkroom/mask-manager/"},
   {"masks_drawn",                "views/darkroom/masking-and-blending/masks/drawn/"},
   {"masks_parametric",           "views/darkroom/masking-and-blending/masks/parametric/"},
   {"masks_raster",               "views/darkroom/masking-and-blending/masks/raster/"},

--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -1331,6 +1331,12 @@ void dt_dev_modulegroups_switch_tab(dt_develop_t *dev, dt_iop_module_t *module)
   DT_DEBUG_CONTROL_SIGNAL_RAISE(dt_control_signal_get_global(), DT_SIGNAL_DEVELOP_MODULEGROUPS_SET, module);
 }
 
+gboolean dt_dev_masks_manager_is_visible(dt_develop_t *dev)
+{
+  return dev && dev->proxy.masks.module && dev->proxy.masks.is_visible
+         && dev->proxy.masks.is_visible(dev->proxy.masks.module);
+}
+
 void dt_dev_masks_list_change(dt_develop_t *dev)
 {
   if(dev->proxy.masks.module && dev->proxy.masks.list_change)

--- a/src/develop/develop.h
+++ b/src/develop/develop.h
@@ -413,6 +413,9 @@ typedef struct dt_develop_t
       void (*list_update)(struct dt_lib_module_t *self);
       /* selected forms change */
       void (*selection_change)(struct dt_lib_module_t *self, struct dt_iop_module_t *module, const int selectid, const int throw_event);
+      /* is the shape manager's window on screen? The darkroom draws the mask overlays while the
+         user is looking at it, the way it used to while its panel section was expanded. */
+      gboolean (*is_visible)(struct dt_lib_module_t *self);
     } masks;
 
     // what is the ID of the module currently doing pipeline chromatic adaptation ?
@@ -620,6 +623,8 @@ void dt_dev_masks_list_change(dt_develop_t *dev);
 void dt_dev_masks_list_update(dt_develop_t *dev);
 void dt_dev_masks_list_remove(dt_develop_t *dev, int formid, int parentid);
 void dt_dev_masks_selection_change(dt_develop_t *dev, struct dt_iop_module_t *module, const int selectid, const int throw_event);
+/* FALSE when no shape manager is registered, which is also the answer when its window is closed */
+gboolean dt_dev_masks_manager_is_visible(dt_develop_t *dev);
 
 /** integrity hash of the forms/shapes stack */
 void dt_dev_masks_update_hash(dt_develop_t *dev);

--- a/src/libs/CMakeLists.txt
+++ b/src/libs/CMakeLists.txt
@@ -8,7 +8,7 @@ add_definitions(-include libs/lib_api.h)
 
 
 # The modules
-set(MODULES export styles tagging collect metadata metadata_view navigation histogram history snapshots modulegroups backgroundjobs masks blending duplicate ioporder textnotes studio_style studio_import)
+set(MODULES export styles tagging collect metadata metadata_view navigation histogram history snapshots modulegroups backgroundjobs shape_manager blending duplicate ioporder textnotes studio_style studio_import)
 
 # The tools
 set(MODULES ${MODULES} filter)
@@ -28,7 +28,7 @@ add_library(history MODULE "history.c")
 add_library(snapshots MODULE "snapshots.c")
 add_library(modulegroups MODULE "modulegroups.c")
 add_library(backgroundjobs MODULE "backgroundjobs.c")
-add_library(masks MODULE "masks.c")
+add_library(shape_manager MODULE "shape_manager.c")
 add_library(blending MODULE "blending.c")
 add_library(duplicate MODULE "duplicate.c")
 add_library(ioporder MODULE "ioporder.c")

--- a/src/libs/CMakeLists.txt
+++ b/src/libs/CMakeLists.txt
@@ -8,7 +8,7 @@ add_definitions(-include libs/lib_api.h)
 
 
 # The modules
-set(MODULES export styles tagging collect metadata metadata_view navigation histogram history snapshots modulegroups backgroundjobs masks duplicate ioporder textnotes studio_style studio_import)
+set(MODULES export styles tagging collect metadata metadata_view navigation histogram history snapshots modulegroups backgroundjobs masks blending duplicate ioporder textnotes studio_style studio_import)
 
 # The tools
 set(MODULES ${MODULES} filter)
@@ -29,6 +29,7 @@ add_library(snapshots MODULE "snapshots.c")
 add_library(modulegroups MODULE "modulegroups.c")
 add_library(backgroundjobs MODULE "backgroundjobs.c")
 add_library(masks MODULE "masks.c")
+add_library(blending MODULE "blending.c")
 add_library(duplicate MODULE "duplicate.c")
 add_library(ioporder MODULE "ioporder.c")
 add_library(textnotes MODULE "textnotes.c")

--- a/src/libs/blending.c
+++ b/src/libs/blending.c
@@ -60,23 +60,23 @@ typedef struct dt_lib_blending_t
 /* The name the panel section has always carried. The module hosts the whole blending body, whose
  * Drawn / Parametric / Raster tabs are the three kinds of mask, so "masking" belongs in it -- and
  * keeping the string spares every translation that already has it. */
-const char *name(struct dt_lib_module_t *self)
+const char *name(struct dt_lib_module_t *self __attribute__((unused)))
 {
   return _("Masking & Blending");
 }
 
-const char **views(dt_lib_module_t *self)
+const char **views(dt_lib_module_t *self __attribute__((unused)))
 {
   static const char *v[] = {"darkroom", NULL};
   return v;
 }
 
-uint32_t container(dt_lib_module_t *self)
+uint32_t container(dt_lib_module_t *self __attribute__((unused)))
 {
   return DT_UI_CONTAINER_PANEL_LEFT_CENTER;
 }
 
-int expandable(dt_lib_module_t *self)
+int expandable(dt_lib_module_t *self __attribute__((unused)))
 {
   return 1;
 }
@@ -91,7 +91,7 @@ int position()
  * from a dev that has since been replaced, and neither may be dereferenced. */
 static gboolean _module_is_current(const dt_iop_module_t *module)
 {
-  return dt_dev_get_global() && module && g_list_find(dt_dev_get_global()->iop, (gpointer)module);
+  return dt_dev_get_global() && module && g_list_find(dt_dev_get_global()->iop, module);
 }
 
 static void _clear_box(dt_lib_module_t *self)

--- a/src/libs/blending.c
+++ b/src/libs/blending.c
@@ -149,9 +149,16 @@ static void _gui_changed_callback(gpointer instance __attribute__((unused)), dt_
   if(IS_NULL_PTR(self) || IS_NULL_PTR(self->data)) return;
 
   dt_lib_blending_t *d = (dt_lib_blending_t *)self->data;
-  dt_iop_module_t *module = dt_dev_get_global()->gui_module;
 
-  if(IS_NULL_PTR(dt_dev_get_global()) || !dt_dev_get_global()->history || !module)
+  /* dt_dev_get_global() is NULL outside the darkroom -- only the views that own that lifetime
+   * publish it -- so it is read once and tested before anything is read through it. Nothing
+   * reaches this callback that early today (dt_lib_init() runs after dt_view_manager_init(),
+   * which darktable.c refuses to continue without a develop), but the guard was written for a
+   * NULL it then dereferenced one line above it. */
+  dt_develop_t *dev = dt_dev_get_global();
+  dt_iop_module_t *module = IS_NULL_PTR(dev) ? NULL : dev->gui_module;
+
+  if(IS_NULL_PTR(dev) || !dev->history || !module)
   {
     _release(self);
     _clear_box(self);

--- a/src/libs/blending.c
+++ b/src/libs/blending.c
@@ -1,0 +1,229 @@
+/*
+    This file is part of Ansel,
+    Copyright (C) 2026 Aurélien PIERRE.
+
+    Ansel is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Ansel is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Ansel.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+/* The left panel's home for the focused module's blending controls.
+ *
+ * It owns no blending state and builds no widget of its own beyond a container and a message
+ * label: dt_iop_gui_init_blending_body() fills self->widget with the focused module's own
+ * blending body, and this module's whole job is to decide which module that is, to tear the
+ * previous one down before the next is built, and to say why the panel is empty when no module
+ * can host one.
+ *
+ * The shape manager (libs/shape_manager.c) is a peer, not a parent: it lists the drawn shapes of
+ * the whole image in its own window, while the Drawn tab inside the body below speaks only for
+ * the focused module. Both rest on develop/masks/ for the shapes themselves.
+ */
+
+#include "common/module_versioning.h"  // DT_MODULE()
+#include "develop/blend_gui.h"    // dt_iop_gui_{init,cleanup}_blending_body(), dt_iop_gui_update_blending()
+#include "develop/develop.h"      // dt_dev_get_global(), dt_history_item_get_name()
+#include "develop/imageop.h"      // dt_iop_module_t, IOP_FLAGS_SUPPORTS_BLENDING
+#include "develop/imageop_gui.h"  // dt_iop_module_gui_t, for module->gui->blend_data
+#include "control/signal.h"       // DT_SIGNAL_DEVELOP_MASKS_GUI_CHANGED
+#include "gui/window_manager.h"   // DT_UI_CONTAINER_PANEL_LEFT_CENTER
+#include "libs/lib.h"
+#include "libs/lib_api.h"
+#include "system/macros.h"        // IS_NULL_PTR()
+#include "system/mem_alloc.h"     // dt_free()
+#include "widgets/widget_settings.h"   // DT_GUI_BOX_SPACING, DT_PIXEL_APPLY_DPI()
+
+#include <glib.h>
+#include <gtk/gtk.h>
+
+DT_MODULE(1)
+
+typedef struct dt_lib_blending_t
+{
+  /* The module whose body is currently built into self->widget, and the one the last refresh
+   * ran for. They differ while a refresh is in flight, which is what tells it to tear the
+   * previous body down before building the next. */
+  dt_iop_module_t *active_module;
+  dt_iop_module_t *hosted_module;
+} dt_lib_blending_t;
+
+
+/* The name the panel section has always carried. The module hosts the whole blending body, whose
+ * Drawn / Parametric / Raster tabs are the three kinds of mask, so "masking" belongs in it -- and
+ * keeping the string spares every translation that already has it. */
+const char *name(struct dt_lib_module_t *self)
+{
+  return _("Masking & Blending");
+}
+
+const char **views(dt_lib_module_t *self)
+{
+  static const char *v[] = {"darkroom", NULL};
+  return v;
+}
+
+uint32_t container(dt_lib_module_t *self)
+{
+  return DT_UI_CONTAINER_PANEL_LEFT_CENTER;
+}
+
+int expandable(dt_lib_module_t *self)
+{
+  return 1;
+}
+
+int position()
+{
+  return 850;
+}
+
+
+/* A module still in dev->iop. The focused module can be one this panel already tore down, or one
+ * from a dev that has since been replaced, and neither may be dereferenced. */
+static gboolean _module_is_current(const dt_iop_module_t *module)
+{
+  return dt_dev_get_global() && module && g_list_find(dt_dev_get_global()->iop, (gpointer)module);
+}
+
+static void _clear_box(dt_lib_module_t *self)
+{
+  if(IS_NULL_PTR(self) || !GTK_IS_WIDGET(self->widget)) return;
+
+  GList *children = gtk_container_get_children(GTK_CONTAINER(self->widget));
+  for(GList *iter = children; iter; iter = g_list_next(iter))
+    gtk_widget_destroy(GTK_WIDGET(iter->data));
+  g_list_free(children);
+  children = NULL;
+}
+
+static gboolean _can_host(const dt_iop_module_t *module)
+{
+  if(!_module_is_current(module) || !module->flags
+     || !(module->flags() & IOP_FLAGS_SUPPORTS_BLENDING) || !module->gui || !module->gui->blend_data)
+    return FALSE;
+
+  return TRUE;
+}
+
+static void _release(dt_lib_module_t *self)
+{
+  if(IS_NULL_PTR(self) || IS_NULL_PTR(self->data)) return;
+  dt_lib_blending_t *d = (dt_lib_blending_t *)self->data;
+  dt_iop_module_t *hosted_module = d->hosted_module;
+  d->hosted_module = NULL;
+
+  if(_can_host(hosted_module))
+    dt_iop_gui_cleanup_blending_body(hosted_module);
+  else
+    _clear_box(self);
+}
+
+static void _show_message(dt_lib_module_t *self, gchar *markup)
+{
+  if(IS_NULL_PTR(self) || !GTK_IS_WIDGET(self->widget) || IS_NULL_PTR(markup)) return;
+
+  GtkWidget *label = gtk_label_new(NULL);
+  gtk_label_set_markup(GTK_LABEL(label), markup);
+  gtk_label_set_xalign(GTK_LABEL(label), 0.0f);
+  gtk_label_set_line_wrap(GTK_LABEL(label), TRUE);
+  gtk_widget_set_margin_top(label, DT_PIXEL_APPLY_DPI(16));
+  gtk_widget_set_margin_bottom(label, DT_PIXEL_APPLY_DPI(16));
+  gtk_widget_set_sensitive(label, FALSE);
+  gtk_box_pack_start(GTK_BOX(self->widget), label, FALSE, FALSE, 0);
+  // self->widget is the expander body: its own visibility encodes the
+  // expanded/collapsed state persisted in conf, so show only the child.
+  gtk_widget_show_all(label);
+}
+
+static void _gui_changed_callback(gpointer instance __attribute__((unused)), dt_lib_module_t *self)
+{
+  if(IS_NULL_PTR(self) || IS_NULL_PTR(self->data)) return;
+
+  dt_lib_blending_t *d = (dt_lib_blending_t *)self->data;
+  dt_iop_module_t *module = dt_dev_get_global()->gui_module;
+
+  if(IS_NULL_PTR(dt_dev_get_global()) || !dt_dev_get_global()->history || !module)
+  {
+    _release(self);
+    _clear_box(self);
+
+    gchar *markup = g_markup_printf_escaped(_("<i>Select a module to edit its blending settings.</i>"));
+
+    _show_message(self, markup);
+    g_free(markup);
+
+    return;
+  }
+
+  if(!_can_host(module))
+  {
+    _release(self);
+    _clear_box(self);
+
+    gchar *module_label = dt_history_item_get_name(module);
+    gchar *markup = g_markup_printf_escaped(_("<i>Blending is not available for the <b>%s</b> module.</i>"), module_label);
+
+    _show_message(self, markup);
+    g_free(markup);
+    dt_free(module_label);
+
+    return;
+  }
+
+  const gboolean module_changed = (d->active_module != module);
+  d->active_module = module;
+
+  if(module_changed) _release(self);
+
+  if(!d->hosted_module) _clear_box(self);
+
+  // dt_iop_gui_init_blending_body() shows the children it packs; don't show
+  // self->widget itself, it is the expander body whose visibility encodes the
+  // expanded/collapsed state persisted in conf.
+  dt_iop_gui_init_blending_body(self->widget, module);
+  d->hosted_module = module;
+
+  dt_iop_gui_update_blending(module);
+}
+
+
+void gui_init(dt_lib_module_t *self)
+{
+  dt_lib_blending_t *d = (dt_lib_blending_t *)dt_calloc_align(sizeof(dt_lib_blending_t));
+  self->data = (void *)d;
+
+  self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_GUI_BOX_SPACING);
+
+  DT_DEBUG_CONTROL_SIGNAL_CONNECT(dt_control_signal_get_global(), DT_SIGNAL_DEVELOP_MASKS_GUI_CHANGED,
+                                  G_CALLBACK(_gui_changed_callback), self);
+
+  // Show the "select a module" message rather than an empty panel on the first display.
+  _gui_changed_callback(NULL, self);
+}
+
+void gui_cleanup(dt_lib_module_t *self)
+{
+  DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(dt_control_signal_get_global(), G_CALLBACK(_gui_changed_callback), self);
+
+  if(!IS_NULL_PTR(self->data))
+  {
+    _release(self);
+    dt_free(self->data);
+    self->data = NULL;
+  }
+}
+
+// clang-format off
+// modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py
+// vim: shiftwidth=2 expandtab tabstop=2 cindent
+// kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;
+// clang-format on

--- a/src/libs/masks.c
+++ b/src/libs/masks.c
@@ -81,8 +81,6 @@ static void _lib_masks_update_list(dt_lib_module_t *self);
 typedef struct dt_lib_masks_t
 {
   GtkWidget *treeview;
-  dt_iop_module_t *active_module;
-  dt_iop_module_t *hosted_module;
 
   /* Replacement for shape_manager_expander */
   GtkWidget *popup_window;
@@ -95,28 +93,21 @@ typedef struct dt_lib_masks_t
 
 const char *name(struct dt_lib_module_t *self)
 {
-  return _("Masking & Blending");
+  return _("Shape Manager");
 }
 
+/* Never shown in a panel: everything this module builds lives in its own window, opened by the
+ * button it pushes into the darkroom toolbox. Same arrangement as libs/export.c, which is also a
+ * module whose interface is a window rather than a panel section. */
 const char **views(dt_lib_module_t *self)
 {
-  static const char *v[] = {"darkroom", NULL};
+  static const char *v[] = {"special", NULL};
   return v;
 }
 
 uint32_t container(dt_lib_module_t *self)
 {
-  return DT_UI_CONTAINER_PANEL_LEFT_CENTER;
-}
-
-int expandable(dt_lib_module_t *self)
-{
-  return 1;
-}
-
-int position()
-{
-  return 850;
+  return DT_UI_CONTAINER_SIZE;
 }
 
 typedef enum dt_masks_tree_cols_t
@@ -165,112 +156,6 @@ static void _lib_masks_get_values(GtkTreeModel *model, GtkTreeIter *iter,
     *formid = g_value_get_int(&gv);
     g_value_unset(&gv);
   }
-}
-
-static gboolean _lib_masks_module_is_current(const dt_iop_module_t *module)
-{
-  return dt_dev_get_global() && module && g_list_find(dt_dev_get_global()->iop, (gpointer)module);
-}
-
-static void _lib_masks_clear_blending_box(dt_lib_module_t *self)
-{
-  if(IS_NULL_PTR(self) || !GTK_IS_WIDGET(self->widget)) return;
-
-  GList *children = gtk_container_get_children(GTK_CONTAINER(self->widget));
-  for(GList *iter = children; iter; iter = g_list_next(iter))
-    gtk_widget_destroy(GTK_WIDGET(iter->data));
-  g_list_free(children);
-  children = NULL;
-}
-
-static gboolean _lib_masks_can_host_blending(const dt_iop_module_t *module)
-{
-  if(!_lib_masks_module_is_current(module) || !module->flags
-     || !(module->flags() & IOP_FLAGS_SUPPORTS_BLENDING) || !module->gui || !module->gui->blend_data)
-    return FALSE;
-
-  return TRUE;
-}
-
-static void _lib_masks_release_blending(dt_lib_module_t *self)
-{
-  if(IS_NULL_PTR(self) || IS_NULL_PTR(self->data)) return;
-  dt_lib_masks_t *lm = (dt_lib_masks_t *)self->data;
-  dt_iop_module_t *hosted_module = lm->hosted_module;
-  lm->hosted_module = NULL;
-
-  if(_lib_masks_can_host_blending(hosted_module))
-    dt_iop_gui_cleanup_blending_body(hosted_module);
-  else
-    _lib_masks_clear_blending_box(self);
-}
-
-static void _lib_masks_show_blending_message(dt_lib_module_t *self, gchar *markup)
-{
-  if(IS_NULL_PTR(self) || !GTK_IS_WIDGET(self->widget) || IS_NULL_PTR(markup)) return;
-
-  GtkWidget *label = gtk_label_new(NULL);
-  gtk_label_set_markup(GTK_LABEL(label), markup);
-  gtk_label_set_xalign(GTK_LABEL(label), 0.0f);
-  gtk_label_set_line_wrap(GTK_LABEL(label), TRUE);
-  gtk_widget_set_margin_top(label, DT_PIXEL_APPLY_DPI(16));
-  gtk_widget_set_margin_bottom(label, DT_PIXEL_APPLY_DPI(16));
-  gtk_widget_set_sensitive(label, FALSE);
-  gtk_box_pack_start(GTK_BOX(self->widget), label, FALSE, FALSE, 0);
-  // self->widget is the expander body: its own visibility encodes the
-  // expanded/collapsed state persisted in conf, so show only the child.
-  gtk_widget_show_all(label);
-}
-
-static void _lib_masks_blending_gui_changed_callback(gpointer instance, dt_lib_module_t *self)
-{
-  if(IS_NULL_PTR(self) || IS_NULL_PTR(self->data)) return;
-
-  dt_lib_masks_t *lm = (dt_lib_masks_t *)self->data;
-  dt_iop_module_t *module = dt_dev_get_global()->gui_module;
-
-  if(IS_NULL_PTR(dt_dev_get_global()) || !dt_dev_get_global()->history || !module)
-  {
-    _lib_masks_release_blending(self);
-    _lib_masks_clear_blending_box(self);
-
-    gchar *markup = g_markup_printf_escaped(_("<i>Select a module to edit its blending settings.</i>"));
-
-    _lib_masks_show_blending_message(self, markup);
-    g_free(markup);
-  
-    return;
-  }
-
-  if(!_lib_masks_can_host_blending(module))
-  {
-    _lib_masks_release_blending(self);
-    _lib_masks_clear_blending_box(self);
-
-    gchar *module_label = dt_history_item_get_name(module);
-    gchar *markup = g_markup_printf_escaped(_("<i>Blending is not available for the <b>%s</b> module.</i>"), module_label);
-
-    _lib_masks_show_blending_message(self, markup);
-    g_free(markup);
-    dt_free(module_label);
-  
-    return;
-  }
-
-  const gboolean module_changed = (lm->active_module != module);
-  lm->active_module = module;
-
-  if(module_changed) _lib_masks_release_blending(self);
-
-  if(!lm->hosted_module) _lib_masks_clear_blending_box(self);
-
-  // dt_iop_gui_init_blending_body() shows the children it packs; don't show
-  // self->widget itself, it is the expander body whose visibility encodes the
-  // expanded/collapsed state persisted in conf.
-  dt_iop_gui_init_blending_body(self->widget, module);
-  lm->hosted_module = module;
-
-  dt_iop_gui_update_blending(module);
 }
 
 /* The shape to create rides on the menu item, the way "masks-operation" already does below --
@@ -1971,10 +1856,9 @@ void gui_init(dt_lib_module_t *self)
   gtk_container_set_border_width(GTK_CONTAINER(shape_manager_container), DT_GUI_BOX_SPACING);
   gtk_container_add(GTK_CONTAINER(d->popup_window), shape_manager_container);
 
-  // The main container for module blending params.
-  // It's populated in blend_gui.c when a mask-able module gets focused.
-  self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_GUI_BOX_SPACING);
-
+  // No panel body: this module's interface is the window built below, so self->widget stays
+  // NULL and the module is never packed -- dt_lib_is_visible_in_view() already excludes a
+  // "special" view from every panel.
 
   // Create and pack the button to control the popup panel.
   // NOTE: it's added to the darkroom module toolbox, aka not here.
@@ -2056,8 +1940,6 @@ void gui_init(dt_lib_module_t *self)
                      TRUE, TRUE, 0);
 
   DT_DEBUG_CONTROL_SIGNAL_CONNECT(dt_control_signal_get_global(), DT_SIGNAL_MASK_CHANGED, G_CALLBACK(_lib_masks_handler_callback), self);
-  DT_DEBUG_CONTROL_SIGNAL_CONNECT(dt_control_signal_get_global(), DT_SIGNAL_DEVELOP_MASKS_GUI_CHANGED,
-                                  G_CALLBACK(_lib_masks_blending_gui_changed_callback), self);
 
   // set proxy functions
   dt_dev_get_global()->proxy.masks.module = self;
@@ -2065,8 +1947,6 @@ void gui_init(dt_lib_module_t *self)
   dt_dev_get_global()->proxy.masks.list_update = _lib_masks_update_list;
   dt_dev_get_global()->proxy.masks.list_remove = _lib_masks_remove_item;
   dt_dev_get_global()->proxy.masks.selection_change = _lib_masks_selection_change;
-
-  _lib_masks_blending_gui_changed_callback(NULL, self);
 }
 
 void gui_cleanup(dt_lib_module_t *self)
@@ -2096,13 +1976,11 @@ void gui_cleanup(dt_lib_module_t *self)
     d->ic_intersection = NULL;
     d->ic_difference = NULL;
     d->ic_exclusion = NULL;
-    _lib_masks_release_blending(self);
   }
 
   dt_free(self->data);
 
   DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(dt_control_signal_get_global(), G_CALLBACK(_lib_masks_handler_callback), self);
-  DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(dt_control_signal_get_global(), G_CALLBACK(_lib_masks_blending_gui_changed_callback), self);
 }
 
 // clang-format off

--- a/src/libs/shape_manager.c
+++ b/src/libs/shape_manager.c
@@ -75,10 +75,10 @@ DT_MODULE(1)
 
 #pragma GCC diagnostic ignored "-Wshadow"
 
-static void _lib_masks_recreate_list(dt_lib_module_t *self);
-static void _lib_masks_update_list(dt_lib_module_t *self);
+static void _shape_manager_recreate_list(dt_lib_module_t *self);
+static void _shape_manager_update_list(dt_lib_module_t *self);
 
-typedef struct dt_lib_masks_t
+typedef struct dt_shape_manager_t
 {
   GtkWidget *treeview;
 
@@ -88,7 +88,7 @@ typedef struct dt_lib_masks_t
 
   GdkPixbuf *ic_inverse, *ic_union, *ic_intersection, *ic_difference, *ic_exclusion;
   int gui_reset;
-} dt_lib_masks_t;
+} dt_shape_manager_t;
 
 
 const char *name(struct dt_lib_module_t *self)
@@ -126,7 +126,7 @@ typedef enum dt_masks_tree_cols_t
   TREE_COUNT
 } dt_masks_tree_cols_t;
 
-static void _lib_masks_get_values(GtkTreeModel *model, GtkTreeIter *iter,
+static void _shape_manager_get_values(GtkTreeModel *model, GtkTreeIter *iter,
                                   dt_iop_module_t **module, int *groupid, int *formid)
 {
   // returns module & groupid & formid if requested
@@ -179,7 +179,7 @@ static void _tree_add_shape_menu_item(GtkWidget *menu, const dt_masks_type_t typ
   if(!IS_NULL_PTR(item)) g_object_set_data(G_OBJECT(item), "masks-shape-type", GINT_TO_POINTER(type));
 }
 
-static void _lib_masks_shape_button_started(GtkWidget *button, dt_iop_module_t *module,
+static void _shape_manager_shape_button_started(GtkWidget *button, dt_iop_module_t *module,
                                             dt_masks_type_t type, gpointer user_data)
 {
   dt_dev_get_global()->form_gui->group_selected = 0;
@@ -210,7 +210,7 @@ static void _tree_add_exist(GtkButton *button, dt_masks_form_t *grp)
 
 static void _tree_group(GtkButton *button, dt_lib_module_t *self)
 {
-  dt_lib_masks_t *lm = (dt_lib_masks_t *)self->data;
+  dt_shape_manager_t *lm = (dt_shape_manager_t *)self->data;
   // we create the new group
   // create_ext registers the group in dev->allforms and dt_masks_append_form() below takes
   // dev->forms's own reference, so both lists have a claim and teardown balances. Neither
@@ -231,7 +231,7 @@ static void _tree_group(GtkButton *button, dt_lib_module_t *self)
     if(gtk_tree_model_get_iter(model, &iter, item))
     {
       int id = -1;
-      _lib_masks_get_values(model, &iter, NULL, NULL, &id);
+      _shape_manager_get_values(model, &iter, NULL, NULL, &id);
 
       if(id > 0)
       {
@@ -250,7 +250,7 @@ static void _tree_group(GtkButton *button, dt_lib_module_t *self)
 
   // add we save
   dt_dev_add_history_item(dt_dev_get_global(), NULL, FALSE, TRUE);
-  _lib_masks_recreate_list(self);
+  _shape_manager_recreate_list(self);
   // dt_masks_change_form_gui(darktable.develop, grp);
 }
 
@@ -291,7 +291,7 @@ static int _tree_format_form_usage_label(char *str, const size_t str_size,
   return nbuse;
 }
 
-static void _set_iter_name(dt_lib_masks_t *lm, dt_masks_form_t *form, int state, float opacity,
+static void _set_iter_name(dt_shape_manager_t *lm, dt_masks_form_t *form, int state, float opacity,
                            GtkTreeModel *model, GtkTreeIter *iter, int index)
 {
   if(IS_NULL_PTR(form)) return;
@@ -345,7 +345,7 @@ static void _tree_delete_unused(GtkButton *button, dt_lib_module_t *self)
   dt_dev_undo_start_record(dev);
 
   dt_masks_cleanup_unused(dev);
-  _lib_masks_recreate_list(self);
+  _shape_manager_recreate_list(self);
 
   // The sweep only rewrote the in-memory snapshots. main.history and main.masks_history are
   // rewritten wholesale from dev->history by the write a commit triggers, so without one the
@@ -356,7 +356,7 @@ static void _tree_delete_unused(GtkButton *button, dt_lib_module_t *self)
   dt_dev_undo_end_record(dev);
 }
 
-static void _add_masks_history_item(dt_lib_masks_t *lm)
+static void _add_masks_history_item(dt_shape_manager_t *lm)
 {
   const int reset = lm->gui_reset;
   lm->gui_reset = 1;
@@ -374,7 +374,7 @@ static void _tree_apply_operation(GtkWidget *menu_item, dt_lib_module_t *self)
       = (dt_masks_state_t)GPOINTER_TO_INT(g_object_get_data(G_OBJECT(menu_item), "masks-operation"));
   if(operation == DT_MASKS_STATE_NONE) return;
 
-  dt_lib_masks_t *lm = (dt_lib_masks_t *)self->data;
+  dt_shape_manager_t *lm = (dt_shape_manager_t *)self->data;
 
   // now we go through all selected nodes
   GtkTreeModel *model = gtk_tree_view_get_model(GTK_TREE_VIEW(lm->treeview));
@@ -389,7 +389,7 @@ static void _tree_apply_operation(GtkWidget *menu_item, dt_lib_module_t *self)
     {
       int grid = -1;
       int id = -1;
-      _lib_masks_get_values(model, &iter, NULL, &grid, &id);
+      _shape_manager_get_values(model, &iter, NULL, &grid, &id);
 
       /* The module owns the copy-on-write: it touches the group before resolving the row, which
        * this loop did not do -- it mutated a refcounted membership block that a history snapshot
@@ -418,7 +418,7 @@ static void _tree_apply_operation(GtkWidget *menu_item, dt_lib_module_t *self)
 
 static void _tree_moveup(GtkButton *button, dt_lib_module_t *self)
 {
-  dt_lib_masks_t *lm = (dt_lib_masks_t *)self->data;
+  dt_shape_manager_t *lm = (dt_shape_manager_t *)self->data;
 
   // we first discard all visible shapes
   dt_masks_change_form_gui(dt_dev_get_global(), NULL);
@@ -436,7 +436,7 @@ static void _tree_moveup(GtkButton *button, dt_lib_module_t *self)
     {
       int grid = -1;
       int id = -1;
-      _lib_masks_get_values(model, &iter, NULL, &grid, &id);
+      _shape_manager_get_values(model, &iter, NULL, &grid, &id);
 
       dt_masks_form_t *group_form = dt_masks_get_from_id(dt_dev_get_global(), grid);
       group_form = dt_masks_cow_touch(dt_dev_get_global(), group_form);
@@ -447,7 +447,7 @@ static void _tree_moveup(GtkButton *button, dt_lib_module_t *self)
   items = NULL;
 
   lm->gui_reset = 0;
-  _lib_masks_recreate_list(self);
+  _shape_manager_recreate_list(self);
 
   // Without this, the reorder only mutates the live group's points list: it's never recorded
   // as its own history step, so the next undo/redo silently discards the new order.
@@ -456,7 +456,7 @@ static void _tree_moveup(GtkButton *button, dt_lib_module_t *self)
 
 static void _tree_movedown(GtkButton *button, dt_lib_module_t *self)
 {
-  dt_lib_masks_t *lm = (dt_lib_masks_t *)self->data;
+  dt_shape_manager_t *lm = (dt_shape_manager_t *)self->data;
 
   // we first discard all visible shapes
   dt_masks_change_form_gui(dt_dev_get_global(), NULL);
@@ -474,7 +474,7 @@ static void _tree_movedown(GtkButton *button, dt_lib_module_t *self)
     {
       int grid = -1;
       int id = -1;
-      _lib_masks_get_values(model, &iter, NULL, &grid, &id);
+      _shape_manager_get_values(model, &iter, NULL, &grid, &id);
 
       dt_masks_form_t *group_form = dt_masks_get_from_id(dt_dev_get_global(), grid);
       group_form = dt_masks_cow_touch(dt_dev_get_global(), group_form);
@@ -485,7 +485,7 @@ static void _tree_movedown(GtkButton *button, dt_lib_module_t *self)
   items = NULL;
 
   lm->gui_reset = 0;
-  _lib_masks_recreate_list(self);
+  _shape_manager_recreate_list(self);
 
   // Without this, the reorder only mutates the live group's points list: it's never recorded
   // as its own history step, so the next undo/redo silently discards the new order.
@@ -494,7 +494,7 @@ static void _tree_movedown(GtkButton *button, dt_lib_module_t *self)
 
 static void _tree_delete_shape(GtkButton *button, dt_lib_module_t *self)
 {
-  dt_lib_masks_t *lm = (dt_lib_masks_t *)self->data;
+  dt_shape_manager_t *lm = (dt_shape_manager_t *)self->data;
 
   // we first discard all visible shapes
   dt_masks_change_form_gui(dt_dev_get_global(), NULL);
@@ -513,7 +513,7 @@ static void _tree_delete_shape(GtkButton *button, dt_lib_module_t *self)
     {
       int grid = -1;
       int id = -1;
-      _lib_masks_get_values(model, &iter, &module, &grid, &id);
+      _shape_manager_get_values(model, &iter, &module, &grid, &id);
 
       dt_masks_form_delete(dt_dev_get_global(), module, dt_masks_get_from_id(dt_dev_get_global(), grid),
                            dt_masks_get_from_id(dt_dev_get_global(), id));
@@ -523,7 +523,7 @@ static void _tree_delete_shape(GtkButton *button, dt_lib_module_t *self)
   items = NULL;
 
   lm->gui_reset = 0;
-  _lib_masks_recreate_list(self);
+  _shape_manager_recreate_list(self);
 
   // Without this, the deletion only mutates the live dev->forms: it's never recorded as its
   // own history step, so the next history navigation (undo/redo) silently discards it and
@@ -533,7 +533,7 @@ static void _tree_delete_shape(GtkButton *button, dt_lib_module_t *self)
 
 static void _tree_duplicate_shape(GtkButton *button, dt_lib_module_t *self)
 {
-  dt_lib_masks_t *lm = (dt_lib_masks_t *)self->data;
+  dt_shape_manager_t *lm = (dt_shape_manager_t *)self->data;
 
   // we get the selected node
   GtkTreeModel *model = gtk_tree_view_get_model(GTK_TREE_VIEW(lm->treeview));
@@ -547,7 +547,7 @@ static void _tree_duplicate_shape(GtkButton *button, dt_lib_module_t *self)
     dt_iop_module_t *module = NULL;
     int grid = -1;
     int id = -1;
-    _lib_masks_get_values(model, &iter, &module, &grid, &id);
+    _shape_manager_get_values(model, &iter, &module, &grid, &id);
 
     // dt_masks_form_duplicate_in_group also attaches the duplicate to the source shape's
     // group (grid), inheriting its state/opacity -- without that, the duplicate would be an
@@ -566,9 +566,9 @@ static void _tree_duplicate_shape(GtkButton *button, dt_lib_module_t *self)
 
       // _add_masks_history_item briefly sets lm->gui_reset while committing, and
       // dt_dev_add_history_item's own list-change signal fires synchronously inside that
-      // window -- _lib_masks_recreate_list's gui_reset guard swallows it. Refresh explicitly,
+      // window -- _shape_manager_recreate_list's gui_reset guard swallows it. Refresh explicitly,
       // now that gui_reset is back to its prior value, so the new row actually appears.
-      _lib_masks_recreate_list(self);
+      _shape_manager_recreate_list(self);
     }
   }
   g_list_free_full(items, (GDestroyNotify)gtk_tree_path_free);
@@ -578,13 +578,13 @@ static void _tree_duplicate_shape(GtkButton *button, dt_lib_module_t *self)
 static void _tree_cell_edited(GtkCellRendererText *cell, gchar *path_string, gchar *new_text,
                               dt_lib_module_t *self)
 {
-  dt_lib_masks_t *lm = (dt_lib_masks_t *)self->data;
+  dt_shape_manager_t *lm = (dt_shape_manager_t *)self->data;
   GtkTreeModel *model = gtk_tree_view_get_model(GTK_TREE_VIEW(lm->treeview));
   GtkTreeIter iter;
   if(!gtk_tree_model_get_iter_from_string(model, &iter, path_string)) return;
 
   int id = -1;
-  _lib_masks_get_values(model, &iter, NULL, NULL, &id);
+  _shape_manager_get_values(model, &iter, NULL, NULL, &id);
   dt_masks_form_t *form = dt_masks_get_from_id(dt_dev_get_global(), id);
   if(IS_NULL_PTR(form)) return;
 
@@ -599,7 +599,7 @@ static void _tree_cell_edited(GtkCellRendererText *cell, gchar *path_string, gch
   dt_dev_add_history_item(dt_dev_get_global(), NULL, FALSE, TRUE);
 }
 
-static void _tree_selection_change(GtkTreeSelection *selection, dt_lib_masks_t *self)
+static void _tree_selection_change(GtkTreeSelection *selection, dt_shape_manager_t *self)
 {
   dt_develop_t *const dev = dt_dev_get_global();
   if(self->gui_reset) return;
@@ -631,7 +631,7 @@ static void _tree_selection_change(GtkTreeSelection *selection, dt_lib_masks_t *
     {
       int grid = -1;
       int id = -1;
-      _lib_masks_get_values(model, &iter, NULL, &grid, &id);
+      _shape_manager_get_values(model, &iter, NULL, &grid, &id);
 
       dt_masks_form_t *form = dt_masks_get_from_id(dev, id);
       if(!IS_NULL_PTR(form))
@@ -642,7 +642,7 @@ static void _tree_selection_change(GtkTreeSelection *selection, dt_lib_masks_t *
         if(nb == 1 && (form->type & DT_MASKS_GROUP))
         {
           dt_iop_module_t *module = NULL;
-          _lib_masks_get_values(model, &iter, &module, NULL, NULL);
+          _shape_manager_get_values(model, &iter, &module, NULL, NULL);
 
           if(module && module->gui && module->gui->blend_data
              && (module->flags() & IOP_FLAGS_SUPPORTS_BLENDING)
@@ -700,7 +700,7 @@ static GtkWidget *_tree_context_menu(GtkTreeSelection *selection, GtkTreeModel *
       // before freeing the list of selected rows, we check if the form is a group or not
       if(gtk_tree_model_get_iter(model, &iter, it0))
       {
-        _lib_masks_get_values(model, &iter, NULL, &parentid, &grpid);
+        _shape_manager_get_values(model, &iter, NULL, &parentid, &grpid);
       }
     }
     g_list_free_full(selected, (GDestroyNotify)gtk_tree_path_free);
@@ -784,7 +784,7 @@ static GtkWidget *_tree_context_menu(GtkTreeSelection *selection, GtkTreeModel *
 
   // Same shape-parameter sliders (size/fading/rotation/opacity) as the darkroom canvas's and
   // the blend module's own shape context menus. Available for any single selected shape, not
-  // just one nested under a group in the tree: _lib_masks_list_recurs also lists every shape
+  // just one nested under a group in the tree: _shape_manager_list_recurs also lists every shape
   // at top level regardless of group membership (TREE_GROUPID == 0 there), so when the tree
   // doesn't hand us the parent directly, look up whichever group actually references it.
   if(nb == 1 && !IS_NULL_PTR(grp) && !(grp->type & DT_MASKS_GROUP))
@@ -948,7 +948,7 @@ static int _tree_button_pressed(GtkWidget *treeview, GdkEventButton *event, dt_l
                                    NULL, NULL)
      && gtk_tree_model_get_iter(model, &iter, mouse_path))
   {
-    _lib_masks_get_values(model, &iter, &module, NULL, NULL);
+    _shape_manager_get_values(model, &iter, &module, NULL, NULL);
   }
   /* single click with the right mouse button? */
   if(event->type == GDK_BUTTON_PRESS && event->button == 1)
@@ -983,7 +983,7 @@ static int _tree_button_pressed(GtkWidget *treeview, GdkEventButton *event, dt_l
 static gboolean _tree_restrict_select(GtkTreeSelection *selection, GtkTreeModel *model, GtkTreePath *path,
                                       gboolean path_currently_selected, gpointer data)
 {
-  dt_lib_masks_t *self = (dt_lib_masks_t *)data;
+  dt_shape_manager_t *self = (dt_shape_manager_t *)data;
   if(self->gui_reset) return TRUE;
 
   // if the change is SELECT->UNSELECT no pb
@@ -1081,9 +1081,9 @@ static void _is_form_used(int formid, dt_masks_form_t *grp, char *text, size_t t
   }
 }
 
-static void _lib_masks_list_recurs(GtkTreeStore *treestore, GtkTreeIter *toplevel, dt_masks_form_t *form,
+static void _shape_manager_list_recurs(GtkTreeStore *treestore, GtkTreeIter *toplevel, dt_masks_form_t *form,
                                    int grp_id, dt_iop_module_t *module, int gstate, float opacity,
-                                   dt_lib_masks_t *lm, int index)
+                                   dt_shape_manager_t *lm, int index)
 {
   if(form->type & (DT_MASKS_CLONE|DT_MASKS_NON_CLONE)) return;
   // we create the text entry
@@ -1151,7 +1151,7 @@ static void _lib_masks_list_recurs(GtkTreeStore *treestore, GtkTreeIter *topleve
       dt_masks_form_group_t *grpt = (dt_masks_form_group_t *)forms->data;
       dt_masks_form_t *f = dt_masks_get_from_id(dt_dev_get_global(), grpt->formid);
       if(f)
-        _lib_masks_list_recurs(treestore, &child, f, form->formid, module, grpt->state, grpt->opacity, lm, index);
+        _shape_manager_list_recurs(treestore, &child, f, form->formid, module, grpt->state, grpt->opacity, lm, index);
       index++;
     }
   }
@@ -1165,7 +1165,7 @@ gboolean _find_mask_iter_by_values(GtkTreeModel *model, GtkTreeIter *iter,
   {
     int fid = -1;
     dt_iop_module_t *mod;
-    _lib_masks_get_values(model, iter, &mod, NULL, &fid);
+    _shape_manager_get_values(model, iter, &mod, NULL, &fid);
     found = (fid == formid)
       && ((level == 1)
           || (IS_NULL_PTR(module) || (mod && (!g_strcmp0(module->op, mod->op)))));
@@ -1184,10 +1184,10 @@ gboolean _find_mask_iter_by_values(GtkTreeModel *model, GtkTreeIter *iter,
   return found;
 }
 
-GList *_lib_masks_get_selected(dt_lib_module_t *self)
+GList *_shape_manager_get_selected(dt_lib_module_t *self)
 {
   GList *res = NULL;
-  dt_lib_masks_t *lm = (dt_lib_masks_t *)self->data;
+  dt_shape_manager_t *lm = (dt_shape_manager_t *)self->data;
 
   GtkTreeModel *model = gtk_tree_view_get_model(GTK_TREE_VIEW(lm->treeview));
 
@@ -1204,7 +1204,7 @@ GList *_lib_masks_get_selected(dt_lib_module_t *self)
       int fid = -1;
       int gid = -1;
       dt_iop_module_t *mod;
-      _lib_masks_get_values(model, &iter, &mod, &gid, &fid);
+      _shape_manager_get_values(model, &iter, &mod, &gid, &fid);
       res = g_list_prepend(res, GINT_TO_POINTER(fid));
       res = g_list_prepend(res, GINT_TO_POINTER(gid));
       res = g_list_prepend(res, (void *)(mod));
@@ -1218,10 +1218,10 @@ GList *_lib_masks_get_selected(dt_lib_module_t *self)
   return res;
 }
 
-static void _lib_masks_recreate_list(dt_lib_module_t *self)
+static void _shape_manager_recreate_list(dt_lib_module_t *self)
 {
   /* first destroy all buttons in list */
-  dt_lib_masks_t *lm = (dt_lib_masks_t *)self->data;
+  dt_shape_manager_t *lm = (dt_shape_manager_t *)self->data;
   if(IS_NULL_PTR(lm)) return;
   if(lm->gui_reset) return;
 
@@ -1235,7 +1235,7 @@ static void _lib_masks_recreate_list(dt_lib_module_t *self)
 
   if(lm->treeview)
   {
-    selectids = _lib_masks_get_selected(self);
+    selectids = _shape_manager_get_selected(self);
   }
 
   // Rebuilding the shape manager list is also used to refresh shapes created
@@ -1254,14 +1254,14 @@ static void _lib_masks_recreate_list(dt_lib_module_t *self)
   for(const GList *forms = dt_dev_get_global()->forms; forms; forms = g_list_next(forms))
   {
     dt_masks_form_t *form = (dt_masks_form_t *)forms->data;
-    if(form->type & DT_MASKS_GROUP) _lib_masks_list_recurs(treestore, NULL, form, 0, NULL, 0, 1.0, lm, 0);
+    if(form->type & DT_MASKS_GROUP) _shape_manager_list_recurs(treestore, NULL, form, 0, NULL, 0, 1.0, lm, 0);
   }
 
   // and we add all forms
   for(const GList *forms = dt_dev_get_global()->forms; forms; forms = g_list_next(forms))
   {
     dt_masks_form_t *form = (dt_masks_form_t *)forms->data;
-    if(!(form->type & DT_MASKS_GROUP)) _lib_masks_list_recurs(treestore, NULL, form, 0, NULL, 0, 1.0, lm, 0);
+    if(!(form->type & DT_MASKS_GROUP)) _shape_manager_list_recurs(treestore, NULL, form, 0, NULL, 0, 1.0, lm, 0);
   }
 
   gtk_tree_view_set_model(GTK_TREE_VIEW(lm->treeview), GTK_TREE_MODEL(treestore));
@@ -1344,7 +1344,7 @@ static void _lib_masks_recreate_list(dt_lib_module_t *self)
   }
 }
 
-static void _lib_masks_update_item(dt_lib_module_t *self, int formid, int parentid, dt_lib_masks_t *lm, GtkTreeModel *model, GtkTreeIter *iter)
+static void _shape_manager_update_item(dt_lib_module_t *self, int formid, int parentid, dt_shape_manager_t *lm, GtkTreeModel *model, GtkTreeIter *iter)
 {
   // we retrieve the forms
   dt_masks_form_t *form = dt_masks_get_from_id(dt_dev_get_global(), formid);
@@ -1382,7 +1382,7 @@ static gboolean _update_foreach(GtkTreeModel *model, GtkTreePath *path, GtkTreeI
   // we retrieve the ids
   int grid = -1;
   int id = -1;
-  _lib_masks_get_values(model, iter, NULL, &grid, &id);
+  _shape_manager_get_values(model, iter, NULL, &grid, &id);
 
   // we retrieve the forms
   dt_masks_form_t *form = dt_masks_get_from_id(dt_dev_get_global(), id);
@@ -1414,9 +1414,9 @@ static gboolean _update_foreach(GtkTreeModel *model, GtkTreePath *path, GtkTreeI
 }
 
 // Update each item of the list
-static void _lib_masks_update_list(dt_lib_module_t *self)
+static void _shape_manager_update_list(dt_lib_module_t *self)
 {
-  dt_lib_masks_t *lm = (dt_lib_masks_t *)self->data;
+  dt_shape_manager_t *lm = (dt_shape_manager_t *)self->data;
   if(IS_NULL_PTR(lm)) return;
   if(IS_NULL_PTR(lm->treeview)) return;
 
@@ -1435,7 +1435,7 @@ static gboolean _remove_foreach(GtkTreeModel *model, GtkTreePath *path, GtkTreeI
 
   int grid = -1;
   int id = -1;
-  _lib_masks_get_values(model, iter, NULL, &grid, &id);
+  _shape_manager_get_values(model, iter, NULL, &grid, &id);
 
   if(grid == refgid && id == refid)
   {
@@ -1445,9 +1445,9 @@ static gboolean _remove_foreach(GtkTreeModel *model, GtkTreePath *path, GtkTreeI
   return 0;
 }
 
-static void _lib_masks_remove_item(dt_lib_module_t *self, int formid, int parentid)
+static void _shape_manager_remove_item(dt_lib_module_t *self, int formid, int parentid)
 {
-  dt_lib_masks_t *lm = (dt_lib_masks_t *)self->data;
+  dt_shape_manager_t *lm = (dt_shape_manager_t *)self->data;
   // for each node , we refresh the string
   GtkTreeModel *model = gtk_tree_view_get_model(GTK_TREE_VIEW(lm->treeview));
   GList *rl = NULL;
@@ -1474,7 +1474,7 @@ static void _lib_masks_remove_item(dt_lib_module_t *self, int formid, int parent
   rl = NULL;
 }
 
-static gboolean _lib_masks_selection_change_r(GtkTreeModel *model, GtkTreeSelection *selection,
+static gboolean _shape_manager_selection_change_r(GtkTreeModel *model, GtkTreeSelection *selection,
                                               GtkTreeIter *iter, struct dt_iop_module_t *module,
                                               const int selectid, int throw_event, const int level)
 {
@@ -1485,7 +1485,7 @@ static gboolean _lib_masks_selection_change_r(GtkTreeModel *model, GtkTreeSelect
   {
     int id = -1;
     dt_iop_module_t *mod;
-    _lib_masks_get_values(model, &i, &mod, NULL, &id);
+    _shape_manager_get_values(model, &i, &mod, NULL, &id);
 
     if((id == selectid)
        && ((level == 1)
@@ -1500,7 +1500,7 @@ static gboolean _lib_masks_selection_change_r(GtkTreeModel *model, GtkTreeSelect
     GtkTreeIter child, parent = i;
     if(gtk_tree_model_iter_children(model, &child, &parent))
     {
-      found = _lib_masks_selection_change_r(model, selection, &child, module, selectid, throw_event, level + 1);
+      found = _shape_manager_selection_change_r(model, selection, &child, module, selectid, throw_event, level + 1);
       if(found)
       {
         break;
@@ -1511,9 +1511,9 @@ static gboolean _lib_masks_selection_change_r(GtkTreeModel *model, GtkTreeSelect
   return found;
 }
 
-static void _lib_masks_selection_change(dt_lib_module_t *self, struct dt_iop_module_t *module, const int selectid, const int throw_event)
+static void _shape_manager_selection_change(dt_lib_module_t *self, struct dt_iop_module_t *module, const int selectid, const int throw_event)
 {
-  dt_lib_masks_t *lm = (dt_lib_masks_t *)self->data;
+  dt_shape_manager_t *lm = (dt_shape_manager_t *)self->data;
   if(IS_NULL_PTR(lm->treeview)) return;
 
   // we first unselect all
@@ -1536,7 +1536,7 @@ static void _lib_masks_selection_change(dt_lib_module_t *self, struct dt_iop_mod
   if(valid)
   {
     gtk_tree_view_expand_all(GTK_TREE_VIEW(lm->treeview));
-    const gboolean found = _lib_masks_selection_change_r(model, selection, &iter, module, selectid, throw_event, 1);
+    const gboolean found = _shape_manager_selection_change_r(model, selection, &iter, module, selectid, throw_event, 1);
     if(!found) gtk_tree_view_collapse_all(GTK_TREE_VIEW(lm->treeview));
   }
 
@@ -1592,11 +1592,11 @@ static gboolean _find_iter_by_parentid_and_formid(GtkTreeModel *model, int paren
   return found;
 }
 
-static void _lib_masks_handler_callback(gpointer instance, const int formid, const int parentid, const dt_masks_event_t event, dt_lib_module_t *self)
+static void _shape_manager_handler_callback(gpointer instance, const int formid, const int parentid, const dt_masks_event_t event, dt_lib_module_t *self)
 {
   if(IS_NULL_PTR(self)) return;
 
-  dt_lib_masks_t *lm = (dt_lib_masks_t *)self->data;
+  dt_shape_manager_t *lm = (dt_shape_manager_t *)self->data;
   if(IS_NULL_PTR(lm)) return;
   GtkTreeModel *model = gtk_tree_view_get_model(GTK_TREE_VIEW(lm->treeview));
   if(!GTK_IS_TREE_MODEL(model)) return;
@@ -1609,33 +1609,33 @@ static void _lib_masks_handler_callback(gpointer instance, const int formid, con
     {
       case DT_MASKS_EVENT_UPDATE :
       {
-        _lib_masks_update_item(self, formid, parentid, lm, model, &iter);
+        _shape_manager_update_item(self, formid, parentid, lm, model, &iter);
       }
       break;
 
       case DT_MASKS_EVENT_CHANGE :
       {
-        _lib_masks_recreate_list(self);
+        _shape_manager_recreate_list(self);
       }
       break;
 
       case DT_MASKS_EVENT_DELETE :
       {
-        _lib_masks_recreate_list(self);
+        _shape_manager_recreate_list(self);
       }
       break;
 
       case DT_MASKS_EVENT_REMOVE :
       {
-        _lib_masks_recreate_list(self);
-        //_lib_masks_remove_item(self, formid, parentid);
+        _shape_manager_recreate_list(self);
+        //_shape_manager_remove_item(self, formid, parentid);
       }
       break;
 
       case DT_MASKS_EVENT_NONE :
       default:
       {
-        dt_print(DT_DEBUG_MASKS, "[_lib_masks_handler_callback] Mask event cannot be found.");
+        dt_print(DT_DEBUG_MASKS, "[_shape_manager_handler_callback] Mask event cannot be found.");
       }
       break;
     }
@@ -1643,19 +1643,19 @@ static void _lib_masks_handler_callback(gpointer instance, const int formid, con
   
   else if(event == DT_MASKS_EVENT_RESET)
   {
-    _lib_masks_recreate_list(self);
+    _shape_manager_recreate_list(self);
   }
 
   else if(event == DT_MASKS_EVENT_DELETE || event == DT_MASKS_EVENT_REMOVE)
   {
     // When a shape is deleted from the model, we may no longer find its previous row in the current tree.
     // In that case, force a full list refresh so stale rows don't remain visible.
-    _lib_masks_recreate_list(self);
+    _shape_manager_recreate_list(self);
   }
 
   else if(event == DT_MASKS_EVENT_ADD)
   {
-    _lib_masks_recreate_list(self);
+    _shape_manager_recreate_list(self);
     dt_masks_form_gui_t *gui = dt_dev_get_global()->form_gui;
     if(IS_NULL_PTR(gui) || !gui->creation)
       dt_masks_set_visible_form(dt_dev_get_global(),
@@ -1673,7 +1673,7 @@ static void _lib_masks_handler_callback(gpointer instance, const int formid, con
 
 /** @brief Is this window on a backend where absolute coordinates mean anything? Wayland gives a
  * client neither its own position nor the right to set it, so there we remember the width only. */
-static gboolean _lib_masks_popup_position_is_usable(GtkWidget *window)
+static gboolean _shape_manager_popup_position_is_usable(GtkWidget *window)
 {
 #ifdef GDK_WINDOWING_WAYLAND
   return !GDK_IS_WAYLAND_DISPLAY(gtk_widget_get_display(window));
@@ -1684,7 +1684,7 @@ static gboolean _lib_masks_popup_position_is_usable(GtkWidget *window)
 
 /** @brief Remember where the user put the panel and how wide they made it. Called on every path
  * that takes the window off screen, since a hidden window no longer has a position to read. */
-static void _lib_masks_popup_save_geometry(dt_lib_masks_t *d)
+static void _shape_manager_popup_save_geometry(dt_shape_manager_t *d)
 {
   if(!GTK_IS_WINDOW(d->popup_window) || !gtk_widget_get_visible(d->popup_window)) return;
 
@@ -1693,7 +1693,7 @@ static void _lib_masks_popup_save_geometry(dt_lib_masks_t *d)
   gtk_window_get_size(GTK_WINDOW(d->popup_window), &width, &height);
   if(width > 0) dt_conf_set_int(DT_MASKS_PANEL_CONF_WIDTH, width);
 
-  if(!_lib_masks_popup_position_is_usable(d->popup_window)) return;
+  if(!_shape_manager_popup_position_is_usable(d->popup_window)) return;
 
   gint x = 0;
   gint y = 0;
@@ -1705,7 +1705,7 @@ static void _lib_masks_popup_save_geometry(dt_lib_masks_t *d)
 /** @brief Put the panel back where it was left, before it is mapped. With nothing stored -- first
  * run, or a session that never moved it -- nothing is imposed and GTK_WIN_POS_CENTER_ON_PARENT
  * still decides, which is what puts the window on the screen the application is on. */
-static void _lib_masks_popup_restore_geometry(dt_lib_masks_t *d)
+static void _shape_manager_popup_restore_geometry(dt_shape_manager_t *d)
 {
   if(!GTK_IS_WINDOW(d->popup_window)) return;
 
@@ -1723,7 +1723,7 @@ static void _lib_masks_popup_restore_geometry(dt_lib_masks_t *d)
     }
   }
 
-  if(!_lib_masks_popup_position_is_usable(d->popup_window)) return;
+  if(!_shape_manager_popup_position_is_usable(d->popup_window)) return;
   if(!dt_conf_key_exists(DT_MASKS_PANEL_CONF_X) || !dt_conf_key_exists(DT_MASKS_PANEL_CONF_Y)) return;
 
   const int x = dt_conf_get_int(DT_MASKS_PANEL_CONF_X);
@@ -1756,9 +1756,9 @@ static void _lib_masks_popup_restore_geometry(dt_lib_masks_t *d)
 /** @brief The toolbox button is the panel's only state: showing and hiding both go through its
  * active flag, so every way of closing the panel leaves the button un-pressed. Re-entrant by
  * design -- the window-manager close path toggles the button, which comes back here. */
-static void _lib_masks_popup_button_toggled_cb(GtkWidget *button, gpointer user_data)
+static void _shape_manager_popup_button_toggled_cb(GtkWidget *button, gpointer user_data)
 {
-  dt_lib_masks_t *d = (dt_lib_masks_t *)user_data;
+  dt_shape_manager_t *d = (dt_shape_manager_t *)user_data;
   if(IS_NULL_PTR(d->popup_window)) return;
 
   const gboolean active = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(button));
@@ -1767,12 +1767,12 @@ static void _lib_masks_popup_button_toggled_cb(GtkWidget *button, gpointer user_
   if(active)
   {
     // before mapping: a move applied to a mapped window makes it jump in view
-    _lib_masks_popup_restore_geometry(d);
+    _shape_manager_popup_restore_geometry(d);
     gtk_widget_show_all(d->popup_window);
   }
   else
   {
-    _lib_masks_popup_save_geometry(d);
+    _shape_manager_popup_save_geometry(d);
     gtk_widget_hide(d->popup_window);
   }
 }
@@ -1780,10 +1780,10 @@ static void _lib_masks_popup_button_toggled_cb(GtkWidget *button, gpointer user_
 /** @brief Closing from the window manager hides the panel, same as the toolbox button, so its
  * widgets and state survive. Un-pressing the button is what actually hides the window (and saves
  * the geometry before it goes), so the two ways of closing cannot disagree. */
-static gboolean _lib_masks_popup_delete_cb(GtkWidget *window __attribute__((unused)),
+static gboolean _shape_manager_popup_delete_cb(GtkWidget *window __attribute__((unused)),
                                            GdkEvent *event __attribute__((unused)), gpointer user_data)
 {
-  dt_lib_masks_t *d = (dt_lib_masks_t *)user_data;
+  dt_shape_manager_t *d = (dt_shape_manager_t *)user_data;
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(d->popup_button), FALSE);
   return TRUE;
 }
@@ -1791,9 +1791,19 @@ static gboolean _lib_masks_popup_delete_cb(GtkWidget *window __attribute__((unus
 /* Idle callback to add the popup button to the module toolbox once the
  * module_toolbox proxy has been initialized. Returns FALSE when done so
  * it is removed from the idle loop. */
-static gboolean _lib_masks_add_popup_button_idle(gpointer user_data)
+/* Published through dev->proxy.masks so the darkroom can draw the mask overlays while the user
+ * is looking at the manager -- what dt_lib_gui_get_expanded() answered while this was a panel
+ * section, and what no expander can answer now that it is a window. */
+static gboolean _shape_manager_is_window_visible(dt_lib_module_t *self)
 {
-  dt_lib_masks_t *d = (dt_lib_masks_t *)user_data;
+  if(IS_NULL_PTR(self) || IS_NULL_PTR(self->data)) return FALSE;
+  dt_shape_manager_t *d = (dt_shape_manager_t *)self->data;
+  return !IS_NULL_PTR(d->popup_window) && gtk_widget_get_visible(d->popup_window);
+}
+
+static gboolean _shape_manager_add_popup_button_idle(gpointer user_data)
+{
+  dt_shape_manager_t *d = (dt_shape_manager_t *)user_data;
   if(!d || !d->popup_button) return FALSE;
 
   if(dt_view_manager_get_global()->proxy.module_toolbox.module)
@@ -1807,7 +1817,7 @@ static gboolean _lib_masks_add_popup_button_idle(gpointer user_data)
 void gui_init(dt_lib_module_t *self)
 {
   /* initialize ui widgets */
-  dt_lib_masks_t *d = (dt_lib_masks_t *)g_malloc0(sizeof(dt_lib_masks_t));
+  dt_shape_manager_t *d = (dt_shape_manager_t *)g_malloc0(sizeof(dt_shape_manager_t));
   self->data = (void *)d;
   d->gui_reset = 0;
 
@@ -1846,7 +1856,7 @@ void gui_init(dt_lib_module_t *self)
 #endif
 
   // Intercept the window close action to hide the widget instead of completely destroying it
-  g_signal_connect(G_OBJECT(d->popup_window), "delete-event", G_CALLBACK(_lib_masks_popup_delete_cb), d);
+  g_signal_connect(G_OBJECT(d->popup_window), "delete-event", G_CALLBACK(_shape_manager_popup_delete_cb), d);
 
   // 3. Create a clean box container inside the popup window to receive original shape elements
   GtkWidget *shape_manager_container = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_GUI_BOX_SPACING);
@@ -1869,8 +1879,8 @@ void gui_init(dt_lib_module_t *self)
    * Schedule adding the popup button via an idle callback so it runs after
    * other modules (including the module_toolbox) have had their gui_init
    * called. The callback will remove itself once it succeeds. */
-  g_idle_add((GSourceFunc)_lib_masks_add_popup_button_idle, d);
-  g_signal_connect(G_OBJECT(d->popup_button), "toggled", G_CALLBACK(_lib_masks_popup_button_toggled_cb), d);
+  g_idle_add((GSourceFunc)_shape_manager_add_popup_button_idle, d);
+  g_signal_connect(G_OBJECT(d->popup_button), "toggled", G_CALLBACK(_shape_manager_popup_button_toggled_cb), d);
 
   // From here, everything goes into the mask manager popup,
   // so there is no child added to self->widget from here.
@@ -1887,7 +1897,7 @@ void gui_init(dt_lib_module_t *self)
     .user_data = NULL,
     .can_start = NULL,
     .form_type = NULL,
-    .started = _lib_masks_shape_button_started,
+    .started = _shape_manager_shape_button_started,
     .exited = NULL,
   };
   GtkWidget *hbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, DT_GUI_BOX_SPACING);
@@ -1939,14 +1949,15 @@ void gui_init(dt_lib_module_t *self)
                                        DT_UI_RESIZE_DYNAMIC),
                      TRUE, TRUE, 0);
 
-  DT_DEBUG_CONTROL_SIGNAL_CONNECT(dt_control_signal_get_global(), DT_SIGNAL_MASK_CHANGED, G_CALLBACK(_lib_masks_handler_callback), self);
+  DT_DEBUG_CONTROL_SIGNAL_CONNECT(dt_control_signal_get_global(), DT_SIGNAL_MASK_CHANGED, G_CALLBACK(_shape_manager_handler_callback), self);
 
   // set proxy functions
   dt_dev_get_global()->proxy.masks.module = self;
-  dt_dev_get_global()->proxy.masks.list_change = _lib_masks_recreate_list;
-  dt_dev_get_global()->proxy.masks.list_update = _lib_masks_update_list;
-  dt_dev_get_global()->proxy.masks.list_remove = _lib_masks_remove_item;
-  dt_dev_get_global()->proxy.masks.selection_change = _lib_masks_selection_change;
+  dt_dev_get_global()->proxy.masks.list_change = _shape_manager_recreate_list;
+  dt_dev_get_global()->proxy.masks.list_update = _shape_manager_update_list;
+  dt_dev_get_global()->proxy.masks.list_remove = _shape_manager_remove_item;
+  dt_dev_get_global()->proxy.masks.selection_change = _shape_manager_selection_change;
+  dt_dev_get_global()->proxy.masks.is_visible = _shape_manager_is_window_visible;
 }
 
 void gui_cleanup(dt_lib_module_t *self)
@@ -1954,13 +1965,13 @@ void gui_cleanup(dt_lib_module_t *self)
   if(IS_NULL_PTR(self->data)) return;
   if(self && self->data)
   {
-    dt_lib_masks_t *d = (dt_lib_masks_t *)self->data;
+    dt_shape_manager_t *d = (dt_shape_manager_t *)self->data;
 
     // Destroy window allocation to prevent leaks
     if(d->popup_window)
     {
       // leaving with the panel open still counts as where the user left it
-      _lib_masks_popup_save_geometry(d);
+      _shape_manager_popup_save_geometry(d);
       gtk_widget_destroy(d->popup_window);
       d->popup_window = NULL;
     }
@@ -1980,7 +1991,7 @@ void gui_cleanup(dt_lib_module_t *self)
 
   dt_free(self->data);
 
-  DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(dt_control_signal_get_global(), G_CALLBACK(_lib_masks_handler_callback), self);
+  DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(dt_control_signal_get_global(), G_CALLBACK(_shape_manager_handler_callback), self);
 }
 
 // clang-format off

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -1103,9 +1103,9 @@ void expose(
   }
   else
   {
-    // display mask if we have a current module activated or if the masks manager module is expanded
+    // display mask if we have a current module activated or if the shape manager window is open
     const gboolean display_masks = (dev->gui_module && dev->gui_module->enabled)
-                                 || dt_lib_gui_get_expanded(dt_lib_get_module("masks"));
+                                 || dt_dev_masks_manager_is_visible(dev);
 
     if(dt_get_debug_flags() & DT_DEBUG_PERF) dt_show_times(&stage, "[darkroom] overlay predicates");
 


### PR DESCRIPTION
`libs/masks.c` was two modules wearing one `DT_MODULE`, and the name fit neither. A mask is drawn, parametric or raster -- the enum says so -- while that file held the blending panel and a manager for drawn shapes only.

## The panel section belonged to blending, not to the shape manager

The module declared a container, an expander and position 850, but the shape manager put nothing in `self->widget`; the comment saying *"there is no child added to self->widget from here"* already admitted it. The section existed for `dt_iop_gui_init_blending_body()`, which fills that widget with the focused module's blending controls.

So the blending host moves to `libs/blending.c` whole -- six functions, the two fields tracking which module's body is built, the `DEVELOP_MASKS_GUI_CHANGED` handler that chooses between building a body and explaining why there is none. It keeps the section's name, **Masking & Blending**: the body's Drawn / Parametric / Raster tabs are the three kinds of mask, and 33 translations already carry the string.

The two halves share no state -- `active_module` and `hosted_module` were touched only by the functions that left -- so nothing had to be published in a header.

## What remains is a module in a window

`views()` returns `"special"` and `container()` returns `DT_UI_CONTAINER_SIZE`, the arrangement `libs/export.c` already uses for a module whose interface is a window. `dt_lib_is_visible_in_view()` then excludes it from every panel, so it is never packed and `self->widget` stays NULL. Nothing indexes `containers[]` with the value: the four readers of `container()` only compare, and `dt_ui_container_add_widget()` has a default case. `gui_init()` still runs unfiltered by `views()`, so the toolbox button and the `dev->proxy.masks` registrations happen exactly as before.

Nothing changes on screen: same window, same button, same behaviour.

## Two defects found by following the consequences

**The darkroom's overlay predicate.** It asked `dt_lib_gui_get_expanded(dt_lib_get_module("masks"))`. Removing `expandable()` had already left the module on `default_expandable()`, which returns TRUE, over a NULL expander -- so it answered true unconditionally and the mask overlays were drawn whether or not anyone was looking at the shapes. The rename would have turned that into a NULL dereference on every darkroom expose. The question does not survive as an expander state, so the manager answers it: `dev->proxy.masks` gains an `is_visible` hook beside the four callbacks the module already registers there, and the window's own visibility is what the darkroom consults.

**A stale plugin.** `libmasks.so` remained installed beside the new ones; both would have loaded, the old one re-registering its proxies and a second toolbar button over the new.

## Verified

Build clean. `check_module_boundaries.sh` at 0, include cycles at 0, `check_unused_includes.sh --changed` at 0. Exercised in the running application: the panel section fills on focusing a maskable module and shows its message otherwise, the toolbox button opens the window, and only `libshape_manager.so` and `libblending.so` are loaded.

One include worth noting: `blending.c` takes `gui/window_manager.h` for `DT_UI_CONTAINER_PANEL_LEFT_CENTER` rather than `gui/application.h`, which was supplying it transitively -- the supply line the tree's include rule exists to stop, caught by removing the include the unused-include gate flagged and watching the build fail.

## Not in this PR

Renaming `develop/masks/` to match what it actually holds -- drawn shapes, never raster or parametric. It touches hundreds of sites, the `masks_history` table, `blend_params->mask_id` and twenty conf keys, and belongs on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)