### PR TITLE
shape manager: the cleanup SonarCloud reported on the rename

### DIFF
--- a/src/libs/shape_manager.c
+++ b/src/libs/shape_manager.c
@@ -86,7 +86,11 @@ typedef struct dt_shape_manager_t
   GtkWidget *popup_window;
   GtkWidget *popup_button;
 
-  GdkPixbuf *ic_inverse, *ic_union, *ic_intersection, *ic_difference, *ic_exclusion;
+  GdkPixbuf *ic_inverse;
+  GdkPixbuf *ic_union;
+  GdkPixbuf *ic_intersection;
+  GdkPixbuf *ic_difference;
+  GdkPixbuf *ic_exclusion;
   int gui_reset;
 } dt_shape_manager_t;
 
@@ -251,7 +255,6 @@ static void _tree_group(GtkButton *button, dt_lib_module_t *self)
   // add we save
   dt_dev_add_history_item(dt_dev_get_global(), NULL, FALSE, TRUE);
   _shape_manager_recreate_list(self);
-  // dt_masks_change_form_gui(darktable.develop, grp);
 }
 
 static int _tree_format_form_usage_label(char *str, const size_t str_size,
@@ -695,14 +698,10 @@ static GtkWidget *_tree_context_menu(GtkTreeSelection *selection, GtkTreeModel *
     GList *selected = gtk_tree_selection_get_selected_rows(selection, NULL);
     GtkTreePath *it0 = (GtkTreePath *)selected->data;
     depth = gtk_tree_path_get_depth(it0);
-    if(nb == 1)
-    {
-      // before freeing the list of selected rows, we check if the form is a group or not
-      if(gtk_tree_model_get_iter(model, &iter, it0))
-      {
-        _shape_manager_get_values(model, &iter, NULL, &parentid, &grpid);
-      }
-    }
+    // A single selected row is the only case whose group the menu below needs to know about;
+    // read it before the list of paths is freed.
+    if(nb == 1 && gtk_tree_model_get_iter(model, &iter, it0))
+      _shape_manager_get_values(model, &iter, NULL, &parentid, &grpid);
     g_list_free_full(selected, (GDestroyNotify)gtk_tree_path_free);
     selected = NULL;
   }
@@ -992,37 +991,35 @@ static gboolean _tree_restrict_select(GtkTreeSelection *selection, GtkTreeModel 
   // if selection is empty, no pb
   if(gtk_tree_selection_count_selected_rows(selection) == 0) return TRUE;
 
-  // now we unselect all members of selection with not the same parent node
-  // idem for all those with a different depth
-  int *indices = gtk_tree_path_get_indices(path);
-  int depth = gtk_tree_path_get_depth(path);
+  /* A row joins the selection only among peers: the same depth, and for a child row the same
+   * parent. Whatever is already selected and does not qualify is dropped.
+   *
+   * The rows to drop are gathered before any is dropped. Unselecting re-enters this function --
+   * with path_currently_selected TRUE, so those calls return at the top -- and the previous form
+   * answered that by re-reading the selection and restarting the walk after every single
+   * removal, which is quadratic for no gain: the list gtk_tree_selection_get_selected_rows()
+   * returns is our own copy, and unselecting does not touch it. */
+  const int *indices = gtk_tree_path_get_indices(path);
+  const int depth = gtk_tree_path_get_depth(path);
 
   GList *items = gtk_tree_selection_get_selected_rows(selection, NULL);
-  GList *items_iter = items;
-  while(items_iter)
+  GList *doomed = NULL;
+  for(const GList *items_iter = items; items_iter; items_iter = g_list_next(items_iter))
   {
     GtkTreePath *item = (GtkTreePath *)items_iter->data;
-    int dd = gtk_tree_path_get_depth(item);
-    int *ii = gtk_tree_path_get_indices(item);
-    int ok = 1;
-    if(dd != depth)
-      ok = 0;
-    else if(dd == 1)
-      ok = 1;
-    else if(ii[dd - 2] != indices[dd - 2])
-      ok = 0;
-    if(!ok)
-    {
-      gtk_tree_selection_unselect_path(selection, item);
-      g_list_free_full(items, (GDestroyNotify)gtk_tree_path_free);
-      items = NULL;
-      items_iter = items = gtk_tree_selection_get_selected_rows(selection, NULL);
-      continue;
-    }
-    items_iter = g_list_next(items_iter);
+    const int dd = gtk_tree_path_get_depth(item);
+    const int *ii = gtk_tree_path_get_indices(item);
+    const gboolean peer = (dd == depth) && (dd == 1 || ii[dd - 2] == indices[dd - 2]);
+    if(!peer) doomed = g_list_prepend(doomed, item);
   }
+
+  for(const GList *doomed_iter = doomed; doomed_iter; doomed_iter = g_list_next(doomed_iter))
+    gtk_tree_selection_unselect_path(selection, (GtkTreePath *)doomed_iter->data);
+
+  // doomed borrows its paths from items, which owns and frees them
+  g_list_free(doomed);
   g_list_free_full(items, (GDestroyNotify)gtk_tree_path_free);
-  items = NULL;
+
   return TRUE;
 }
 
@@ -1170,7 +1167,8 @@ gboolean _find_mask_iter_by_values(GtkTreeModel *model, GtkTreeIter *iter,
       && ((level == 1)
           || (IS_NULL_PTR(module) || (mod && (!g_strcmp0(module->op, mod->op)))));
     if(found) return found;
-    GtkTreeIter child, parent = *iter;
+    GtkTreeIter child;
+    GtkTreeIter parent = *iter;
     if(gtk_tree_model_iter_children(model, &child, &parent))
     {
       found = _find_mask_iter_by_values(model, &child, module, formid, level + 1);
@@ -1275,7 +1273,7 @@ static void _shape_manager_recreate_list(dt_lib_module_t *self)
       GtkTreeModel *model = GTK_TREE_MODEL(treestore);
       dt_iop_module_t *mod = (dt_iop_module_t *)ids->data;
       ids = g_list_next(ids);
-      // const int gid = GPOINTER_TO_INT(ids->data); // not needed, skip it
+      // the group id sits between the module and the form id, and this walk has no use for it
       ids = g_list_next(ids);
       const int fid = GPOINTER_TO_INT(ids->data);
       ids = g_list_next(ids);
@@ -1497,7 +1495,8 @@ static gboolean _shape_manager_selection_change_r(GtkTreeModel *model, GtkTreeSe
     }
 
     // check for children if any
-    GtkTreeIter child, parent = i;
+    GtkTreeIter child;
+    GtkTreeIter parent = i;
     if(gtk_tree_model_iter_children(model, &child, &parent))
     {
       found = _shape_manager_selection_change_r(model, selection, &child, module, selectid, throw_event, level + 1);
@@ -1628,7 +1627,6 @@ static void _shape_manager_handler_callback(gpointer instance, const int formid,
       case DT_MASKS_EVENT_REMOVE :
       {
         _shape_manager_recreate_list(self);
-        //_shape_manager_remove_item(self, formid, parentid);
       }
       break;
 
@@ -1937,7 +1935,8 @@ void gui_init(dt_lib_module_t *self)
   gtk_tree_selection_set_mode(selection, GTK_SELECTION_MULTIPLE);
   gtk_tree_selection_set_select_function(selection, _tree_restrict_select, d, NULL);
   gtk_tree_view_set_headers_visible(GTK_TREE_VIEW(d->treeview), FALSE);
-  // gtk_tree_view_set_tooltip_column(GTK_TREE_VIEW(d->treeview),TREE_USED_TEXT);
+  // A query-tooltip handler rather than a tooltip column: only the rows that carry a "used by"
+  // text show one, which a column would not let us decide per row.
   g_object_set(d->treeview, "has-tooltip", TRUE, (gchar *)0);
   g_signal_connect(d->treeview, "query-tooltip", G_CALLBACK(_tree_query_tooltip), NULL);
   g_signal_connect(selection, "changed", G_CALLBACK(_tree_selection_change), d);

--- a/src/libs/shape_manager.c
+++ b/src/libs/shape_manager.c
@@ -576,8 +576,10 @@ static void _tree_duplicate_shape(GtkButton *button __attribute__((unused)), dt_
   items = NULL;
 }
 
-static void _tree_cell_edited(GtkCellRendererText *cell __attribute__((unused)), gchar *path_string, gchar *new_text,
-                              dt_lib_module_t *self)
+/* The "edited" signal hands both strings as gchar *, but this only reads them -- and the
+ * connection goes through a GCallback cast, so nothing checks the signature against GTK's. */
+static void _tree_cell_edited(GtkCellRendererText *cell __attribute__((unused)), const gchar *path_string,
+                              const gchar *new_text, dt_lib_module_t *self)
 {
   dt_shape_manager_t *lm = (dt_shape_manager_t *)self->data;
   GtkTreeModel *model = gtk_tree_view_get_model(GTK_TREE_VIEW(lm->treeview));
@@ -592,7 +594,7 @@ static void _tree_cell_edited(GtkCellRendererText *cell __attribute__((unused)),
   // we want to make sure that the new name is not an empty string. else this would convert
   // in the xmp file into "<rdf:li/>" which produces problems. we use a single whitespace
   // as the pure minimum text.
-  gchar *text = strlen(new_text) == 0 ? " " : new_text;
+  const gchar *text = strlen(new_text) == 0 ? " " : new_text;
 
   // first, we need to update the mask name
 
@@ -1278,7 +1280,7 @@ static GtkTreeStore *_tree_store_build(dt_shape_manager_t *lm)
 
 /* Puts back what was selected before the store was replaced. selectids holds three entries per
  * row -- module, group id, form id -- as _shape_manager_get_selected() built it. */
-static void _tree_restore_selection(dt_shape_manager_t *lm, GtkTreeModel *model, GList *selectids)
+static void _tree_restore_selection(dt_shape_manager_t *lm, GtkTreeModel *model, const GList *selectids)
 {
   const GList *ids = selectids;
   while(ids)

--- a/src/libs/shape_manager.c
+++ b/src/libs/shape_manager.c
@@ -676,6 +676,109 @@ static void _tree_selection_change(GtkTreeSelection *selection, dt_shape_manager
     dt_dev_pixelpipe_change_zoom_main(dev);
 }
 
+/* The five shapes a group can gain, as their own submenu. Offered on an empty selection and on a
+ * selected group alike, which is why it is not written out twice. */
+static void _menu_append_new_shape_submenu(GtkMenuShell *menu, dt_iop_module_t *module)
+{
+  GtkWidget *add_menu = gtk_menu_new();
+  GtkWidget *add_item = gtk_menu_item_new_with_label(_("Add new shape ..."));
+  gtk_menu_item_set_submenu(GTK_MENU_ITEM(add_item), add_menu);
+  gtk_menu_shell_append(menu, add_item);
+
+  _tree_add_shape_menu_item(add_menu, DT_MASKS_BRUSH, module);
+  _tree_add_shape_menu_item(add_menu, DT_MASKS_CIRCLE, module);
+  _tree_add_shape_menu_item(add_menu, DT_MASKS_ELLIPSE, module);
+  _tree_add_shape_menu_item(add_menu, DT_MASKS_POLYGON, module);
+  _tree_add_shape_menu_item(add_menu, DT_MASKS_GRADIENT, module);
+}
+
+/* The shapes already drawn on this image that grp could take, each labelled with the modules
+ * already using it. A shape the caller's own module holds is skipped -- that is what the label
+ * formatter reports by refusing to write a label. */
+static void _menu_append_existing_shapes(GtkMenuShell *menu, dt_masks_form_t *grp, const int grpid,
+                                         dt_iop_module_t *module)
+{
+  gboolean any = FALSE;
+  GtkWidget *shapes_menu = gtk_menu_new();
+
+  for(const GList *forms = dt_dev_get_global()->forms; forms; forms = g_list_next(forms))
+  {
+    const dt_masks_form_t *form = (const dt_masks_form_t *)forms->data;
+    if((form->type & (DT_MASKS_CLONE | DT_MASKS_NON_CLONE)) || form->formid == grpid) continue;
+
+    char str[10000] = "";
+    if(_tree_format_form_usage_label(str, sizeof(str), form, module) == -1) continue;
+
+    GtkWidget *item = gtk_menu_item_new_with_label(str);
+    g_object_set_data(G_OBJECT(item), "formid", GUINT_TO_POINTER(form->formid));
+    g_object_set_data(G_OBJECT(item), "module", module);
+    g_signal_connect(G_OBJECT(item), "activate", G_CALLBACK(_tree_add_exist), grp);
+    gtk_menu_shell_append(GTK_MENU_SHELL(shapes_menu), item);
+    any = TRUE;
+  }
+
+  if(!any)
+  {
+    gtk_widget_destroy(shapes_menu);
+    return;
+  }
+
+  GtkWidget *item = gtk_menu_item_new_with_label(_("Add shape ..."));
+  gtk_menu_item_set_submenu(GTK_MENU_ITEM(item), shapes_menu);
+  gtk_menu_shell_append(menu, item);
+}
+
+/* One entry per combine mode, plus the reordering pair. The same Invert/Union/Intersection/
+ * Difference/Exclusion grouping the darkroom canvas and the blend module offer; all five differ
+ * by a constant, so they ride on the menu item under "masks-operation". */
+static void _menu_append_operations(GtkMenuShell *menu, dt_lib_module_t *self, const int nb)
+{
+  static const struct
+  {
+    const char *label;
+    dt_masks_state_t state;
+  } combine[] = {
+    { N_("Union"), DT_MASKS_STATE_UNION },
+    { N_("Intersection"), DT_MASKS_STATE_INTERSECTION },
+    { N_("Difference"), DT_MASKS_STATE_DIFFERENCE },
+    { N_("Exclusion"), DT_MASKS_STATE_EXCLUSION },
+  };
+
+  gtk_menu_shell_append(menu, gtk_separator_menu_item_new());
+
+  GtkWidget *item = gtk_menu_item_new_with_label(_("Operation"));
+  GtkWidget *op_submenu = gtk_menu_new();
+  gtk_menu_item_set_submenu(GTK_MENU_ITEM(item), op_submenu);
+  gtk_menu_shell_append(menu, item);
+
+  item = gtk_menu_item_new_with_label(_("Invert shape"));
+  g_object_set_data(G_OBJECT(item), "masks-operation", GINT_TO_POINTER(DT_MASKS_STATE_INVERSE));
+  g_signal_connect(item, "activate", (GCallback)_tree_apply_operation, self);
+  gtk_menu_shell_append(GTK_MENU_SHELL(op_submenu), item);
+
+  // Combining is a question about one shape against its group; several at once has no answer.
+  if(nb == 1)
+  {
+    gtk_menu_shell_append(GTK_MENU_SHELL(op_submenu), gtk_separator_menu_item_new());
+    for(size_t i = 0; i < sizeof(combine) / sizeof(combine[0]); i++)
+    {
+      item = gtk_menu_item_new_with_label(_(combine[i].label));
+      g_object_set_data(G_OBJECT(item), "masks-operation", GINT_TO_POINTER(combine[i].state));
+      g_signal_connect(item, "activate", (GCallback)_tree_apply_operation, self);
+      gtk_menu_shell_append(GTK_MENU_SHELL(op_submenu), item);
+    }
+  }
+
+  gtk_menu_shell_append(menu, gtk_separator_menu_item_new());
+  item = gtk_menu_item_new_with_label(_("Move up"));
+  g_signal_connect(item, "activate", (GCallback)_tree_moveup, self);
+  gtk_menu_shell_append(menu, item);
+  item = gtk_menu_item_new_with_label(_("Move down"));
+  g_signal_connect(item, "activate", (GCallback)_tree_movedown, self);
+  gtk_menu_shell_append(menu, item);
+  gtk_menu_shell_append(menu, gtk_separator_menu_item_new());
+}
+
 static GtkWidget *_tree_context_menu(GtkTreeSelection *selection, GtkTreeModel *model,
                                      dt_lib_module_t *self, dt_iop_module_t *module)
 {
@@ -705,68 +808,21 @@ static GtkWidget *_tree_context_menu(GtkTreeSelection *selection, GtkTreeModel *
   }
   if(depth > 1) from_group = 1;
 
+  // The form the single selected row names, when there is one: several sections below ask
+  // whether it is a group, and one lookup answers them all.
+  dt_masks_form_t *grp = dt_masks_get_from_id(dt_dev_get_global(), grpid);
+  const gboolean grp_is_group = !IS_NULL_PTR(grp) && (grp->type & DT_MASKS_GROUP);
+
   if(nb == 0)
   {
-    GtkWidget *add_menu = gtk_menu_new();
-    GtkWidget *add_item = gtk_menu_item_new_with_label(_("Add new shape ..."));
-    gtk_menu_item_set_submenu(GTK_MENU_ITEM(add_item), add_menu);
-    gtk_menu_shell_append(menu, add_item);
-
-    _tree_add_shape_menu_item(add_menu, DT_MASKS_BRUSH, module);
-    _tree_add_shape_menu_item(add_menu, DT_MASKS_CIRCLE, module);
-    _tree_add_shape_menu_item(add_menu, DT_MASKS_ELLIPSE, module);
-    _tree_add_shape_menu_item(add_menu, DT_MASKS_POLYGON, module);
-    _tree_add_shape_menu_item(add_menu, DT_MASKS_GRADIENT, module);
-
+    _menu_append_new_shape_submenu(menu, module);
     gtk_menu_shell_append(menu, gtk_separator_menu_item_new());
   }
 
-  if(nb == 1)
+  if(nb == 1 && grp_is_group)
   {
-    dt_masks_form_t *grp = dt_masks_get_from_id(dt_dev_get_global(), grpid);
-    if(grp && (grp->type & DT_MASKS_GROUP))
-    {
-      GtkWidget *add_menu = gtk_menu_new();
-      GtkWidget *add_item = gtk_menu_item_new_with_label(_("Add new shape ..."));
-      gtk_menu_item_set_submenu(GTK_MENU_ITEM(add_item), add_menu);
-      gtk_menu_shell_append(menu, add_item);
-
-      _tree_add_shape_menu_item(add_menu, DT_MASKS_BRUSH, module);
-      _tree_add_shape_menu_item(add_menu, DT_MASKS_CIRCLE, module);
-      _tree_add_shape_menu_item(add_menu, DT_MASKS_ELLIPSE, module);
-      _tree_add_shape_menu_item(add_menu, DT_MASKS_POLYGON, module);
-      _tree_add_shape_menu_item(add_menu, DT_MASKS_GRADIENT, module);
-
-      // existing forms
-      gboolean has_unused_shapes = FALSE;
-      GtkWidget *menu0 = gtk_menu_new();
-      for(GList *forms = dt_dev_get_global()->forms; forms; forms = g_list_next(forms))
-      {
-        dt_masks_form_t *form = (dt_masks_form_t *)forms->data;
-        if((form->type & (DT_MASKS_CLONE|DT_MASKS_NON_CLONE)) || form->formid == grpid)
-        {
-          continue;
-        }
-        char str[10000] = "";
-        const int nbuse = _tree_format_form_usage_label(str, sizeof(str), form, module);
-        if(nbuse == -1) continue;
-
-        // we add the menu entry
-        item = gtk_menu_item_new_with_label(str);
-        g_object_set_data(G_OBJECT(item), "formid", GUINT_TO_POINTER(form->formid));
-        g_object_set_data(G_OBJECT(item), "module", module);
-        g_signal_connect(G_OBJECT(item), "activate", G_CALLBACK(_tree_add_exist), grp);
-        gtk_menu_shell_append(GTK_MENU_SHELL(menu0), item);
-        has_unused_shapes = TRUE;
-      }
-
-      if(has_unused_shapes)
-      {
-        item = gtk_menu_item_new_with_label(_("Add shape ..."));
-        gtk_menu_item_set_submenu(GTK_MENU_ITEM(item), menu0);
-        gtk_menu_shell_append(menu, item);
-      }
-    }
+    _menu_append_new_shape_submenu(menu, module);
+    _menu_append_existing_shapes(menu, grp, grpid, module);
   }
 
   if(nb > 1 && !from_group)
@@ -777,14 +833,12 @@ static GtkWidget *_tree_context_menu(GtkTreeSelection *selection, GtkTreeModel *
     gtk_menu_shell_append(menu, item);
   }
 
-  dt_masks_form_t *grp = dt_masks_get_from_id(dt_dev_get_global(), grpid);
-
   // Same shape-parameter sliders (size/fading/rotation/opacity) as the darkroom canvas's and
   // the blend module's own shape context menus. Available for any single selected shape, not
   // just one nested under a group in the tree: _shape_manager_list_recurs also lists every shape
   // at top level regardless of group membership (TREE_GROUPID == 0 there), so when the tree
   // doesn't hand us the parent directly, look up whichever group actually references it.
-  if(nb == 1 && !IS_NULL_PTR(grp) && !(grp->type & DT_MASKS_GROUP))
+  if(nb == 1 && !IS_NULL_PTR(grp) && !grp_is_group)
   {
     const int holding_group = from_group ? parentid
                                          : dt_masks_group_find_holder(dt_dev_get_global(), grpid);
@@ -797,53 +851,9 @@ static GtkWidget *_tree_context_menu(GtkTreeSelection *selection, GtkTreeModel *
     }
   }
 
-  if(from_group && depth < 3)
-  {
-    gtk_menu_shell_append(menu, gtk_separator_menu_item_new());
+  if(from_group && depth < 3) _menu_append_operations(menu, self, nb);
 
-    // Same "Operation" submenu grouping (Invert/Union/Intersection/Difference/Exclusion) as
-    // the darkroom canvas's and the blend module's own shape context menus.
-    item = gtk_menu_item_new_with_label(_("Operation"));
-    GtkWidget *op_submenu = gtk_menu_new();
-    gtk_menu_item_set_submenu(GTK_MENU_ITEM(item), op_submenu);
-    gtk_menu_shell_append(menu, item);
-
-    item = gtk_menu_item_new_with_label(_("Invert shape"));
-    g_object_set_data(G_OBJECT(item), "masks-operation", GINT_TO_POINTER(DT_MASKS_STATE_INVERSE));
-      g_signal_connect(item, "activate", (GCallback)_tree_apply_operation, self);
-    gtk_menu_shell_append(GTK_MENU_SHELL(op_submenu), item);
-    if(nb == 1)
-    {
-      gtk_menu_shell_append(GTK_MENU_SHELL(op_submenu), gtk_separator_menu_item_new());
-      item = gtk_menu_item_new_with_label(_("Union"));
-      g_object_set_data(G_OBJECT(item), "masks-operation", GINT_TO_POINTER(DT_MASKS_STATE_UNION));
-      g_signal_connect(item, "activate", (GCallback)_tree_apply_operation, self);
-      gtk_menu_shell_append(GTK_MENU_SHELL(op_submenu), item);
-      item = gtk_menu_item_new_with_label(_("Intersection"));
-      g_object_set_data(G_OBJECT(item), "masks-operation", GINT_TO_POINTER(DT_MASKS_STATE_INTERSECTION));
-      g_signal_connect(item, "activate", (GCallback)_tree_apply_operation, self);
-      gtk_menu_shell_append(GTK_MENU_SHELL(op_submenu), item);
-      item = gtk_menu_item_new_with_label(_("Difference"));
-      g_object_set_data(G_OBJECT(item), "masks-operation", GINT_TO_POINTER(DT_MASKS_STATE_DIFFERENCE));
-      g_signal_connect(item, "activate", (GCallback)_tree_apply_operation, self);
-      gtk_menu_shell_append(GTK_MENU_SHELL(op_submenu), item);
-      item = gtk_menu_item_new_with_label(_("Exclusion"));
-      g_object_set_data(G_OBJECT(item), "masks-operation", GINT_TO_POINTER(DT_MASKS_STATE_EXCLUSION));
-      g_signal_connect(item, "activate", (GCallback)_tree_apply_operation, self);
-      gtk_menu_shell_append(GTK_MENU_SHELL(op_submenu), item);
-    }
-
-    gtk_menu_shell_append(menu, gtk_separator_menu_item_new());
-    item = gtk_menu_item_new_with_label(_("Move up"));
-    g_signal_connect(item, "activate", (GCallback)_tree_moveup, self);
-    gtk_menu_shell_append(menu, item);
-    item = gtk_menu_item_new_with_label(_("Move down"));
-    g_signal_connect(item, "activate", (GCallback)_tree_movedown, self);
-    gtk_menu_shell_append(menu, item);
-    gtk_menu_shell_append(menu, gtk_separator_menu_item_new());
-  }
-
-  if(!from_group && !(grp && (grp->type & DT_MASKS_GROUP)) && nb == 1)
+  if(!from_group && !grp_is_group && nb == 1)
   {
     item = gtk_menu_item_new_with_label(_("Duplicate shape"));
     g_signal_connect(item, "activate", (GCallback)_tree_duplicate_shape, self);
@@ -853,18 +863,10 @@ static GtkWidget *_tree_context_menu(GtkTreeSelection *selection, GtkTreeModel *
   
   if(!from_group && nb > 0)
   {
-    if(!(grp && (grp->type & DT_MASKS_GROUP)))
-    {
-      item = gtk_menu_item_new_with_label(_("Delete shape"));
-      g_signal_connect(item, "activate", (GCallback)_tree_delete_shape, self);
-      gtk_menu_shell_append(menu, item);
-    }
-    else
-    {
-      item = gtk_menu_item_new_with_label(_("Delete mask"));
-      g_signal_connect(item, "activate", (GCallback)_tree_delete_shape, self);
-      gtk_menu_shell_append(menu, item);
-    }
+    // One entry, named for what the row holds -- the whole mask when it is a group.
+    item = gtk_menu_item_new_with_label(grp_is_group ? _("Delete mask") : _("Delete shape"));
+    g_signal_connect(item, "activate", (GCallback)_tree_delete_shape, self);
+    gtk_menu_shell_append(menu, item);
   }
   else if(nb > 0 && depth < 3)
   {

--- a/src/libs/shape_manager.c
+++ b/src/libs/shape_manager.c
@@ -1237,138 +1237,128 @@ GList *_shape_manager_get_selected(dt_lib_module_t *self)
   return res;
 }
 
+/* Expands to the row, scrolls it into view and selects it. */
+static void _tree_reveal_row(dt_shape_manager_t *lm, GtkTreeModel *model, GtkTreeIter *iter,
+                             const gboolean exclusive)
+{
+  GtkTreeSelection *selection = gtk_tree_view_get_selection(GTK_TREE_VIEW(lm->treeview));
+  GtkTreePath *path = gtk_tree_model_get_path(model, iter);
+
+  if(exclusive) gtk_tree_selection_unselect_all(selection);
+  gtk_tree_view_expand_to_path(GTK_TREE_VIEW(lm->treeview), path);
+  gtk_tree_view_scroll_to_cell(GTK_TREE_VIEW(lm->treeview), path, NULL, TRUE, 0.5, 0.5);
+  gtk_tree_selection_select_iter(selection, iter);
+
+  gtk_tree_path_free(path);
+}
+
+static void _tree_store_add_forms(GtkTreeStore *treestore, dt_shape_manager_t *lm, const gboolean groups)
+{
+  for(const GList *forms = dt_dev_get_global()->forms; forms; forms = g_list_next(forms))
+  {
+    dt_masks_form_t *form = (dt_masks_form_t *)forms->data;
+    if(!!(form->type & DT_MASKS_GROUP) != groups) continue;
+
+    const _tree_row_t row = { .form = form, .opacity = 1.0f };
+    _shape_manager_list_recurs(treestore, NULL, lm, &row);
+  }
+}
+
+/* Groups first, then the shapes no group holds: that is the order the tree shows them in. */
+static GtkTreeStore *_tree_store_build(dt_shape_manager_t *lm)
+{
+  // we store : text ; *module ; groupid ; formid
+  GtkTreeStore *treestore = gtk_tree_store_new(TREE_COUNT, G_TYPE_STRING, G_TYPE_POINTER, G_TYPE_INT,
+                                               G_TYPE_INT, G_TYPE_BOOLEAN, GDK_TYPE_PIXBUF, G_TYPE_BOOLEAN,
+                                               GDK_TYPE_PIXBUF, G_TYPE_BOOLEAN, G_TYPE_BOOLEAN, G_TYPE_STRING);
+  _tree_store_add_forms(treestore, lm, TRUE);
+  _tree_store_add_forms(treestore, lm, FALSE);
+  return treestore;
+}
+
+/* Puts back what was selected before the store was replaced. selectids holds three entries per
+ * row -- module, group id, form id -- as _shape_manager_get_selected() built it. */
+static void _tree_restore_selection(dt_shape_manager_t *lm, GtkTreeModel *model, GList *selectids)
+{
+  const GList *ids = selectids;
+  while(ids)
+  {
+    dt_iop_module_t *mod = (dt_iop_module_t *)ids->data;
+    ids = g_list_next(ids);
+    // the group id sits between the module and the form id, and this walk has no use for it
+    ids = g_list_next(ids);
+    const int fid = GPOINTER_TO_INT(ids->data);
+    ids = g_list_next(ids);
+
+    GtkTreeIter iter;
+    // An empty store leaves iter untouched, and _find_mask_iter_by_values() then walks a
+    // stack-garbage iterator: gtk_tree_store_get_value() and gtk_tree_store_iter_next() assert
+    // on it, and the walk has no reason to terminate. Nothing later can make the store
+    // non-empty, so stop rather than skip.
+    if(!gtk_tree_model_get_iter_first(model, &iter)) return;
+
+    if(_find_mask_iter_by_values(model, &iter, mod, fid, 1)) _tree_reveal_row(lm, model, &iter, FALSE);
+  }
+}
+
+/* Points the tree at the focused module's mask group, and says whether it moved the selection --
+ * the caller replays the selection handler when it did, so the canvas follows. */
+static gboolean _tree_select_module_group(dt_shape_manager_t *lm, GtkTreeModel *model,
+                                          const dt_masks_form_gui_t *gui)
+{
+  dt_iop_module_t *const module = dt_dev_get_global()->gui_module;
+  const int group_id = (!IS_NULL_PTR(module) && module->blend_params
+                        && (module->flags() & IOP_FLAGS_SUPPORTS_BLENDING)
+                        && !(module->flags() & IOP_FLAGS_NO_MASKS))
+                           ? module->blend_params->mask_id
+                           : 0;
+
+  if(group_id <= 0) return FALSE;
+  // Mid-creation the tree follows the shape being drawn, not the module.
+  if(!IS_NULL_PTR(gui) && gui->creation) return FALSE;
+
+  GtkTreeIter iter;
+  if(!gtk_tree_model_get_iter_first(model, &iter)) return FALSE;
+  if(!_find_mask_iter_by_values(model, &iter, module, group_id, 1)) return FALSE;
+
+  _tree_reveal_row(lm, model, &iter, TRUE);
+  return TRUE;
+}
+
 static void _shape_manager_recreate_list(dt_lib_module_t *self)
 {
-  /* first destroy all buttons in list */
   dt_shape_manager_t *lm = (dt_shape_manager_t *)self->data;
-  if(IS_NULL_PTR(lm)) return;
-  if(lm->gui_reset) return;
+  if(IS_NULL_PTR(lm) || lm->gui_reset) return;
 
+  // Everything below drives the tree itself, so the handlers it would wake must stay quiet.
   const int gui_reset = lm->gui_reset;
   lm->gui_reset = 1;
-  gboolean sync_center_view = FALSE;
 
-  // if a treeview is already present, let's get the currently selected items
-  // as we are going to recreate the tree.
-  GList *selectids = NULL;
+  // The tree is about to be replaced, so what is selected has to be read before it goes.
+  GList *selectids = lm->treeview ? _shape_manager_get_selected(self) : NULL;
 
-  if(lm->treeview)
-  {
-    selectids = _shape_manager_get_selected(self);
-  }
-
-  // Rebuilding the shape manager list is also used to refresh shapes created
-  // during continuous creation. In that case, the active creation button must
-  // stay active until the user cancels creation explicitly.
+  // Rebuilding the list also refreshes shapes created during continuous creation. In that case
+  // the active creation button must stay active until the user cancels creation explicitly.
   dt_masks_form_gui_t *gui = dt_dev_get_global()->form_gui;
   if(IS_NULL_PTR(gui) || !gui->creation) dt_masks_shape_buttons_deactivate_all(NULL);
 
-  GtkTreeStore *treestore;
-  // we store : text ; *module ; groupid ; formid
-  treestore = gtk_tree_store_new(TREE_COUNT, G_TYPE_STRING, G_TYPE_POINTER, G_TYPE_INT, G_TYPE_INT,
-                                 G_TYPE_BOOLEAN, GDK_TYPE_PIXBUF, G_TYPE_BOOLEAN, GDK_TYPE_PIXBUF,
-                                 G_TYPE_BOOLEAN, G_TYPE_BOOLEAN, G_TYPE_STRING);
+  GtkTreeStore *treestore = _tree_store_build(lm);
+  GtkTreeModel *model = GTK_TREE_MODEL(treestore);
+  gtk_tree_view_set_model(GTK_TREE_VIEW(lm->treeview), model);
 
-  // we first add all groups
-  for(const GList *forms = dt_dev_get_global()->forms; forms; forms = g_list_next(forms))
-  {
-    dt_masks_form_t *form = (dt_masks_form_t *)forms->data;
-    if(form->type & DT_MASKS_GROUP)
-    {
-      const _tree_row_t row = { .form = form, .opacity = 1.0f };
-      _shape_manager_list_recurs(treestore, NULL, lm, &row);
-    }
-  }
-
-  // and we add all forms
-  for(const GList *forms = dt_dev_get_global()->forms; forms; forms = g_list_next(forms))
-  {
-    dt_masks_form_t *form = (dt_masks_form_t *)forms->data;
-    if(!(form->type & DT_MASKS_GROUP))
-    {
-      const _tree_row_t row = { .form = form, .opacity = 1.0f };
-      _shape_manager_list_recurs(treestore, NULL, lm, &row);
-    }
-  }
-
-  gtk_tree_view_set_model(GTK_TREE_VIEW(lm->treeview), GTK_TREE_MODEL(treestore));
-  
-  // select the images as selected in the previous tree
   if(selectids)
   {
-    GList *ids = selectids;
-    while(ids)
-    {
-      GtkTreeModel *model = GTK_TREE_MODEL(treestore);
-      dt_iop_module_t *mod = (dt_iop_module_t *)ids->data;
-      ids = g_list_next(ids);
-      // the group id sits between the module and the form id, and this walk has no use for it
-      ids = g_list_next(ids);
-      const int fid = GPOINTER_TO_INT(ids->data);
-      ids = g_list_next(ids);
-
-      GtkTreeIter iter;
-      // An empty store leaves iter untouched, and _find_mask_iter_by_values() then walks a
-      // stack-garbage iterator: gtk_tree_store_get_value() and gtk_tree_store_iter_next()
-      // assert on it, and the walk has no reason to terminate. Nothing later in this loop can
-      // make the store non-empty, so stop rather than skip.
-      if(!gtk_tree_model_get_iter_first(model, &iter)) break;
-      // get formid in group for the given module
-      const gboolean found = _find_mask_iter_by_values(model, &iter, mod, fid, 1);
-
-      if(found)
-      {
-        GtkTreePath *path = gtk_tree_model_get_path(model, &iter);
-        gtk_tree_view_expand_to_path(GTK_TREE_VIEW(lm->treeview), path);
-        gtk_tree_view_scroll_to_cell(GTK_TREE_VIEW(lm->treeview), path, NULL, TRUE, 0.5, 0.5);
-        gtk_tree_path_free(path);
-        GtkTreeSelection *selection = gtk_tree_view_get_selection(GTK_TREE_VIEW(lm->treeview));
-        gtk_tree_selection_select_iter(selection, &iter);
-      }
-    }
+    _tree_restore_selection(lm, model, selectids);
     g_list_free(selectids);
-    selectids = NULL;
   }
 
-  // After list refresh, keep the tree selection aligned with the current GUI module mask group.
-  dt_iop_module_t *const current_module = dt_dev_get_global()->gui_module;
-  const int current_group_id
-      = (!IS_NULL_PTR(current_module) && current_module->blend_params
-         && (current_module->flags() & IOP_FLAGS_SUPPORTS_BLENDING)
-         && !(current_module->flags() & IOP_FLAGS_NO_MASKS))
-            ? current_module->blend_params->mask_id
-            : 0;
-
-  if(current_group_id > 0 && (IS_NULL_PTR(gui) || !gui->creation))
-  {
-    GtkTreeModel *model = GTK_TREE_MODEL(treestore);
-    GtkTreeIter iter;
-    if(gtk_tree_model_get_iter_first(model, &iter))
-    {
-      const gboolean found = _find_mask_iter_by_values(model, &iter, current_module, current_group_id, 1);
-      if(found)
-      {
-        GtkTreeSelection *selection = gtk_tree_view_get_selection(GTK_TREE_VIEW(lm->treeview));
-        GtkTreePath *path = gtk_tree_model_get_path(model, &iter);
-        gtk_tree_selection_unselect_all(selection);
-        gtk_tree_view_expand_to_path(GTK_TREE_VIEW(lm->treeview), path);
-        gtk_tree_view_scroll_to_cell(GTK_TREE_VIEW(lm->treeview), path, NULL, TRUE, 0.5, 0.5);
-        gtk_tree_selection_select_iter(selection, &iter);
-        gtk_tree_path_free(path);
-        sync_center_view = TRUE;
-      }
-    }
-  }
+  const gboolean sync_center_view = _tree_select_module_group(lm, model, gui);
 
   g_object_unref(treestore);
-
   lm->gui_reset = gui_reset;
 
   if(sync_center_view)
-  {
-    GtkTreeSelection *selection = gtk_tree_view_get_selection(GTK_TREE_VIEW(lm->treeview));
-    _tree_selection_change(selection, lm);
-  }
+    _tree_selection_change(gtk_tree_view_get_selection(GTK_TREE_VIEW(lm->treeview)), lm);
 }
 
 static void _shape_manager_update_item(dt_lib_module_t *self __attribute__((unused)), int formid, int parentid, dt_shape_manager_t *lm, GtkTreeModel *model, GtkTreeIter *iter)
@@ -1854,7 +1844,7 @@ void gui_init(dt_lib_module_t *self)
 
   // 2. Setup the non-modal popup window
   d->popup_window = gtk_window_new(GTK_WINDOW_TOPLEVEL);
-  gtk_window_set_title(GTK_WINDOW(d->popup_window), _("Shape Manager Panel"));
+  gtk_window_set_title(GTK_WINDOW(d->popup_window), _("Shape Manager"));
   gtk_window_set_type_hint(GTK_WINDOW(d->popup_window), GDK_WINDOW_TYPE_HINT_UTILITY);
   
   // NON-MODAL & NO FOCUS STEAL: Prevents window manager from stealing active focus when mapped/shown

--- a/src/libs/shape_manager.c
+++ b/src/libs/shape_manager.c
@@ -95,7 +95,7 @@ typedef struct dt_shape_manager_t
 } dt_shape_manager_t;
 
 
-const char *name(struct dt_lib_module_t *self)
+const char *name(struct dt_lib_module_t *self __attribute__((unused)))
 {
   return _("Shape Manager");
 }
@@ -103,13 +103,13 @@ const char *name(struct dt_lib_module_t *self)
 /* Never shown in a panel: everything this module builds lives in its own window, opened by the
  * button it pushes into the darkroom toolbox. Same arrangement as libs/export.c, which is also a
  * module whose interface is a window rather than a panel section. */
-const char **views(dt_lib_module_t *self)
+const char **views(dt_lib_module_t *self __attribute__((unused)))
 {
   static const char *v[] = {"special", NULL};
   return v;
 }
 
-uint32_t container(dt_lib_module_t *self)
+uint32_t container(dt_lib_module_t *self __attribute__((unused)))
 {
   return DT_UI_CONTAINER_SIZE;
 }
@@ -183,8 +183,8 @@ static void _tree_add_shape_menu_item(GtkWidget *menu, const dt_masks_type_t typ
   if(!IS_NULL_PTR(item)) g_object_set_data(G_OBJECT(item), "masks-shape-type", GINT_TO_POINTER(type));
 }
 
-static void _shape_manager_shape_button_started(GtkWidget *button, dt_iop_module_t *module,
-                                            dt_masks_type_t type, gpointer user_data)
+static void _shape_manager_shape_button_started(GtkWidget *button __attribute__((unused)), dt_iop_module_t *module __attribute__((unused)),
+                                            dt_masks_type_t type __attribute__((unused)), gpointer user_data __attribute__((unused)))
 {
   dt_dev_get_global()->form_gui->group_selected = 0;
 }
@@ -212,7 +212,7 @@ static void _tree_add_exist(GtkButton *button, dt_masks_form_t *grp)
   }
 }
 
-static void _tree_group(GtkButton *button, dt_lib_module_t *self)
+static void _tree_group(GtkButton *button __attribute__((unused)), dt_lib_module_t *self)
 {
   dt_shape_manager_t *lm = (dt_shape_manager_t *)self->data;
   // we create the new group
@@ -330,7 +330,7 @@ static void _set_iter_name(dt_shape_manager_t *lm, dt_masks_form_t *form, int st
                      (!IS_NULL_PTR(icop)), TREE_IC_INVERSE, icinv, TREE_IC_INVERSE_VISIBLE, (!IS_NULL_PTR(icinv)), -1);
 }
 
-static void _tree_delete_unused(GtkButton *button, dt_lib_module_t *self)
+static void _tree_delete_unused(GtkButton *button __attribute__((unused)), dt_lib_module_t *self)
 {
   dt_develop_t *dev = dt_dev_get_global();
 
@@ -419,7 +419,7 @@ static void _tree_apply_operation(GtkWidget *menu_item, dt_lib_module_t *self)
   }
 }
 
-static void _tree_moveup(GtkButton *button, dt_lib_module_t *self)
+static void _tree_moveup(GtkButton *button __attribute__((unused)), dt_lib_module_t *self)
 {
   dt_shape_manager_t *lm = (dt_shape_manager_t *)self->data;
 
@@ -457,7 +457,7 @@ static void _tree_moveup(GtkButton *button, dt_lib_module_t *self)
   _add_masks_history_item(lm);
 }
 
-static void _tree_movedown(GtkButton *button, dt_lib_module_t *self)
+static void _tree_movedown(GtkButton *button __attribute__((unused)), dt_lib_module_t *self)
 {
   dt_shape_manager_t *lm = (dt_shape_manager_t *)self->data;
 
@@ -495,7 +495,7 @@ static void _tree_movedown(GtkButton *button, dt_lib_module_t *self)
   _add_masks_history_item(lm);
 }
 
-static void _tree_delete_shape(GtkButton *button, dt_lib_module_t *self)
+static void _tree_delete_shape(GtkButton *button __attribute__((unused)), dt_lib_module_t *self)
 {
   dt_shape_manager_t *lm = (dt_shape_manager_t *)self->data;
 
@@ -534,7 +534,7 @@ static void _tree_delete_shape(GtkButton *button, dt_lib_module_t *self)
   dt_dev_add_history_item(dt_dev_get_global(), NULL, FALSE, TRUE);
 }
 
-static void _tree_duplicate_shape(GtkButton *button, dt_lib_module_t *self)
+static void _tree_duplicate_shape(GtkButton *button __attribute__((unused)), dt_lib_module_t *self)
 {
   dt_shape_manager_t *lm = (dt_shape_manager_t *)self->data;
 
@@ -578,7 +578,7 @@ static void _tree_duplicate_shape(GtkButton *button, dt_lib_module_t *self)
   items = NULL;
 }
 
-static void _tree_cell_edited(GtkCellRendererText *cell, gchar *path_string, gchar *new_text,
+static void _tree_cell_edited(GtkCellRendererText *cell __attribute__((unused)), gchar *path_string, gchar *new_text,
                               dt_lib_module_t *self)
 {
   dt_shape_manager_t *lm = (dt_shape_manager_t *)self->data;
@@ -979,7 +979,7 @@ static int _tree_button_pressed(GtkWidget *treeview, GdkEventButton *event, dt_l
   return handled;
 }
 
-static gboolean _tree_restrict_select(GtkTreeSelection *selection, GtkTreeModel *model, GtkTreePath *path,
+static gboolean _tree_restrict_select(GtkTreeSelection *selection, GtkTreeModel *model __attribute__((unused)), GtkTreePath *path,
                                       gboolean path_currently_selected, gpointer data)
 {
   dt_shape_manager_t *self = (dt_shape_manager_t *)data;
@@ -1024,7 +1024,7 @@ static gboolean _tree_restrict_select(GtkTreeSelection *selection, GtkTreeModel 
 }
 
 static gboolean _tree_query_tooltip(GtkWidget *widget, gint x, gint y, gboolean keyboard_tip,
-                                    GtkTooltip *tooltip, gpointer data)
+                                    GtkTooltip *tooltip, gpointer data __attribute__((unused)))
 {
   GtkTreeIter iter;
   GtkTreeView *tree_view = GTK_TREE_VIEW(widget);
@@ -1342,7 +1342,7 @@ static void _shape_manager_recreate_list(dt_lib_module_t *self)
   }
 }
 
-static void _shape_manager_update_item(dt_lib_module_t *self, int formid, int parentid, dt_shape_manager_t *lm, GtkTreeModel *model, GtkTreeIter *iter)
+static void _shape_manager_update_item(dt_lib_module_t *self __attribute__((unused)), int formid, int parentid, dt_shape_manager_t *lm, GtkTreeModel *model, GtkTreeIter *iter)
 {
   // we retrieve the forms
   dt_masks_form_t *form = dt_masks_get_from_id(dt_dev_get_global(), formid);
@@ -1373,7 +1373,7 @@ static void _shape_manager_update_item(dt_lib_module_t *self, int formid, int pa
   return;
 }
 
-static gboolean _update_foreach(GtkTreeModel *model, GtkTreePath *path, GtkTreeIter *iter, gpointer data)
+static gboolean _update_foreach(GtkTreeModel *model, GtkTreePath *path __attribute__((unused)), GtkTreeIter *iter, gpointer data)
 {
   if(IS_NULL_PTR(iter)) return 0;
 
@@ -1591,7 +1591,7 @@ static gboolean _find_iter_by_parentid_and_formid(GtkTreeModel *model, int paren
   return found;
 }
 
-static void _shape_manager_handler_callback(gpointer instance, const int formid, const int parentid, const dt_masks_event_t event, dt_lib_module_t *self)
+static void _shape_manager_handler_callback(gpointer instance __attribute__((unused)), const int formid, const int parentid, const dt_masks_event_t event, dt_lib_module_t *self)
 {
   if(IS_NULL_PTR(self)) return;
 

--- a/src/libs/shape_manager.c
+++ b/src/libs/shape_manager.c
@@ -232,19 +232,17 @@ static void _tree_group(GtkButton *button __attribute__((unused)), dt_lib_module
   {
     GtkTreePath *item = (GtkTreePath *)items_iter->data;
     GtkTreeIter iter;
-    if(gtk_tree_model_get_iter(model, &iter, item))
-    {
-      int id = -1;
-      _shape_manager_get_values(model, &iter, NULL, NULL, &id);
+    if(!gtk_tree_model_get_iter(model, &iter, item)) continue;
 
-      if(id > 0)
-      {
-        dt_masks_form_t *member = dt_masks_get_from_id(dt_dev_get_global(), id);
-        if(!IS_NULL_PTR(member))
-          dt_masks_group_add_form_with_state(dt_dev_get_global(), mask, member, mask->formid,
-                                             DT_MASKS_STATE_USE | DT_MASKS_STATE_UNION, 1.0f);
-      }
-    }
+    int id = -1;
+    _shape_manager_get_values(model, &iter, NULL, NULL, &id);
+    if(id <= 0) continue;
+
+    dt_masks_form_t *member = dt_masks_get_from_id(dt_dev_get_global(), id);
+    if(IS_NULL_PTR(member)) continue;
+
+    dt_masks_group_add_form_with_state(dt_dev_get_global(), mask, member, mask->formid,
+                                       DT_MASKS_STATE_USE | DT_MASKS_STATE_UNION, 1.0f);
   }
   g_list_free_full(items, (GDestroyNotify)gtk_tree_path_free);
   items = NULL;
@@ -270,23 +268,23 @@ static int _tree_format_form_usage_label(char *str, const size_t str_size,
   for(const GList *modules = dt_dev_get_global()->iop; modules; modules = g_list_next(modules))
   {
     dt_iop_module_t *m = (dt_iop_module_t *)modules->data;
-    dt_masks_form_t *grp = dt_masks_get_from_id(m->dev, m->blend_params->mask_id);
-    if(grp && (grp->type & DT_MASKS_GROUP))
+    const dt_masks_form_t *grp = dt_masks_get_from_id(m->dev, m->blend_params->mask_id);
+    if(IS_NULL_PTR(grp) || !(grp->type & DT_MASKS_GROUP)) continue;
+
+    for(const GList *pts = grp->points; pts; pts = g_list_next(pts))
     {
-      for(const GList *pts = grp->points; pts; pts = g_list_next(pts))
-      {
-        dt_masks_form_group_t *pt = (dt_masks_form_group_t *)pts->data;
-        if(pt->formid == form->formid)
-        {
-          if(m == module) return -1;
-          if(nbuse == 0) g_strlcat(str, " (", str_size);
-          g_strlcat(str, " ", str_size);
-          gchar *module_label = dt_history_item_get_name(m);
-          g_strlcat(str, module_label, str_size);
-          dt_free(module_label);
-          nbuse++;
-        }
-      }
+      const dt_masks_form_group_t *pt = (const dt_masks_form_group_t *)pts->data;
+      if(pt->formid != form->formid) continue;
+
+      // The caller's own module is not worth naming to it, and says so by asking for no label.
+      if(m == module) return -1;
+
+      if(nbuse == 0) g_strlcat(str, " (", str_size);
+      g_strlcat(str, " ", str_size);
+      gchar *module_label = dt_history_item_get_name(m);
+      g_strlcat(str, module_label, str_size);
+      dt_free(module_label);
+      nbuse++;
     }
   }
 
@@ -1048,33 +1046,38 @@ static gboolean _tree_query_tooltip(GtkWidget *widget, gint x, gint y, gboolean 
   return show;
 }
 
-static void _is_form_used(int formid, dt_masks_form_t *grp, char *text, size_t text_length, int *nb)
+/* Appends the name of every group inside grp that lists formid, one per line, and counts them.
+ * Recurses into member groups, so a shape held by a nested group names that group too. */
+static void _groups_naming_form(const int formid, const dt_masks_form_t *grp, char *text,
+                                const size_t text_length, int *nb)
 {
-  if(IS_NULL_PTR(grp))
+  if(IS_NULL_PTR(grp) || !(grp->type & DT_MASKS_GROUP)) return;
+
+  for(const GList *points = grp->points; points; points = g_list_next(points))
   {
-    for(const GList *forms = dt_dev_get_global()->forms; forms; forms = g_list_next(forms))
+    const dt_masks_form_group_t *point = (const dt_masks_form_group_t *)points->data;
+    const dt_masks_form_t *form = dt_masks_get_from_id(dt_dev_get_global(), point->formid);
+    if(IS_NULL_PTR(form)) continue;
+
+    if(point->formid == formid)
     {
-      dt_masks_form_t *form = (dt_masks_form_t *)forms->data;
-      if(form->type & DT_MASKS_GROUP) _is_form_used(formid, form, text, text_length, nb);
+      (*nb)++;
+      if(*nb > 1) g_strlcat(text, "\n", text_length);
+      g_strlcat(text, grp->name, text_length);
     }
+
+    if(form->type & DT_MASKS_GROUP) _groups_naming_form(formid, form, text, text_length, nb);
   }
-  else if(grp->type & DT_MASKS_GROUP)
+}
+
+/* Same, over every group in the image. The entry and the walk used to be one function switching
+ * on a NULL group, which is why it took one. */
+static void _is_form_used(const int formid, char *text, const size_t text_length, int *nb)
+{
+  for(const GList *forms = dt_dev_get_global()->forms; forms; forms = g_list_next(forms))
   {
-    for(const GList *points = grp->points; points; points = g_list_next(points))
-    {
-      dt_masks_form_group_t *point = (dt_masks_form_group_t *)points->data;
-      dt_masks_form_t *form = dt_masks_get_from_id(dt_dev_get_global(), point->formid);
-      if(form)
-      {
-        if(point->formid == formid)
-        {
-          (*nb)++;
-          if(*nb > 1) g_strlcat(text, "\n", text_length);
-          g_strlcat(text, grp->name, text_length);
-        }
-        if(form->type & DT_MASKS_GROUP) _is_form_used(formid, form, text, text_length, nb);
-      }
-    }
+    const dt_masks_form_t *form = (const dt_masks_form_t *)forms->data;
+    if(form->type & DT_MASKS_GROUP) _groups_naming_form(formid, form, text, text_length, nb);
   }
 }
 
@@ -1100,7 +1103,7 @@ static void _shape_manager_list_recurs(GtkTreeStore *treestore, GtkTreeIter *top
   if(gstate & DT_MASKS_STATE_INVERSE) icinv = lm->ic_inverse;
   char str2[1000] = "";
   int nbuse = 0;
-  if(grp_id == 0) _is_form_used(form->formid, NULL, str2, sizeof(str2), &nbuse);
+  if(grp_id == 0) _is_form_used(form->formid, str2, sizeof(str2), &nbuse);
 
   if(!(form->type & DT_MASKS_GROUP))
   {
@@ -1478,6 +1481,8 @@ static gboolean _shape_manager_selection_change_r(GtkTreeModel *model, GtkTreeSe
 {
   gboolean found = FALSE;
 
+  // The walk stops at the first match, whether this level made it or a child did, so the loop
+  // carries that in its own condition rather than breaking out of it twice.
   GtkTreeIter i = *iter;
   do
   {
@@ -1491,21 +1496,15 @@ static gboolean _shape_manager_selection_change_r(GtkTreeModel *model, GtkTreeSe
     {
       gtk_tree_selection_select_iter(selection, &i);
       found = TRUE;
-      break;
+      continue;
     }
 
     // check for children if any
     GtkTreeIter child;
     GtkTreeIter parent = i;
     if(gtk_tree_model_iter_children(model, &child, &parent))
-    {
       found = _shape_manager_selection_change_r(model, selection, &child, module, selectid, throw_event, level + 1);
-      if(found)
-      {
-        break;
-      }
-    }
-  } while(gtk_tree_model_iter_next(model, &i) == TRUE);
+  } while(!found && gtk_tree_model_iter_next(model, &i) == TRUE);
 
   return found;
 }

--- a/src/libs/shape_manager.c
+++ b/src/libs/shape_manager.c
@@ -600,6 +600,24 @@ static void _tree_cell_edited(GtkCellRendererText *cell __attribute__((unused)),
   dt_dev_add_history_item(dt_dev_get_global(), NULL, FALSE, TRUE);
 }
 
+/* A group's own module, when the tree row names one that can show masks. Presses its "show and
+ * edit" toggle, so selecting a module's mask group in the manager lights the module's own
+ * button too. */
+static void _show_masks_on_owning_module(GtkTreeModel *model, GtkTreeIter *iter)
+{
+  dt_iop_module_t *module = NULL;
+  _shape_manager_get_values(model, iter, &module, NULL, NULL);
+
+  if(IS_NULL_PTR(module) || IS_NULL_PTR(module->gui) || IS_NULL_PTR(module->gui->blend_data)
+     || !(module->flags() & IOP_FLAGS_SUPPORTS_BLENDING) || (module->flags() & IOP_FLAGS_NO_MASKS))
+    return;
+
+  dt_iop_gui_blend_data_t *bd = (dt_iop_gui_blend_data_t *)module->gui->blend_data;
+  bd->masks_shown = 1;
+  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(bd->masks_edit), TRUE);
+  gtk_widget_queue_draw(bd->masks_edit);
+}
+
 static void _tree_selection_change(GtkTreeSelection *selection, dt_shape_manager_t *self)
 {
   dt_develop_t *const dev = dt_dev_get_global();
@@ -628,35 +646,20 @@ static void _tree_selection_change(GtkTreeSelection *selection, dt_shape_manager
   {
     GtkTreePath *item = (GtkTreePath *)items_iter->data;
     GtkTreeIter iter;
-    if(gtk_tree_model_get_iter(model, &iter, item))
-    {
-      int grid = -1;
-      int id = -1;
-      _shape_manager_get_values(model, &iter, NULL, &grid, &id);
+    if(!gtk_tree_model_get_iter(model, &iter, item)) continue;
 
-      dt_masks_form_t *form = dt_masks_get_from_id(dev, id);
-      if(!IS_NULL_PTR(form))
-      {
-        if(nb == 1) selected_form = form;
-        dt_masks_group_add_form_with_state(dev, grp, form, grid, DT_MASKS_STATE_USE, 1.0f);
-        // we eventually set the "show masks" icon of iops
-        if(nb == 1 && (form->type & DT_MASKS_GROUP))
-        {
-          dt_iop_module_t *module = NULL;
-          _shape_manager_get_values(model, &iter, &module, NULL, NULL);
+    int grid = -1;
+    int id = -1;
+    _shape_manager_get_values(model, &iter, NULL, &grid, &id);
 
-          if(module && module->gui && module->gui->blend_data
-             && (module->flags() & IOP_FLAGS_SUPPORTS_BLENDING)
-             && !(module->flags() & IOP_FLAGS_NO_MASKS))
-          {
-            dt_iop_gui_blend_data_t *bd = (dt_iop_gui_blend_data_t *)module->gui->blend_data;
-            bd->masks_shown = 1;
-            gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(bd->masks_edit), TRUE);
-            gtk_widget_queue_draw(bd->masks_edit);
-          }
-        }
-      }
-    }
+    dt_masks_form_t *form = dt_masks_get_from_id(dev, id);
+    if(IS_NULL_PTR(form)) continue;
+
+    if(nb == 1) selected_form = form;
+    dt_masks_group_add_form_with_state(dev, grp, form, grid, DT_MASKS_STATE_USE, 1.0f);
+
+    // we eventually set the "show masks" icon of iops
+    if(nb == 1 && (form->type & DT_MASKS_GROUP)) _show_masks_on_owning_module(model, &iter);
   }
   g_list_free_full(items, (GDestroyNotify)gtk_tree_path_free);
   items = NULL;
@@ -1083,79 +1086,92 @@ static void _is_form_used(const int formid, char *text, const size_t text_length
   }
 }
 
-static void _shape_manager_list_recurs(GtkTreeStore *treestore, GtkTreeIter *toplevel, dt_masks_form_t *form,
-                                   int grp_id, dt_iop_module_t *module, int gstate, float opacity,
-                                   dt_shape_manager_t *lm, int index)
+/* What one row of the tree says about the form it shows. The recursion used to pass these as
+ * nine separate arguments; only treestore and lm are the same for every row. */
+typedef struct _tree_row_t
 {
-  if(form->type & (DT_MASKS_CLONE|DT_MASKS_NON_CLONE)) return;
-  // we create the text entry
-  char str[256] = "";
-  g_strlcat(str, form->name, sizeof(str));
-  // we get the right pixbufs
-  GdkPixbuf *icop = NULL;
-  GdkPixbuf *icinv = NULL;
-  if(gstate & DT_MASKS_STATE_UNION)
-    icop = lm->ic_union;
-  else if(gstate & DT_MASKS_STATE_INTERSECTION)
-    icop = lm->ic_intersection;
-  else if(gstate & DT_MASKS_STATE_DIFFERENCE)
-    icop = lm->ic_difference;
-  else if(gstate & DT_MASKS_STATE_EXCLUSION)
-    icop = lm->ic_exclusion;
-  if(gstate & DT_MASKS_STATE_INVERSE) icinv = lm->ic_inverse;
-  char str2[1000] = "";
-  int nbuse = 0;
-  if(grp_id == 0) _is_form_used(form->formid, str2, sizeof(str2), &nbuse);
+  dt_masks_form_t *form;
+  int grp_id;              // 0 for a row listed at top level, the parent group's id otherwise
+  dt_iop_module_t *module; // the module owning the group this row sits under, when there is one
+  int gstate;              // the combine/invert bits this form carries inside its parent
+  float opacity;
+  int index;               // rank inside the parent, which _set_iter_name() shows
+} _tree_row_t;
 
-  if(!(form->type & DT_MASKS_GROUP))
+/* The module whose drawn mask is this group, if any. A group listed at top level with no module
+ * yet is the only case worth asking about: a nested one inherits its parent's. */
+static dt_iop_module_t *_module_owning_group(const dt_masks_form_t *group)
+{
+  for(const GList *iops = dt_dev_get_global()->iop; iops; iops = g_list_next(iops))
   {
-    // we just add it to the tree
-    GtkTreeIter child;
-    gtk_tree_store_append(treestore, &child, toplevel);
-    gtk_tree_store_set(treestore, &child, TREE_TEXT, str, TREE_MODULE, module, TREE_GROUPID, grp_id,
-                       TREE_FORMID, form->formid, TREE_EDITABLE, (grp_id == 0), TREE_IC_OP, icop,
-                       TREE_IC_OP_VISIBLE, (!IS_NULL_PTR(icop)), TREE_IC_INVERSE, icinv, TREE_IC_INVERSE_VISIBLE,
-                       (!IS_NULL_PTR(icinv)), TREE_IC_USED_VISIBLE, (nbuse > 0),
-                       TREE_USED_TEXT, str2, -1);
-    _set_iter_name(lm, form, gstate, opacity, GTK_TREE_MODEL(treestore), &child, index);
+    dt_iop_module_t *iop = (dt_iop_module_t *)iops->data;
+    if((iop->flags() & IOP_FLAGS_SUPPORTS_BLENDING) && !(iop->flags() & IOP_FLAGS_NO_MASKS)
+       && iop->blend_params->mask_id == group->formid)
+      return iop;
   }
-  else
+  return NULL;
+}
+
+/* Appends the row and returns its iter, which a group needs to hang its members from. Shapes and
+ * groups are described identically here; only what happens afterwards differs. */
+static void _tree_append_row(GtkTreeStore *treestore, GtkTreeIter *toplevel, dt_shape_manager_t *lm,
+                             const _tree_row_t *row, GtkTreeIter *child)
+{
+  GdkPixbuf *icop = NULL;
+  if(row->gstate & DT_MASKS_STATE_UNION)
+    icop = lm->ic_union;
+  else if(row->gstate & DT_MASKS_STATE_INTERSECTION)
+    icop = lm->ic_intersection;
+  else if(row->gstate & DT_MASKS_STATE_DIFFERENCE)
+    icop = lm->ic_difference;
+  else if(row->gstate & DT_MASKS_STATE_EXCLUSION)
+    icop = lm->ic_exclusion;
+
+  GdkPixbuf *icinv = (row->gstate & DT_MASKS_STATE_INVERSE) ? lm->ic_inverse : NULL;
+
+  // Only a top-level row asks who else uses the shape: a row under a group already says so.
+  char used_by[1000] = "";
+  int nbuse = 0;
+  if(row->grp_id == 0) _is_form_used(row->form->formid, used_by, sizeof(used_by), &nbuse);
+
+  gtk_tree_store_append(treestore, child, toplevel);
+  gtk_tree_store_set(treestore, child, TREE_TEXT, row->form->name, TREE_MODULE, row->module,
+                     TREE_GROUPID, row->grp_id, TREE_FORMID, row->form->formid,
+                     TREE_EDITABLE, (row->grp_id == 0), TREE_IC_OP, icop,
+                     TREE_IC_OP_VISIBLE, (!IS_NULL_PTR(icop)), TREE_IC_INVERSE, icinv,
+                     TREE_IC_INVERSE_VISIBLE, (!IS_NULL_PTR(icinv)),
+                     TREE_IC_USED_VISIBLE, (nbuse > 0), TREE_USED_TEXT, used_by, -1);
+  _set_iter_name(lm, row->form, row->gstate, row->opacity, GTK_TREE_MODEL(treestore), child, row->index);
+}
+
+static void _shape_manager_list_recurs(GtkTreeStore *treestore, GtkTreeIter *toplevel,
+                                       dt_shape_manager_t *lm, const _tree_row_t *row)
+{
+  // Clone sources belong to retouch's own UI, not to this tree.
+  if(row->form->type & (DT_MASKS_CLONE | DT_MASKS_NON_CLONE)) return;
+
+  _tree_row_t self = *row;
+  if((self.form->type & DT_MASKS_GROUP) && self.grp_id == 0 && IS_NULL_PTR(self.module))
+    self.module = _module_owning_group(self.form);
+
+  GtkTreeIter child;
+  _tree_append_row(treestore, toplevel, lm, &self, &child);
+
+  if(!(self.form->type & DT_MASKS_GROUP)) return;
+
+  int index = 0;
+  for(const GList *forms = self.form->points; forms; forms = g_list_next(forms))
   {
-    // we first check if it's a "module" group or not
-    if(grp_id == 0 && !module)
+    const dt_masks_form_group_t *grpt = (const dt_masks_form_group_t *)forms->data;
+    dt_masks_form_t *member = dt_masks_get_from_id(dt_dev_get_global(), grpt->formid);
+    if(!IS_NULL_PTR(member))
     {
-      for(const GList *iops = dt_dev_get_global()->iop; iops; iops = g_list_next(iops))
-      {
-        dt_iop_module_t *iop = (dt_iop_module_t *)iops->data;
-        if((iop->flags() & IOP_FLAGS_SUPPORTS_BLENDING) && !(iop->flags() & IOP_FLAGS_NO_MASKS)
-           && iop->blend_params->mask_id == form->formid)
-        {
-          module = iop;
-          break;
-        }
-      }
+      const _tree_row_t member_row = { .form = member, .grp_id = self.form->formid,
+                                       .module = self.module, .gstate = grpt->state,
+                                       .opacity = grpt->opacity, .index = index };
+      _shape_manager_list_recurs(treestore, &child, lm, &member_row);
     }
-
-    // we add the group node to the tree
-    GtkTreeIter child;
-    gtk_tree_store_append(treestore, &child, toplevel);
-    gtk_tree_store_set(treestore, &child, TREE_TEXT, str, TREE_MODULE, module, TREE_GROUPID, grp_id,
-                       TREE_FORMID, form->formid, TREE_EDITABLE, (grp_id == 0), TREE_IC_OP, icop,
-                       TREE_IC_OP_VISIBLE, (!IS_NULL_PTR(icop)), TREE_IC_INVERSE, icinv, TREE_IC_INVERSE_VISIBLE,
-                       (!IS_NULL_PTR(icinv)), TREE_IC_USED_VISIBLE, (nbuse > 0),
-                       TREE_USED_TEXT, str2, -1);
-    _set_iter_name(lm, form, gstate, opacity, GTK_TREE_MODEL(treestore), &child, index);
-
-    index = 0;
-    // we add all nodes to the tree
-    for(const GList *forms = form->points; forms; forms = g_list_next(forms))
-    {
-      dt_masks_form_group_t *grpt = (dt_masks_form_group_t *)forms->data;
-      dt_masks_form_t *f = dt_masks_get_from_id(dt_dev_get_global(), grpt->formid);
-      if(f)
-        _shape_manager_list_recurs(treestore, &child, f, form->formid, module, grpt->state, grpt->opacity, lm, index);
-      index++;
-    }
+    index++;
   }
 }
 
@@ -1257,14 +1273,22 @@ static void _shape_manager_recreate_list(dt_lib_module_t *self)
   for(const GList *forms = dt_dev_get_global()->forms; forms; forms = g_list_next(forms))
   {
     dt_masks_form_t *form = (dt_masks_form_t *)forms->data;
-    if(form->type & DT_MASKS_GROUP) _shape_manager_list_recurs(treestore, NULL, form, 0, NULL, 0, 1.0, lm, 0);
+    if(form->type & DT_MASKS_GROUP)
+    {
+      const _tree_row_t row = { .form = form, .opacity = 1.0f };
+      _shape_manager_list_recurs(treestore, NULL, lm, &row);
+    }
   }
 
   // and we add all forms
   for(const GList *forms = dt_dev_get_global()->forms; forms; forms = g_list_next(forms))
   {
     dt_masks_form_t *form = (dt_masks_form_t *)forms->data;
-    if(!(form->type & DT_MASKS_GROUP)) _shape_manager_list_recurs(treestore, NULL, form, 0, NULL, 0, 1.0, lm, 0);
+    if(!(form->type & DT_MASKS_GROUP))
+    {
+      const _tree_row_t row = { .form = form, .opacity = 1.0f };
+      _shape_manager_list_recurs(treestore, NULL, lm, &row);
+    }
   }
 
   gtk_tree_view_set_model(GTK_TREE_VIEW(lm->treeview), GTK_TREE_MODEL(treestore));

--- a/tools/check_module_boundaries.sh
+++ b/tools/check_module_boundaries.sh
@@ -411,7 +411,7 @@ fi
 #                  are excluded; naming the type there is the design, not the leak.
 masks_include_baseline=19
 masks_gui_include_baseline=11
-masks_member_baseline=79
+masks_member_baseline=78
 masks_write_baseline=16
 masks_alloc_baseline=1
 masks_forms_baseline=75

--- a/tools/check_module_boundaries.sh
+++ b/tools/check_module_boundaries.sh
@@ -414,7 +414,7 @@ masks_gui_include_baseline=11
 masks_member_baseline=78
 masks_write_baseline=16
 masks_alloc_baseline=1
-masks_forms_baseline=75
+masks_forms_baseline=74
 masks_row_baseline=35
 
 # Members no other struct in the tree uses. Keep it that way: adding an ambiguous name here


### PR DESCRIPTION
#1357 renamed `libs/masks.c` to `libs/shape_manager.c`, and SonarCloud — which does not follow renames — re-read the whole 2000-line file as new and reported 61 findings against code the rename only moved. This is where they get answered, judged on their own rather than as the side effect of a `git mv`.

## Two that were more than smells

**`_tree_restrict_select()` was quadratic.** It keeps a selection among peers by dropping whatever no longer qualifies, and dropped them one at a time — re-reading the entire selection and restarting the walk from the top after every single removal. The chained assignment Sonar flagged is what the restart needed. The list `gtk_tree_selection_get_selected_rows()` hands back is our own copy: unselecting does not touch it, so nothing has to be re-read. One pass gathers, one pass drops.

**The context menu wrote the same things repeatedly.** The five-entry "Add new shape ..." submenu appeared twice in full; the four combine modes, which differ by a constant and nothing else, were four copies of the same five lines; the form under the selected row was looked up twice and its "is it a group?" test written four times in three spellings; and the delete entry had two branches differing only in a label. At a cognitive complexity of 50 across 213 lines, that was the bulk of it.

## The rest

`_shape_manager_list_recurs()` took nine arguments and then wrote its row twice, once per branch, in identical code. `AGENTS.md`'s answer to a long argument list is a struct, and `_tree_row_t` is what one row of the tree actually says. `_shape_manager_recreate_list()` built the store, replayed the old selection and pointed the tree at the focused module's group all inline; each is a question with its own answer, and the reveal sequence they both used is now written once.

`_is_form_used()` was two functions sharing a name, told apart by whether you passed it a NULL group — and its only caller always passed NULL. Loops that wrapped their whole body in a guarding `if` test the reason to skip and `continue` instead. `_shape_manager_selection_change_r()` broke out of its walk in two places that meant the same thing, so the loop carries it.

Nineteen parameters across seventeen functions are named because a callback signature demands them; they are marked `__attribute__((unused))` — the spelling this tree already uses, and not the `(void)arg` `AGENTS.md` rules out. Four commented-out lines go, one of which carried a reason rather than code and stays as the prose it was.

## Two baselines fall

`check_module_boundaries.sh` counts what reaches into the masks module from outside. Folding the group's name read into the row helper takes member reads from 79 to 78, and merging the two walks over `dev->forms` takes that count from 75 to 74. Each baseline falls in the commit that took the ground, as the gate requires.

## Verified

Build clean; module boundaries, include cycles and the unused-include gate all pass. Exercised in the running application: the context menu in each of its states, Ctrl+ and Shift+click selection including mixed depths, the tree's ordering and its operation/inverse icons and "used by" tooltip, and the refresh after creating, deleting and grouping shapes.

No entry appears, disappears or changes label, and no callback moves. `shape_manager.c` is 86 lines shorter despite the comments added.

Left alone: the 17 `pointer-to-const` suggestions. They are minor, several were already answered incidentally while restructuring, and rather than guess which remain I would rather let the next analysis say.

🤖 Generated with [Claude Code](https://claude.com/claude-code)