### PR TITLE
tagging: replace a #pragma once with the tree's include guard

### DIFF
--- a/src/libs/tagging_completion.h
+++ b/src/libs/tagging_completion.h
@@ -16,7 +16,8 @@
     along with Ansel.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#pragma once
+#ifndef DT_LIBS_TAGGING_COMPLETION_H
+#define DT_LIBS_TAGGING_COMPLETION_H
 
 #include <gtk/gtk.h>
 
@@ -29,3 +30,5 @@ gboolean dt_tagging_completion_match_selected(GtkEntryCompletion *completion, Gt
 
 /** Cancel pending completion work and clear an entry while preserving its completion. */
 void dt_tagging_entry_clear(GtkEntry *entry);
+
+#endif // DT_LIBS_TAGGING_COMPLETION_H


### PR DESCRIPTION
`tools/pragma_once_to_guards.py --verify` has been failing on master since a5ae1bc163 added `src/libs/tagging_completion.h` with a `#pragma once`:

```
src/libs/tagging_completion.h: #pragma once is forbidden, use an include guard
```

CLAUDE.md's first rule explains why this is enforced rather than a preference: `#pragma once` silently makes a cyclic include graph compile, which is how three include cycles survived here for years. Replaced with `DT_LIBS_TAGGING_COMPLETION_H`, the guard name the path prescribes. The verifier passes; the header still compiles standalone.

Found while running the gates for #1360's fix; filed separately so it does not ride on that change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)