### PR TITLE
Fix Flatpak language selection

### DIFF
--- a/packaging/flatpak/photos.ansel.Ansel.json
+++ b/packaging/flatpak/photos.ansel.Ansel.json
@@ -4,6 +4,7 @@
     "runtime-version": "49",
     "sdk": "org.gnome.Sdk",
     "command": "ansel",
+    "separate-locales": false,
     "build-options": {
         "libdir": "/app/lib"
     },


### PR DESCRIPTION
Closes #1343.

Set the Flatpak manifest's top-level `separate-locales` property to `false`, so Ansel translation catalogs are bundled in the application payload rather than split into a separate locale extension.

Validation:
- Full Flatpak build passed.
- The app payload contains 33 `ansel.mo` catalogs.
- No separate Locale ref is produced.
- Manually verified that language selection works after restart.