### PR TITLE
Fix issue #1365 and by the way some pb with color labels

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2188,6 +2188,52 @@ shortcut type already uses. Any future direct caller of `gtk_widget_add_accelera
 keyboard shortcut in this codebase has the same problem: it needs a closure the internal
 dispatcher can invoke, not just a GTK-level accelerator that no window will ever activate.
 
+### An accel path absent from the user's config is not a shortcut the user cleared
+
+`_insert_accel()` (`src/widgets/accelerators.c`) used to seed every accel path with
+`gtk_accel_map_add_entry(path, 0, 0)` and let `gtk_accel_map_load()` fill in the keys. That
+reads the user's config correctly and loses the app's own defaults: the load runs *before* any
+widget registers (`gui/application.c`), so a path the config has never heard of comes back with
+key 0, and `_update_shortcut_state()` — comparing that 0 against a non-zero app default with
+`accels->init` FALSE, i.e. "a config file exists" — files it under "the user changed this" and
+records the shortcut as permanently unbound. **Every newly added default shortcut was born dead
+for anyone with an existing `keyboardrc`**, silently, with the menu simply showing no
+accelerator.
+
+Accel pathes are built from **translated** GUI labels — that is why the config file is
+localized, one per language — so the same thing happens when a translation lands or changes for
+a label that already had a shortcut. F5 stopped applying the purple colour label in French when
+`po/fr.po` gained "⬤ Violet" for a menu entry that had been falling back to the English "⬤
+Purple" (commit `b7dcf716`): the path moved, the F5 saved under the old one was orphaned, and
+the new one was read as user-cleared. Every other colour kept its key because its translation
+had not moved. The orphaned line stays in the file — GTK has no API to delete a map entry — but
+it is inert: `_find_path_for_keys()` scans `accels->acceleratables`, not the accel map, and
+`gtk_accel_map_change_entry(..., replace=FALSE)` only reports a conflict against entries an
+accel group actually uses, so it does not block rebinding those keys either (measured, not
+assumed).
+
+Fixed by registering the app default **as the accel-map entry's own default**,
+`gtk_accel_map_add_entry(shortcut->path, shortcut->key, shortcut->mods)`. `add_entry` only sets
+the current value when it *creates* the entry, so anything the config supplied still wins; and
+it makes GTK's changed/unchanged bookkeeping mean what this code needs on the way out, since
+`gtk_accel_map_save()` comments out an entry sitting at its default and writes every other one
+as a live line. A shortcut the user cleared is therefore saved as a real `(path "")` line and
+read back as a *known* path with key 0 — still cleared, this time because the file says so
+rather than because the file is silent. `src/tests/unittests/test_accel_map_defaults.c` pins
+all four cases, including the old `(0, 0)` spelling's inability to tell the two apart.
+
+One migration cost, paid once: a config written by an older build recorded a cleared default as
+a *commented* line, which reads back as "unknown path", so such a shortcut returns to its
+default on the first run after this change. It is then saved under the new spelling and stays
+cleared from there on. There is no marker in the file to distinguish the two eras, so this is
+not avoidable — only bounded.
+
+**Do not verify this class of change by reading GTK's source or reasoning about it.** Every
+question here (does the parser register an empty entry? does `add_entry` overwrite a loaded
+value? how is a cleared entry saved?) is answered in seconds by a ten-line program calling
+`gtk_accel_map_load`/`add_entry`/`lookup_entry`/`save` and printing the file — and two
+plausible readings of that API were wrong when measured.
+
 ### A weak pointer must be removed before the struct holding it is freed
 
 `dt_shortcut_set_closure()` (`src/widgets/accelerators.c`) registers `&pc->widget` — the third

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -93,7 +93,7 @@ src/apps/ansel-cli/main.c
 src/pixel/chromatic_adaptation.h
 src/common/collection.c
 src/common/color_vocabulary.c
-src/common/colorlabels.c
+src/metadata/colorlabels.c
 src/colorprofiles/colorspaces.c
 src/common/colorchecker.h
 src/common/colorchecker.c

--- a/po/af.po
+++ b/po/af.po
@@ -4404,10 +4404,20 @@ msgstr ""
 msgid "unknown/invalid"
 msgstr "onbekend"
 
-#: ../src/common/colorlabels.c:336
+#: ../src/metadata/colorlabels.c:267
 #, c-format
 msgid "Color label set to %s for %i image(s)"
 msgstr ""
+
+#: ../src/metadata/colorlabels.c:270
+#, c-format
+msgid "Color label %s removed for %i image(s)"
+msgstr "Kleur etiket %s verwyder vir %i beeld(e)"
+
+#: ../src/metadata/colorlabels.c:265
+#, c-format
+msgid "Color labels removed for %i image(s)"
+msgstr "Kleur etikette verwyder vir %i beeld(e)"
 
 #: ../src/common/colorspaces.c:1691
 #, fuzzy

--- a/po/ansel.pot
+++ b/po/ansel.pot
@@ -4201,9 +4201,19 @@ msgstr ""
 msgid "unknown/invalid"
 msgstr ""
 
-#: ../src/common/colorlabels.c:336
+#: ../src/metadata/colorlabels.c:267
 #, c-format
 msgid "Color label set to %s for %i image(s)"
+msgstr ""
+
+#: ../src/metadata/colorlabels.c:270
+#, c-format
+msgid "Color label %s removed for %i image(s)"
+msgstr ""
+
+#: ../src/metadata/colorlabels.c:265
+#, c-format
+msgid "Color labels removed for %i image(s)"
 msgstr ""
 
 #: ../src/common/colorspaces.c:1691

--- a/po/ca.po
+++ b/po/ca.po
@@ -4467,10 +4467,20 @@ msgstr ""
 msgid "unknown/invalid"
 msgstr "desconegut"
 
-#: ../src/common/colorlabels.c:336
+#: ../src/metadata/colorlabels.c:267
 #, c-format
 msgid "Color label set to %s for %i image(s)"
 msgstr ""
+
+#: ../src/metadata/colorlabels.c:270
+#, c-format
+msgid "Color label %s removed for %i image(s)"
+msgstr "Etiqueta de color %s suprimida de %i imatge(s)"
+
+#: ../src/metadata/colorlabels.c:265
+#, c-format
+msgid "Color labels removed for %i image(s)"
+msgstr "Etiquetes de color suprimides de %i imatge(s)"
 
 #: ../src/common/colorspaces.c:1691
 #, fuzzy

--- a/po/cs.po
+++ b/po/cs.po
@@ -4305,10 +4305,20 @@ msgstr ""
 msgid "unknown/invalid"
 msgstr "neznámý"
 
-#: ../src/common/colorlabels.c:336
+#: ../src/metadata/colorlabels.c:267
 #, c-format
 msgid "Color label set to %s for %i image(s)"
 msgstr ""
+
+#: ../src/metadata/colorlabels.c:270
+#, c-format
+msgid "Color label %s removed for %i image(s)"
+msgstr "Barevný štítek %s odstraněn u %i obrázku(ů)"
+
+#: ../src/metadata/colorlabels.c:265
+#, c-format
+msgid "Color labels removed for %i image(s)"
+msgstr "Barevné štítky odstraněny u %i obrázku(ů)"
 
 #: ../src/common/colorspaces.c:1691
 #, fuzzy

--- a/po/da.po
+++ b/po/da.po
@@ -4465,10 +4465,20 @@ msgstr ""
 msgid "unknown/invalid"
 msgstr "ukendt"
 
-#: ../src/common/colorlabels.c:336
+#: ../src/metadata/colorlabels.c:267
 #, c-format
 msgid "Color label set to %s for %i image(s)"
 msgstr ""
+
+#: ../src/metadata/colorlabels.c:270
+#, c-format
+msgid "Color label %s removed for %i image(s)"
+msgstr "Farvemærkat %s fjernet fra %i billede(r)"
+
+#: ../src/metadata/colorlabels.c:265
+#, c-format
+msgid "Color labels removed for %i image(s)"
+msgstr "Farvemærkater fjernet fra %i billede(r)"
 
 #: ../src/common/colorspaces.c:1691
 #, fuzzy

--- a/po/de.po
+++ b/po/de.po
@@ -4412,10 +4412,20 @@ msgstr "leer"
 msgid "unknown/invalid"
 msgstr "unbekannt/ungültig"
 
-#: ../src/common/colorlabels.c:336
+#: ../src/metadata/colorlabels.c:267
 #, c-format
 msgid "Color label set to %s for %i image(s)"
 msgstr "Farbmarkierung auf %s bei %i Bild(ern) gesetzt"
+
+#: ../src/metadata/colorlabels.c:270
+#, c-format
+msgid "Color label %s removed for %i image(s)"
+msgstr "Farbmarkierung %s bei %i Bild(ern) entfernt"
+
+#: ../src/metadata/colorlabels.c:265
+#, c-format
+msgid "Color labels removed for %i image(s)"
+msgstr "Farbmarkierungen bei %i Bild(ern) entfernt"
 
 #: ../src/common/colorspaces.c:1691
 #, fuzzy

--- a/po/de.po
+++ b/po/de.po
@@ -10090,7 +10090,7 @@ msgstr "<span foreground='#2222BB'>⬤</span> Blau"
 
 #: ../src/gui/actions/image.c:233
 msgid "<span foreground='#BB22BB'>⬤</span> Purple"
-msgstr "<span foreground='#2222BB'>⬤</span> Lila"
+msgstr "<span foreground='#BB22BB'>⬤</span> Lila"
 
 #: ../src/gui/actions/image.c:238
 msgid "<span foreground='#BBBBBB'>⬤</span> Clear labels"

--- a/po/el.po
+++ b/po/el.po
@@ -4498,10 +4498,20 @@ msgstr ""
 msgid "unknown/invalid"
 msgstr "άγνωστο"
 
-#: ../src/common/colorlabels.c:336
+#: ../src/metadata/colorlabels.c:267
 #, c-format
 msgid "Color label set to %s for %i image(s)"
 msgstr ""
+
+#: ../src/metadata/colorlabels.c:270
+#, c-format
+msgid "Color label %s removed for %i image(s)"
+msgstr "Η χρωματική ετικέτα %s αφαιρέθηκε από %i εικόνα(ες)"
+
+#: ../src/metadata/colorlabels.c:265
+#, c-format
+msgid "Color labels removed for %i image(s)"
+msgstr "Οι χρωματικές ετικέτες αφαιρέθηκαν από %i εικόνα(ες)"
 
 #: ../src/common/colorspaces.c:1691
 #, fuzzy

--- a/po/eo.po
+++ b/po/eo.po
@@ -4313,10 +4313,20 @@ msgstr ""
 msgid "unknown/invalid"
 msgstr "nekonata"
 
-#: ../src/common/colorlabels.c:336
+#: ../src/metadata/colorlabels.c:267
 #, c-format
 msgid "Color label set to %s for %i image(s)"
 msgstr ""
+
+#: ../src/metadata/colorlabels.c:270
+#, c-format
+msgid "Color label %s removed for %i image(s)"
+msgstr "Kolora etikedo %s forigita de %i bildo(j)"
+
+#: ../src/metadata/colorlabels.c:265
+#, c-format
+msgid "Color labels removed for %i image(s)"
+msgstr "Koloraj etikedoj forigitaj de %i bildo(j)"
 
 #: ../src/common/colorspaces.c:1691
 #, fuzzy

--- a/po/es.po
+++ b/po/es.po
@@ -10045,9 +10045,8 @@ msgid "<span foreground='#2222BB'>⬤</span> Blue"
 msgstr "<span foreground='#2222BB'>⬤</span> Azul"
 
 #: ../src/gui/actions/image.c:233
-#, fuzzy
 msgid "<span foreground='#BB22BB'>⬤</span> Purple"
-msgstr "<span foreground='#2222BB'>⬤</span> Azul"
+msgstr "<span foreground='#BB22BB'>⬤</span> Púrpura"
 
 #: ../src/gui/actions/image.c:238
 msgid "<span foreground='#BBBBBB'>⬤</span> Clear labels"

--- a/po/es.po
+++ b/po/es.po
@@ -4373,10 +4373,20 @@ msgstr "vacío"
 msgid "unknown/invalid"
 msgstr "desconocido/no válido"
 
-#: ../src/common/colorlabels.c:336
+#: ../src/metadata/colorlabels.c:267
 #, c-format
 msgid "Color label set to %s for %i image(s)"
 msgstr "Etiqueta de color establecida en %s para %i imagen(es)"
+
+#: ../src/metadata/colorlabels.c:270
+#, c-format
+msgid "Color label %s removed for %i image(s)"
+msgstr "Etiqueta de color %s quitada de %i imagen(es)"
+
+#: ../src/metadata/colorlabels.c:265
+#, c-format
+msgid "Color labels removed for %i image(s)"
+msgstr "Etiquetas de color quitadas de %i imagen(es)"
 
 #: ../src/common/colorspaces.c:1691
 #, fuzzy

--- a/po/fi.po
+++ b/po/fi.po
@@ -4306,10 +4306,20 @@ msgstr ""
 msgid "unknown/invalid"
 msgstr "tuntematon"
 
-#: ../src/common/colorlabels.c:336
+#: ../src/metadata/colorlabels.c:267
 #, c-format
 msgid "Color label set to %s for %i image(s)"
 msgstr ""
+
+#: ../src/metadata/colorlabels.c:270
+#, c-format
+msgid "Color label %s removed for %i image(s)"
+msgstr "Värileima %s poistettu %i kuvasta"
+
+#: ../src/metadata/colorlabels.c:265
+#, c-format
+msgid "Color labels removed for %i image(s)"
+msgstr "Värileimat poistettu %i kuvasta"
 
 #: ../src/common/colorspaces.c:1691
 #, fuzzy

--- a/po/fr.po
+++ b/po/fr.po
@@ -21415,7 +21415,7 @@ msgstr "Alterner entre l'inclusion/l'exclusion des images marquées bleu"
 
 #: ../src/libs/tools/filter.c:660
 msgid "Toggle filtering in/out images with purple label"
-msgstr "Alterner entre l'inclusion/l'exclusion des images marquée pourpre"
+msgstr "Alterner entre l'inclusion/l'exclusion des images marquées violet"
 
 #: ../src/libs/tools/filter.c:672
 msgid "Toggle filtering in/out unedited images"

--- a/po/fr.po
+++ b/po/fr.po
@@ -4382,10 +4382,20 @@ msgstr "vide"
 msgid "unknown/invalid"
 msgstr "inconnu/invalide"
 
-#: ../src/common/colorlabels.c:336
+#: ../src/metadata/colorlabels.c:267
 #, c-format
 msgid "Color label set to %s for %i image(s)"
 msgstr "Label de couleur défini à %s pour %i image(s)"
+
+#: ../src/metadata/colorlabels.c:270
+#, c-format
+msgid "Color label %s removed for %i image(s)"
+msgstr "Label de couleur %s retiré de %i image(s)"
+
+#: ../src/metadata/colorlabels.c:265
+#, c-format
+msgid "Color labels removed for %i image(s)"
+msgstr "Labels de couleur retirés de %i image(s)"
 
 #: ../src/common/colorspaces.c:1691
 msgid "(unknown name)"

--- a/po/gl.po
+++ b/po/gl.po
@@ -4345,10 +4345,20 @@ msgstr ""
 msgid "unknown/invalid"
 msgstr ""
 
-#: ../src/common/colorlabels.c:336
+#: ../src/metadata/colorlabels.c:267
 #, c-format
 msgid "Color label set to %s for %i image(s)"
 msgstr ""
+
+#: ../src/metadata/colorlabels.c:270
+#, c-format
+msgid "Color label %s removed for %i image(s)"
+msgstr "Etiqueta de cor %s eliminada de %i imaxe(s)"
+
+#: ../src/metadata/colorlabels.c:265
+#, c-format
+msgid "Color labels removed for %i image(s)"
+msgstr "Etiquetas de cor eliminadas de %i imaxe(s)"
 
 #: ../src/common/colorspaces.c:1691
 #, fuzzy

--- a/po/he.po
+++ b/po/he.po
@@ -4274,10 +4274,20 @@ msgstr ""
 msgid "unknown/invalid"
 msgstr "לא ידוע"
 
-#: ../src/common/colorlabels.c:336
+#: ../src/metadata/colorlabels.c:267
 #, c-format
 msgid "Color label set to %s for %i image(s)"
 msgstr ""
+
+#: ../src/metadata/colorlabels.c:270
+#, c-format
+msgid "Color label %s removed for %i image(s)"
+msgstr "תווית הצבע %s הוסרה מ־%i תמונות"
+
+#: ../src/metadata/colorlabels.c:265
+#, c-format
+msgid "Color labels removed for %i image(s)"
+msgstr "תוויות הצבע הוסרו מ־%i תמונות"
 
 #: ../src/common/colorspaces.c:1691
 #, fuzzy

--- a/po/hu.po
+++ b/po/hu.po
@@ -4317,10 +4317,20 @@ msgstr ""
 msgid "unknown/invalid"
 msgstr "ismeretlen"
 
-#: ../src/common/colorlabels.c:336
+#: ../src/metadata/colorlabels.c:267
 #, c-format
 msgid "Color label set to %s for %i image(s)"
 msgstr ""
+
+#: ../src/metadata/colorlabels.c:270
+#, c-format
+msgid "Color label %s removed for %i image(s)"
+msgstr "%s színcímke eltávolítva %i képről"
+
+#: ../src/metadata/colorlabels.c:265
+#, c-format
+msgid "Color labels removed for %i image(s)"
+msgstr "Színcímkék eltávolítva %i képről"
 
 #: ../src/common/colorspaces.c:1691
 #, fuzzy

--- a/po/it.po
+++ b/po/it.po
@@ -4387,10 +4387,20 @@ msgstr "Vuoto"
 msgid "unknown/invalid"
 msgstr "Sconosciuto/non valido"
 
-#: ../src/common/colorlabels.c:336
+#: ../src/metadata/colorlabels.c:267
 #, c-format
 msgid "Color label set to %s for %i image(s)"
 msgstr "Etichetta colore impostata a %s per %i immagine/i"
+
+#: ../src/metadata/colorlabels.c:270
+#, c-format
+msgid "Color label %s removed for %i image(s)"
+msgstr "Etichetta colore %s rimossa da %i immagine/i"
+
+#: ../src/metadata/colorlabels.c:265
+#, c-format
+msgid "Color labels removed for %i image(s)"
+msgstr "Etichette colore rimosse da %i immagine/i"
 
 #: ../src/common/colorspaces.c:1691
 msgid "(unknown name)"

--- a/po/ja.po
+++ b/po/ja.po
@@ -4294,10 +4294,20 @@ msgstr ""
 msgid "unknown/invalid"
 msgstr "不明"
 
-#: ../src/common/colorlabels.c:336
+#: ../src/metadata/colorlabels.c:267
 #, c-format
 msgid "Color label set to %s for %i image(s)"
 msgstr ""
+
+#: ../src/metadata/colorlabels.c:270
+#, c-format
+msgid "Color label %s removed for %i image(s)"
+msgstr "カラーラベル %s を %i 枚の画像から削除しました"
+
+#: ../src/metadata/colorlabels.c:265
+#, c-format
+msgid "Color labels removed for %i image(s)"
+msgstr "%i 枚の画像からカラーラベルを削除しました"
 
 #: ../src/common/colorspaces.c:1691
 #, fuzzy

--- a/po/nb.po
+++ b/po/nb.po
@@ -4459,10 +4459,20 @@ msgstr ""
 msgid "unknown/invalid"
 msgstr "ukjent"
 
-#: ../src/common/colorlabels.c:336
+#: ../src/metadata/colorlabels.c:267
 #, c-format
 msgid "Color label set to %s for %i image(s)"
 msgstr ""
+
+#: ../src/metadata/colorlabels.c:270
+#, c-format
+msgid "Color label %s removed for %i image(s)"
+msgstr "Fargemerking %s fjernet fra %i bilde(r)"
+
+#: ../src/metadata/colorlabels.c:265
+#, c-format
+msgid "Color labels removed for %i image(s)"
+msgstr "Fargemerkinger fjernet fra %i bilde(r)"
 
 #: ../src/common/colorspaces.c:1691
 #, fuzzy

--- a/po/nl.po
+++ b/po/nl.po
@@ -4322,10 +4322,20 @@ msgstr ""
 msgid "unknown/invalid"
 msgstr "onbekend"
 
-#: ../src/common/colorlabels.c:336
+#: ../src/metadata/colorlabels.c:267
 #, c-format
 msgid "Color label set to %s for %i image(s)"
 msgstr ""
+
+#: ../src/metadata/colorlabels.c:270
+#, c-format
+msgid "Color label %s removed for %i image(s)"
+msgstr "Kleurlabel %s verwijderd van %i afbeelding(en)"
+
+#: ../src/metadata/colorlabels.c:265
+#, c-format
+msgid "Color labels removed for %i image(s)"
+msgstr "Kleurlabels verwijderd van %i afbeelding(en)"
 
 #: ../src/common/colorspaces.c:1691
 #, fuzzy

--- a/po/pl.po
+++ b/po/pl.po
@@ -4300,10 +4300,20 @@ msgstr ""
 msgid "unknown/invalid"
 msgstr "nieznany"
 
-#: ../src/common/colorlabels.c:336
+#: ../src/metadata/colorlabels.c:267
 #, c-format
 msgid "Color label set to %s for %i image(s)"
 msgstr ""
+
+#: ../src/metadata/colorlabels.c:270
+#, c-format
+msgid "Color label %s removed for %i image(s)"
+msgstr "Usunięto etykietę koloru %s z %i zdjęć"
+
+#: ../src/metadata/colorlabels.c:265
+#, c-format
+msgid "Color labels removed for %i image(s)"
+msgstr "Usunięto etykiety kolorów z %i zdjęć"
 
 #: ../src/common/colorspaces.c:1691
 #, fuzzy

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -4311,10 +4311,20 @@ msgstr ""
 msgid "unknown/invalid"
 msgstr "desconhecido"
 
-#: ../src/common/colorlabels.c:336
+#: ../src/metadata/colorlabels.c:267
 #, c-format
 msgid "Color label set to %s for %i image(s)"
 msgstr ""
+
+#: ../src/metadata/colorlabels.c:270
+#, c-format
+msgid "Color label %s removed for %i image(s)"
+msgstr "Etiqueta de cor %s removida de %i imagem(ns)"
+
+#: ../src/metadata/colorlabels.c:265
+#, c-format
+msgid "Color labels removed for %i image(s)"
+msgstr "Etiquetas de cor removidas de %i imagem(ns)"
 
 #: ../src/common/colorspaces.c:1691
 #, fuzzy

--- a/po/pt_PT.po
+++ b/po/pt_PT.po
@@ -4478,10 +4478,20 @@ msgstr ""
 msgid "unknown/invalid"
 msgstr "desconhecido"
 
-#: ../src/common/colorlabels.c:336
+#: ../src/metadata/colorlabels.c:267
 #, c-format
 msgid "Color label set to %s for %i image(s)"
 msgstr ""
+
+#: ../src/metadata/colorlabels.c:270
+#, c-format
+msgid "Color label %s removed for %i image(s)"
+msgstr "Rótulo de cor %s removido de %i imagem(ns)"
+
+#: ../src/metadata/colorlabels.c:265
+#, c-format
+msgid "Color labels removed for %i image(s)"
+msgstr "Rótulos de cor removidos de %i imagem(ns)"
 
 #: ../src/common/colorspaces.c:1691
 #, fuzzy

--- a/po/ro.po
+++ b/po/ro.po
@@ -4402,10 +4402,20 @@ msgstr ""
 msgid "unknown/invalid"
 msgstr ""
 
-#: ../src/common/colorlabels.c:336
+#: ../src/metadata/colorlabels.c:267
 #, c-format
 msgid "Color label set to %s for %i image(s)"
 msgstr ""
+
+#: ../src/metadata/colorlabels.c:270
+#, c-format
+msgid "Color label %s removed for %i image(s)"
+msgstr "Eticheta de culoare %s eliminată de la %i imagine(i)"
+
+#: ../src/metadata/colorlabels.c:265
+#, c-format
+msgid "Color labels removed for %i image(s)"
+msgstr "Etichetele de culoare eliminate de la %i imagine(i)"
 
 #: ../src/common/colorspaces.c:1691
 #, fuzzy

--- a/po/ru.po
+++ b/po/ru.po
@@ -4289,10 +4289,20 @@ msgstr ""
 msgid "unknown/invalid"
 msgstr "Неизвестно"
 
-#: ../src/common/colorlabels.c:336
+#: ../src/metadata/colorlabels.c:267
 #, c-format
 msgid "Color label set to %s for %i image(s)"
 msgstr ""
+
+#: ../src/metadata/colorlabels.c:270
+#, c-format
+msgid "Color label %s removed for %i image(s)"
+msgstr "Цветовая метка %s снята с %i снимка(ов)"
+
+#: ../src/metadata/colorlabels.c:265
+#, c-format
+msgid "Color labels removed for %i image(s)"
+msgstr "Цветовые метки сняты с %i снимка(ов)"
 
 #: ../src/common/colorspaces.c:1691
 #, fuzzy

--- a/po/sk.po
+++ b/po/sk.po
@@ -4429,10 +4429,20 @@ msgstr ""
 msgid "unknown/invalid"
 msgstr "neznáme"
 
-#: ../src/common/colorlabels.c:336
+#: ../src/metadata/colorlabels.c:267
 #, c-format
 msgid "Color label set to %s for %i image(s)"
 msgstr ""
+
+#: ../src/metadata/colorlabels.c:270
+#, c-format
+msgid "Color label %s removed for %i image(s)"
+msgstr "Farebná značka %s odstránená z %i obrázku(ov)"
+
+#: ../src/metadata/colorlabels.c:265
+#, c-format
+msgid "Color labels removed for %i image(s)"
+msgstr "Farebné značky odstránené z %i obrázku(ov)"
 
 #: ../src/common/colorspaces.c:1691
 #, fuzzy

--- a/po/sl.po
+++ b/po/sl.po
@@ -4379,10 +4379,20 @@ msgstr ""
 msgid "unknown/invalid"
 msgstr "neznano"
 
-#: ../src/common/colorlabels.c:336
+#: ../src/metadata/colorlabels.c:267
 #, c-format
 msgid "Color label set to %s for %i image(s)"
 msgstr ""
+
+#: ../src/metadata/colorlabels.c:270
+#, c-format
+msgid "Color label %s removed for %i image(s)"
+msgstr "Oznaka barve %s odstranjena z %i slike"
+
+#: ../src/metadata/colorlabels.c:265
+#, c-format
+msgid "Color labels removed for %i image(s)"
+msgstr "Oznake barve odstranjene z %i slike"
 
 #: ../src/common/colorspaces.c:1691
 #, fuzzy

--- a/po/sq.po
+++ b/po/sq.po
@@ -4322,10 +4322,20 @@ msgstr ""
 msgid "unknown/invalid"
 msgstr "e panjohur"
 
-#: ../src/common/colorlabels.c:336
+#: ../src/metadata/colorlabels.c:267
 #, c-format
 msgid "Color label set to %s for %i image(s)"
 msgstr ""
+
+#: ../src/metadata/colorlabels.c:270
+#, c-format
+msgid "Color label %s removed for %i image(s)"
+msgstr "Etiketa me ngjyrë %s u hoq nga %i imazh(e)"
+
+#: ../src/metadata/colorlabels.c:265
+#, c-format
+msgid "Color labels removed for %i image(s)"
+msgstr "Etiketat me ngjyrë u hoqën nga %i imazh(e)"
 
 #: ../src/common/colorspaces.c:1691
 #, fuzzy

--- a/po/sr.po
+++ b/po/sr.po
@@ -4430,10 +4430,20 @@ msgstr ""
 msgid "unknown/invalid"
 msgstr "непознато"
 
-#: ../src/common/colorlabels.c:336
+#: ../src/metadata/colorlabels.c:267
 #, c-format
 msgid "Color label set to %s for %i image(s)"
 msgstr ""
+
+#: ../src/metadata/colorlabels.c:270
+#, c-format
+msgid "Color label %s removed for %i image(s)"
+msgstr "Ознака у боји %s уклоњена са %i слике"
+
+#: ../src/metadata/colorlabels.c:265
+#, c-format
+msgid "Color labels removed for %i image(s)"
+msgstr "Ознаке у боји уклоњене са %i слике"
 
 #: ../src/common/colorspaces.c:1691
 #, fuzzy

--- a/po/sr@latin.po
+++ b/po/sr@latin.po
@@ -4430,10 +4430,20 @@ msgstr ""
 msgid "unknown/invalid"
 msgstr "nepoznato"
 
-#: ../src/common/colorlabels.c:336
+#: ../src/metadata/colorlabels.c:267
 #, c-format
 msgid "Color label set to %s for %i image(s)"
 msgstr ""
+
+#: ../src/metadata/colorlabels.c:270
+#, c-format
+msgid "Color label %s removed for %i image(s)"
+msgstr "Oznaka u boji %s uklonjena sa %i slike"
+
+#: ../src/metadata/colorlabels.c:265
+#, c-format
+msgid "Color labels removed for %i image(s)"
+msgstr "Oznake u boji uklonjene sa %i slike"
 
 #: ../src/common/colorspaces.c:1691
 #, fuzzy

--- a/po/sv.po
+++ b/po/sv.po
@@ -4478,10 +4478,20 @@ msgstr ""
 msgid "unknown/invalid"
 msgstr "okänd"
 
-#: ../src/common/colorlabels.c:336
+#: ../src/metadata/colorlabels.c:267
 #, c-format
 msgid "Color label set to %s for %i image(s)"
 msgstr ""
+
+#: ../src/metadata/colorlabels.c:270
+#, c-format
+msgid "Color label %s removed for %i image(s)"
+msgstr "Färgmarkering %s borttagen från %i bild(er)"
+
+#: ../src/metadata/colorlabels.c:265
+#, c-format
+msgid "Color labels removed for %i image(s)"
+msgstr "Färgmarkeringar borttagna från %i bild(er)"
 
 #: ../src/common/colorspaces.c:1691
 #, fuzzy

--- a/po/th.po
+++ b/po/th.po
@@ -4330,10 +4330,20 @@ msgstr ""
 msgid "unknown/invalid"
 msgstr ""
 
-#: ../src/common/colorlabels.c:336
+#: ../src/metadata/colorlabels.c:267
 #, c-format
 msgid "Color label set to %s for %i image(s)"
 msgstr ""
+
+#: ../src/metadata/colorlabels.c:270
+#, c-format
+msgid "Color label %s removed for %i image(s)"
+msgstr "ลบป้ายสี %s ออกจากรูปภาพ %i รูป"
+
+#: ../src/metadata/colorlabels.c:265
+#, c-format
+msgid "Color labels removed for %i image(s)"
+msgstr "ลบป้ายสีออกจากรูปภาพ %i รูป"
 
 #: ../src/common/colorspaces.c:1691
 #, fuzzy

--- a/po/tr.po
+++ b/po/tr.po
@@ -4313,10 +4313,20 @@ msgstr ""
 msgid "unknown/invalid"
 msgstr "bilinmeyen"
 
-#: ../src/common/colorlabels.c:336
+#: ../src/metadata/colorlabels.c:267
 #, c-format
 msgid "Color label set to %s for %i image(s)"
 msgstr ""
+
+#: ../src/metadata/colorlabels.c:270
+#, c-format
+msgid "Color label %s removed for %i image(s)"
+msgstr "%s renk etiketi %i görüntüden kaldırıldı"
+
+#: ../src/metadata/colorlabels.c:265
+#, c-format
+msgid "Color labels removed for %i image(s)"
+msgstr "Renk etiketleri %i görüntüden kaldırıldı"
 
 #: ../src/common/colorspaces.c:1691
 #, fuzzy

--- a/po/uk.po
+++ b/po/uk.po
@@ -4309,10 +4309,20 @@ msgstr ""
 msgid "unknown/invalid"
 msgstr "невідомо"
 
-#: ../src/common/colorlabels.c:336
+#: ../src/metadata/colorlabels.c:267
 #, c-format
 msgid "Color label set to %s for %i image(s)"
 msgstr ""
+
+#: ../src/metadata/colorlabels.c:270
+#, c-format
+msgid "Color label %s removed for %i image(s)"
+msgstr "Кольорову позначку %s знято з %i зображень"
+
+#: ../src/metadata/colorlabels.c:265
+#, c-format
+msgid "Color labels removed for %i image(s)"
+msgstr "Кольорові позначки знято з %i зображень"
 
 #: ../src/common/colorspaces.c:1691
 #, fuzzy

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -4289,10 +4289,20 @@ msgstr "空白"
 msgid "unknown/invalid"
 msgstr "未知/无效"
 
-#: ../src/common/colorlabels.c:336
+#: ../src/metadata/colorlabels.c:267
 #, c-format
 msgid "Color label set to %s for %i image(s)"
 msgstr "将颜色标签 %s 设置给 %i 张图片。"
+
+#: ../src/metadata/colorlabels.c:270
+#, c-format
+msgid "Color label %s removed for %i image(s)"
+msgstr "已将颜色标签 %s 从 %i 张图片移除。"
+
+#: ../src/metadata/colorlabels.c:265
+#, c-format
+msgid "Color labels removed for %i image(s)"
+msgstr "已移除 %i 张图片的颜色标签。"
 
 #: ../src/common/colorspaces.c:1691
 #, fuzzy

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -9794,7 +9794,7 @@ msgstr "<span foreground='#2222BB'>⬤</span> 蓝色"
 
 #: ../src/gui/actions/image.c:233
 msgid "<span foreground='#BB22BB'>⬤</span> Purple"
-msgstr "<span foreground='#2222BB'>⬤</span> 紫色"
+msgstr "<span foreground='#BB22BB'>⬤</span> 紫色"
 
 #: ../src/gui/actions/image.c:238
 msgid "<span foreground='#BBBBBB'>⬤</span> Clear labels"

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -4298,10 +4298,20 @@ msgstr ""
 msgid "unknown/invalid"
 msgstr "未知"
 
-#: ../src/common/colorlabels.c:336
+#: ../src/metadata/colorlabels.c:267
 #, c-format
 msgid "Color label set to %s for %i image(s)"
 msgstr ""
+
+#: ../src/metadata/colorlabels.c:270
+#, c-format
+msgid "Color label %s removed for %i image(s)"
+msgstr "已將色彩標籤 %s 從 %i 張影像移除。"
+
+#: ../src/metadata/colorlabels.c:265
+#, c-format
+msgid "Color labels removed for %i image(s)"
+msgstr "已移除 %i 張影像的色彩標籤。"
 
 #: ../src/common/colorspaces.c:1691
 #, fuzzy

--- a/src/metadata/colorlabels.c
+++ b/src/metadata/colorlabels.c
@@ -166,7 +166,9 @@ typedef enum dt_colorlabels_actions_t
 } dt_colorlabels_actions_t;
 
 
-static void _colorlabels_execute(GList *imgs, const int labels, GList **undo, const gboolean undo_on, int action)
+// Returns the action actually performed: DT_CA_ADD when the labels were added to the images,
+// DT_CA_TOGGLE when they were removed from all of them, DT_CA_SET when they were set verbatim.
+static int _colorlabels_execute(GList *imgs, const int labels, GList **undo, const gboolean undo_on, int action)
 {
   if(action == DT_CA_TOGGLE)
   {
@@ -228,6 +230,8 @@ static void _colorlabels_execute(GList *imgs, const int labels, GList **undo, co
       *undo = g_list_append(*undo, undocolorlabels);
     }
   }
+
+  return action;
 }
 
 void dt_colorlabels_toggle_label_on_list(GList *list, const int color, const gboolean undo_on)
@@ -236,13 +240,17 @@ void dt_colorlabels_toggle_label_on_list(GList *list, const int color, const gbo
   GList *undo = NULL;
   if(undo_on) dt_undo_start_group(dt_undo_get_global(), DT_UNDO_COLORLABELS);
 
+  // The toggle resolves to an addition as soon as one image lacks the label, and to a removal
+  // only when every image already carries it: ask _colorlabels_execute() what it actually did
+  // instead of assuming, or the toast announces an addition on the way out too.
+  int done;
   if(color == 5)
   {
-    _colorlabels_execute(list, 0, &undo, undo_on, DT_CA_SET);
+    done = _colorlabels_execute(list, 0, &undo, undo_on, DT_CA_SET);
   }
   else
   {
-    _colorlabels_execute(list, label, &undo, undo_on, DT_CA_TOGGLE);
+    done = _colorlabels_execute(list, label, &undo, undo_on, DT_CA_TOGGLE);
   }
 
   if(undo_on)
@@ -251,8 +259,16 @@ void dt_colorlabels_toggle_label_on_list(GList *list, const int color, const gbo
     dt_undo_end_group(dt_undo_get_global());
   }
   dt_collection_hint_message(dt_collection_get_global());
-  dt_metadata_notify(DT_METADATA_NOTICE_TOAST, _("Color label set to %s for %i image(s)"),
-                     dt_colorlabels_get_name(color), g_list_length(list));
+
+  const int count = (int)g_list_length(list);
+  if(color == 5)
+    dt_metadata_notify(DT_METADATA_NOTICE_TOAST, _("Color labels removed for %i image(s)"), count);
+  else if(done == DT_CA_ADD)
+    dt_metadata_notify(DT_METADATA_NOTICE_TOAST, _("Color label set to %s for %i image(s)"),
+                       dt_colorlabels_get_name(color), count);
+  else
+    dt_metadata_notify(DT_METADATA_NOTICE_TOAST, _("Color label %s removed for %i image(s)"),
+                       dt_colorlabels_get_name(color), count);
 }
 
 int dt_colorlabels_check_label(const int32_t imgid, const int color)

--- a/src/widgets/accelerators.c
+++ b/src/widgets/accelerators.c
@@ -536,7 +536,10 @@ static gboolean _update_shortcut_state(dt_shortcut_t *shortcut, GtkAccelKey *key
     else
     {
       // We loaded user config file, and user made changes in there.
-      // We will need to update our "defaults", which now become rather a memory of previous state
+      // We will need to update our "defaults", which now become rather a memory of previous state.
+      // A path the config never mentioned cannot land here anymore: _insert_accel() seeds the
+      // accel_map entry with this shortcut's own default, so an absent path arrives equal to it
+      // and takes the branch above. Reaching this one means the file really did say something else.
       shortcut->key = key->accel_key;
       shortcut->mods = key->accel_mods;
       shortcut->type = DT_SHORTCUT_USER;
@@ -618,8 +621,33 @@ static void _connect_accel(dt_shortcut_t *shortcut);
 
 static void _insert_accel(dt_accels_t *accels, dt_shortcut_t *shortcut)
 {
-  // init an accel_map entry with no keys so Gtk collects them from user config later.
-  gtk_accel_map_add_entry(shortcut->path, 0, 0);
+  // Register the app default as the accel_map entry's OWN default, not as an entry with no
+  // keys. Both spellings let the user config win -- gtk_accel_map_add_entry() only sets the
+  // current value when it creates the entry, and gtk_accel_map_load() has already run by now
+  // (see gui/application.c), so a path the user config knows about keeps whatever that file
+  // said. The difference is what happens to a path the config does NOT know about, and with
+  // (0, 0) that case was indistinguishable from a shortcut the user had cleared: the entry
+  // came back with key 0, _update_shortcut_state() compared it against a non-zero app default,
+  // concluded "the user changed this" and recorded the shortcut as permanently unbound. Every
+  // newly added default shortcut was therefore born dead for anyone with an existing config.
+  //
+  // Accel pathes are built from TRANSLATED menu labels (that is why the config file is
+  // localized), so the same happens when a label's translation lands or changes: the shortcut
+  // is looked up under a path that config has never seen. That is how F5 stopped applying the
+  // purple label in French -- the fr catalogue gained "Violet" for a menu entry that used to
+  // fall back to the English "Purple", and the F5 saved under the old path was orphaned.
+  //
+  // Passing the default here also makes GTK's own changed/unchanged bookkeeping mean what we
+  // need on the way out: gtk_accel_map_save() comments out an entry that still sits at its
+  // default and writes the others verbatim, so a shortcut the user cleared is saved as a real
+  // (path "") line and is read back as a known path with key 0 -- still cleared, this time
+  // because the file says so rather than because the file is silent.
+  //
+  // One-time cost of the change: a config written by an older build recorded a cleared default
+  // shortcut as a commented line, which reads back as "unknown path", so such a shortcut is
+  // restored to its default once. It is then saved under the new spelling and stays cleared
+  // from there on.
+  gtk_accel_map_add_entry(shortcut->path, shortcut->key, shortcut->mods);
   dt_pthread_mutex_lock(&accels->lock);
   g_hash_table_insert(accels->acceleratables, shortcut->path, shortcut);
 

--- a/tests/unittests/CMakeLists.txt
+++ b/tests/unittests/CMakeLists.txt
@@ -32,6 +32,7 @@ set(LIB_ANSEL_UNIT_TESTS
   test_tagging_completion
   test_tagging_completion_model
   test_metadata_notify
+  test_accel_map_defaults
   # Not database tests, but they want the same standalone-binary-linking-lib_ansel treatment,
   # and splitting the list to say so would be more ceremony than it is worth.
   test_pipe_cache_policy

--- a/tests/unittests/test_accel_map_defaults.c
+++ b/tests/unittests/test_accel_map_defaults.c
@@ -1,0 +1,161 @@
+/*
+    This file is part of Ansel,
+    Copyright (C) 2026 Aurélien PIERRE.
+
+    Ansel is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Ansel is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Ansel.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+/** The GtkAccelMap contract _insert_accel() (widgets/accelerators.c) is built on.
+ *
+ * Shortcuts are reconciled between three sources: the app default declared in the code, the
+ * user's keyboardrc, and the GtkAccelMap that sits between them. dt_accels_load_user_config()
+ * reads the file first, then every shortcut registers its accel path, and only the difference
+ * between the two decides whether a shortcut is at its default, was rebound, or was cleared.
+ *
+ * That difference is only legible if the app default is registered AS the accel_map entry's
+ * default. Registering (path, 0, 0) instead -- what the code did until the purple-label bug --
+ * makes "this config predates the shortcut" and "the user cleared this shortcut" arrive
+ * identically, as key 0, and _update_shortcut_state() then reads both as a deliberate user
+ * override. _a_zero_default_cannot_tell_absent_from_cleared() pins that failure so the reason
+ * for the current spelling stays visible.
+ *
+ * These tests exercise GTK, not Ansel code: they state what accelerators.c assumes, so a GTK
+ * whose bookkeeping changed is caught here rather than as shortcuts going quietly dead. Each
+ * test uses accel pathes of its own -- the GtkAccelMap is process-global with no reset call,
+ * and gtk_accel_map_load() merges into whatever is already there.
+ */
+
+#include <gtk/gtk.h>
+
+#include <stdarg.h>
+#include <stddef.h>
+// cmocka.h declares `extern jmp_buf global_expect_assert_env' at file scope without including
+// <setjmp.h> itself. Same suppression as the other tests here, and for the same reason.
+#include <setjmp.h>  // NOLINT(misc-include-cleaner)
+#include <stdint.h>
+#include <cmocka.h>
+
+#define APP_DEFAULT_KEY GDK_KEY_F5
+
+/** Write a keyboardrc holding the given lines, and load it the way the app does. */
+static void _load_config(const char *contents)
+{
+  gchar *path = g_build_filename(g_get_tmp_dir(), "ansel-test-keyboardrc", NULL);
+  gchar *file = g_strconcat("; test GtkAccelMap rc-file\n", contents, NULL);
+  assert_true(g_file_set_contents(path, file, -1, NULL));
+  gtk_accel_map_load(path);
+  g_free(file);
+  g_free(path);
+}
+
+/** The key the map holds for a path once its shortcut has registered its own default. */
+static guint _register_and_read(const char *path, guint default_key)
+{
+  gtk_accel_map_add_entry(path, default_key, 0);
+  GtkAccelKey key = { 0 };
+  assert_true(gtk_accel_map_lookup_entry(path, &key));
+  return key.accel_key;
+}
+
+/** A shortcut whose path the config never mentions must come up at its app default.
+ *
+ * This is the whole bug: a shortcut added by a new version, or one whose accel path moved
+ * because the translated menu label it is built from changed, is absent from every config
+ * written before it existed. F5 for the purple colour label was lost this way when the French
+ * catalogue translated "Purple" as "Violet".
+ */
+static void _an_absent_path_takes_the_app_default(void **state)
+{
+  (void)state;
+  _load_config("(gtk_accel_path \"<AnselTest1>/known\" \"F1\")\n");
+  assert_int_equal(_register_and_read("<AnselTest1>/absent", APP_DEFAULT_KEY), APP_DEFAULT_KEY);
+}
+
+/** A shortcut the user cleared must stay cleared, and says so with a live empty entry. */
+static void _an_emptied_entry_stays_cleared(void **state)
+{
+  (void)state;
+  _load_config("(gtk_accel_path \"<AnselTest2>/cleared\" \"\")\n");
+  assert_int_equal(_register_and_read("<AnselTest2>/cleared", APP_DEFAULT_KEY), 0);
+}
+
+/** A shortcut the user rebound keeps the user's keys, not the app's. */
+static void _a_user_binding_wins_over_the_default(void **state)
+{
+  (void)state;
+  _load_config("(gtk_accel_path \"<AnselTest3>/rebound\" \"<Control>k\")\n");
+  gtk_accel_map_add_entry("<AnselTest3>/rebound", APP_DEFAULT_KEY, 0);
+  GtkAccelKey key = { 0 };
+  assert_true(gtk_accel_map_lookup_entry("<AnselTest3>/rebound", &key));
+  assert_int_equal(key.accel_key, GDK_KEY_k);
+  assert_int_equal(key.accel_mods & GDK_CONTROL_MASK, GDK_CONTROL_MASK);
+}
+
+/** Why the default is registered rather than (0, 0): with (0, 0) the two cases above are
+ * the same value, and the one that must win cannot be told from the one that must not. */
+static void _a_zero_default_cannot_tell_absent_from_cleared(void **state)
+{
+  (void)state;
+  _load_config("(gtk_accel_path \"<AnselTest4>/cleared\" \"\")\n");
+  assert_int_equal(_register_and_read("<AnselTest4>/cleared", 0), 0);
+  assert_int_equal(_register_and_read("<AnselTest4>/absent", 0), 0);
+}
+
+/** The other half of the contract, on the way out: gtk_accel_map_save() comments out an entry
+ * still sitting at its default and writes every other one as a live line. That is what makes a
+ * cleared shortcut survive the next start -- it is saved as a real (path "") line, which is
+ * what _an_emptied_entry_stays_cleared() reads back. */
+static void _saving_marks_defaults_as_comments_and_changes_as_lines(void **state)
+{
+  (void)state;
+  gtk_accel_map_add_entry("<AnselTest5>/default", APP_DEFAULT_KEY, 0);
+  gtk_accel_map_add_entry("<AnselTest5>/cleared", APP_DEFAULT_KEY, 0);
+  assert_true(gtk_accel_map_change_entry("<AnselTest5>/cleared", 0, 0, TRUE));
+
+  gchar *path = g_build_filename(g_get_tmp_dir(), "ansel-test-keyboardrc-save", NULL);
+  gtk_accel_map_save(path);
+
+  gchar *contents = NULL;
+  assert_true(g_file_get_contents(path, &contents, NULL, NULL));
+  assert_non_null(g_strstr_len(contents, -1, "; (gtk_accel_path \"<AnselTest5>/default\" \"F5\")"));
+  assert_non_null(g_strstr_len(contents, -1, "\n(gtk_accel_path \"<AnselTest5>/cleared\" \"\")"));
+  g_free(contents);
+  g_free(path);
+}
+
+int main(void)
+{
+  // The accel map is a plain hash table populated by gtk_init(), and unreachable without it.
+  // The result is deliberately ignored: a headless runner opens no display and answers FALSE,
+  // having initialised everything these tests touch anyway.
+  int argc = 0;
+  char **argv = NULL;
+  gtk_init_check(&argc, &argv);
+
+  const struct CMUnitTest tests[] = {
+    cmocka_unit_test(_an_absent_path_takes_the_app_default),
+    cmocka_unit_test(_an_emptied_entry_stays_cleared),
+    cmocka_unit_test(_a_user_binding_wins_over_the_default),
+    cmocka_unit_test(_a_zero_default_cannot_tell_absent_from_cleared),
+    cmocka_unit_test(_saving_marks_defaults_as_comments_and_changes_as_lines),
+  };
+
+  return cmocka_run_group_tests(tests, NULL, NULL);
+}
+
+// clang-format off
+// modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py
+// vim: shiftwidth=2 expandtab tabstop=2 cindent
+// kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;
+// clang-format on


### PR DESCRIPTION
During my test about the fix of #1365, I discovered the shortcut for the purple color label was unset because of an old config. Claude AI proposes me a way to take into account a new shortcut path as it is and not as a shortcut removed by a user.
Beside, I discovered also two different translations in French for purple ("Pourpre" and "Violet"). By using Claude AI, latter found some issues in the translations for other languages (mainly not the text but the color code mapped to the text).