### PR TITLE
accels: release a removed closure through the one function that unregisters its weak pointer

### DIFF
--- a/src/widgets/accelerators.c
+++ b/src/widgets/accelerators.c
@@ -315,9 +315,17 @@ void dt_shortcut_remove_closure(dt_shortcut_t *shortcut, gpointer data)
 
   if(cl)
   {
-    g_closure_unref(cl->base);
+    /* Unlink first, then release through the SAME function the list's own destroy notify uses.
+     * This used to unref the closure and dt_free() the struct inline, which skipped
+     * g_object_remove_weak_pointer(): the weak pointer registered in dt_shortcut_set_closure()
+     * records the address &pc->widget, so leaving it behind means the widget's eventual
+     * destruction writes NULL into a freed PayloadClosure. That is heap corruption, and it
+     * aborts wherever the next allocation lands rather than here -- at startup, in the sqlite3
+     * call under dt_iop_load_modules_so(), because _init_module_so() builds and immediately
+     * destroys a throwaway GUI instance for every module, which is precisely what this function
+     * is called for. */
     shortcut->closure = g_list_delete_link(shortcut->closure, link);
-    dt_free(cl);
+    _g_list_closure_unref(cl);
     // fprintf(stdout, "removing: %s at %p - %i entries remaining\n", shortcut->path, data, g_list_length(shortcut->closure));
   }
 }


### PR DESCRIPTION
Fixes #1378 — Ansel aborts on startup with `corrupted size vs. prev_size in fastbins` /
`malloc(): mismatching next->prev_size`, on Linux, for every launch.

### Root cause

`PayloadClosure` has two release paths, and only one honours the weak pointer added in
ba708a4414:

* `_g_list_closure_unref()` — the closure list's destroy notify — calls
  `g_object_remove_weak_pointer()` correctly.
* `dt_shortcut_remove_closure()` unref'd the `GClosure` and `dt_free()`d the struct inline,
  skipping it.

`dt_shortcut_set_closure()` registers the weak pointer against the address `&pc->widget`, so a
struct freed on the second path leaves GObject holding a pointer into freed heap; the widget's
eventual destruction writes NULL through it. Like all heap corruption it aborts wherever the
next allocation lands rather than at the write — observed both inside sqlite3 under
`dt_preset_repository_list_for_upgrade()` and in a ~60-frame `gtk_container_destroy()`
recursion, which is the same damage detected in two unrelated places.

It hits at startup because this function is called for exactly the case its doc comment names —
destroying module instances. `dt_iop_load_modules_so()` → `_init_module_so()` builds a throwaway
`dt_iop_module_t` GUI for every module and destroys it immediately, and bauhaus controls
register their shortcuts carrying that instance's widget, so each of those widgets is finalized
moments after its closure was freed.

### The change

Unlink first, then release through the same function the destroy notify uses, so the struct has
a single owner and no path can skip the unregistration again. Two lines of code.

`ba708a4414` itself is left intact — the `target_widget` threading and the dispatcher no longer
type-guessing `base->data` both stay.

### How it was found

Bisected over the 75 commits since `1d18ce320f`: first bad commit `ba708a4414`, its direct
parent `c7c02f6660` tested good, so there is no gap. Reverting that commit, or disabling just
its two weak-pointer calls while keeping everything else, each avoid the crash independently.

### Verification

* Startup no longer aborts; a 45 s run stays up where master aborts within a second.
* Reproduced beforehand on a pristine profile (`--configdir` / `--library` on an empty
  directory), so it was never configuration- or database-dependent.
* `ansel-cli` was unaffected throughout, which matches the diagnosis: it never builds the
  per-module GUI.

Also checked while here: the weak pointers on stack locals in `_dispatch_selected_shortcut()`
have no early return between registration and removal, so they are correctly balanced and need
no change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A8nHYyDgesAbt5aZygsxF4
