### PR TITLE
shape manager: two lists, and reusing a module's mask

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1293,16 +1293,62 @@ displayed rank and the effective one can differ by one.
 ### The shape manager's two lists, and the graph questions behind them
 
 `libs/shape_manager.c` shows the forms in two trees, split by one question: is this group some
-module's drawn mask, or nobody's yet? The left list is the inventory — every shape, plus the groups
-no module uses — and the right one is the assignment. A shape a module uses appears in both, once
-as itself and once as a member, the same arrangement the Drawn tab already uses. Membership is
-derived per rebuild by `_form_belongs_to()`, never stored, so a form crosses lists the moment a
-module claims or releases its group — which is why both stores are always rebuilt together.
+module's drawn mask, or nobody's yet? The left list is the inventory — every shape and every
+group, module masks included — and the right one is the assignment, holding only the groups a
+module actually renders. A module mask is therefore listed in BOTH: once in the inventory, where
+it can be picked up like any other group (nested into another mask through the "+", or attached
+to more modules through the chooser) and reused, and once in the assignment, under the module that
+renders it. A shape a module uses appears in both for the same reason, once as itself and once as
+a member — the arrangement the Drawn tab already uses. Membership is derived per rebuild by
+`_group_is_module_mask()`, never stored, so a group's assignment-list row appears or disappears the
+moment a module claims or releases it — which is why both stores are always rebuilt together.
 
 Every tree handler is handed a `dt_shape_manager_list_t`, not the module, because the first thing
 each needs to know is which tree the gesture came from. **That includes the context menu items**:
 connecting them with the module instead is what once made every menu action dereference arbitrary
 memory.
+
+A module mask is shown FLAT in the inventory -- one row, no expander, its members not appended
+under it -- and expandable in the module list, which is where that subtree belongs. `_tree_row_t`
+carries the `flat` flag that stops `_shape_manager_list_recurs()` after the row itself.
+
+Both lists order module masks by **reverse `iop_order`**, walking `dev->iop` from `g_list_last()`
+backwards -- the "bottom of the stack first" convention the module chooser and the module groups
+panel's Pipeline tab already use, so a mask sits where its module does everywhere else. That walk
+is scoped like `_modules_owning_group()`, every module in `dev->iop` rather than only the ones
+`dt_iop_module_is_in_pipeline()` shows: the "unclaimed groups" pass afterwards skips anything
+`_group_is_module_mask()` claims, so a narrower scope here would drop a hidden instance's mask
+from both passes.
+
+**Three GTK behaviours here were measured offscreen, not reasoned about, and each one contradicted
+the obvious guess:**
+
+- **Names carry no `ellipsize`, and that is what guarantees they are never compressed.** A
+  `GtkTreeView` with no ellipsize reports its true full-content preferred width, that width
+  propagates through a `GTK_POLICY_NEVER` scrolled window (a `min-content-width` smaller than the
+  content does NOT lower it), and `gtk_window_resize()` -- which restores the persisted panel
+  width -- cannot force a window below its content minimum: GTK clamps it back up. So the width
+  floor is structural, not something the panel has to compute.
+- **A `GtkPaned` with `resize=TRUE` on both children splits new width between them**, drifting the
+  divider on every window resize. The inventory is packed `resize=FALSE` so the divider holds and
+  the module list absorbs the growth; a manual drag still repositions it.
+- **Of two renderers packed with `gtk_tree_view_column_pack_end()`, the FIRST packed lands at the
+  true right edge**, each later one closer to the content. The "used by" icon is therefore packed
+  BEFORE the note text to end up to its right.
+
+**`_shape_manager_selection_change_in()` must reveal by path, never `gtk_tree_view_expand_all()`.**
+The recursive search walks the MODEL, which holds every row whatever the view has collapsed, so it
+needs nothing expanded; expanding everything was only about making the match visible afterwards,
+and it blew every unrelated group open to do it -- visible as "creating a shape expands all the
+groups". `gtk_tree_view_expand_to_path()` on the found row does the same job. The paired
+`collapse_all()` on the not-found branch went with it: without an `expand_all()` to undo, it would
+have destroyed the user's own expansions on any selection event that missed.
+
+**`dev->form_gui` can be NULL while this panel is open.** It is allocated on entering darkroom and
+freed back to NULL on leaving it (`views/darkroom.c`, `views/studio_capture.c`), and this panel is
+a standalone toplevel that outlives that. `dt_masks_change_form_gui()` is NULL-safe throughout and
+does NOT allocate one, so a caller cannot assume it has one afterwards -- `_tree_selection_change()`
+dereferenced it unguarded and crashed (SIGSEGV, observed live).
 
 The graph questions live in `develop/masks_group.h`, id-keyed and by value like the rest of that
 header — `dt_masks_group_contains()` (cycle guard: wiring a group into one that already holds it

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1242,6 +1242,76 @@ are now refcounted (`dt_masks_form_t.refcount`, `src/develop/masks/masks_history
   already guarantees a GUI-side edit clones instead of mutating a form an in-flight pipeline run
   is holding.
 
+### A mask shared between modules is `mask_id`, and nothing else
+
+`blend_params->mask_id` lives inside each module's own params blob, so nothing stops several
+modules from naming the same group — and that IS a shared mask. There is no back-reference from a
+group to the modules using it, and there must not be one: the answer is derived by walking
+`dev->iop`, which is what `_modules_owning_group()` (`libs/shape_manager.c`) does. Caching it in a
+hash table would buy nothing over ~80 modules and would cost an invalidation problem, since
+`dev->iop` is rebuilt on module add/remove and on history navigation — stored raw module pointers
+would dangle.
+
+Two consequences a reader has to hold together:
+
+- **Detaching a shape from a shared group detaches it for every module rendering that group.**
+  There is one membership, not one per module. The shape manager's attachment dialog says so by
+  reopening with those modules unticked; anything else offering a detach has to mean the same
+  thing.
+- **The tree stores one module per row**, so a shared group is listed once, attributed to
+  `_module_owning_group()` — the *first* owner in pipeline order. `_modules_owning_group()`
+  returns all of them and is the one to use for any question about who renders a group.
+
+`dt_iop_gui_blend_set_drawn_mask_group()` (`develop/blend_gui.h`) is how a module starts using a
+group: it points `mask_id`, raises `DEVELOP_MASK_ENABLED | DEVELOP_MASK_SHAPE`, refreshes the
+raster-mask source table and repaints whatever of the blend GUI exists. It tolerates a module the
+user has never expanded (no `dt_iop_gui_blend_data_t`) and commits nothing, so a caller attaching
+one group to several modules commits once. Before it existed, that sequence lived only inside
+`blend_gui.c`'s own widget callbacks and anything else had to write `blend_params` by hand.
+
+### The same shape applied twice in one mask is legal, and not always a no-op
+
+A module renders one group, that group can nest others, and nothing stops a shape from sitting in
+both. Whether the second application changes anything depends entirely on the combine operator
+(`develop/masks/group.c`): union is `max(dst, src·opacity)` and intersection `min(b1, b2·opacity)`,
+both idempotent — but difference is `b1·(1−b2)`, so applying it twice gives `b1·(1−b2)²`, and
+exclusion does not settle either. **So a duplicate instance must never be greyed out or refused as
+redundant**: the panel would claim an absence of effect the pipeline does not honour. Mark it and
+leave it alone. `dt_masks_group_first_use()` answers which application the later ones are read
+against, walking in compositing order — a group's members in their own order, descending into a
+member group at the position that group sits at.
+
+Compositing order is that walk, forward: `dt_masks_group_get_mask()` fills its buffers walking
+`points` forward and folds them in the same index order, so the topmost member is the base and each
+later one combines onto the result of those above it. A list that does not show that order does not
+show what the mask does — which is why the Drawn tab's mask tree is built in one pass
+(`_blendop_masks_group_tree_append`). Its *available shapes* list below deliberately keeps groups
+first instead: that one is a catalogue to pick from, not a rendering order.
+
+Note `nb_ok` is only incremented for members that actually rasterize something: a shape that draws
+nothing (`DT_MASKS_RASTER_EMPTY`) occupies a row in the list but no rank in the composition, so the
+displayed rank and the effective one can differ by one.
+
+### The shape manager's two lists, and the graph questions behind them
+
+`libs/shape_manager.c` shows the forms in two trees, split by one question: is this group some
+module's drawn mask, or nobody's yet? The left list is the inventory — every shape, plus the groups
+no module uses — and the right one is the assignment. A shape a module uses appears in both, once
+as itself and once as a member, the same arrangement the Drawn tab already uses. Membership is
+derived per rebuild by `_form_belongs_to()`, never stored, so a form crosses lists the moment a
+module claims or releases its group — which is why both stores are always rebuilt together.
+
+Every tree handler is handed a `dt_shape_manager_list_t`, not the module, because the first thing
+each needs to know is which tree the gesture came from. **That includes the context menu items**:
+connecting them with the module instead is what once made every menu action dereference arbitrary
+memory.
+
+The graph questions live in `develop/masks_group.h`, id-keyed and by value like the rest of that
+header — `dt_masks_group_contains()` (cycle guard: wiring a group into one that already holds it
+makes every walk non-terminating), `dt_masks_group_covers_shapes()`, `dt_masks_group_first_use()`.
+They walk `->points` where `->points` belongs. Asking them from `libs/` by hand is what
+`tools/check_module_boundaries.sh` section 9 counts and refuses.
+
 ### The unused-shape sweep's used-set is not a subset of the snapshot it sweeps
 
 "Delete unused shapes" in the shape manager (`libs/shape_manager.c`, `dt_masks_cleanup_unused()`) keeps a

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1242,32 +1242,30 @@ are now refcounted (`dt_masks_form_t.refcount`, `src/develop/masks/masks_history
   already guarantees a GUI-side edit clones instead of mutating a form an in-flight pipeline run
   is holding.
 
-### A mask shared between modules is `mask_id`, and nothing else
+### Each module owns its mask group; what modules share is a shape
 
-`blend_params->mask_id` lives inside each module's own params blob, so nothing stops several
-modules from naming the same group — and that IS a shared mask. There is no back-reference from a
-group to the modules using it, and there must not be one: the answer is derived by walking
-`dev->iop`, which is what `_modules_owning_group()` (`libs/shape_manager.c`) does. Caching it in a
-hash table would buy nothing over ~80 modules and would cost an invalidation problem, since
-`dev->iop` is rebuilt on module add/remove and on history navigation — stored raw module pointers
-would dangle.
+`blend_params->mask_id` lives inside each module's own params blob, so several modules naming the
+same group is *representable* — but it is not what anything builds, and code here should not
+create it. A module owns ONE mask group of its own, named "Mask <module>", and a shape or shape
+group used by several modules is nested as a member of each of their masks.
 
-Two consequences a reader has to hold together:
+That separation is what keeps the modules independent. A module's own mask carries its own combine
+operators, opacities and member order, so attaching the same shape group to a second module cannot
+disturb the first, and detaching it from one removes the membership from that module's mask alone.
+Pointing several modules at one mask group would make every one of those settings — and every
+detach — common to all of them. `_tree_row_assign_to_modules()` (`libs/shape_manager.c`) is the
+path that creates a module's mask when it has none, and `dt_iop_gui_blend_set_drawn_mask_group()`
+(`develop/blend_gui.h`) is the one that points `mask_id` at it, raises `DEVELOP_MASK_ENABLED |
+DEVELOP_MASK_SHAPE`, refreshes the raster-mask source table and repaints whatever of the blend GUI
+exists. It tolerates a module the user has never expanded (no `dt_iop_gui_blend_data_t`) and
+commits nothing, so a caller wiring several modules commits per module and once for the forms.
 
-- **Detaching a shape from a shared group detaches it for every module rendering that group.**
-  There is one membership, not one per module. The shape manager's attachment dialog says so by
-  reopening with those modules unticked; anything else offering a detach has to mean the same
-  thing.
-- **The tree stores one module per row**, so a shared group is listed once, attributed to
-  `_module_owning_group()` — the *first* owner in pipeline order. `_modules_owning_group()`
-  returns all of them and is the one to use for any question about who renders a group.
-
-`dt_iop_gui_blend_set_drawn_mask_group()` (`develop/blend_gui.h`) is how a module starts using a
-group: it points `mask_id`, raises `DEVELOP_MASK_ENABLED | DEVELOP_MASK_SHAPE`, refreshes the
-raster-mask source table and repaints whatever of the blend GUI exists. It tolerates a module the
-user has never expanded (no `dt_iop_gui_blend_data_t`) and commits nothing, so a caller attaching
-one group to several modules commits once. Before it existed, that sequence lived only inside
-`blend_gui.c`'s own widget callbacks and anything else had to write `blend_params` by hand.
+There is no back-reference from a group to the modules using it, and there must not be one: the
+answer is derived by walking `dev->iop`, which is what `_modules_owning_group()` does. Caching it
+would buy nothing over ~80 modules and would cost an invalidation problem, since `dev->iop` is
+rebuilt on module add/remove and on history navigation — stored raw module pointers would dangle.
+`_module_owning_group()` returns the first of them, which is all a tree row storing one module can
+show; anything asking *who renders this group* wants the list.
 
 ### The same shape applied twice in one mask is legal, and not always a no-op
 

--- a/data/themes/ansel.css
+++ b/data/themes/ansel.css
@@ -353,6 +353,20 @@ menu separator {
   min-height: 1px;
 }
 
+/* The shape manager holds two separate lists side by side -- the shapes that exist, and the
+ * masks modules render. What separates them is each list's own section heading and recessed
+ * frame, so the paned handle paints nothing: it is only the gap between the two, and the width
+ * it keeps is the room to grab it by. Same choice as `filechooser paned separator` below. */
+#shape-manager-lists > separator {
+  min-width: 0.35em;
+  background: transparent;
+}
+
+#shape-manager-list {
+  padding-left: 0.4em;
+  padding-right: 0.4em;
+}
+
 /**
  * A treeview row separator is not a `separator` widget: GtkTreeView draws it as a row of its own,
  * and the rule above -- which styles the widget -- does not reach it.

--- a/doc/include-hygiene-roadmap.md
+++ b/doc/include-hygiene-roadmap.md
@@ -521,7 +521,7 @@ drains in FIFO order on the throttle's schedule.
 
 **Do NOT merge queued requests.** An earlier draft of this plan proposed collapsing N pending
 requests into one that takes the union of their `add_new_pipe_node` / `has_forms` /
-`has_raster` flags. That is the wrong shape: masks, module enable/disable, the mask manager
+`has_raster` flags. That is the wrong shape: masks, module enable/disable, the shape manager
 and ordinary parameter edits all commit history with different resync needs, and any merging
 rule is a place to silently drop one. Keep every request, process them in order, stay boring.
 

--- a/doc/masks-enclosure-p2.md
+++ b/doc/masks-enclosure-p2.md
@@ -195,16 +195,22 @@ dt_masks_result_t dt_masks_form_set_retouch_mode(struct dt_develop_t *dev, int f
 int               dt_masks_group_create_for_module(struct dt_iop_module_t *module, const char *name);
 ```
 
+> **The line numbers below are historical.** They were verified against `libs/masks.c` as it stood
+> when this survey was made. That file is now `libs/shape_manager.c` and has been substantially
+> rewritten since — the panel was split into two lists and grew per-row actions — so the numbers
+> locate nothing in the current tree. The file and symbol names are still right; find the code by
+> those.
+
 Every one: resolve → `dt_masks_cow_touch()` → **re-resolve the row from the touched group** →
 mutate → compare. An id-keyed signature is the only shape that *can* be written this way, which is
 the whole point: cloning a parent also clones its `dt_masks_form_group_t` blocks, so any entry
 pointer taken before the touch belongs to the abandoned copy.
 
-- `set_member_operation` closes **six verified COW holes** (`libs/masks.c` 502/557/612/667/722 and
+- `set_member_operation` closes **six verified COW holes** (`libs/shape_manager.c` 502/557/612/667/722 and
   `blend_gui.c:2091`) and collapses five ~50-line handlers into one. Do it in a single commit —
   fixing it in five places separately is how one gets missed.
 - `add_member` becomes the **sole constructor** for `dt_masks_form_group_t`, retiring the three
-  hand-rolled `malloc`s (`libs/masks.c` 365-369 / 970-974, `retouch.c` 685-690). It keeps the
+  hand-rolled `malloc`s (`libs/shape_manager.c` 365-369 / 970-974, `retouch.c` 685-690). It keeps the
   self-inclusion guard and the `dt_masks_form_update_gravity_center()` all three skip, and
   `parentid` is never a parameter — always stamped `group_id`.
 - `move_member` is **keyed on formid, not index**: the GTK model already carries
@@ -225,7 +231,7 @@ assumptions — took for granted. They are the reason to read this document befo
    `dev->forms`" is wrong about which end is dangerous: every *writer* of `dev->forms` is on the GUI
    thread, and the only cross-thread reader is `pixelpipe_hb.c:1629`'s snapshot on the worker.
    Single writer ⟹ the unlocked GUI reads are benign today. The genuinely racy site is the unlocked
-   **write** at `libs/masks.c:377`. Read-side locking in the new enumerators is cheap insurance, not
+   **write** at `libs/shape_manager.c:377`. Read-side locking in the new enumerators is cheap insurance, not
    a bug fix — and it is still a behaviour change that needs approval.
 3. **P2 does not make `dt_masks_form_t` opaque, and no phase of P2 will.** Three blockers survive:
    the rasterisers take *non-const* `dt_masks_form_t *` because they lazily fill cached geometry (12
@@ -319,5 +325,5 @@ zero callers, because they shipped ahead of their consumers.)
   external-facing, and `masks/masks_functions.h`, which is module-private. So the reach will not
   drop until the `masks_gui.h` edge is cut, and that — not `blend.h` — is the one carrying the
   surface to the rest of the tree. Retarget the next header tranche accordingly.
-- **Then** the write API against `libs/masks.c` and `blend_gui.c` (the six COW holes), and finally
+- **Then** the write API against `libs/shape_manager.c` and `blend_gui.c` (the six COW holes), and finally
   the P2b per-shape geometry axis for `retouch.c` and `spots.c`.

--- a/doc/studio-capture.md
+++ b/doc/studio-capture.md
@@ -33,7 +33,7 @@ match the current view; nothing is ever removed. Hiding must target the
 auto-creates around each button, not the button itself: a visible-but-empty
 wrapper still reserves a cell and its spacing in the flow layout, which used
 to leave gaps and push later buttons rightward whenever a view hid some of
-its siblings (visible in darkroom as the mask manager button drifting away
+its siblings (visible in darkroom as the shape manager button drifting away
 from the rest, and in Studio Capture as its buttons failing to pack flush
 left) — `view_enter()` now hides/shows `gtk_widget_get_parent()` of the
 button when that parent is a `GtkFlowBoxChild`.
@@ -108,7 +108,7 @@ view, and its state (a global toggle, not tied to any one `dev`) is correct
 in both views already.
 
 Auto-set, the pipeline node graph (both darkroom-editing concepts) and the
-mask manager popup (`libs/masks.c`) stay `DT_VIEW_DARKROOM` only, unextracted.
+shape manager popup (`libs/shape_manager.c`) stay `DT_VIEW_DARKROOM` only, unextracted.
 
 ## Import module
 

--- a/src/develop/blend_gui.c
+++ b/src/develop/blend_gui.c
@@ -2236,8 +2236,8 @@ static void _blendop_masks_group_duplicate_callback(GtkWidget *menu_item, dt_iop
   const int parentid = GPOINTER_TO_INT(g_object_get_data(G_OBJECT(menu_item), "blend-parentid"));
 
   // dt_masks_form_duplicate_in_group also attaches the duplicate to the group right away,
-  // inheriting the source entry's state/opacity -- same helper used by the mask manager's
-  // own "Duplicate shape" action (libs/masks.c).
+  // inheriting the source entry's state/opacity -- same helper used by the shape manager's
+  // own "Duplicate shape" action (libs/shape_manager.c).
   const int nid = dt_masks_form_duplicate_in_group(module->dev, parentid, formid);
   if(nid <= 0) return;
 

--- a/src/develop/blend_gui.c
+++ b/src/develop/blend_gui.c
@@ -1745,17 +1745,19 @@ static void _blendop_masks_apply_and_commit(dt_iop_module_t *module)
   dt_control_queue_redraw_center();
 }
 
-gboolean dt_iop_gui_blend_set_drawn_mask_group(dt_iop_module_t *module, dt_masks_form_t *group)
+gboolean dt_iop_gui_blend_set_drawn_mask_group(dt_iop_module_t *module, const int group_id)
 {
   if(!dt_iop_module_supports_drawn_mask(module)) return FALSE;
+
+  const dt_masks_form_t *group = dt_masks_get_from_id(module->dev, group_id);
   if(IS_NULL_PTR(group) || !(group->type & DT_MASKS_GROUP)) return FALSE;
 
   const uint32_t drawn = DEVELOP_MASK_ENABLED | DEVELOP_MASK_SHAPE;
-  const gboolean changed = (module->blend_params->mask_id != group->formid)
+  const gboolean changed = (module->blend_params->mask_id != group_id)
                            || ((module->blend_params->mask_mode & drawn) != drawn);
   if(!changed) return FALSE;
 
-  module->blend_params->mask_id = group->formid;
+  module->blend_params->mask_id = group_id;
   module->blend_params->mask_mode |= drawn;
 
   // Reads blend_params->mask_mode back rather than taking it as an argument, so it has to come

--- a/src/develop/blend_gui.c
+++ b/src/develop/blend_gui.c
@@ -1745,6 +1745,39 @@ static void _blendop_masks_apply_and_commit(dt_iop_module_t *module)
   dt_control_queue_redraw_center();
 }
 
+gboolean dt_iop_gui_blend_set_drawn_mask_group(dt_iop_module_t *module, dt_masks_form_t *group)
+{
+  if(!dt_iop_module_supports_drawn_mask(module)) return FALSE;
+  if(IS_NULL_PTR(group) || !(group->type & DT_MASKS_GROUP)) return FALSE;
+
+  const uint32_t drawn = DEVELOP_MASK_ENABLED | DEVELOP_MASK_SHAPE;
+  const gboolean changed = (module->blend_params->mask_id != group->formid)
+                           || ((module->blend_params->mask_mode & drawn) != drawn);
+  if(!changed) return FALSE;
+
+  module->blend_params->mask_id = group->formid;
+  module->blend_params->mask_mode |= drawn;
+
+  // Reads blend_params->mask_mode back rather than taking it as an argument, so it has to come
+  // after the write above.
+  dt_iop_set_mask_mode(module, module->blend_params->mask_mode);
+
+  /* A module the user has never expanded has no blend GUI to refresh, and one whose blending
+   * body was never built has a dt_iop_gui_blend_data_t but no widgets in it -- which is exactly
+   * what blending_box records, the same gate _blendop_masks_mode_callback() applies. */
+  if(!IS_NULL_PTR(module->gui) && !IS_NULL_PTR(module->gui->blend_data))
+  {
+    const dt_iop_gui_blend_data_t *bd = (const dt_iop_gui_blend_data_t *)module->gui->blend_data;
+    if(bd->blending_box) dt_iop_gui_update_blending(module);
+    dt_iop_gui_blend_masks_update(module);
+  }
+
+  dt_iop_add_remove_mask_indicator(module);
+  dt_iop_gui_update_header(module);
+
+  return TRUE;
+}
+
 static void _blendop_masks_group_name_commit(dt_iop_module_t *module, const gchar *new_text)
 {
   if(IS_NULL_PTR(module)) return;

--- a/src/develop/blend_gui.h
+++ b/src/develop/blend_gui.h
@@ -214,10 +214,13 @@ void dt_iop_gui_blend_masks_update(dt_iop_module_t *module);
  * Nothing is committed to history -- a caller attaching one group to several modules commits
  * once, at the end.
  *
+ * Takes the group's id rather than the group: a caller outside develop/masks has no business
+ * reaching into a dt_masks_form_t to read one, and the id is what blend_params stores anyway.
+ *
  * @return TRUE if anything actually changed, FALSE if the module already used that group with
  * drawn blending on, or if it cannot carry a drawn mask at all.
  */
-gboolean dt_iop_gui_blend_set_drawn_mask_group(dt_iop_module_t *module, struct dt_masks_form_t *group);
+gboolean dt_iop_gui_blend_set_drawn_mask_group(dt_iop_module_t *module, int group_id);
 
 gboolean blend_color_picker_apply(dt_iop_module_t *module, GtkWidget *picker, dt_dev_pixelpipe_t *pipe,
                                   dt_dev_pixelpipe_iop_t *piece);

--- a/src/develop/blend_gui.h
+++ b/src/develop/blend_gui.h
@@ -200,6 +200,25 @@ void dt_iop_gui_blending_reload_defaults(dt_iop_module_t *module);
  * implement and could not have, since every widget it drives is private to this one. */
 void dt_iop_gui_blend_masks_update(dt_iop_module_t *module);
 
+/** Make `group` the module's drawn mask and switch drawn blending on.
+ *
+ * The sequence a module needs to start using a drawn mask -- point blend_params->mask_id at the
+ * group, raise DEVELOP_MASK_ENABLED | DEVELOP_MASK_SHAPE, refresh the raster-mask source table,
+ * and repaint whatever of the blend GUI exists -- lived only inside this file's own widget
+ * callbacks, so anything else wanting to attach a mask had to write blend_params by hand. It is
+ * one function now, and the blend GUI's own callbacks are not its only caller.
+ *
+ * The module's blend GUI need not have been built: a module the user has never expanded has no
+ * dt_iop_gui_blend_data_t, and this only refreshes the widgets that exist.
+ *
+ * Nothing is committed to history -- a caller attaching one group to several modules commits
+ * once, at the end.
+ *
+ * @return TRUE if anything actually changed, FALSE if the module already used that group with
+ * drawn blending on, or if it cannot carry a drawn mask at all.
+ */
+gboolean dt_iop_gui_blend_set_drawn_mask_group(dt_iop_module_t *module, struct dt_masks_form_t *group);
+
 gboolean blend_color_picker_apply(dt_iop_module_t *module, GtkWidget *picker, dt_dev_pixelpipe_t *pipe,
                                   dt_dev_pixelpipe_iop_t *piece);
 

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -738,17 +738,17 @@ gboolean dt_iop_is_hidden(dt_iop_module_t *module)
   return dt_iop_so_is_hidden(module->so);
 }
 
-gboolean dt_iop_module_instance_exists(dt_iop_module_t *module)
+gboolean dt_iop_module_instance_exists(dt_iop_module_t *iop)
 {
-  if(IS_NULL_PTR(module)) return FALSE;
-  if(module->multi_priority == 0) return TRUE;
+  if(IS_NULL_PTR(iop)) return FALSE;
+  if(iop->multi_priority == 0) return TRUE;
 
-  dt_develop_t *const dev = module->dev;
+  dt_develop_t *const dev = iop->dev;
   if(IS_NULL_PTR(dev)) return FALSE;
 
   dt_pthread_rwlock_rdlock(&dev->history_mutex);
   const gboolean exists = !IS_NULL_PTR(
-      dt_dev_history_get_last_item_by_module(dev->history, module, dt_dev_get_history_end_ext(dev)));
+      dt_dev_history_get_last_item_by_module(dev->history, iop, dt_dev_get_history_end_ext(dev)));
   dt_pthread_rwlock_unlock(&dev->history_mutex);
 
   return exists;
@@ -775,17 +775,17 @@ static gboolean _module_carries_history(dt_iop_module_t *module)
   return found;
 }
 
-gboolean dt_iop_module_is_in_pipeline(dt_iop_module_t *module)
+gboolean dt_iop_module_is_in_pipeline(dt_iop_module_t *iop)
 {
-  if(IS_NULL_PTR(module) || dt_iop_is_hidden(module)) return FALSE;
-  if(!module->enabled && !_module_carries_history(module)) return FALSE;
-  return dt_iop_module_instance_exists(module);
+  if(IS_NULL_PTR(iop) || dt_iop_is_hidden(iop)) return FALSE;
+  if(!iop->enabled && !_module_carries_history(iop)) return FALSE;
+  return dt_iop_module_instance_exists(iop);
 }
 
-gboolean dt_iop_module_supports_drawn_mask(dt_iop_module_t *module)
+gboolean dt_iop_module_supports_drawn_mask(dt_iop_module_t *iop)
 {
-  if(IS_NULL_PTR(module) || IS_NULL_PTR(module->blend_params)) return FALSE;
-  const int flags = module->flags();
+  if(IS_NULL_PTR(iop) || IS_NULL_PTR(iop->blend_params)) return FALSE;
+  const int flags = iop->flags();
   return (flags & IOP_FLAGS_SUPPORTS_BLENDING) && !(flags & IOP_FLAGS_NO_MASKS);
 }
 

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -89,6 +89,7 @@
 #include "develop/blend.h"
 #include "develop/blend_gui.h"
 #include "develop/develop.h"
+#include "develop/dev_history.h"   // dt_dev_history_get_last_item_by_module(), dt_dev_get_history_end_ext()
 #include "pixel/format.h"
 #include "develop/masks.h"
 #include "develop/tiling.h"
@@ -735,6 +736,57 @@ gboolean dt_iop_so_is_hidden(dt_iop_module_so_t *module)
 gboolean dt_iop_is_hidden(dt_iop_module_t *module)
 {
   return dt_iop_so_is_hidden(module->so);
+}
+
+gboolean dt_iop_module_instance_exists(dt_iop_module_t *module)
+{
+  if(IS_NULL_PTR(module)) return FALSE;
+  if(module->multi_priority == 0) return TRUE;
+
+  dt_develop_t *const dev = module->dev;
+  if(IS_NULL_PTR(dev)) return FALSE;
+
+  dt_pthread_rwlock_rdlock(&dev->history_mutex);
+  const gboolean exists = !IS_NULL_PTR(
+      dt_dev_history_get_last_item_by_module(dev->history, module, dt_dev_get_history_end_ext(dev)));
+  dt_pthread_rwlock_unlock(&dev->history_mutex);
+
+  return exists;
+}
+
+/* Whether any history item at all names the module, regardless of where the history cursor sits.
+ * That is a different question from dt_iop_module_instance_exists(): a module the user has
+ * touched and then undone past is still part of the pipeline they are working on. */
+static gboolean _module_carries_history(dt_iop_module_t *module)
+{
+  dt_develop_t *const dev = module->dev;
+  if(IS_NULL_PTR(dev)) return FALSE;
+
+  gboolean found = FALSE;
+  dt_pthread_rwlock_rdlock(&dev->history_mutex);
+  for(const GList *history = g_list_last(dev->history); history && !found;
+      history = g_list_previous(history))
+  {
+    const dt_dev_history_item_t *item = (const dt_dev_history_item_t *)history->data;
+    found = (item->module == module);
+  }
+  dt_pthread_rwlock_unlock(&dev->history_mutex);
+
+  return found;
+}
+
+gboolean dt_iop_module_is_in_pipeline(dt_iop_module_t *module)
+{
+  if(IS_NULL_PTR(module) || dt_iop_is_hidden(module)) return FALSE;
+  if(!module->enabled && !_module_carries_history(module)) return FALSE;
+  return dt_iop_module_instance_exists(module);
+}
+
+gboolean dt_iop_module_supports_drawn_mask(dt_iop_module_t *module)
+{
+  if(IS_NULL_PTR(module) || IS_NULL_PTR(module->blend_params)) return FALSE;
+  const int flags = module->flags();
+  return (flags & IOP_FLAGS_SUPPORTS_BLENDING) && !(flags & IOP_FLAGS_NO_MASKS);
 }
 
 void dt_iop_reload_defaults(dt_iop_module_t *module)

--- a/src/develop/imageop.h
+++ b/src/develop/imageop.h
@@ -441,6 +441,23 @@ void dt_iop_cleanup_pipe(struct dt_iop_module_t *module, struct dt_dev_pixelpipe
 gboolean dt_iop_so_is_hidden(dt_iop_module_so_t *module);
 gboolean dt_iop_is_hidden(dt_iop_module_t *module);
 
+/** Whether this instance conceptually exists yet.
+ *
+ * An extra instance is created by a history item, so one whose item sits past the current
+ * history end is only a disabled pipeline node referenced by an entry the user has not reached:
+ * it exists in dev->iop but not, as far as anything the user can act on is concerned. A base
+ * instance (multi_priority 0) always exists. */
+gboolean dt_iop_module_instance_exists(dt_iop_module_t *module);
+
+/** Whether the module is part of the pipeline the user sees -- the rule the "Pipeline" tab of
+ *  the module groups panel lists modules by, so that a list of pipeline modules built anywhere
+ *  else agrees with what that tab shows. Includes disabled modules that carry history. */
+gboolean dt_iop_module_is_in_pipeline(dt_iop_module_t *module);
+
+/** Whether the module can carry a drawn mask, i.e. whether offering it one means anything.
+ *  Supports blending, and is not one of the modules that opt out of masks specifically. */
+gboolean dt_iop_module_supports_drawn_mask(dt_iop_module_t *module);
+
 /** Check if the module is currently visible in GUI */
 gboolean dt_iop_is_visible(dt_iop_module_t *module);
 

--- a/src/develop/imageop.h
+++ b/src/develop/imageop.h
@@ -447,16 +447,16 @@ gboolean dt_iop_is_hidden(dt_iop_module_t *module);
  * history end is only a disabled pipeline node referenced by an entry the user has not reached:
  * it exists in dev->iop but not, as far as anything the user can act on is concerned. A base
  * instance (multi_priority 0) always exists. */
-gboolean dt_iop_module_instance_exists(dt_iop_module_t *module);
+gboolean dt_iop_module_instance_exists(dt_iop_module_t *iop);
 
 /** Whether the module is part of the pipeline the user sees -- the rule the "Pipeline" tab of
  *  the module groups panel lists modules by, so that a list of pipeline modules built anywhere
  *  else agrees with what that tab shows. Includes disabled modules that carry history. */
-gboolean dt_iop_module_is_in_pipeline(dt_iop_module_t *module);
+gboolean dt_iop_module_is_in_pipeline(dt_iop_module_t *iop);
 
 /** Whether the module can carry a drawn mask, i.e. whether offering it one means anything.
  *  Supports blending, and is not one of the modules that opt out of masks specifically. */
-gboolean dt_iop_module_supports_drawn_mask(dt_iop_module_t *module);
+gboolean dt_iop_module_supports_drawn_mask(dt_iop_module_t *iop);
 
 /** Check if the module is currently visible in GUI */
 gboolean dt_iop_is_visible(dt_iop_module_t *module);

--- a/src/develop/masks/masks.c
+++ b/src/develop/masks/masks.c
@@ -1454,7 +1454,7 @@ void dt_masks_form_delete(dt_develop_t *dev, struct dt_iop_module_t *module, dt_
 
   if(mask_form->type & DT_MASKS_GROUP && mask_form->type & DT_MASKS_CLONE)
   {
-    // when removing a cloning group the children have to be removed, too, as they won't be shown in the mask manager
+    // when removing a cloning group the children have to be removed, too, as they won't be shown in the shape manager
     // and are thus not accessible afterwards.
     while(mask_form->points)
     {

--- a/src/develop/masks/masks.c
+++ b/src/develop/masks/masks.c
@@ -2091,6 +2091,112 @@ dt_masks_result_t dt_masks_group_get_member(dt_develop_t *dev, const int group_i
 }
 
 
+/* The membership graph queries. All three walk ->points, which is why they live here: outside the
+ * module a caller would have to reach into dt_masks_form_t and dt_masks_form_group_t to ask. */
+
+static gboolean _group_contains_recurs(dt_develop_t *dev, const int container_id, const int needle_id)
+{
+  if(container_id == needle_id) return TRUE;
+
+  const dt_masks_form_t *container = dt_masks_get_from_id(dev, container_id);
+  if(IS_NULL_PTR(container) || !(container->type & DT_MASKS_GROUP)) return FALSE;
+
+  for(const GList *pts = container->points; pts; pts = g_list_next(pts))
+  {
+    const dt_masks_form_group_t *pt = (const dt_masks_form_group_t *)pts->data;
+    if(_group_contains_recurs(dev, pt->formid, needle_id)) return TRUE;
+  }
+
+  return FALSE;
+}
+
+dt_masks_result_t dt_masks_group_contains(dt_develop_t *dev, const int container_id, const int needle_id)
+{
+  if(IS_NULL_PTR(dev)) return DT_MASKS_INVALID;
+  return _group_contains_recurs(dev, container_id, needle_id) ? DT_MASKS_OK : DT_MASKS_NOT_FOUND;
+}
+
+static gboolean _group_covers_recurs(dt_develop_t *dev, const int group_id, const int target_id,
+                                     gboolean *has_shapes)
+{
+  const dt_masks_form_t *group = dt_masks_get_from_id(dev, group_id);
+  if(IS_NULL_PTR(group) || !(group->type & DT_MASKS_GROUP)) return TRUE;
+
+  for(const GList *pts = group->points; pts; pts = g_list_next(pts))
+  {
+    const dt_masks_form_group_t *pt = (const dt_masks_form_group_t *)pts->data;
+    const dt_masks_form_t *member = dt_masks_get_from_id(dev, pt->formid);
+    if(IS_NULL_PTR(member)) continue;
+
+    if(member->type & DT_MASKS_GROUP)
+    {
+      if(!_group_covers_recurs(dev, pt->formid, target_id, has_shapes)) return FALSE;
+      continue;
+    }
+
+    if(!IS_NULL_PTR(has_shapes)) *has_shapes = TRUE;
+    if(!_group_contains_recurs(dev, target_id, pt->formid)) return FALSE;
+  }
+
+  return TRUE;
+}
+
+dt_masks_result_t dt_masks_group_covers_shapes(dt_develop_t *dev, const int group_id, const int target_id,
+                                               gboolean *has_shapes)
+{
+  if(IS_NULL_PTR(dev)) return DT_MASKS_INVALID;
+  if(!IS_NULL_PTR(has_shapes)) *has_shapes = FALSE;
+  return _group_covers_recurs(dev, group_id, target_id, has_shapes) ? DT_MASKS_OK : DT_MASKS_NOT_FOUND;
+}
+
+static gboolean _first_use_recurs(dt_develop_t *dev, const int group_id, const int formid,
+                                  int *holder_id, guint *index, const dt_masks_form_t **holder)
+{
+  const dt_masks_form_t *group = dt_masks_get_from_id(dev, group_id);
+  if(IS_NULL_PTR(group) || !(group->type & DT_MASKS_GROUP)) return FALSE;
+
+  guint i = 0;
+  for(const GList *pts = group->points; pts; pts = g_list_next(pts))
+  {
+    const dt_masks_form_group_t *pt = (const dt_masks_form_group_t *)pts->data;
+
+    if(pt->formid == formid)
+    {
+      if(!IS_NULL_PTR(holder_id)) *holder_id = group_id;
+      if(!IS_NULL_PTR(index)) *index = i;
+      *holder = group;
+      return TRUE;
+    }
+
+    /* Descend where the member sits, not after the whole level: a shape inside a member group is
+     * composited at that group's position, so pre-order is the compositing order. */
+    const dt_masks_form_t *member = dt_masks_get_from_id(dev, pt->formid);
+    if(!IS_NULL_PTR(member) && (member->type & DT_MASKS_GROUP)
+       && _first_use_recurs(dev, pt->formid, formid, holder_id, index, holder))
+      return TRUE;
+
+    i++;
+  }
+
+  return FALSE;
+}
+
+dt_masks_result_t dt_masks_group_first_use(dt_develop_t *dev, const int root_id, const int formid,
+                                           int *holder_id, guint *index,
+                                           char *holder_name, const size_t holder_name_size)
+{
+  if(IS_NULL_PTR(dev)) return DT_MASKS_INVALID;
+
+  const dt_masks_form_t *holder = NULL;
+  if(!_first_use_recurs(dev, root_id, formid, holder_id, index, &holder)) return DT_MASKS_NOT_FOUND;
+
+  // Copied, not borrowed: the next copy-on-write replaces the object the name lives in.
+  if(!IS_NULL_PTR(holder_name) && holder_name_size > 0)
+    g_strlcpy(holder_name, IS_NULL_PTR(holder) ? "" : holder->name, holder_name_size);
+
+  return DT_MASKS_OK;
+}
+
 dt_masks_result_t dt_masks_group_set_member_opacity(dt_develop_t *dev, const int group_id, const int formid,
                                                     const float opacity, dt_masks_member_t *out)
 {

--- a/src/develop/masks/masks_gui.c
+++ b/src/develop/masks/masks_gui.c
@@ -1495,7 +1495,7 @@ dt_masks_form_group_t *dt_masks_form_group_from_parentid(dt_develop_t *dev, int 
 // corrupted or maliciously crafted masks_history (a group referencing an ancestor of itself --
 // dt_masks_group_add_form guards against this interactively via _find_in_group, but a raw
 // DB/XMP load does not validate it) cannot stack-overflow the caller; the UI never nests
-// groups anywhere near this deep (see the `depth < 3` guards in libs/masks.c).
+// groups anywhere near this deep (see the `depth < 3` guards in libs/shape_manager.c).
 
 /**
  * @brief Get the selected group entry from the GUI selection index.
@@ -2182,7 +2182,7 @@ static gboolean _masks_remove_or_delete_finish(struct dt_iop_module_t *module, d
 
   if(res && next_formid > 0)
   {
-    // The mask manager rebuilds its tree on the delete/remove signal, so apply
+    // The shape manager rebuilds its tree on the delete/remove signal, so apply
     // the replacement selection after the signal has finished refreshing lists.
     mask_gui->group_selected = next_form_index;
     mask_gui->form_selected = TRUE;

--- a/src/develop/masks_group.h
+++ b/src/develop/masks_group.h
@@ -203,7 +203,7 @@ dt_masks_result_t dt_masks_group_first_use(struct dt_develop_t *dev, int root_id
  *
  * A shape's own dt_masks_form_t does not record who holds it, and the row's parentid records where
  * it was AUTHORED, not where it currently lives -- so a caller holding only a shape id, as the
- * mask-manager tree does when it lists shapes at top level, has to search. Returns the first
+ * shape manager's tree does when it lists shapes at top level, has to search. Returns the first
  * holder found; a shape referenced by two groups has no single answer, and the caller wanting a
  * specific one already knows which.
  *

--- a/src/develop/masks_group.h
+++ b/src/develop/masks_group.h
@@ -153,6 +153,52 @@ dt_masks_result_t dt_masks_group_get_member(struct dt_develop_t *dev, int group_
                                             dt_masks_member_t *out);
 
 /**
+ * @brief Whether @p container_id holds @p needle_id, at any depth (and trivially when they are
+ * the same id).
+ *
+ * The question every caller wiring one group into another has to ask first: closing a cycle in
+ * the membership graph makes every walk over it non-terminating, the tree builds included.
+ *
+ * @return DT_MASKS_OK when it does, DT_MASKS_NOT_FOUND when it does not, DT_MASKS_INVALID for a
+ *         NULL dev. A @p container_id that names no group, or names a shape, is NOT_FOUND.
+ */
+dt_masks_result_t dt_masks_group_contains(struct dt_develop_t *dev, int container_id, int needle_id);
+
+/**
+ * @brief Whether every shape @p group_id ultimately holds is also held by @p target_id.
+ *
+ * Leaf by leaf and at any depth on both sides, so it answers for a group of groups too. What it
+ * means is that nesting @p group_id into @p target_id would add no shape the target does not
+ * already apply -- NOT that it would change nothing, which is a different question the combine
+ * operators answer (a shape applied twice in difference or exclusion does change the mask).
+ *
+ * @param has_shapes (may be NULL) set to TRUE as soon as a leaf shape is met, so a caller can
+ *                   tell "all covered" from "there was nothing in it to cover".
+ * @return DT_MASKS_OK when every leaf is covered, DT_MASKS_NOT_FOUND when one is not,
+ *         DT_MASKS_INVALID for a NULL dev.
+ */
+dt_masks_result_t dt_masks_group_covers_shapes(struct dt_develop_t *dev, int group_id, int target_id,
+                                               gboolean *has_shapes);
+
+/**
+ * @brief Where the mask rooted at @p root_id FIRST applies @p formid.
+ *
+ * Walked in compositing order: a group's members in their own order, descending into a member
+ * group at the position that group sits at. A shape can legitimately appear more than once in one
+ * mask -- union and intersection are idempotent, difference and exclusion are not -- so this
+ * answers which application the later ones are read against, not which ones are redundant.
+ *
+ * @param holder_id (may be NULL) the group directly holding that first use.
+ * @param index (may be NULL) its position inside that group, i.e. its compositing rank.
+ * @param holder_name (may be NULL) copied, not borrowed, like dt_masks_form_get_info()'s name.
+ * @return DT_MASKS_OK when found, DT_MASKS_NOT_FOUND when the mask does not apply it at all,
+ *         DT_MASKS_INVALID for a NULL dev.
+ */
+dt_masks_result_t dt_masks_group_first_use(struct dt_develop_t *dev, int root_id, int formid,
+                                           int *holder_id, guint *index,
+                                           char *holder_name, size_t holder_name_size);
+
+/**
  * @brief Which group references @p formid, searching every group in dev->forms depth-first.
  *
  * A shape's own dt_masks_form_t does not record who holds it, and the row's parentid records where

--- a/src/develop/masks_gui.h
+++ b/src/develop/masks_gui.h
@@ -41,7 +41,7 @@
  * @details Cut out of develop/masks.h so that the data model and the rasterisation API no
  * longer feed widgets/draw.h (and GTK behind it) to every consumer that only wants
  * get_mask() -- which was every IOP that includes blend.h. This header is what the
- * darkroom view, libs/masks.c, blend_gui.c and the shape editors include.
+ * darkroom view, libs/shape_manager.c, blend_gui.c and the shape editors include.
  */
 
 #ifndef DT_DEVELOP_MASKS_GUI_H
@@ -80,7 +80,7 @@ typedef struct dt_masks_form_gui_t
 {
   // Owning develop instance, set once at init. Mask GUI code must use this (or an explicit
   // dev/module argument) instead of the darktable.develop global: shape handlers can run with
-  // module == NULL (mask-manager editing), and reaching for the global both couples every
+  // module == NULL (shape manager editing), and reaching for the global both couples every
   // shape file to the whole application and hides which develop instance the code mutates.
   struct dt_develop_t *dev;
 

--- a/src/libs/modulegroups.c
+++ b/src/libs/modulegroups.c
@@ -447,7 +447,10 @@ static gboolean _is_module_in_tab(dt_iop_module_t *module, dt_modulesgroups_tabs
   switch(current_tab)
   {
     case MOD_TAB_ACTIVE:
-      return (_is_module_in_history(module) || module->enabled);
+      // The one place this rule is written. Anything else that needs to list the pipeline's
+      // modules -- the shape manager's module chooser, say -- asks the same function, so the
+      // two cannot answer differently.
+      return dt_iop_module_is_in_pipeline(module);
     case MOD_TAB_ALL:
       return (_is_module_in_history(module) || module->enabled || !(module->flags() & IOP_FLAGS_DEPRECATED));
 
@@ -1166,8 +1169,6 @@ static gboolean _update_iop_visibility(gpointer user_data)
   for(int i = 0; i < MOD_TAB_LAST; i++) gtk_widget_set_visible(d->pages[i], i == tab);
 
   /* Walk every develop module and decide whether it belongs to the active tab and which box should host it. */
-  const int history_end = dt_dev_get_history_end_ext(dev);
-
   for(GList *modules = g_list_last(dev->iop); modules; modules = g_list_previous(modules))
   {
     dt_iop_module_t *module = (dt_iop_module_t *)modules->data;
@@ -1187,11 +1188,7 @@ static gboolean _update_iop_visibility(gpointer user_data)
     // FIXME: at some point, we will need to embrace the nodal paradigm and use a "create instance"
     // approach, even for the first instance, instead of mixing GUI toolboxes à la Lightroom for the first
     // (base) instance and then nodal approach for the others.
-    dt_pthread_rwlock_rdlock(&dev->history_mutex);
-    const gboolean in_history = !IS_NULL_PTR(dt_dev_history_get_last_item_by_module(dev->history, module, history_end));
-    dt_pthread_rwlock_unlock(&dev->history_mutex);
-
-    if(visible && (in_history || module->multi_priority == 0))
+    if(visible && dt_iop_module_instance_exists(module))
     {
       _modulegroups_setup_drag_source(self, module);
       _modulegroups_move_widget(w, target);

--- a/src/libs/shape_manager.c
+++ b/src/libs/shape_manager.c
@@ -180,6 +180,9 @@ typedef enum dt_masks_tree_cols_t
    * detaches. Exactly one is TRUE on a form row, and neither on the separator. */
   TREE_IC_DELETE_VISIBLE,
   TREE_IC_UNLINK_VISIBLE,
+  /* What the row has to say about itself beyond its name -- currently only that the same shape
+   * is reached twice within one module's mask. Empty on every row that has nothing to add. */
+  TREE_NOTE,
   TREE_IS_SEPARATOR,
   TREE_COUNT
 } dt_masks_tree_cols_t;
@@ -1844,6 +1847,8 @@ typedef struct _tree_row_t
   int gstate;              // the combine/invert bits this form carries inside its parent
   float opacity;
   int index;               // rank inside the parent, which _set_iter_name() shows
+  int root_id;             /* the module mask this row sits somewhere inside, 0 outside the
+                            * module list -- the scope the note below is searched in */
 } _tree_row_t;
 
 /* Every module whose drawn mask is this group, in pipeline order.
@@ -1881,6 +1886,46 @@ static dt_iop_module_t *_module_owning_group(const dt_masks_form_t *group)
   return first;
 }
 
+/* Where the module's mask FIRST applies this shape, walked the way the tree shows it: members in
+ * their own order, descending into a member group at the position that group sits at.
+ *
+ * A shape can legitimately be applied twice inside one mask, and the second application is not
+ * always a no-op -- union and intersection are idempotent, but difference squares its own
+ * factor and exclusion does not settle either (develop/masks/group.c). So neither instance can
+ * be treated as void; what the list can say is which one came first, since that is the one the
+ * later ones are read against.
+ *
+ * @return FALSE if the shape is not in this mask at all. */
+static gboolean _first_use_in_mask(dt_develop_t *dev, const int group_id, const int formid,
+                                   int *parent_id, int *index, const char **group_name)
+{
+  const dt_masks_form_t *group = dt_masks_get_from_id(dev, group_id);
+  if(IS_NULL_PTR(group) || !(group->type & DT_MASKS_GROUP)) return FALSE;
+
+  int i = 0;
+  for(const GList *pts = group->points; pts; pts = g_list_next(pts))
+  {
+    const dt_masks_form_group_t *pt = (const dt_masks_form_group_t *)pts->data;
+
+    if(pt->formid == formid)
+    {
+      *parent_id = group_id;
+      *index = i;
+      *group_name = group->name;
+      return TRUE;
+    }
+
+    const dt_masks_form_t *member = dt_masks_get_from_id(dev, pt->formid);
+    if(!IS_NULL_PTR(member) && (member->type & DT_MASKS_GROUP)
+       && _first_use_in_mask(dev, pt->formid, formid, parent_id, index, group_name))
+      return TRUE;
+
+    i++;
+  }
+
+  return FALSE;
+}
+
 /* Appends the row and returns its iter, which a group needs to hang its members from. Shapes and
  * groups are described identically here; only what happens afterwards differs. */
 static void _tree_append_row(GtkTreeStore *treestore, GtkTreeIter *toplevel, dt_shape_manager_t *lm,
@@ -1903,6 +1948,24 @@ static void _tree_append_row(GtkTreeStore *treestore, GtkTreeIter *toplevel, dt_
   int nbuse = 0;
   if(row->grp_id == 0) _is_form_used(row->form->formid, used_by, sizeof(used_by), &nbuse);
 
+  /* Only inside a module's mask, and only for a shape sitting under a group: a top-level row is
+   * not reached through anything, and a group's own duplication is a different question.
+   *
+   * Only the instances AFTER the first are marked. Both used to be, symmetrically, which said
+   * that the shape appears twice but not which application the other is measured against. */
+  gchar *note = NULL;
+  if(row->root_id > 0 && row->grp_id > 0 && !(row->form->type & DT_MASKS_GROUP))
+  {
+    int first_parent = 0;
+    int first_index = 0;
+    const char *first_group = NULL;
+    if(_first_use_in_mask(dt_dev_get_global(), row->root_id, row->form->formid, &first_parent,
+                          &first_index, &first_group)
+       && (first_parent != row->grp_id || first_index != row->index))
+      // Same wording the Drawn tab's shape list already uses for the same kind of remark.
+      note = g_strdup_printf(_("Already in '%s'"), first_group);
+  }
+
   gtk_tree_store_append(treestore, child, toplevel);
   gtk_tree_store_set(treestore, child, TREE_TEXT, row->form->name, TREE_MODULE, row->module,
                      TREE_GROUPID, row->grp_id, TREE_FORMID, row->form->formid,
@@ -1911,7 +1974,9 @@ static void _tree_append_row(GtkTreeStore *treestore, GtkTreeIter *toplevel, dt_
                      TREE_IC_INVERSE_VISIBLE, (!IS_NULL_PTR(icinv)),
                      TREE_IC_USED_VISIBLE, (nbuse > 0), TREE_USED_TEXT, used_by,
                      TREE_IC_DELETE_VISIBLE, (row->grp_id == 0),
-                     TREE_IC_UNLINK_VISIBLE, (row->grp_id != 0), -1);
+                     TREE_IC_UNLINK_VISIBLE, (row->grp_id != 0),
+                     TREE_NOTE, IS_NULL_PTR(note) ? "" : note, -1);
+  dt_free(note);
   _set_iter_name(lm, row->form, row->gstate, row->opacity, GTK_TREE_MODEL(treestore), child, row->index);
 }
 
@@ -1939,7 +2004,8 @@ static void _shape_manager_list_recurs(GtkTreeStore *treestore, GtkTreeIter *top
     {
       const _tree_row_t member_row = { .form = member, .grp_id = self.form->formid,
                                        .module = self.module, .gstate = grpt->state,
-                                       .opacity = grpt->opacity, .index = index };
+                                       .opacity = grpt->opacity, .index = index,
+                                       .root_id = self.root_id };
       _shape_manager_list_recurs(treestore, &child, lm, &member_row);
     }
     index++;
@@ -2048,7 +2114,12 @@ static gboolean _tree_store_add_forms(GtkTreeStore *treestore, dt_shape_manager_
     if(!!(form->type & DT_MASKS_GROUP) != groups) continue;
     if(_form_belongs_to(form) != which) continue;
 
-    const _tree_row_t row = { .form = form, .opacity = 1.0f };
+    /* The mask this row and everything under it belongs to. Only the module list has one: the
+     * inventory's groups are nobody's mask, so a shape under them is reached once and there is
+     * nothing to warn about. */
+    const int root_id = (which == DT_SHAPE_LIST_MODULES && groups) ? form->formid : 0;
+
+    const _tree_row_t row = { .form = form, .opacity = 1.0f, .root_id = root_id };
     _shape_manager_list_recurs(treestore, NULL, lm, &row);
     any = TRUE;
   }
@@ -2074,7 +2145,8 @@ static GtkTreeStore *_tree_store_build(dt_shape_manager_t *lm, const dt_shape_li
   GtkTreeStore *treestore = gtk_tree_store_new(TREE_COUNT, G_TYPE_STRING, G_TYPE_POINTER, G_TYPE_INT,
                                                G_TYPE_INT, G_TYPE_BOOLEAN, GDK_TYPE_PIXBUF, G_TYPE_BOOLEAN,
                                                GDK_TYPE_PIXBUF, G_TYPE_BOOLEAN, G_TYPE_BOOLEAN, G_TYPE_STRING,
-                                               G_TYPE_BOOLEAN, G_TYPE_BOOLEAN, G_TYPE_BOOLEAN);
+                                               G_TYPE_BOOLEAN, G_TYPE_BOOLEAN, G_TYPE_STRING,
+                                               G_TYPE_BOOLEAN);
   const gboolean had_groups = _tree_store_add_forms(treestore, lm, which, TRUE);
   if(which == DT_SHAPE_LIST_MODULES) return treestore;
 
@@ -2864,6 +2936,15 @@ void gui_init(dt_lib_module_t *self)
     // Kept so a freshly created group's row can be opened straight into editing.
     list->name_col = col;
     list->name_renderer = renderer;
+
+    /* What the row has to say about itself, in italics against the right end of the name column,
+     * so it reads as an annotation rather than as part of the shape's name. Empty on every row
+     * that has nothing to add, which costs those no space. */
+    renderer = gtk_cell_renderer_text_new();
+    g_object_set(renderer, "style", PANGO_STYLE_ITALIC, "xalign", 1.0f, NULL);
+    gtk_cell_renderer_set_sensitive(renderer, FALSE);
+    gtk_tree_view_column_pack_end(col, renderer, FALSE);
+    gtk_tree_view_column_add_attribute(col, renderer, "text", TREE_NOTE);
 
     renderer = gtk_cell_renderer_pixbuf_new();
     // A theme with no symbolic variant of that icon leaves the pixbuf NULL: name the icon instead

--- a/src/libs/shape_manager.c
+++ b/src/libs/shape_manager.c
@@ -40,7 +40,7 @@
 */
 #include "develop/imageop_gui.h"
 #include "develop/masks.h"
-#include "develop/masks_group.h"   // dt_masks_group_set_member_operation()
+#include "develop/masks_group.h"   // dt_masks_group_set_member_operation(), dt_masks_group_get_member()
 #include "develop/masks_gui.h"
 #include "develop/masks/masks_history.h"   // dt_masks_form_unref()
 #include "common/logging.h"
@@ -100,6 +100,12 @@ typedef struct dt_shape_manager_list_t
   /* The rightmost column, the one carrying the per-row trash / minus icon. Kept because a click
    * and a tooltip are both answered by comparing against the column the pointer is over. */
   GtkTreeViewColumn *action_col;
+
+  /* The "add to the selected module group" column, on the inventory list only -- NULL on the
+   * module list. Its renderer is kept because whether the button is available is not a property
+   * of the row but of the other list's selection, and that is a renderer-wide sensitivity. */
+  GtkTreeViewColumn *add_col;
+  GtkCellRenderer *add_renderer;
 
   dt_shape_list_t which;
   dt_lib_module_t *self;   // the module both lists belong to
@@ -611,6 +617,106 @@ static void _tree_delete_shape(GtkButton *button __attribute__((unused)), dt_sha
   dt_dev_add_history_item(dt_dev_get_global(), NULL, FALSE, TRUE);
 }
 
+/* The group the module list currently points at, which is what the inventory's "+" adds to.
+ *
+ * A row that is itself a group answers for itself; any other row hands the question up to its
+ * parent, so clicking "+" after selecting a shape inside a module's mask adds to that mask
+ * rather than doing nothing. Returns 0 when nothing usable is selected, which is also what
+ * greys the button out. */
+static int _selected_group_in_module_list(const dt_shape_manager_t *lm)
+{
+  const dt_shape_manager_list_t *list = &lm->lists[DT_SHAPE_LIST_MODULES];
+  if(IS_NULL_PTR(list->treeview)) return 0;
+
+  GtkTreeModel *model = NULL;
+  GtkTreeSelection *selection = gtk_tree_view_get_selection(GTK_TREE_VIEW(list->treeview));
+  GList *rows = gtk_tree_selection_get_selected_rows(selection, &model);
+  if(IS_NULL_PTR(rows)) return 0;
+
+  int group_id = 0;
+  GtkTreeIter iter;
+  if(gtk_tree_model_get_iter(model, &iter, (GtkTreePath *)rows->data))
+  {
+    int grid = -1;
+    int fid = -1;
+    _shape_manager_get_values(model, &iter, NULL, &grid, &fid);
+
+    const dt_masks_form_t *form = dt_masks_get_from_id(dt_dev_get_global(), fid);
+    if(!IS_NULL_PTR(form) && (form->type & DT_MASKS_GROUP))
+      group_id = fid;
+    else if(grid > 0)
+      group_id = grid;
+  }
+
+  g_list_free_full(rows, (GDestroyNotify)gtk_tree_path_free);
+  return group_id;
+}
+
+/* Whether container_id holds needle_id, at any depth. A group added to a group that already
+ * contains it would make the membership graph cyclic, and every walk over it -- the tree build
+ * first of all -- would not terminate. */
+static gboolean _group_contains(const dt_develop_t *dev, const int container_id, const int needle_id)
+{
+  if(container_id == needle_id) return TRUE;
+
+  const dt_masks_form_t *container = dt_masks_get_from_id((dt_develop_t *)dev, container_id);
+  if(IS_NULL_PTR(container) || !(container->type & DT_MASKS_GROUP)) return FALSE;
+
+  for(const GList *pts = container->points; pts; pts = g_list_next(pts))
+  {
+    const dt_masks_form_group_t *pt = (const dt_masks_form_group_t *)pts->data;
+    if(_group_contains(dev, pt->formid, needle_id)) return TRUE;
+  }
+
+  return FALSE;
+}
+
+/* The "+" is available exactly when the module list points at a group. That is a property of the
+ * other list's selection rather than of any row, so it is the renderer's own sensitivity, and
+ * the inventory has to be redrawn when it changes. */
+static void _shape_manager_sync_add_sensitivity(const dt_shape_manager_t *lm)
+{
+  const dt_shape_manager_list_t *list = &lm->lists[DT_SHAPE_LIST_SHAPES];
+  if(IS_NULL_PTR(list->add_renderer)) return;
+
+  const gboolean available = (_selected_group_in_module_list(lm) > 0);
+  if(gtk_cell_renderer_get_sensitive(list->add_renderer) == available) return;
+
+  gtk_cell_renderer_set_sensitive(list->add_renderer, available);
+  if(!IS_NULL_PTR(list->treeview)) gtk_widget_queue_draw(list->treeview);
+}
+
+/* The inventory's "+": add this row's form to the group the module list points at. */
+static void _tree_row_add_to_group(dt_shape_manager_list_t *list, GtkTreeModel *model, GtkTreeIter *iter)
+{
+  dt_lib_module_t *self = list->self;
+  dt_shape_manager_t *lm = (dt_shape_manager_t *)self->data;
+  dt_develop_t *const dev = dt_dev_get_global();
+
+  const int group_id = _selected_group_in_module_list(lm);
+  if(group_id <= 0) return;
+
+  int fid = -1;
+  _shape_manager_get_values(model, iter, NULL, NULL, &fid);
+
+  dt_masks_form_t *form = dt_masks_get_from_id(dev, fid);
+  dt_masks_form_t *grp = dt_masks_get_from_id(dev, group_id);
+  if(IS_NULL_PTR(form) || IS_NULL_PTR(grp) || !(grp->type & DT_MASKS_GROUP)) return;
+
+  // Adding a group to itself, or to one of its own descendants, would close a cycle.
+  if(_group_contains(dev, fid, group_id)) return;
+
+  // Already a member: nothing to add, and a no-op must not write an undo step.
+  if(dt_masks_group_get_member(dev, group_id, fid, NULL) == DT_MASKS_OK) return;
+
+  grp = dt_masks_cow_touch(dev, grp);
+  if(IS_NULL_PTR(dt_masks_group_add_form(dev, grp, form))) return;
+
+  dt_dev_add_history_item(dev, NULL, FALSE, TRUE);
+  _shape_manager_recreate_list(self);
+  _shape_manager_broadcast(self, 0, 0, DT_MASKS_EVENT_CHANGE);
+}
+
 /* The per-row action icon at the right end of every form row, the same two the shape lists of
  * the Drawn tab offer (develop/blend_gui.c): a top-level row carries a trash and is deleted from
  * every mask and from the list of shapes, a row under a group carries a minus and is only
@@ -751,6 +857,12 @@ static void _tree_selection_change(GtkTreeSelection *selection, dt_shape_manager
 {
   const dt_shape_manager_t *lm = (const dt_shape_manager_t *)list->self->data;
   dt_develop_t *const dev = dt_dev_get_global();
+
+  /* Ahead of the gui_reset gate: what the module list points at decides whether the inventory's
+   * "+" is available, and that stays true while the panel is driving itself -- a rebuild
+   * reselects rows with gui_reset raised, and the button must follow. */
+  if(list->which == DT_SHAPE_LIST_MODULES) _shape_manager_sync_add_sensitivity(lm);
+
   if(lm->gui_reset) return;
   dt_masks_form_gui_t *creation_gui = dev->form_gui;
   if(!IS_NULL_PTR(creation_gui) && creation_gui->creation) return;
@@ -1089,12 +1201,23 @@ static int _tree_button_pressed(GtkWidget *treeview, GdkEventButton *event, dt_s
   /* single click with the right mouse button? */
   if(event->type == GDK_BUTTON_PRESS && event->button == 1)
   {
-    // The action icons act on the row under the pointer alone, whatever is selected: they are
-    // buttons the row carries, not a command applied to the selection.
+    // The action icons act on the row under the pointer alone, whatever is selected in this
+    // list: they are buttons the row carries, not a command applied to the selection.
     if(on_row && mouse_col == list->action_col)
     {
       gtk_tree_path_free(mouse_path);
       _tree_row_action(list, model, &iter);
+      return 1;
+    }
+
+    /* The "+" is the one exception: it reads the OTHER list's selection, which is what it adds
+     * to. Greyed out when there is none, and then a click on it does nothing rather than
+     * falling through to selecting the row -- the row under a disabled button is not what the
+     * user was aiming at. */
+    if(on_row && !IS_NULL_PTR(list->add_col) && mouse_col == list->add_col)
+    {
+      gtk_tree_path_free(mouse_path);
+      _tree_row_add_to_group(list, model, &iter);
       return 1;
     }
 
@@ -1194,12 +1317,14 @@ static gboolean _tree_query_tooltip(GtkWidget *widget, gint x, gint y, gboolean 
     {
       GtkTreeIter action_iter;
       int grid = -1;
-      gboolean got = (action_column == list->action_col)
+      const gboolean on_action = (action_column == list->action_col);
+      const gboolean on_add = !IS_NULL_PTR(list->add_col) && (action_column == list->add_col);
+      gboolean got = (on_action || on_add)
                      && gtk_tree_model_get_iter(model, &action_iter, action_path);
       if(got) _shape_manager_get_values(model, &action_iter, NULL, &grid, NULL);
       gtk_tree_path_free(action_path);
 
-      if(got)
+      if(got && on_action)
       {
         gtk_tooltip_set_text(tooltip,
                              (grid == 0)
@@ -1207,6 +1332,26 @@ static gboolean _tree_query_tooltip(GtkWidget *widget, gint x, gint y, gboolean 
                                      "and removed from the list of available shapes.")
                                  : _("Detach this shape from the mask. The shape is kept and stays "
                                      "available for reuse."));
+        return TRUE;
+      }
+
+      if(got && on_add)
+      {
+        // The button says what it will do, so it has to name what is selected right now.
+        const dt_shape_manager_t *lm = (const dt_shape_manager_t *)list->self->data;
+        const int group_id = _selected_group_in_module_list(lm);
+        const dt_masks_form_t *grp = dt_masks_get_from_id(dt_dev_get_global(), group_id);
+
+        if(IS_NULL_PTR(grp))
+        {
+          gtk_tooltip_set_text(tooltip, _("Select a mask in the module groups list to add this shape to it."));
+        }
+        else
+        {
+          gchar *text = g_strdup_printf(_("Add this shape to the mask '%s'."), grp->name);
+          gtk_tooltip_set_text(tooltip, text);
+          dt_free(text);
+        }
         return TRUE;
       }
     }
@@ -1616,6 +1761,9 @@ static void _shape_manager_recreate_list(dt_lib_module_t *self)
   }
 
   lm->gui_reset = gui_reset;
+
+  // Both models were replaced, so whatever the module list held may or may not have come back.
+  _shape_manager_sync_add_sensitivity(lm);
 
   if(!IS_NULL_PTR(follow))
     _tree_selection_change(gtk_tree_view_get_selection(GTK_TREE_VIEW(follow->treeview)), follow);
@@ -2293,6 +2441,23 @@ void gui_init(dt_lib_module_t *self)
      * which is what keeps the action flush right. Clicks are answered in _tree_button_pressed()
      * by comparing the column, the way develop/blend_gui.c does for the same two icons. */
     gtk_tree_view_column_set_expand(col, TRUE);
+
+    /* The inventory's "+", between the "used by" icon and the trash. Shown on the same rows the
+     * trash is -- the top-level ones -- and greyed out until the module list points at a mask. */
+    if(list->which == DT_SHAPE_LIST_SHAPES)
+    {
+      list->add_col = gtk_tree_view_column_new();
+      gtk_tree_view_column_set_sizing(list->add_col, GTK_TREE_VIEW_COLUMN_FIXED);
+      gtk_tree_view_column_set_fixed_width(list->add_col, DT_PIXEL_APPLY_DPI(24));
+
+      list->add_renderer = gtk_cell_renderer_pixbuf_new();
+      g_object_set(list->add_renderer, "icon-name", "list-add-symbolic", "stock-size", GTK_ICON_SIZE_MENU, NULL);
+      gtk_cell_renderer_set_sensitive(list->add_renderer, FALSE);
+      gtk_tree_view_column_pack_start(list->add_col, list->add_renderer, FALSE);
+      gtk_tree_view_column_add_attribute(list->add_col, list->add_renderer, "visible", TREE_IC_DELETE_VISIBLE);
+
+      gtk_tree_view_append_column(GTK_TREE_VIEW(list->treeview), list->add_col);
+    }
 
     list->action_col = gtk_tree_view_column_new();
     gtk_tree_view_column_set_sizing(list->action_col, GTK_TREE_VIEW_COLUMN_FIXED);

--- a/src/libs/shape_manager.c
+++ b/src/libs/shape_manager.c
@@ -2761,7 +2761,7 @@ void gui_init(dt_lib_module_t *self)
   g_idle_add((GSourceFunc)_shape_manager_add_popup_button_idle, d);
   g_signal_connect(G_OBJECT(d->popup_button), "toggled", G_CALLBACK(_shape_manager_popup_button_toggled_cb), d);
 
-  // From here, everything goes into the mask manager popup,
+  // From here, everything goes into the shape manager popup,
   // so there is no child added to self->widget from here.
   const dt_masks_shape_buttons_config_t shape_buttons_config = {
     .dev = dt_dev_get_global(),

--- a/src/libs/shape_manager.c
+++ b/src/libs/shape_manager.c
@@ -61,8 +61,10 @@
 #include "common/conf.h"          // dt_conf_get_int(), dt_conf_key_exists()
 
 #include "widgets/label.h"   // dt_gui_symbolic_icon_pixbuf()
+#include "widgets/dialog.h"        // dt_gui_refocus_parent()
 #include "widgets/togglebutton.h"
 #include "control/signal.h"
+#include "control/user_message.h"   // dt_control_log()
 
 #ifdef GDK_WINDOWING_WAYLAND
 #include <gdk/gdkwayland.h>   // conditional-ok: GDK_IS_WAYLAND_DISPLAY() is used only inside the same #ifdef
@@ -106,6 +108,14 @@ typedef struct dt_shape_manager_list_t
    * by comparing against the column the pointer is over. */
   GtkTreeViewColumn *add_col;
 
+  /* The "pick the modules that should render this" column, inventory only. */
+  GtkTreeViewColumn *assign_col;
+
+  /* The name column and the renderer inside it, kept so a row can be opened straight into
+   * editing -- gtk_tree_view_set_cursor_on_cell() needs both. */
+  GtkTreeViewColumn *name_col;
+  GtkCellRenderer *name_renderer;
+
   dt_shape_list_t which;
   dt_lib_module_t *self;   // the module both lists belong to
 } dt_shape_manager_list_t;
@@ -124,6 +134,7 @@ typedef struct dt_shape_manager_t
    * so availability is shown by swapping the icon for a differently tinted one. */
   GdkPixbuf *ic_add;
   GdkPixbuf *ic_add_off;
+  GdkPixbuf *ic_assign;
   GdkPixbuf *ic_inverse;
   GdkPixbuf *ic_union;
   GdkPixbuf *ic_intersection;
@@ -675,6 +686,34 @@ static gboolean _group_contains(const dt_develop_t *dev, const int container_id,
   return FALSE;
 }
 
+/* Whether every shape the group ultimately holds is already rendered by the target, directly or
+ * through one of its own sub-groups. Sets *any as soon as it meets a leaf shape, so a caller can
+ * tell "all covered" from "nothing in it to cover". */
+static gboolean _group_leaves_all_in(dt_develop_t *dev, const int group_id, const int target_id,
+                                     gboolean *any)
+{
+  const dt_masks_form_t *group = dt_masks_get_from_id(dev, group_id);
+  if(IS_NULL_PTR(group) || !(group->type & DT_MASKS_GROUP)) return TRUE;
+
+  for(const GList *pts = group->points; pts; pts = g_list_next(pts))
+  {
+    const dt_masks_form_group_t *pt = (const dt_masks_form_group_t *)pts->data;
+    const dt_masks_form_t *member = dt_masks_get_from_id(dev, pt->formid);
+    if(IS_NULL_PTR(member)) continue;
+
+    if(member->type & DT_MASKS_GROUP)
+    {
+      if(!_group_leaves_all_in(dev, pt->formid, target_id, any)) return FALSE;
+      continue;
+    }
+
+    *any = TRUE;
+    if(!_group_contains(dev, target_id, pt->formid)) return FALSE;
+  }
+
+  return TRUE;
+}
+
 /* Whether this row's "+" can do anything. Three ways it cannot: nothing is selected in the module
  * list, so there is nowhere to add to; the form is already a member of that group, and re-adding
  * it would write an undo step for a no-op; or the row is a group that already contains the
@@ -697,6 +736,16 @@ static gboolean _row_can_be_added(const dt_shape_manager_t *lm, GtkTreeModel *mo
 
   if(dt_masks_group_get_member(dev, group_id, fid, NULL) == DT_MASKS_OK) return FALSE;
   if(_group_contains(dev, fid, group_id)) return FALSE;
+
+  /* A group every one of whose shapes the target already renders would add nothing: nesting it
+   * duplicates coverage the mask already has. Checked leaf by leaf and at any depth on both
+   * sides, so it holds for a group of groups too. */
+  const dt_masks_form_t *row_form = dt_masks_get_from_id(dev, fid);
+  if(!IS_NULL_PTR(row_form) && (row_form->type & DT_MASKS_GROUP))
+  {
+    gboolean any = FALSE;
+    if(_group_leaves_all_in(dev, fid, group_id, &any) && any) return FALSE;
+  }
 
   return TRUE;
 }
@@ -735,6 +784,309 @@ static void _shape_manager_sync_add_sensitivity(const dt_shape_manager_t *lm)
   const dt_shape_manager_list_t *list = &lm->lists[DT_SHAPE_LIST_SHAPES];
   if(IS_NULL_PTR(list->add_col) || IS_NULL_PTR(list->treeview)) return;
   gtk_widget_queue_draw(list->treeview);
+}
+
+/* Opens the module list's row for that group straight into name editing.
+ *
+ * The tree has just been rebuilt, so the row is found by id rather than kept across the rebuild:
+ * every iter from before it is stale. Only a top-level row is editable (TREE_EDITABLE), which a
+ * module group in that list always is. */
+static void _tree_edit_group_name(dt_lib_module_t *self, const int formid)
+{
+  dt_shape_manager_t *lm = (dt_shape_manager_t *)self->data;
+  const dt_shape_manager_list_t *list = &lm->lists[DT_SHAPE_LIST_MODULES];
+  if(IS_NULL_PTR(list->treeview) || IS_NULL_PTR(list->name_col) || IS_NULL_PTR(list->name_renderer))
+    return;
+
+  GtkTreeModel *model = gtk_tree_view_get_model(GTK_TREE_VIEW(list->treeview));
+  if(!GTK_IS_TREE_MODEL(model)) return;
+
+  GtkTreeIter iter;
+  if(!gtk_tree_model_get_iter_first(model, &iter)) return;
+
+  do
+  {
+    int fid = -1;
+    _shape_manager_get_values(model, &iter, NULL, NULL, &fid);
+    if(fid != formid) continue;
+
+    GtkTreePath *path = gtk_tree_model_get_path(model, &iter);
+    if(!IS_NULL_PTR(path))
+    {
+      gtk_tree_view_set_cursor_on_cell(GTK_TREE_VIEW(list->treeview), path, list->name_col,
+                                       list->name_renderer, TRUE);
+      gtk_tree_path_free(path);
+    }
+    return;
+  } while(gtk_tree_model_iter_next(model, &iter));
+}
+
+/* ---------------------------------------------------------------------------------------------
+ * The module chooser: which modules should render a shape.
+ *
+ * Same set of modules as the "Pipeline" tab of the module groups panel, in the same order --
+ * dev->iop walked backwards, so the list reads bottom-up the way the pipeline is applied --
+ * narrowed to the ones a drawn mask means anything to. Disabled modules are in: attaching a mask
+ * to a module that is off is legitimate, it applies the day the module is switched on.
+ * ------------------------------------------------------------------------------------------- */
+
+typedef enum dt_modchooser_col_t
+{
+  MODCHOOSER_CHECKED = 0,
+  MODCHOOSER_WAS_CHECKED,   // as the dialog opened, so validation can act on the difference
+  MODCHOOSER_NAME,
+  MODCHOOSER_MODULE,
+  MODCHOOSER_COUNT
+} dt_modchooser_col_t;
+
+static void _modchooser_toggled(GtkCellRendererToggle *cell __attribute__((unused)), gchar *path_string,
+                                GtkListStore *store)
+{
+  GtkTreeIter iter;
+  if(!gtk_tree_model_get_iter_from_string(GTK_TREE_MODEL(store), &iter, path_string)) return;
+
+  gboolean checked = FALSE;
+  gtk_tree_model_get(GTK_TREE_MODEL(store), &iter, MODCHOOSER_CHECKED, &checked, -1);
+  gtk_list_store_set(store, &iter, MODCHOOSER_CHECKED, !checked, -1);
+}
+
+/* A left click anywhere on the row toggles it, not just on the 12 pixels of the checkbox. */
+static gboolean _modchooser_button_pressed(GtkWidget *treeview, GdkEventButton *event,
+                                           GtkListStore *store)
+{
+  if(event->type != GDK_BUTTON_PRESS || event->button != GDK_BUTTON_PRIMARY) return FALSE;
+
+  GtkTreePath *path = NULL;
+  if(!gtk_tree_view_get_path_at_pos(GTK_TREE_VIEW(treeview), (gint)event->x, (gint)event->y, &path,
+                                    NULL, NULL, NULL))
+    return FALSE;
+
+  gchar *path_string = gtk_tree_path_to_string(path);
+  gtk_tree_path_free(path);
+  _modchooser_toggled(NULL, path_string, store);
+  dt_free(path_string);
+
+  return TRUE;
+}
+
+/* Runs the attachment manager modally and answers with what the user changed: the modules to
+ * attach the shape to, and the ones to detach it from. Both lists are in the order the modules
+ * were listed, borrow their modules, and are freed by the caller with g_list_free().
+ *
+ * A box is ticked when the shape is already a DIRECT member of that module's mask. Direct, not
+ * at any depth: the box is the attachment this dialog manages, and unticking it has to be able
+ * to undo exactly what ticking it did. A shape reaching a module through a nested group is that
+ * group's business, not this dialog's.
+ *
+ * @return whether the user validated; both lists are empty when nothing changed. */
+static gboolean _modchooser_run(const dt_masks_form_t *form, GList **to_attach, GList **to_detach)
+{
+  *to_attach = NULL;
+  *to_detach = NULL;
+
+  dt_develop_t *const dev = dt_dev_get_global();
+  GtkListStore *store = gtk_list_store_new(MODCHOOSER_COUNT, G_TYPE_BOOLEAN, G_TYPE_BOOLEAN,
+                                           G_TYPE_STRING, G_TYPE_POINTER);
+
+  gboolean any = FALSE;
+  for(const GList *iops = g_list_last(dt_dev_get_global()->iop); iops; iops = g_list_previous(iops))
+  {
+    dt_iop_module_t *module = (dt_iop_module_t *)iops->data;
+    if(!dt_iop_module_is_in_pipeline(module) || !dt_iop_module_supports_drawn_mask(module)) continue;
+
+    const gboolean attached
+        = (dt_masks_group_get_member(dev, module->blend_params->mask_id, form->formid, NULL) == DT_MASKS_OK);
+
+    gchar *label = dt_history_item_get_name(module);
+    GtkTreeIter iter;
+    gtk_list_store_append(store, &iter);
+    gtk_list_store_set(store, &iter, MODCHOOSER_CHECKED, attached, MODCHOOSER_WAS_CHECKED, attached,
+                       MODCHOOSER_NAME, label, MODCHOOSER_MODULE, module, -1);
+    dt_free(label);
+    any = TRUE;
+  }
+
+  if(!any)
+  {
+    g_object_unref(store);
+    dt_control_log(_("No module in the pipeline can carry a drawn mask."));
+    return FALSE;
+  }
+
+  /* Parented to the main window rather than to the shape manager's own panel: that panel is a
+   * UTILITY window that declines focus, which is not something to hang a modal dialog off. */
+  GtkWindow *parent = GTK_WINDOW(dt_gui_main_window());
+  GtkWidget *dialog = gtk_dialog_new_with_buttons(_("Modules using this shape"), parent,
+                                                  GTK_DIALOG_DESTROY_WITH_PARENT | GTK_DIALOG_MODAL,
+                                                  _("Cancel"), GTK_RESPONSE_CANCEL,
+                                                  _("Apply"), GTK_RESPONSE_ACCEPT, NULL);
+  gtk_dialog_set_default_response(GTK_DIALOG(dialog), GTK_RESPONSE_ACCEPT);
+
+  GtkWidget *content = gtk_dialog_get_content_area(GTK_DIALOG(dialog));
+  gtk_container_set_border_width(GTK_CONTAINER(content), DT_GUI_BOX_SPACING);
+  gtk_box_set_spacing(GTK_BOX(content), DT_GUI_BOX_SPACING);
+
+  gchar *intro = g_strdup_printf(_("Tick the modules that should use the shape '%s', untick the ones "
+                                   "that should stop."), form->name);
+  GtkWidget *label = dt_ui_label_new(intro);
+  dt_free(intro);
+  gtk_box_pack_start(GTK_BOX(content), label, FALSE, FALSE, 0);
+
+  GtkWidget *treeview = gtk_tree_view_new_with_model(GTK_TREE_MODEL(store));
+  gtk_tree_view_set_headers_visible(GTK_TREE_VIEW(treeview), FALSE);
+  gtk_tree_selection_set_mode(gtk_tree_view_get_selection(GTK_TREE_VIEW(treeview)), GTK_SELECTION_NONE);
+
+  GtkTreeViewColumn *col = gtk_tree_view_column_new();
+  GtkCellRenderer *renderer = gtk_cell_renderer_toggle_new();
+  g_object_set(renderer, "activatable", TRUE, NULL);
+  g_signal_connect(renderer, "toggled", G_CALLBACK(_modchooser_toggled), store);
+  gtk_tree_view_column_pack_start(col, renderer, FALSE);
+  gtk_tree_view_column_add_attribute(col, renderer, "active", MODCHOOSER_CHECKED);
+
+  renderer = gtk_cell_renderer_text_new();
+  gtk_tree_view_column_pack_start(col, renderer, TRUE);
+  gtk_tree_view_column_add_attribute(col, renderer, "text", MODCHOOSER_NAME);
+  gtk_tree_view_append_column(GTK_TREE_VIEW(treeview), col);
+
+  g_signal_connect(treeview, "button-press-event", G_CALLBACK(_modchooser_button_pressed), store);
+
+  gtk_box_pack_start(GTK_BOX(content),
+                     dt_ui_scroll_wrap(treeview, 200, "plugins/darkroom/masks/modulechooserheight",
+                                       DT_UI_RESIZE_DYNAMIC),
+                     TRUE, TRUE, 0);
+
+  gtk_widget_show_all(dialog);
+  const gint response = gtk_dialog_run(GTK_DIALOG(dialog));
+
+  if(response == GTK_RESPONSE_ACCEPT)
+  {
+    GtkTreeIter iter;
+    gboolean valid = gtk_tree_model_get_iter_first(GTK_TREE_MODEL(store), &iter);
+    while(valid)
+    {
+      gboolean checked = FALSE;
+      gboolean was_checked = FALSE;
+      dt_iop_module_t *module = NULL;
+      gtk_tree_model_get(GTK_TREE_MODEL(store), &iter, MODCHOOSER_CHECKED, &checked,
+                         MODCHOOSER_WAS_CHECKED, &was_checked, MODCHOOSER_MODULE, &module, -1);
+
+      // Only the rows the user actually moved: an untouched module is left exactly as it was.
+      if(!IS_NULL_PTR(module) && checked != was_checked)
+      {
+        if(checked)
+          *to_attach = g_list_prepend(*to_attach, module);
+        else
+          *to_detach = g_list_prepend(*to_detach, module);
+      }
+
+      valid = gtk_tree_model_iter_next(GTK_TREE_MODEL(store), &iter);
+    }
+    *to_attach = g_list_reverse(*to_attach);
+    *to_detach = g_list_reverse(*to_detach);
+  }
+
+  gtk_widget_destroy(dialog);
+  g_object_unref(store);
+  dt_gui_refocus_parent(parent);
+
+  return response == GTK_RESPONSE_ACCEPT;
+}
+
+/* Puts the row's form to work in the modules the user picks.
+ *
+ * One group is created and SHARED by every picked module that has no mask of its own -- the link
+ * is each module's own blend_params->mask_id, so several naming the same group is exactly what a
+ * shared mask is, and nothing else has to be stored for it. A module that already has a mask
+ * keeps it and receives the shape into it instead: repointing it at the shared group would
+ * orphan the shapes it already carries. */
+static void _tree_row_assign_to_modules(dt_shape_manager_list_t *list, GtkTreeModel *model,
+                                        GtkTreeIter *iter)
+{
+  dt_lib_module_t *self = list->self;
+  dt_develop_t *const dev = dt_dev_get_global();
+
+  int fid = -1;
+  _shape_manager_get_values(model, iter, NULL, NULL, &fid);
+  dt_masks_form_t *form = dt_masks_get_from_id(dev, fid);
+  if(IS_NULL_PTR(form)) return;
+
+  GList *to_attach = NULL;
+  GList *to_detach = NULL;
+  if(!_modchooser_run(form, &to_attach, &to_detach)) return;
+
+  dt_masks_form_t *shared = NULL;
+  gboolean changed = FALSE;
+
+  /* Detaching first, so a module the user unticked and a module they ticked cannot fight over
+   * the same group within one validation. Note what a shared group means here: the shape is
+   * removed from the GROUP, so every module rendering that group stops using it -- there is one
+   * membership, not one per module. Reopening the dialog shows exactly that. */
+  for(const GList *m = to_detach; m; m = g_list_next(m))
+  {
+    dt_iop_module_t *module = (dt_iop_module_t *)m->data;
+    dt_masks_form_t *own = dt_masks_get_from_id(dev, module->blend_params->mask_id);
+    if(IS_NULL_PTR(own) || !(own->type & DT_MASKS_GROUP)) continue;
+
+    // Empties the group and deletes it if nothing is left, which dt_masks_form_delete() handles.
+    dt_masks_form_delete(dev, module, own, form);
+    dt_iop_gui_blend_masks_update(module);
+    changed = TRUE;
+  }
+
+  for(const GList *m = to_attach; m; m = g_list_next(m))
+  {
+    dt_iop_module_t *module = (dt_iop_module_t *)m->data;
+    dt_masks_form_t *own = dt_masks_get_from_id(dev, module->blend_params->mask_id);
+
+    if(!IS_NULL_PTR(own) && (own->type & DT_MASKS_GROUP))
+    {
+      // The module already renders a mask: add the shape to it rather than replacing it.
+      if(dt_masks_group_get_member(dev, own->formid, fid, NULL) == DT_MASKS_OK) continue;
+      if(_group_contains(dev, fid, own->formid)) continue;
+
+      own = dt_masks_cow_touch(dev, own);
+      if(IS_NULL_PTR(dt_masks_group_add_form(dev, own, form))) continue;
+
+      dt_iop_gui_blend_masks_update(module);
+      changed = TRUE;
+      continue;
+    }
+
+    if(IS_NULL_PTR(shared))
+    {
+      /* Named after the first module that needs it, which is the first ticked one in pipeline
+       * order -- the name is the user's to change, and the rename below opens on it. */
+      shared = dt_masks_create_ext(dev, DT_MASKS_GROUP);
+      if(IS_NULL_PTR(shared)) break;
+
+      gchar *name = dt_dev_get_masks_group_name(module);
+      g_strlcpy(shared->name, name, sizeof(shared->name));
+      dt_free(name);
+
+      dt_masks_group_add_form_with_state(dev, shared, form, shared->formid,
+                                         DT_MASKS_STATE_USE | DT_MASKS_STATE_UNION, 1.0f);
+      dt_masks_append_form(dev, shared);
+      changed = TRUE;
+    }
+
+    if(dt_iop_gui_blend_set_drawn_mask_group(module, shared))
+    {
+      // A module's blend_params are its own history entry; the forms get one of their own below.
+      dt_dev_add_history_item(dev, module, TRUE, TRUE);
+      changed = TRUE;
+    }
+  }
+
+  g_list_free(to_attach);
+  g_list_free(to_detach);
+  if(!changed) return;
+
+  dt_dev_add_history_item(dev, NULL, FALSE, TRUE);
+  _shape_manager_recreate_list(self);
+  _shape_manager_broadcast(self, 0, 0, DT_MASKS_EVENT_CHANGE);
+
+  // A group the user has just conjured wants a name, so its row opens straight into editing.
+  if(!IS_NULL_PTR(shared)) _tree_edit_group_name(self, shared->formid);
 }
 
 /* The inventory's "+": add this row's form to the group the module list points at. */
@@ -1265,6 +1617,13 @@ static int _tree_button_pressed(GtkWidget *treeview, GdkEventButton *event, dt_s
       return 1;
     }
 
+    if(on_row && !IS_NULL_PTR(list->assign_col) && mouse_col == list->assign_col)
+    {
+      gtk_tree_path_free(mouse_path);
+      _tree_row_assign_to_modules(list, model, &iter);
+      return 1;
+    }
+
     handled = _tree_apply_click_selection(treeview, selection, event, mouse_path);
   }
   else if(event->type == GDK_BUTTON_PRESS && event->button == 3)
@@ -1363,7 +1722,8 @@ static gboolean _tree_query_tooltip(GtkWidget *widget, gint x, gint y, gboolean 
       int grid = -1;
       const gboolean on_action = (action_column == list->action_col);
       const gboolean on_add = !IS_NULL_PTR(list->add_col) && (action_column == list->add_col);
-      gboolean got = (on_action || on_add)
+      const gboolean on_assign = !IS_NULL_PTR(list->assign_col) && (action_column == list->assign_col);
+      gboolean got = (on_action || on_add || on_assign)
                      && gtk_tree_model_get_iter(model, &action_iter, action_path);
       if(got) _shape_manager_get_values(model, &action_iter, NULL, &grid, NULL);
       gtk_tree_path_free(action_path);
@@ -1376,6 +1736,13 @@ static gboolean _tree_query_tooltip(GtkWidget *widget, gint x, gint y, gboolean 
                                      "and removed from the list of available shapes.")
                                  : _("Detach this shape from the mask. The shape is kept and stays "
                                      "available for reuse."));
+        return TRUE;
+      }
+
+      if(got && on_assign)
+      {
+        gtk_tooltip_set_text(tooltip, _("Manage which modules use this shape. A mask is created for the "
+                                        "ticked ones that have none, and shared between them."));
         return TRUE;
       }
 
@@ -1403,10 +1770,12 @@ static gboolean _tree_query_tooltip(GtkWidget *widget, gint x, gint y, gboolean 
             text = g_strdup_printf(_("Add this shape to the mask '%s'."), grp->name);
           else if(member)
             text = g_strdup_printf(_("This shape is already part of the mask '%s'."), grp->name);
-          else
-            // The remaining refusal: this group already holds the mask, at some depth.
+          else if(_group_contains(dt_dev_get_global(), fid, group_id))
             text = g_strdup_printf(_("This group cannot be added to the mask '%s': it already contains it."),
                                    grp->name);
+          else
+            // The remaining refusal: every shape it holds is already in the target.
+            text = g_strdup_printf(_("The mask '%s' already uses every shape of this group."), grp->name);
           gtk_tooltip_set_text(tooltip, text);
           dt_free(text);
         }
@@ -2442,6 +2811,7 @@ void gui_init(dt_lib_module_t *self)
 
   d->ic_add = dt_gui_symbolic_icon_pixbuf("list-add-symbolic", GTK_ICON_SIZE_MENU, &fg_color, NULL);
   d->ic_add_off = dt_gui_symbolic_icon_pixbuf("list-add-symbolic", GTK_ICON_SIZE_MENU, &used_color, NULL);
+  d->ic_assign = dt_gui_symbolic_icon_pixbuf("view-list-symbolic", GTK_ICON_SIZE_MENU, &fg_color, NULL);
 
   /* The two lists sit side by side in a paned, so the split is the user's and persists. Each
    * half is built identically -- the only thing that differs between them is which forms their
@@ -2491,6 +2861,9 @@ void gui_init(dt_lib_module_t *self)
     gtk_tree_view_column_add_attribute(col, renderer, "text", TREE_TEXT);
     gtk_tree_view_column_add_attribute(col, renderer, "editable", TREE_EDITABLE);
     g_signal_connect(renderer, "edited", (GCallback)_tree_cell_edited, list);
+    // Kept so a freshly created group's row can be opened straight into editing.
+    list->name_col = col;
+    list->name_renderer = renderer;
 
     renderer = gtk_cell_renderer_pixbuf_new();
     // A theme with no symbolic variant of that icon leaves the pixbuf NULL: name the icon instead
@@ -2529,6 +2902,22 @@ void gui_init(dt_lib_module_t *self)
       gtk_tree_view_column_set_cell_data_func(list->add_col, renderer, _add_cell_data_func, d, NULL);
 
       gtk_tree_view_append_column(GTK_TREE_VIEW(list->treeview), list->add_col);
+
+      /* And next to it, the button that picks the modules instead of reusing a selected mask.
+       * Always available: it needs nothing selected anywhere. */
+      list->assign_col = gtk_tree_view_column_new();
+      gtk_tree_view_column_set_sizing(list->assign_col, GTK_TREE_VIEW_COLUMN_FIXED);
+      gtk_tree_view_column_set_fixed_width(list->assign_col, DT_PIXEL_APPLY_DPI(24));
+
+      renderer = gtk_cell_renderer_pixbuf_new();
+      if(IS_NULL_PTR(d->ic_assign))
+        g_object_set(renderer, "icon-name", "view-list-symbolic", "stock-size", GTK_ICON_SIZE_MENU, NULL);
+      else
+        g_object_set(renderer, "pixbuf", d->ic_assign, NULL);
+      gtk_tree_view_column_pack_start(list->assign_col, renderer, FALSE);
+      gtk_tree_view_column_add_attribute(list->assign_col, renderer, "visible", TREE_IC_DELETE_VISIBLE);
+
+      gtk_tree_view_append_column(GTK_TREE_VIEW(list->treeview), list->assign_col);
     }
 
     list->action_col = gtk_tree_view_column_new();
@@ -2622,6 +3011,7 @@ void gui_cleanup(dt_lib_module_t *self)
     if(!IS_NULL_PTR(d->ic_used)) g_object_unref(d->ic_used);
     if(!IS_NULL_PTR(d->ic_add)) g_object_unref(d->ic_add);
     if(!IS_NULL_PTR(d->ic_add_off)) g_object_unref(d->ic_add_off);
+    if(!IS_NULL_PTR(d->ic_assign)) g_object_unref(d->ic_assign);
     if(!IS_NULL_PTR(d->ic_inverse)) g_object_unref(d->ic_inverse);
     if(!IS_NULL_PTR(d->ic_union)) g_object_unref(d->ic_union);
     if(!IS_NULL_PTR(d->ic_intersection)) g_object_unref(d->ic_intersection);
@@ -2631,6 +3021,7 @@ void gui_cleanup(dt_lib_module_t *self)
     d->ic_used = NULL;
     d->ic_add = NULL;
     d->ic_add_off = NULL;
+    d->ic_assign = NULL;
     d->ic_inverse = NULL;
     d->ic_union = NULL;
     d->ic_intersection = NULL;

--- a/src/libs/shape_manager.c
+++ b/src/libs/shape_manager.c
@@ -815,8 +815,8 @@ typedef enum dt_modchooser_col_t
   MODCHOOSER_COUNT
 } dt_modchooser_col_t;
 
-static void _modchooser_toggled(GtkCellRendererToggle *cell __attribute__((unused)), gchar *path_string,
-                                GtkListStore *store)
+static void _modchooser_toggled(GtkCellRendererToggle *cell __attribute__((unused)),
+                                const gchar *path_string, GtkListStore *store)
 {
   GtkTreeIter iter;
   if(!gtk_tree_model_get_iter_from_string(GTK_TREE_MODEL(store), &iter, path_string)) return;
@@ -833,7 +833,7 @@ static void _modchooser_toggled(GtkCellRendererToggle *cell __attribute__((unuse
 }
 
 /* A left click anywhere on the row toggles it, not just on the 12 pixels of the checkbox. */
-static gboolean _modchooser_button_pressed(GtkWidget *treeview, GdkEventButton *event,
+static gboolean _modchooser_button_pressed(GtkWidget *treeview, const GdkEventButton *event,
                                            GtkListStore *store)
 {
   if(event->type != GDK_BUTTON_PRESS || event->button != GDK_BUTTON_PRIMARY) return FALSE;
@@ -860,17 +860,42 @@ static gboolean _modchooser_button_pressed(GtkWidget *treeview, GdkEventButton *
  *
  * The window is modal, so GTK routes every button press in the application to it; a press landing
  * on one of its own GdkWindows is inside it and is left to the widget under the pointer. */
-static gboolean _modchooser_button_press(GtkWidget *dialog, GdkEventButton *event,
+static gboolean _modchooser_button_press(GtkWidget *dialog, const GdkEventButton *event,
                                          gpointer user_data __attribute__((unused)))
 {
   if(event->type != GDK_BUTTON_PRESS) return FALSE;
 
-  GdkWindow *const toplevel = gtk_widget_get_window(dialog);
+  const GdkWindow *const toplevel = gtk_widget_get_window(dialog);
   for(GdkWindow *w = event->window; !IS_NULL_PTR(w); w = gdk_window_get_parent(w))
     if(w == toplevel) return FALSE;
 
   gtk_dialog_response(GTK_DIALOG(dialog), GTK_RESPONSE_CANCEL);
   return TRUE;
+}
+
+/* Reads the validated dialog back: the rows whose box the user actually moved, in the order they
+ * were listed. An untouched module goes in neither list -- ticking a box and unticking it again
+ * is not a change, and reporting it as one would rewrite a mask the user left alone. */
+static void _modchooser_collect(GtkListStore *store, GList **to_attach, GList **to_detach)
+{
+  GtkTreeIter iter;
+  for(gboolean valid = gtk_tree_model_get_iter_first(GTK_TREE_MODEL(store), &iter); valid;
+      valid = gtk_tree_model_iter_next(GTK_TREE_MODEL(store), &iter))
+  {
+    gboolean checked = FALSE;
+    gboolean was_checked = FALSE;
+    dt_iop_module_t *module = NULL;
+    gtk_tree_model_get(GTK_TREE_MODEL(store), &iter, MODCHOOSER_CHECKED, &checked,
+                       MODCHOOSER_WAS_CHECKED, &was_checked, MODCHOOSER_MODULE, &module, -1);
+
+    if(IS_NULL_PTR(module) || checked == was_checked) continue;
+
+    GList **target = checked ? to_attach : to_detach;
+    *target = g_list_prepend(*target, module);
+  }
+
+  *to_attach = g_list_reverse(*to_attach);
+  *to_detach = g_list_reverse(*to_detach);
 }
 
 /* Runs the attachment manager modally and answers with what the user changed: the modules to
@@ -1002,38 +1027,38 @@ static gboolean _modchooser_run(const dt_masks_form_t *form, GList **to_attach, 
   gtk_widget_show_all(dialog);
   const gint response = gtk_dialog_run(GTK_DIALOG(dialog));
 
-  if(response == GTK_RESPONSE_ACCEPT)
-  {
-    GtkTreeIter iter;
-    gboolean valid = gtk_tree_model_get_iter_first(GTK_TREE_MODEL(store), &iter);
-    while(valid)
-    {
-      gboolean checked = FALSE;
-      gboolean was_checked = FALSE;
-      dt_iop_module_t *module = NULL;
-      gtk_tree_model_get(GTK_TREE_MODEL(store), &iter, MODCHOOSER_CHECKED, &checked,
-                         MODCHOOSER_WAS_CHECKED, &was_checked, MODCHOOSER_MODULE, &module, -1);
-
-      // Only the rows the user actually moved: an untouched module is left exactly as it was.
-      if(!IS_NULL_PTR(module) && checked != was_checked)
-      {
-        if(checked)
-          *to_attach = g_list_prepend(*to_attach, module);
-        else
-          *to_detach = g_list_prepend(*to_detach, module);
-      }
-
-      valid = gtk_tree_model_iter_next(GTK_TREE_MODEL(store), &iter);
-    }
-    *to_attach = g_list_reverse(*to_attach);
-    *to_detach = g_list_reverse(*to_detach);
-  }
+  if(response == GTK_RESPONSE_ACCEPT) _modchooser_collect(store, to_attach, to_detach);
 
   gtk_widget_destroy(dialog);
   g_object_unref(store);
   dt_gui_refocus_parent(parent);
 
   return response == GTK_RESPONSE_ACCEPT;
+}
+
+/* Gives a module a drawn mask of its own -- an empty group named after it, with drawn blending
+ * switched on -- and answers it, writing its id to own_id. Answers NULL if the form could not be
+ * made; the abandoned one is registered in dev->allforms and released with the image. */
+static dt_masks_form_t *_module_create_own_mask(dt_develop_t *dev, dt_iop_module_t *module, int *own_id)
+{
+  dt_masks_form_t *own = dt_masks_create_ext(dev, DT_MASKS_GROUP);
+  if(IS_NULL_PTR(own)) return NULL;
+
+  gchar *name = dt_dev_get_masks_group_name(module);
+  g_strlcpy(own->name, name, sizeof(own->name));
+  dt_free(name);
+
+  dt_masks_form_info_t own_info = { 0 };
+  if(!dt_masks_form_get_info(own, &own_info)) return NULL;
+  *own_id = own_info.formid;
+
+  dt_masks_append_form(dev, own);
+
+  // A module's blend_params are its own history entry; the forms get one of their own later.
+  if(dt_iop_gui_blend_set_drawn_mask_group(module, *own_id))
+    dt_dev_add_history_item(dev, module, TRUE, TRUE);
+
+  return own;
 }
 
 /* Puts the row's form to work in the modules the user picks.
@@ -1090,25 +1115,8 @@ static void _tree_row_assign_to_modules(dt_shape_manager_list_t *list, GtkTreeMo
 
     if(IS_NULL_PTR(own) || !(own->type & DT_MASKS_GROUP))
     {
-      // No mask of its own yet: give it one, named after it, and switch drawn blending on.
-      own = dt_masks_create_ext(dev, DT_MASKS_GROUP);
+      own = _module_create_own_mask(dev, module, &own_id);
       if(IS_NULL_PTR(own)) break;
-
-      gchar *name = dt_dev_get_masks_group_name(module);
-      g_strlcpy(own->name, name, sizeof(own->name));
-      dt_free(name);
-
-      dt_masks_form_info_t own_info = { 0 };
-      if(!dt_masks_form_get_info(own, &own_info)) break;
-      own_id = own_info.formid;
-
-      dt_masks_append_form(dev, own);
-
-      if(dt_iop_gui_blend_set_drawn_mask_group(module, own_id))
-      {
-        // A module's blend_params are its own history entry; the forms get one of their own below.
-        dt_dev_add_history_item(dev, module, TRUE, TRUE);
-      }
 
       created_id = own_id;
       created_count++;
@@ -1144,7 +1152,7 @@ static void _tree_row_assign_to_modules(dt_shape_manager_list_t *list, GtkTreeMo
 static void _tree_row_add_to_group(dt_shape_manager_list_t *list, GtkTreeModel *model, GtkTreeIter *iter)
 {
   dt_lib_module_t *self = list->self;
-  dt_shape_manager_t *lm = (dt_shape_manager_t *)self->data;
+  const dt_shape_manager_t *const lm = (const dt_shape_manager_t *)self->data;
   dt_develop_t *const dev = dt_dev_get_global();
 
   // The same question the icon was drawn from, so a greyed "+" cannot act.
@@ -1755,6 +1763,101 @@ static gboolean _tree_restrict_select(GtkTreeSelection *selection, GtkTreeModel 
   return TRUE;
 }
 
+/* What the action column's icon does depends on the row's depth: a top-level row owns its shape
+ * and deleting it is permanent, a nested one only holds a membership. */
+static const char *_tooltip_action_text(const int grid)
+{
+  return (grid == 0) ? _("Permanently delete this shape. It is detached from every mask "
+                         "and removed from the list of available shapes.")
+                     : _("Detach this shape from the mask. The shape is kept and stays "
+                         "available for reuse.");
+}
+
+/* The chooser manages attachments for whatever the row holds, so the text names it. */
+static gchar *_tooltip_assign_text(GtkTreeModel *model, GtkTreeIter *iter)
+{
+  int fid = -1;
+  _shape_manager_get_values(model, iter, NULL, NULL, &fid);
+
+  dt_masks_form_info_t row_info = { 0 };
+  dt_masks_form_get_info(dt_masks_get_from_id(dt_dev_get_global(), fid), &row_info);
+
+  return g_strdup_printf(_("Manage which modules use this %s. A mask is created for the "
+                           "ticked ones that have none, and shared between them."),
+                         row_info.is_group ? _("group") : _("shape"));
+}
+
+/* The "+" says what it will do, so it has to name what is selected right now -- and when it is
+ * dead, which of the reasons it is dead for. The refusals are read off the same questions
+ * _row_can_be_added() asks, so the wording can never disagree with the icon. */
+static gchar *_tooltip_add_text(const dt_shape_manager_t *lm, GtkTreeModel *model, GtkTreeIter *iter)
+{
+  const int group_id = _selected_group_in_module_list(lm);
+  const dt_masks_form_t *grp = dt_masks_get_from_id(dt_dev_get_global(), group_id);
+
+  if(IS_NULL_PTR(grp))
+    return g_strdup(_("Select a mask in the module groups list to add this shape to it."));
+
+  if(_row_can_be_added(lm, model, iter))
+    return g_strdup_printf(_("Add this to the mask '%s'."), grp->name);
+
+  int fid = -1;
+  _shape_manager_get_values(model, iter, NULL, NULL, &fid);
+  dt_develop_t *const dev = dt_dev_get_global();
+
+  if(dt_masks_group_contains(dev, group_id, fid) == DT_MASKS_OK)
+    return g_strdup_printf(_("This is already part of the mask '%s'."), grp->name);
+
+  if(dt_masks_group_contains(dev, fid, group_id) == DT_MASKS_OK)
+    return g_strdup_printf(_("This group cannot be added to the mask '%s': it already contains it."),
+                           grp->name);
+
+  // The remaining refusal: every shape it holds is already in the target.
+  return g_strdup_printf(_("The mask '%s' already uses every shape of this group."), grp->name);
+}
+
+/* The tooltip of the row's buttons, answered from the column the pointer is over.
+ *
+ * The pointer's column has to be asked here rather than left to gtk_tree_view_get_tooltip_context(),
+ * which reports the row but not the column, and rewrites x/y on the way.
+ *
+ * @return whether the pointer was over a button column, i.e. whether the tooltip was set. */
+static gboolean _tree_button_tooltip(const dt_shape_manager_list_t *list, GtkTreeView *tree_view,
+                                     const gint x, const gint y, GtkTooltip *tooltip)
+{
+  gint bx = 0, by = 0;
+  gtk_tree_view_convert_widget_to_bin_window_coords(tree_view, x, y, &bx, &by);
+
+  GtkTreePath *path = NULL;
+  GtkTreeViewColumn *column = NULL;
+  if(!gtk_tree_view_get_path_at_pos(tree_view, bx, by, &path, &column, NULL, NULL)) return FALSE;
+
+  const gboolean on_action = (column == list->action_col);
+  const gboolean on_add = !IS_NULL_PTR(list->add_col) && (column == list->add_col);
+  const gboolean on_assign = !IS_NULL_PTR(list->assign_col) && (column == list->assign_col);
+
+  GtkTreeModel *model = gtk_tree_view_get_model(tree_view);
+  GtkTreeIter iter;
+  const gboolean got = (on_action || on_add || on_assign) && gtk_tree_model_get_iter(model, &iter, path);
+  gtk_tree_path_free(path);
+  if(!got) return FALSE;
+
+  if(on_action)
+  {
+    int grid = -1;
+    _shape_manager_get_values(model, &iter, NULL, &grid, NULL);
+    gtk_tooltip_set_text(tooltip, _tooltip_action_text(grid));
+    return TRUE;
+  }
+
+  gchar *text = on_assign ? _tooltip_assign_text(model, &iter)
+                          : _tooltip_add_text((const dt_shape_manager_t *)list->self->data, model, &iter);
+  gtk_tooltip_set_text(tooltip, text);
+  dt_free(text);
+
+  return TRUE;
+}
+
 static gboolean _tree_query_tooltip(GtkWidget *widget, gint x, gint y, gboolean keyboard_tip,
                                     GtkTooltip *tooltip, gpointer data)
 {
@@ -1766,94 +1869,9 @@ static gboolean _tree_query_tooltip(GtkWidget *widget, gint x, gint y, gboolean 
   gboolean show = FALSE;
   const dt_shape_manager_list_t *list = (const dt_shape_manager_list_t *)data;
 
-  /* The action icon says what it does, and what it does depends on the row's depth, so the
-   * pointer's column is asked first: gtk_tree_view_get_tooltip_context() below reports the row
-   * but not the column, and it rewrites x/y on the way. Keyboard tooltips carry no position. */
-  if(!keyboard_tip && !IS_NULL_PTR(list))
-  {
-    gint bx = 0, by = 0;
-    gtk_tree_view_convert_widget_to_bin_window_coords(tree_view, x, y, &bx, &by);
-
-    GtkTreePath *action_path = NULL;
-    GtkTreeViewColumn *action_column = NULL;
-    if(gtk_tree_view_get_path_at_pos(tree_view, bx, by, &action_path, &action_column, NULL, NULL))
-    {
-      GtkTreeIter action_iter;
-      int grid = -1;
-      const gboolean on_action = (action_column == list->action_col);
-      const gboolean on_add = !IS_NULL_PTR(list->add_col) && (action_column == list->add_col);
-      const gboolean on_assign = !IS_NULL_PTR(list->assign_col) && (action_column == list->assign_col);
-      gboolean got = (on_action || on_add || on_assign)
-                     && gtk_tree_model_get_iter(model, &action_iter, action_path);
-      if(got) _shape_manager_get_values(model, &action_iter, NULL, &grid, NULL);
-      gtk_tree_path_free(action_path);
-
-      if(got && on_action)
-      {
-        gtk_tooltip_set_text(tooltip,
-                             (grid == 0)
-                                 ? _("Permanently delete this shape. It is detached from every mask "
-                                     "and removed from the list of available shapes.")
-                                 : _("Detach this shape from the mask. The shape is kept and stays "
-                                     "available for reuse."));
-        return TRUE;
-      }
-
-      if(got && on_assign)
-      {
-        int fid = -1;
-        _shape_manager_get_values(model, &action_iter, NULL, NULL, &fid);
-        dt_masks_form_info_t row_info = { 0 };
-        dt_masks_form_get_info(dt_masks_get_from_id(dt_dev_get_global(), fid), &row_info);
-
-        gchar *text = g_strdup_printf(_("Manage which modules use this %s. A mask is created for the "
-                                        "ticked ones that have none, and shared between them."),
-                                      row_info.is_group ? _("group") : _("shape"));
-        gtk_tooltip_set_text(tooltip, text);
-        dt_free(text);
-        return TRUE;
-      }
-
-      if(got && on_add)
-      {
-        // The button says what it will do, so it has to name what is selected right now -- and
-        // when it is dead, which of the reasons it is dead for.
-        const dt_shape_manager_t *lm = (const dt_shape_manager_t *)list->self->data;
-        const int group_id = _selected_group_in_module_list(lm);
-        const dt_masks_form_t *grp = dt_masks_get_from_id(dt_dev_get_global(), group_id);
-
-        if(IS_NULL_PTR(grp))
-        {
-          gtk_tooltip_set_text(tooltip, _("Select a mask in the module groups list to add this shape to it."));
-        }
-        else
-        {
-          int fid = -1;
-          _shape_manager_get_values(model, &action_iter, NULL, NULL, &fid);
-          dt_develop_t *const dev = dt_dev_get_global();
-
-          // Same reasoning _row_can_be_added() applies, so the wording never disagrees with it.
-          const gboolean already_in = (dt_masks_group_contains(dev, group_id, fid) == DT_MASKS_OK);
-          const gboolean would_cycle = (dt_masks_group_contains(dev, fid, group_id) == DT_MASKS_OK);
-
-          gchar *text;
-          if(_row_can_be_added(lm, model, &action_iter))
-            text = g_strdup_printf(_("Add this to the mask '%s'."), grp->name);
-          else if(already_in)
-            text = g_strdup_printf(_("This is already part of the mask '%s'."), grp->name);
-          else if(would_cycle)
-            text = g_strdup_printf(_("This group cannot be added to the mask '%s': it already contains it."),
-                                   grp->name);
-          else
-            // The remaining refusal: every shape it holds is already in the target.
-            text = g_strdup_printf(_("The mask '%s' already uses every shape of this group."), grp->name);
-          gtk_tooltip_set_text(tooltip, text);
-          dt_free(text);
-        }
-        return TRUE;
-      }
-    }
-  }
+  // Keyboard tooltips carry no position, so they can only be about the row.
+  if(!keyboard_tip && !IS_NULL_PTR(list) && _tree_button_tooltip(list, tree_view, x, y, tooltip))
+    return TRUE;
 
   if(!gtk_tree_view_get_tooltip_context(tree_view, &x, &y, keyboard_tip, &model, &path, &iter)) return FALSE;
 
@@ -2648,17 +2666,15 @@ static gboolean _find_iter_by_parentid_and_formid(GtkTreeModel *model, int paren
   return found;
 }
 
-static void _shape_manager_handler_callback(gpointer instance __attribute__((unused)), const int formid, const int parentid, const dt_masks_event_t event, dt_lib_module_t *self)
+/* Answers whether the event names a row this panel is currently showing, refreshing every row
+ * that does when the event is an UPDATE.
+ *
+ * A single-row event can name a row in either list -- or in both, when a module group holds a
+ * shape the inventory also lists -- so both are asked. */
+static gboolean _shape_manager_refresh_row(dt_lib_module_t *self, dt_shape_manager_t *lm,
+                                           const int formid, const int parentid,
+                                           const dt_masks_event_t event)
 {
-  if(IS_NULL_PTR(self)) return;
-
-  dt_shape_manager_t *lm = (dt_shape_manager_t *)self->data;
-  if(IS_NULL_PTR(lm)) return;
-
-  /* The row a single-row event names can be in either list -- or in both, when a module group
-   * holds a shape the inventory also lists -- so both are asked, and an UPDATE refreshes every
-   * row that answers. `found` is what the branches below used to read off the one tree there
-   * was: whether the event named a row this panel is currently showing at all. */
   gboolean found = FALSE;
   for(int i = 0; i < DT_SHAPE_LIST_COUNT; i++)
   {
@@ -2676,6 +2692,18 @@ static void _shape_manager_handler_callback(gpointer instance __attribute__((unu
     if(event == DT_MASKS_EVENT_UPDATE)
       _shape_manager_update_item(self, formid, parentid, lm, model, &iter);
   }
+
+  return found;
+}
+
+static void _shape_manager_handler_callback(gpointer instance __attribute__((unused)), const int formid, const int parentid, const dt_masks_event_t event, dt_lib_module_t *self)
+{
+  if(IS_NULL_PTR(self)) return;
+
+  dt_shape_manager_t *lm = (dt_shape_manager_t *)self->data;
+  if(IS_NULL_PTR(lm)) return;
+
+  const gboolean found = _shape_manager_refresh_row(self, lm, formid, parentid, event);
 
   if(found)
   {

--- a/src/libs/shape_manager.c
+++ b/src/libs/shape_manager.c
@@ -2231,6 +2231,9 @@ void gui_init(dt_lib_module_t *self)
    * half is built identically -- the only thing that differs between them is which forms their
    * store holds, which _tree_store_build() decides from list->which. */
   GtkWidget *lists_paned = gtk_paned_new(GTK_ORIENTATION_HORIZONTAL);
+  // Named so the theme can draw the divider between the two lists: a paned's handle is invisible
+  // by default, and these are two separate inventories rather than two views of one thing.
+  gtk_widget_set_name(lists_paned, "shape-manager-lists");
 
   static const struct
   {
@@ -2321,10 +2324,12 @@ void gui_init(dt_lib_module_t *self)
     g_signal_connect(selection, "changed", G_CALLBACK(_tree_selection_change), list);
     g_signal_connect(list->treeview, "button-press-event", (GCallback)_tree_button_pressed, list);
 
-    /* Each half is a titled column of its own: with two trees side by side and no headers, a
-     * label is the only thing saying which is which. */
+    /* Each half is a titled section of its own: with two trees side by side and no column
+     * headers, the heading is what says which is which, and the rule the theme draws under a
+     * section label is what closes each list off from the other. */
     GtkWidget *half = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_GUI_BOX_SPACING);
-    GtkWidget *title = dt_ui_label_new(_(list_defs[i].title));
+    gtk_widget_set_name(half, "shape-manager-list");
+    GtkWidget *title = dt_ui_section_label_new(_(list_defs[i].title));
     gtk_widget_set_tooltip_text(title, _(list_defs[i].tooltip));
     gtk_box_pack_start(GTK_BOX(half), title, FALSE, FALSE, 0);
 

--- a/src/libs/shape_manager.c
+++ b/src/libs/shape_manager.c
@@ -79,13 +79,35 @@ static void _shape_manager_update_list(dt_lib_module_t *self);
 static void _shape_manager_broadcast(dt_lib_module_t *self, const int formid, const int parentid,
                                      const dt_masks_event_t event);
 
-typedef struct dt_shape_manager_t
+/* The panel splits the forms by the one question that separates them: is this group some
+ * module's drawn mask, or nobody's yet? The left list is the inventory -- every shape, plus the
+ * groups no module uses -- and the right one is the assignment: the groups modules actually
+ * render, members underneath. A shape a module uses therefore appears in both, once as itself
+ * and once as a member, which is the arrangement a module's own Drawn tab already uses. */
+typedef enum dt_shape_list_t
+{
+  DT_SHAPE_LIST_SHAPES = 0,   // every shape, plus the groups no module uses
+  DT_SHAPE_LIST_MODULES,      // the groups that are some module's drawn mask
+  DT_SHAPE_LIST_COUNT
+} dt_shape_list_t;
+
+/* One of the two lists. Every tree handler is handed this rather than the module, because the
+ * first thing each of them needs to know is which of the two trees the user acted on. */
+typedef struct dt_shape_manager_list_t
 {
   GtkWidget *treeview;
 
   /* The rightmost column, the one carrying the per-row trash / minus icon. Kept because a click
    * and a tooltip are both answered by comparing against the column the pointer is over. */
   GtkTreeViewColumn *action_col;
+
+  dt_shape_list_t which;
+  dt_lib_module_t *self;   // the module both lists belong to
+} dt_shape_manager_list_t;
+
+typedef struct dt_shape_manager_t
+{
+  dt_shape_manager_list_t lists[DT_SHAPE_LIST_COUNT];
 
   /* Replacement for shape_manager_expander */
   GtkWidget *popup_window;
@@ -228,9 +250,9 @@ static void _tree_add_exist(GtkButton *button, dt_masks_form_t *grp)
   }
 }
 
-static void _tree_group(GtkButton *button __attribute__((unused)), dt_lib_module_t *self)
+static void _tree_group(GtkButton *button __attribute__((unused)), dt_shape_manager_list_t *list)
 {
-  dt_shape_manager_t *lm = (dt_shape_manager_t *)self->data;
+  dt_lib_module_t *self = list->self;
   // we create the new group
   // create_ext registers the group in dev->allforms and dt_masks_append_form() below takes
   // dev->forms's own reference, so both lists have a claim and teardown balances. Neither
@@ -240,8 +262,8 @@ static void _tree_group(GtkButton *button __attribute__((unused)), dt_lib_module
   g_snprintf(mask->name, sizeof(mask->name), _("Mask #%d"), g_list_length(dt_dev_get_global()->forms));
 
   // we add all selected forms to this group
-  GtkTreeModel *model = gtk_tree_view_get_model(GTK_TREE_VIEW(lm->treeview));
-  GtkTreeSelection *selection = gtk_tree_view_get_selection(GTK_TREE_VIEW(lm->treeview));
+  GtkTreeModel *model = gtk_tree_view_get_model(GTK_TREE_VIEW(list->treeview));
+  GtkTreeSelection *selection = gtk_tree_view_get_selection(GTK_TREE_VIEW(list->treeview));
 
   GList *items = gtk_tree_selection_get_selected_rows(selection, NULL);
   for(GList *items_iter = items; items_iter; items_iter = g_list_next(items_iter))
@@ -345,8 +367,9 @@ static void _set_iter_name(dt_shape_manager_t *lm, dt_masks_form_t *form, int st
                      (!IS_NULL_PTR(icop)), TREE_IC_INVERSE, icinv, TREE_IC_INVERSE_VISIBLE, (!IS_NULL_PTR(icinv)), -1);
 }
 
-static void _tree_delete_unused(GtkButton *button __attribute__((unused)), dt_lib_module_t *self)
+static void _tree_delete_unused(GtkButton *button __attribute__((unused)), dt_shape_manager_list_t *list)
 {
+  dt_lib_module_t *self = list->self;
   dt_develop_t *dev = dt_dev_get_global();
 
   /* The undo record has to be opened HERE, before the sweep. dt_dev_add_history_item() below
@@ -413,17 +436,18 @@ static void _add_masks_history_item(dt_shape_manager_t *lm)
 /* One handler for all five operations. They differed by a single constant and were otherwise
  * identical to the line, which is how five copies of a copy-on-write mistake got written; the
  * operation now rides on the menu item, the way develop/blend_gui.c already carries "blend-state". */
-static void _tree_apply_operation(GtkWidget *menu_item, dt_lib_module_t *self)
+static void _tree_apply_operation(GtkWidget *menu_item, dt_shape_manager_list_t *list)
 {
   const dt_masks_state_t operation
       = (dt_masks_state_t)GPOINTER_TO_INT(g_object_get_data(G_OBJECT(menu_item), "masks-operation"));
   if(operation == DT_MASKS_STATE_NONE) return;
 
+  dt_lib_module_t *self = list->self;
   dt_shape_manager_t *lm = (dt_shape_manager_t *)self->data;
 
   // now we go through all selected nodes
-  GtkTreeModel *model = gtk_tree_view_get_model(GTK_TREE_VIEW(lm->treeview));
-  GtkTreeSelection *selection = gtk_tree_view_get_selection(GTK_TREE_VIEW(lm->treeview));
+  GtkTreeModel *model = gtk_tree_view_get_model(GTK_TREE_VIEW(list->treeview));
+  GtkTreeSelection *selection = gtk_tree_view_get_selection(GTK_TREE_VIEW(list->treeview));
   int change = 0;
   GList *items = gtk_tree_selection_get_selected_rows(selection, NULL);
   for(const GList *items_iter = items; items_iter; items_iter = g_list_next(items_iter))
@@ -466,16 +490,17 @@ static void _tree_apply_operation(GtkWidget *menu_item, dt_lib_module_t *self)
   }
 }
 
-static void _tree_moveup(GtkButton *button __attribute__((unused)), dt_lib_module_t *self)
+static void _tree_moveup(GtkButton *button __attribute__((unused)), dt_shape_manager_list_t *list)
 {
+  dt_lib_module_t *self = list->self;
   dt_shape_manager_t *lm = (dt_shape_manager_t *)self->data;
 
   // we first discard all visible shapes
   dt_masks_change_form_gui(dt_dev_get_global(), NULL);
 
   // now we go through all selected nodes
-  GtkTreeModel *model = gtk_tree_view_get_model(GTK_TREE_VIEW(lm->treeview));
-  GtkTreeSelection *selection = gtk_tree_view_get_selection(GTK_TREE_VIEW(lm->treeview));
+  GtkTreeModel *model = gtk_tree_view_get_model(GTK_TREE_VIEW(list->treeview));
+  GtkTreeSelection *selection = gtk_tree_view_get_selection(GTK_TREE_VIEW(list->treeview));
   lm->gui_reset = 1;
   GList *items = gtk_tree_selection_get_selected_rows(selection, NULL);
   for(const GList *items_iter = items; items_iter; items_iter = g_list_next(items_iter))
@@ -505,16 +530,17 @@ static void _tree_moveup(GtkButton *button __attribute__((unused)), dt_lib_modul
   _add_masks_history_item(lm);
 }
 
-static void _tree_movedown(GtkButton *button __attribute__((unused)), dt_lib_module_t *self)
+static void _tree_movedown(GtkButton *button __attribute__((unused)), dt_shape_manager_list_t *list)
 {
+  dt_lib_module_t *self = list->self;
   dt_shape_manager_t *lm = (dt_shape_manager_t *)self->data;
 
   // we first discard all visible shapes
   dt_masks_change_form_gui(dt_dev_get_global(), NULL);
 
   // now we go through all selected nodes
-  GtkTreeModel *model = gtk_tree_view_get_model(GTK_TREE_VIEW(lm->treeview));
-  GtkTreeSelection *selection = gtk_tree_view_get_selection(GTK_TREE_VIEW(lm->treeview));
+  GtkTreeModel *model = gtk_tree_view_get_model(GTK_TREE_VIEW(list->treeview));
+  GtkTreeSelection *selection = gtk_tree_view_get_selection(GTK_TREE_VIEW(list->treeview));
   lm->gui_reset = 1;
   GList *items = gtk_tree_selection_get_selected_rows(selection, NULL);
   for(const GList *items_iter = items; items_iter; items_iter = g_list_next(items_iter))
@@ -544,16 +570,17 @@ static void _tree_movedown(GtkButton *button __attribute__((unused)), dt_lib_mod
   _add_masks_history_item(lm);
 }
 
-static void _tree_delete_shape(GtkButton *button __attribute__((unused)), dt_lib_module_t *self)
+static void _tree_delete_shape(GtkButton *button __attribute__((unused)), dt_shape_manager_list_t *list)
 {
+  dt_lib_module_t *self = list->self;
   dt_shape_manager_t *lm = (dt_shape_manager_t *)self->data;
 
   // we first discard all visible shapes
   dt_masks_change_form_gui(dt_dev_get_global(), NULL);
 
   // now we go through all selected nodes
-  GtkTreeModel *model = gtk_tree_view_get_model(GTK_TREE_VIEW(lm->treeview));
-  GtkTreeSelection *selection = gtk_tree_view_get_selection(GTK_TREE_VIEW(lm->treeview));
+  GtkTreeModel *model = gtk_tree_view_get_model(GTK_TREE_VIEW(list->treeview));
+  GtkTreeSelection *selection = gtk_tree_view_get_selection(GTK_TREE_VIEW(list->treeview));
   dt_iop_module_t *module = NULL;
   lm->gui_reset = 1;
   GList *items = gtk_tree_selection_get_selected_rows(selection, NULL);
@@ -593,8 +620,9 @@ static void _tree_delete_shape(GtkButton *button __attribute__((unused)), dt_lib
  *
  * dt_masks_form_delete() reads that distinction off its group argument: a group to detach from,
  * or NULL to destroy. A top-level row has group id 0, which no form answers to. */
-static void _tree_row_action(dt_lib_module_t *self, GtkTreeModel *model, GtkTreeIter *iter)
+static void _tree_row_action(dt_shape_manager_list_t *list, GtkTreeModel *model, GtkTreeIter *iter)
 {
+  dt_lib_module_t *self = list->self;
   dt_shape_manager_t *lm = (dt_shape_manager_t *)self->data;
   dt_develop_t *const dev = dt_dev_get_global();
 
@@ -625,13 +653,14 @@ static void _tree_row_action(dt_lib_module_t *self, GtkTreeModel *model, GtkTree
   dt_dev_add_history_item(dev, NULL, FALSE, TRUE);
 }
 
-static void _tree_duplicate_shape(GtkButton *button __attribute__((unused)), dt_lib_module_t *self)
+static void _tree_duplicate_shape(GtkButton *button __attribute__((unused)), dt_shape_manager_list_t *list)
 {
+  dt_lib_module_t *self = list->self;
   dt_shape_manager_t *lm = (dt_shape_manager_t *)self->data;
 
   // we get the selected node
-  GtkTreeModel *model = gtk_tree_view_get_model(GTK_TREE_VIEW(lm->treeview));
-  GtkTreeSelection *selection = gtk_tree_view_get_selection(GTK_TREE_VIEW(lm->treeview));
+  GtkTreeModel *model = gtk_tree_view_get_model(GTK_TREE_VIEW(list->treeview));
+  GtkTreeSelection *selection = gtk_tree_view_get_selection(GTK_TREE_VIEW(list->treeview));
   GList *items = gtk_tree_selection_get_selected_rows(selection, NULL);
   if(IS_NULL_PTR(items)) return;
   GtkTreePath *item = (GtkTreePath *)items->data;
@@ -673,10 +702,9 @@ static void _tree_duplicate_shape(GtkButton *button __attribute__((unused)), dt_
 /* The "edited" signal hands both strings as gchar *, but this only reads them -- and the
  * connection goes through a GCallback cast, so nothing checks the signature against GTK's. */
 static void _tree_cell_edited(GtkCellRendererText *cell __attribute__((unused)), const gchar *path_string,
-                              const gchar *new_text, dt_lib_module_t *self)
+                              const gchar *new_text, dt_shape_manager_list_t *list)
 {
-  dt_shape_manager_t *lm = (dt_shape_manager_t *)self->data;
-  GtkTreeModel *model = gtk_tree_view_get_model(GTK_TREE_VIEW(lm->treeview));
+  GtkTreeModel *model = gtk_tree_view_get_model(GTK_TREE_VIEW(list->treeview));
   GtkTreeIter iter;
   if(!gtk_tree_model_get_iter_from_string(model, &iter, path_string)) return;
 
@@ -719,11 +747,11 @@ static void _show_masks_on_owning_module(GtkTreeModel *model, GtkTreeIter *iter)
   gtk_widget_queue_draw(bd->masks_edit);
 }
 
-static void _tree_selection_change(GtkTreeSelection *selection, dt_shape_manager_t *self)
+static void _tree_selection_change(GtkTreeSelection *selection, dt_shape_manager_list_t *list)
 {
-
+  const dt_shape_manager_t *lm = (const dt_shape_manager_t *)list->self->data;
   dt_develop_t *const dev = dt_dev_get_global();
-  if(self->gui_reset) return;
+  if(lm->gui_reset) return;
   dt_masks_form_gui_t *creation_gui = dev->form_gui;
   if(!IS_NULL_PTR(creation_gui) && creation_gui->creation) return;
 
@@ -740,7 +768,7 @@ static void _tree_selection_change(GtkTreeSelection *selection, dt_shape_manager
   }
 
   // else, we create a new form group with the selection and display it
-  GtkTreeModel *model = gtk_tree_view_get_model(GTK_TREE_VIEW(self->treeview));
+  GtkTreeModel *model = gtk_tree_view_get_model(GTK_TREE_VIEW(list->treeview));
   dt_masks_form_t *grp = dt_masks_create(DT_MASKS_GROUP);
   dt_masks_form_t *selected_form = NULL;
   GList *items = gtk_tree_selection_get_selected_rows(selection, NULL);
@@ -1035,8 +1063,9 @@ static int _tree_apply_click_selection(GtkWidget *treeview, GtkTreeSelection *se
  * function allows the row -- yet no selection change follows a modified click, while a plain one
  * works. Why it stays inert was not found; driving the two gestures here is not a workaround for
  * that so much as the place this widget already adjusts its own selection. */
-static int _tree_button_pressed(GtkWidget *treeview, GdkEventButton *event, dt_lib_module_t *self)
+static int _tree_button_pressed(GtkWidget *treeview, GdkEventButton *event, dt_shape_manager_list_t *list)
 {
+  dt_lib_module_t *self = list->self;
   // we first need to adjust selection
   GtkTreeSelection *selection = gtk_tree_view_get_selection(GTK_TREE_VIEW(treeview));
   GtkTreeModel *model = gtk_tree_view_get_model(GTK_TREE_VIEW(treeview));
@@ -1060,13 +1089,12 @@ static int _tree_button_pressed(GtkWidget *treeview, GdkEventButton *event, dt_l
   /* single click with the right mouse button? */
   if(event->type == GDK_BUTTON_PRESS && event->button == 1)
   {
-    dt_shape_manager_t *lm = (dt_shape_manager_t *)self->data;
     // The action icons act on the row under the pointer alone, whatever is selected: they are
     // buttons the row carries, not a command applied to the selection.
-    if(on_row && mouse_col == lm->action_col)
+    if(on_row && mouse_col == list->action_col)
     {
       gtk_tree_path_free(mouse_path);
-      _tree_row_action(self, model, &iter);
+      _tree_row_action(list, model, &iter);
       return 1;
     }
 
@@ -1150,12 +1178,12 @@ static gboolean _tree_query_tooltip(GtkWidget *widget, gint x, gint y, gboolean 
   GtkTreePath *path = NULL;
   gchar *tmp = NULL;
   gboolean show = FALSE;
-  dt_shape_manager_t *lm = (dt_shape_manager_t *)data;
+  const dt_shape_manager_list_t *list = (const dt_shape_manager_list_t *)data;
 
   /* The action icon says what it does, and what it does depends on the row's depth, so the
    * pointer's column is asked first: gtk_tree_view_get_tooltip_context() below reports the row
    * but not the column, and it rewrites x/y on the way. Keyboard tooltips carry no position. */
-  if(!keyboard_tip && !IS_NULL_PTR(lm))
+  if(!keyboard_tip && !IS_NULL_PTR(list))
   {
     gint bx = 0, by = 0;
     gtk_tree_view_convert_widget_to_bin_window_coords(tree_view, x, y, &bx, &by);
@@ -1166,7 +1194,7 @@ static gboolean _tree_query_tooltip(GtkWidget *widget, gint x, gint y, gboolean 
     {
       GtkTreeIter action_iter;
       int grid = -1;
-      gboolean got = (action_column == lm->action_col)
+      gboolean got = (action_column == list->action_col)
                      && gtk_tree_model_get_iter(model, &action_iter, action_path);
       if(got) _shape_manager_get_values(model, &action_iter, NULL, &grid, NULL);
       gtk_tree_path_free(action_path);
@@ -1374,14 +1402,13 @@ gboolean _find_mask_iter_by_values(GtkTreeModel *model, GtkTreeIter *iter,
   return found;
 }
 
-GList *_shape_manager_get_selected(dt_lib_module_t *self)
+GList *_shape_manager_get_selected(dt_shape_manager_list_t *list)
 {
   GList *res = NULL;
-  dt_shape_manager_t *lm = (dt_shape_manager_t *)self->data;
 
-  GtkTreeModel *model = gtk_tree_view_get_model(GTK_TREE_VIEW(lm->treeview));
+  GtkTreeModel *model = gtk_tree_view_get_model(GTK_TREE_VIEW(list->treeview));
 
-  GtkTreeSelection *selection = gtk_tree_view_get_selection(GTK_TREE_VIEW(lm->treeview));
+  GtkTreeSelection *selection = gtk_tree_view_get_selection(GTK_TREE_VIEW(list->treeview));
 
   GList *items = gtk_tree_selection_get_selected_rows(selection, &model);
 
@@ -1409,22 +1436,37 @@ GList *_shape_manager_get_selected(dt_lib_module_t *self)
 }
 
 /* Expands to the row, scrolls it into view and selects it. */
-static void _tree_reveal_row(dt_shape_manager_t *lm, GtkTreeModel *model, GtkTreeIter *iter,
+static void _tree_reveal_row(dt_shape_manager_list_t *list, GtkTreeModel *model, GtkTreeIter *iter,
                              const gboolean exclusive)
 {
-  GtkTreeSelection *selection = gtk_tree_view_get_selection(GTK_TREE_VIEW(lm->treeview));
+  GtkTreeSelection *selection = gtk_tree_view_get_selection(GTK_TREE_VIEW(list->treeview));
   GtkTreePath *path = gtk_tree_model_get_path(model, iter);
 
   if(exclusive) gtk_tree_selection_unselect_all(selection);
-  gtk_tree_view_expand_to_path(GTK_TREE_VIEW(lm->treeview), path);
-  gtk_tree_view_scroll_to_cell(GTK_TREE_VIEW(lm->treeview), path, NULL, TRUE, 0.5, 0.5);
+  gtk_tree_view_expand_to_path(GTK_TREE_VIEW(list->treeview), path);
+  gtk_tree_view_scroll_to_cell(GTK_TREE_VIEW(list->treeview), path, NULL, TRUE, 0.5, 0.5);
   gtk_tree_selection_select_iter(selection, iter);
 
   gtk_tree_path_free(path);
 }
 
+/* Which of the two lists a top-level form belongs in. Only a group can be claimed by a module,
+ * so a plain shape is always in the inventory -- including one a module's group holds, which is
+ * then listed twice, once here and once as that group's member. */
+static dt_shape_list_t _form_belongs_to(const dt_masks_form_t *form)
+{
+  if(IS_NULL_PTR(form) || !(form->type & DT_MASKS_GROUP)) return DT_SHAPE_LIST_SHAPES;
+
+  GList *owners = _modules_owning_group(form);
+  const gboolean assigned = !IS_NULL_PTR(owners);
+  g_list_free(owners);
+
+  return assigned ? DT_SHAPE_LIST_MODULES : DT_SHAPE_LIST_SHAPES;
+}
+
 /* Returns whether it added anything, which is what tells the caller a separator is worth having. */
-static gboolean _tree_store_add_forms(GtkTreeStore *treestore, dt_shape_manager_t *lm, const gboolean groups)
+static gboolean _tree_store_add_forms(GtkTreeStore *treestore, dt_shape_manager_t *lm,
+                                      const dt_shape_list_t which, const gboolean groups)
 {
   gboolean any = FALSE;
 
@@ -1432,6 +1474,7 @@ static gboolean _tree_store_add_forms(GtkTreeStore *treestore, dt_shape_manager_
   {
     dt_masks_form_t *form = (dt_masks_form_t *)forms->data;
     if(!!(form->type & DT_MASKS_GROUP) != groups) continue;
+    if(_form_belongs_to(form) != which) continue;
 
     const _tree_row_t row = { .form = form, .opacity = 1.0f };
     _shape_manager_list_recurs(treestore, NULL, lm, &row);
@@ -1451,15 +1494,18 @@ static gboolean _tree_row_is_separator(GtkTreeModel *model, GtkTreeIter *iter,
   return is_separator;
 }
 
-/* Groups first, then the shapes no group holds: that is the order the tree shows them in. */
-static GtkTreeStore *_tree_store_build(dt_shape_manager_t *lm)
+/* The inventory list shows the unclaimed groups first, then every shape, with a rule between
+ * them. The module list has only groups, so it gets neither the second pass nor the rule. */
+static GtkTreeStore *_tree_store_build(dt_shape_manager_t *lm, const dt_shape_list_t which)
 {
   // we store : text ; *module ; groupid ; formid
   GtkTreeStore *treestore = gtk_tree_store_new(TREE_COUNT, G_TYPE_STRING, G_TYPE_POINTER, G_TYPE_INT,
                                                G_TYPE_INT, G_TYPE_BOOLEAN, GDK_TYPE_PIXBUF, G_TYPE_BOOLEAN,
                                                GDK_TYPE_PIXBUF, G_TYPE_BOOLEAN, G_TYPE_BOOLEAN, G_TYPE_STRING,
                                                G_TYPE_BOOLEAN, G_TYPE_BOOLEAN, G_TYPE_BOOLEAN);
-  const gboolean had_groups = _tree_store_add_forms(treestore, lm, TRUE);
+  const gboolean had_groups = _tree_store_add_forms(treestore, lm, which, TRUE);
+  if(which == DT_SHAPE_LIST_MODULES) return treestore;
+
 
   /* A rule between the module groups and the loose shapes, added between the two passes and kept
    * only when both sides of it exist -- one opening or closing the list would be a line against
@@ -1475,7 +1521,7 @@ static GtkTreeStore *_tree_store_build(dt_shape_manager_t *lm)
                        TREE_GROUPID, -1, TREE_EDITABLE, FALSE, -1);
   }
 
-  const gboolean had_shapes = _tree_store_add_forms(treestore, lm, FALSE);
+  const gboolean had_shapes = _tree_store_add_forms(treestore, lm, which, FALSE);
   if(had_groups && !had_shapes) gtk_tree_store_remove(treestore, &separator);
 
   return treestore;
@@ -1483,7 +1529,7 @@ static GtkTreeStore *_tree_store_build(dt_shape_manager_t *lm)
 
 /* Puts back what was selected before the store was replaced. selectids holds three entries per
  * row -- module, group id, form id -- as _shape_manager_get_selected() built it. */
-static void _tree_restore_selection(dt_shape_manager_t *lm, GtkTreeModel *model, const GList *selectids)
+static void _tree_restore_selection(dt_shape_manager_list_t *list, GtkTreeModel *model, const GList *selectids)
 {
   const GList *ids = selectids;
   while(ids)
@@ -1502,13 +1548,13 @@ static void _tree_restore_selection(dt_shape_manager_t *lm, GtkTreeModel *model,
     // non-empty, so stop rather than skip.
     if(!gtk_tree_model_get_iter_first(model, &iter)) return;
 
-    if(_find_mask_iter_by_values(model, &iter, mod, fid, 1)) _tree_reveal_row(lm, model, &iter, FALSE);
+    if(_find_mask_iter_by_values(model, &iter, mod, fid, 1)) _tree_reveal_row(list, model, &iter, FALSE);
   }
 }
 
 /* Points the tree at the focused module's mask group, and says whether it moved the selection --
  * the caller replays the selection handler when it did, so the canvas follows. */
-static gboolean _tree_select_module_group(dt_shape_manager_t *lm, GtkTreeModel *model,
+static gboolean _tree_select_module_group(dt_shape_manager_list_t *list, GtkTreeModel *model,
                                           const dt_masks_form_gui_t *gui)
 {
   dt_iop_module_t *const module = dt_dev_get_global()->gui_module;
@@ -1522,7 +1568,7 @@ static gboolean _tree_select_module_group(dt_shape_manager_t *lm, GtkTreeModel *
   if(!gtk_tree_model_get_iter_first(model, &iter)) return FALSE;
   if(!_find_mask_iter_by_values(model, &iter, module, group_id, 1)) return FALSE;
 
-  _tree_reveal_row(lm, model, &iter, TRUE);
+  _tree_reveal_row(list, model, &iter, TRUE);
   return TRUE;
 }
 
@@ -1531,35 +1577,48 @@ static void _shape_manager_recreate_list(dt_lib_module_t *self)
   dt_shape_manager_t *lm = (dt_shape_manager_t *)self->data;
   if(IS_NULL_PTR(lm) || lm->gui_reset) return;
 
-  // Everything below drives the tree itself, so the handlers it would wake must stay quiet.
+  // Everything below drives the trees itself, so the handlers they would wake must stay quiet.
   const int gui_reset = lm->gui_reset;
   lm->gui_reset = 1;
-
-  // The tree is about to be replaced, so what is selected has to be read before it goes.
-  GList *selectids = lm->treeview ? _shape_manager_get_selected(self) : NULL;
 
   // Rebuilding the list also refreshes shapes created during continuous creation. In that case
   // the active creation button must stay active until the user cancels creation explicitly.
   dt_masks_form_gui_t *gui = dt_dev_get_global()->form_gui;
   if(IS_NULL_PTR(gui) || !gui->creation) dt_masks_shape_buttons_deactivate_all(NULL);
 
-  GtkTreeStore *treestore = _tree_store_build(lm);
-  GtkTreeModel *model = GTK_TREE_MODEL(treestore);
-  gtk_tree_view_set_model(GTK_TREE_VIEW(lm->treeview), model);
-
-  if(selectids)
+  /* Both stores are rebuilt from scratch: a form crosses from one list to the other the moment
+   * a module claims or releases its group, so neither can be refreshed on its own. */
+  dt_shape_manager_list_t *follow = NULL;
+  for(int i = 0; i < DT_SHAPE_LIST_COUNT; i++)
   {
-    _tree_restore_selection(lm, model, selectids);
-    g_list_free(selectids);
+    dt_shape_manager_list_t *list = &lm->lists[i];
+    if(IS_NULL_PTR(list->treeview)) continue;
+
+    // The store is about to be replaced, so what is selected has to be read before it goes.
+    GList *selectids = _shape_manager_get_selected(list);
+
+    GtkTreeStore *treestore = _tree_store_build(lm, list->which);
+    GtkTreeModel *model = GTK_TREE_MODEL(treestore);
+    gtk_tree_view_set_model(GTK_TREE_VIEW(list->treeview), model);
+
+    if(selectids)
+    {
+      _tree_restore_selection(list, model, selectids);
+      g_list_free(selectids);
+    }
+
+    // Only the module list can follow the focused module's own mask group; the inventory does
+    // not hold it.
+    if(list->which == DT_SHAPE_LIST_MODULES && _tree_select_module_group(list, model, gui))
+      follow = list;
+
+    g_object_unref(treestore);
   }
 
-  const gboolean sync_center_view = _tree_select_module_group(lm, model, gui);
-
-  g_object_unref(treestore);
   lm->gui_reset = gui_reset;
 
-  if(sync_center_view)
-    _tree_selection_change(gtk_tree_view_get_selection(GTK_TREE_VIEW(lm->treeview)), lm);
+  if(!IS_NULL_PTR(follow))
+    _tree_selection_change(gtk_tree_view_get_selection(GTK_TREE_VIEW(follow->treeview)), follow);
 }
 
 static void _shape_manager_update_item(dt_lib_module_t *self __attribute__((unused)), int formid, int parentid, dt_shape_manager_t *lm, GtkTreeModel *model, GtkTreeIter *iter)
@@ -1631,17 +1690,22 @@ static gboolean _update_foreach(GtkTreeModel *model, GtkTreePath *path __attribu
   return 0;
 }
 
-// Update each item of the list
+// Update each item of both lists. The same form can have a row in each, so neither is skipped.
 static void _shape_manager_update_list(dt_lib_module_t *self)
 {
   dt_shape_manager_t *lm = (dt_shape_manager_t *)self->data;
   if(IS_NULL_PTR(lm)) return;
-  if(IS_NULL_PTR(lm->treeview)) return;
 
-  // for each node , we refresh the string
-  GtkTreeModel *model = gtk_tree_view_get_model(GTK_TREE_VIEW(lm->treeview));
-  if(!GTK_IS_TREE_MODEL(model)) return;
-  gtk_tree_model_foreach(model, _update_foreach, lm);
+  for(int i = 0; i < DT_SHAPE_LIST_COUNT; i++)
+  {
+    const dt_shape_manager_list_t *list = &lm->lists[i];
+    if(IS_NULL_PTR(list->treeview)) continue;
+
+    // for each node , we refresh the string
+    GtkTreeModel *model = gtk_tree_view_get_model(GTK_TREE_VIEW(list->treeview));
+    if(!GTK_IS_TREE_MODEL(model)) continue;
+    gtk_tree_model_foreach(model, _update_foreach, lm);
+  }
 }
 
 static gboolean _remove_foreach(GtkTreeModel *model, GtkTreePath *path, GtkTreeIter *iter, gpointer data)
@@ -1663,11 +1727,12 @@ static gboolean _remove_foreach(GtkTreeModel *model, GtkTreePath *path, GtkTreeI
   return 0;
 }
 
-static void _shape_manager_remove_item(dt_lib_module_t *self, int formid, int parentid)
+/* Drops the (formid, parentid) row from one list's store. */
+static void _shape_manager_remove_item_from(const dt_shape_manager_list_t *list, int formid, int parentid)
 {
-  dt_shape_manager_t *lm = (dt_shape_manager_t *)self->data;
-  // for each node , we refresh the string
-  GtkTreeModel *model = gtk_tree_view_get_model(GTK_TREE_VIEW(lm->treeview));
+  if(IS_NULL_PTR(list->treeview)) return;
+  GtkTreeModel *model = gtk_tree_view_get_model(GTK_TREE_VIEW(list->treeview));
+  if(!GTK_IS_TREE_MODEL(model)) return;
   GList *rl = NULL;
   g_object_set_data(G_OBJECT(model), "formid", GUINT_TO_POINTER(formid));
   g_object_set_data(G_OBJECT(model), "groupid", GUINT_TO_POINTER(parentid));
@@ -1690,6 +1755,15 @@ static void _shape_manager_remove_item(dt_lib_module_t *self, int formid, int pa
   }
   g_list_free(rl);
   rl = NULL;
+}
+
+static void _shape_manager_remove_item(dt_lib_module_t *self, int formid, int parentid)
+{
+  dt_shape_manager_t *lm = (dt_shape_manager_t *)self->data;
+  if(IS_NULL_PTR(lm)) return;
+
+  for(int i = 0; i < DT_SHAPE_LIST_COUNT; i++)
+    _shape_manager_remove_item_from(&lm->lists[i], formid, parentid);
 }
 
 static gboolean _shape_manager_selection_change_r(GtkTreeModel *model, GtkTreeSelection *selection,
@@ -1726,13 +1800,15 @@ static gboolean _shape_manager_selection_change_r(GtkTreeModel *model, GtkTreeSe
   return found;
 }
 
-static void _shape_manager_selection_change(dt_lib_module_t *self, struct dt_iop_module_t *module, const int selectid, const int throw_event)
+/* Points one list at the form, and says whether it holds it at all. */
+static gboolean _shape_manager_selection_change_in(dt_shape_manager_t *lm, const dt_shape_manager_list_t *list,
+                                                  struct dt_iop_module_t *module, const int selectid,
+                                                  const int throw_event)
 {
-  dt_shape_manager_t *lm = (dt_shape_manager_t *)self->data;
-  if(IS_NULL_PTR(lm->treeview)) return;
+  if(IS_NULL_PTR(list->treeview)) return FALSE;
 
   // we first unselect all
-  GtkTreeSelection *selection = gtk_tree_view_get_selection(GTK_TREE_VIEW(lm->treeview));
+  GtkTreeSelection *selection = gtk_tree_view_get_selection(GTK_TREE_VIEW(list->treeview));
   lm->gui_reset = 1;
   gtk_tree_selection_unselect_all(selection);
   lm->gui_reset = 0;
@@ -1740,22 +1816,34 @@ static void _shape_manager_selection_change(dt_lib_module_t *self, struct dt_iop
   // we go through all nodes
   lm->gui_reset = 1 - throw_event;
   GtkTreeIter iter;
-  GtkTreeModel *model = gtk_tree_view_get_model(GTK_TREE_VIEW(lm->treeview));
+  GtkTreeModel *model = gtk_tree_view_get_model(GTK_TREE_VIEW(list->treeview));
   if(!GTK_IS_TREE_MODEL(model))
   {
     lm->gui_reset = 0;
-    return;
+    return FALSE;
   }
-  gboolean valid = gtk_tree_model_get_iter_first(model, &iter);
 
-  if(valid)
+  gboolean found = FALSE;
+  if(gtk_tree_model_get_iter_first(model, &iter))
   {
-    gtk_tree_view_expand_all(GTK_TREE_VIEW(lm->treeview));
-    const gboolean found = _shape_manager_selection_change_r(model, selection, &iter, module, selectid, throw_event, 1);
-    if(!found) gtk_tree_view_collapse_all(GTK_TREE_VIEW(lm->treeview));
+    gtk_tree_view_expand_all(GTK_TREE_VIEW(list->treeview));
+    found = _shape_manager_selection_change_r(model, selection, &iter, module, selectid, throw_event, 1);
+    if(!found) gtk_tree_view_collapse_all(GTK_TREE_VIEW(list->treeview));
   }
 
   lm->gui_reset = 0;
+  return found;
+}
+
+/* A form can have a row in either list, or in both -- a shape is listed in the inventory and
+ * again under whichever module group holds it -- so both are pointed at it. */
+static void _shape_manager_selection_change(dt_lib_module_t *self, struct dt_iop_module_t *module, const int selectid, const int throw_event)
+{
+  dt_shape_manager_t *lm = (dt_shape_manager_t *)self->data;
+  if(IS_NULL_PTR(lm)) return;
+
+  for(int i = 0; i < DT_SHAPE_LIST_COUNT; i++)
+    _shape_manager_selection_change_in(lm, &lm->lists[i], module, selectid, throw_event);
 }
 
 static gboolean _find_child_iter_by_formid(GtkTreeModel *model, GtkTreeIter *parent_iter, int formid, GtkTreeIter *child_iter)
@@ -1813,33 +1901,39 @@ static void _shape_manager_handler_callback(gpointer instance __attribute__((unu
 
   dt_shape_manager_t *lm = (dt_shape_manager_t *)self->data;
   if(IS_NULL_PTR(lm)) return;
-  GtkTreeModel *model = gtk_tree_view_get_model(GTK_TREE_VIEW(lm->treeview));
-  if(!GTK_IS_TREE_MODEL(model)) return;
-  GtkTreeIter iter;
-  gboolean found_iter = gtk_tree_model_get_iter_first(model, &iter);
 
-  if(found_iter && _find_iter_by_parentid_and_formid(model, parentid, formid, &iter))
+  /* The row a single-row event names can be in either list -- or in both, when a module group
+   * holds a shape the inventory also lists -- so both are asked, and an UPDATE refreshes every
+   * row that answers. `found` is what the branches below used to read off the one tree there
+   * was: whether the event named a row this panel is currently showing at all. */
+  gboolean found = FALSE;
+  for(int i = 0; i < DT_SHAPE_LIST_COUNT; i++)
+  {
+    const dt_shape_manager_list_t *list = &lm->lists[i];
+    if(IS_NULL_PTR(list->treeview)) continue;
+
+    GtkTreeModel *model = gtk_tree_view_get_model(GTK_TREE_VIEW(list->treeview));
+    if(!GTK_IS_TREE_MODEL(model)) continue;
+
+    GtkTreeIter iter;
+    if(!gtk_tree_model_get_iter_first(model, &iter)) continue;
+    if(!_find_iter_by_parentid_and_formid(model, parentid, formid, &iter)) continue;
+
+    found = TRUE;
+    if(event == DT_MASKS_EVENT_UPDATE)
+      _shape_manager_update_item(self, formid, parentid, lm, model, &iter);
+  }
+
+  if(found)
   {
     switch(event)
     {
       case DT_MASKS_EVENT_UPDATE :
-      {
-        _shape_manager_update_item(self, formid, parentid, lm, model, &iter);
-      }
-      break;
+        // already done, once per list holding the row
+        break;
 
       case DT_MASKS_EVENT_CHANGE :
-      {
-        _shape_manager_recreate_list(self);
-      }
-      break;
-
       case DT_MASKS_EVENT_DELETE :
-      {
-        _shape_manager_recreate_list(self);
-      }
-      break;
-
       case DT_MASKS_EVENT_REMOVE :
       {
         _shape_manager_recreate_list(self);
@@ -2061,9 +2155,9 @@ void gui_init(dt_lib_module_t *self)
   // first mapping only, so a panel the user has dragged elsewhere keeps its place.
   gtk_window_set_position(GTK_WINDOW(d->popup_window), GTK_WIN_POS_CENTER_ON_PARENT);
 
-  // Let the user shrink the panel down to a narrow strip: the shape list carries its own
-  // height rule (dt_ui_scroll_wrap below), the width is theirs to set.
-  gtk_widget_set_size_request(d->popup_window, DT_PIXEL_APPLY_DPI(300), -1);
+  /* No width request of its own: the two lists below each carry a min-content-width, so the
+   * window's own minimum is what they add up to, and it grows with whatever the user drags the
+   * paned or the frame to. Heights come from each list's dt_ui_scroll_wrap() rule. */
 
 #ifdef GDK_WINDOWING_QUARTZ
   dt_osx_disallow_fullscreen(d->popup_window);
@@ -2121,87 +2215,140 @@ void gui_init(dt_lib_module_t *self)
   // surplus with the shape list below and stretch the buttons vertically.
   gtk_box_pack_start(GTK_BOX(shape_manager_container), hbox, FALSE, FALSE, 0);
 
-  d->treeview = gtk_tree_view_new();
-  GtkTreeViewColumn *col = gtk_tree_view_column_new();
-  gtk_tree_view_column_set_title(col, "shapes");
-  gtk_tree_view_append_column(GTK_TREE_VIEW(d->treeview), col);
-
-  GtkCellRenderer *renderer = gtk_cell_renderer_pixbuf_new();
-  gtk_tree_view_column_pack_start(col, renderer, FALSE);
-  gtk_tree_view_column_set_attributes(col, renderer, "pixbuf", TREE_IC_OP, NULL);
-  gtk_tree_view_column_add_attribute(col, renderer, "visible", TREE_IC_OP_VISIBLE);
-  renderer = gtk_cell_renderer_pixbuf_new();
-  gtk_tree_view_column_pack_start(col, renderer, FALSE);
-  gtk_tree_view_column_set_attributes(col, renderer, "pixbuf", TREE_IC_INVERSE, NULL);
-  gtk_tree_view_column_add_attribute(col, renderer, "visible", TREE_IC_INVERSE_VISIBLE);
-  renderer = gtk_cell_renderer_text_new();
-  gtk_tree_view_column_pack_start(col, renderer, TRUE);
-  gtk_tree_view_column_add_attribute(col, renderer, "text", TREE_TEXT);
-  gtk_tree_view_column_add_attribute(col, renderer, "editable", TREE_EDITABLE);
-  g_signal_connect(renderer, "edited", (GCallback)_tree_cell_edited, self);
-  /* Icon marking a shape shared by several modules. It is a remark about the shape rather than
+  /* The "used by" icon, tinted once for both trees. It is a remark about the shape rather than
    * something to click, so it is drawn in the theme's own disabled grey -- a flat grey, next to
    * the action icon it sits beside, rather than the washed-out foreground a GtkCellRenderer's
-   * insensitive state produces. A cell renderer has no colour of its own, so the icon is loaded
-   * once as a pre-tinted pixbuf; the model still only carries whether this row shows one. */
+   * insensitive state produces. A cell renderer has no colour of its own, hence a pre-tinted
+   * pixbuf; the model still only carries whether a row shows one. */
   GdkRGBA used_color;
-  if(!gtk_style_context_lookup_color(gtk_widget_get_style_context(d->treeview), "disabled_fg_color",
-                                     &used_color))
+  if(!gtk_style_context_lookup_color(gtk_widget_get_style_context(shape_manager_container),
+                                     "disabled_fg_color", &used_color))
     used_color = (GdkRGBA){ 0.62, 0.62, 0.62, 1.0 };
 
   d->ic_used = dt_gui_symbolic_icon_pixbuf("mail-attachment-symbolic", GTK_ICON_SIZE_MENU, &used_color, NULL);
 
-  renderer = gtk_cell_renderer_pixbuf_new();
-  // A theme with no symbolic variant of that icon leaves the pixbuf NULL: name the icon instead
-  // and let GTK draw it, untinted, rather than show nothing.
-  if(IS_NULL_PTR(d->ic_used))
-    g_object_set(renderer, "icon-name", "mail-attachment-symbolic", "stock-size", GTK_ICON_SIZE_MENU, NULL);
-  else
-    g_object_set(renderer, "pixbuf", d->ic_used, NULL);
-  gtk_tree_view_column_pack_end(col, renderer, FALSE);
-  gtk_tree_view_column_add_attribute(col, renderer, "visible", TREE_IC_USED_VISIBLE);
+  /* The two lists sit side by side in a paned, so the split is the user's and persists. Each
+   * half is built identically -- the only thing that differs between them is which forms their
+   * store holds, which _tree_store_build() decides from list->which. */
+  GtkWidget *lists_paned = gtk_paned_new(GTK_ORIENTATION_HORIZONTAL);
 
-  /* The per-row action icon, to the right of everything the name column carries -- the "used by"
-   * icon included, since that one is packed at that column's end. Both renderers live in this one
-   * column and exactly one of them is visible on any row, so the icon lands in the same place
-   * whichever action the row offers. The name column expands to take up the slack, which is what
-   * keeps the action flush right. Clicks are answered in _tree_button_pressed() by comparing the
-   * column, the way develop/blend_gui.c does for the same two icons. */
-  gtk_tree_view_column_set_expand(col, TRUE);
+  static const struct
+  {
+    const char *title;
+    const char *tooltip;
+    const char *height_key;
+  } list_defs[DT_SHAPE_LIST_COUNT] = {
+    [DT_SHAPE_LIST_SHAPES] = { N_("All shapes"),
+                               N_("Every shape drawn on this image, and the groups no module uses yet."),
+                               "plugins/darkroom/masks/windowheight" },
+    [DT_SHAPE_LIST_MODULES] = { N_("Module groups"),
+                                N_("The masks modules actually render, and the shapes each one is made of."),
+                                "plugins/darkroom/masks/moduleslistheight" },
+  };
 
-  d->action_col = gtk_tree_view_column_new();
-  gtk_tree_view_column_set_sizing(d->action_col, GTK_TREE_VIEW_COLUMN_FIXED);
-  gtk_tree_view_column_set_fixed_width(d->action_col, DT_PIXEL_APPLY_DPI(24));
+  for(int i = 0; i < DT_SHAPE_LIST_COUNT; i++)
+  {
+    dt_shape_manager_list_t *list = &d->lists[i];
+    list->which = (dt_shape_list_t)i;
+    list->self = self;
+    list->treeview = gtk_tree_view_new();
 
-  renderer = gtk_cell_renderer_pixbuf_new();
-  g_object_set(renderer, "icon-name", "list-remove-symbolic", "stock-size", GTK_ICON_SIZE_MENU, NULL);
-  gtk_tree_view_column_pack_start(d->action_col, renderer, FALSE);
-  gtk_tree_view_column_add_attribute(d->action_col, renderer, "visible", TREE_IC_UNLINK_VISIBLE);
+    GtkTreeViewColumn *col = gtk_tree_view_column_new();
+    gtk_tree_view_append_column(GTK_TREE_VIEW(list->treeview), col);
 
-  renderer = gtk_cell_renderer_pixbuf_new();
-  g_object_set(renderer, "icon-name", "user-trash-symbolic", "stock-size", GTK_ICON_SIZE_MENU, NULL);
-  gtk_tree_view_column_pack_start(d->action_col, renderer, FALSE);
-  gtk_tree_view_column_add_attribute(d->action_col, renderer, "visible", TREE_IC_DELETE_VISIBLE);
+    GtkCellRenderer *renderer = gtk_cell_renderer_pixbuf_new();
+    gtk_tree_view_column_pack_start(col, renderer, FALSE);
+    gtk_tree_view_column_set_attributes(col, renderer, "pixbuf", TREE_IC_OP, NULL);
+    gtk_tree_view_column_add_attribute(col, renderer, "visible", TREE_IC_OP_VISIBLE);
 
-  gtk_tree_view_append_column(GTK_TREE_VIEW(d->treeview), d->action_col);
+    renderer = gtk_cell_renderer_pixbuf_new();
+    gtk_tree_view_column_pack_start(col, renderer, FALSE);
+    gtk_tree_view_column_set_attributes(col, renderer, "pixbuf", TREE_IC_INVERSE, NULL);
+    gtk_tree_view_column_add_attribute(col, renderer, "visible", TREE_IC_INVERSE_VISIBLE);
 
-  GtkTreeSelection *selection = gtk_tree_view_get_selection(GTK_TREE_VIEW(d->treeview));
-  gtk_tree_selection_set_mode(selection, GTK_SELECTION_MULTIPLE);
-  gtk_tree_selection_set_select_function(selection, _tree_restrict_select, d, NULL);
-  gtk_tree_view_set_row_separator_func(GTK_TREE_VIEW(d->treeview), _tree_row_is_separator, NULL, NULL);
-  gtk_tree_view_set_headers_visible(GTK_TREE_VIEW(d->treeview), FALSE);
-  // A query-tooltip handler rather than a tooltip column: only the rows that carry a "used by"
-  // text show one, which a column would not let us decide per row.
-  g_object_set(d->treeview, "has-tooltip", TRUE, (gchar *)0);
-  g_signal_connect(d->treeview, "query-tooltip", G_CALLBACK(_tree_query_tooltip), d);
-  g_signal_connect(selection, "changed", G_CALLBACK(_tree_selection_change), d);
-  g_signal_connect(d->treeview, "button-press-event", (GCallback)_tree_button_pressed, self);
+    renderer = gtk_cell_renderer_text_new();
+    g_object_set(renderer, "ellipsize", PANGO_ELLIPSIZE_MIDDLE, NULL);
+    gtk_tree_view_column_pack_start(col, renderer, TRUE);
+    gtk_tree_view_column_add_attribute(col, renderer, "text", TREE_TEXT);
+    gtk_tree_view_column_add_attribute(col, renderer, "editable", TREE_EDITABLE);
+    g_signal_connect(renderer, "edited", (GCallback)_tree_cell_edited, list);
 
-  // Auto-grows to its content (the side panel scrolls) up to a user-set, persisted height.
-  gtk_box_pack_start(GTK_BOX(shape_manager_container),
-                     dt_ui_scroll_wrap(d->treeview, 90, "plugins/darkroom/masks/windowheight",
-                                       DT_UI_RESIZE_DYNAMIC),
-                     TRUE, TRUE, 0);
+    renderer = gtk_cell_renderer_pixbuf_new();
+    // A theme with no symbolic variant of that icon leaves the pixbuf NULL: name the icon instead
+    // and let GTK draw it, untinted, rather than show nothing.
+    if(IS_NULL_PTR(d->ic_used))
+      g_object_set(renderer, "icon-name", "mail-attachment-symbolic", "stock-size", GTK_ICON_SIZE_MENU, NULL);
+    else
+      g_object_set(renderer, "pixbuf", d->ic_used, NULL);
+    gtk_tree_view_column_pack_end(col, renderer, FALSE);
+    gtk_tree_view_column_add_attribute(col, renderer, "visible", TREE_IC_USED_VISIBLE);
+
+    /* The per-row action icon, to the right of everything the name column carries -- the "used
+     * by" icon included, since that one is packed at that column's end. Both renderers live in
+     * this one column and exactly one of them is visible on any row, so the icon lands in the
+     * same place whichever action the row offers. The name column expands to take up the slack,
+     * which is what keeps the action flush right. Clicks are answered in _tree_button_pressed()
+     * by comparing the column, the way develop/blend_gui.c does for the same two icons. */
+    gtk_tree_view_column_set_expand(col, TRUE);
+
+    list->action_col = gtk_tree_view_column_new();
+    gtk_tree_view_column_set_sizing(list->action_col, GTK_TREE_VIEW_COLUMN_FIXED);
+    gtk_tree_view_column_set_fixed_width(list->action_col, DT_PIXEL_APPLY_DPI(24));
+
+    renderer = gtk_cell_renderer_pixbuf_new();
+    g_object_set(renderer, "icon-name", "list-remove-symbolic", "stock-size", GTK_ICON_SIZE_MENU, NULL);
+    gtk_tree_view_column_pack_start(list->action_col, renderer, FALSE);
+    gtk_tree_view_column_add_attribute(list->action_col, renderer, "visible", TREE_IC_UNLINK_VISIBLE);
+
+    renderer = gtk_cell_renderer_pixbuf_new();
+    g_object_set(renderer, "icon-name", "user-trash-symbolic", "stock-size", GTK_ICON_SIZE_MENU, NULL);
+    gtk_tree_view_column_pack_start(list->action_col, renderer, FALSE);
+    gtk_tree_view_column_add_attribute(list->action_col, renderer, "visible", TREE_IC_DELETE_VISIBLE);
+
+    gtk_tree_view_append_column(GTK_TREE_VIEW(list->treeview), list->action_col);
+
+    GtkTreeSelection *selection = gtk_tree_view_get_selection(GTK_TREE_VIEW(list->treeview));
+    gtk_tree_selection_set_mode(selection, GTK_SELECTION_MULTIPLE);
+    gtk_tree_selection_set_select_function(selection, _tree_restrict_select, d, NULL);
+    // Only the inventory list carries a rule; the module list holds groups alone.
+    if(list->which == DT_SHAPE_LIST_SHAPES)
+      gtk_tree_view_set_row_separator_func(GTK_TREE_VIEW(list->treeview), _tree_row_is_separator, NULL, NULL);
+    gtk_tree_view_set_headers_visible(GTK_TREE_VIEW(list->treeview), FALSE);
+    // A query-tooltip handler rather than a tooltip column: only the rows that carry a "used by"
+    // text show one, which a column would not let us decide per row.
+    g_object_set(list->treeview, "has-tooltip", TRUE, (gchar *)0);
+    g_signal_connect(list->treeview, "query-tooltip", G_CALLBACK(_tree_query_tooltip), list);
+    g_signal_connect(selection, "changed", G_CALLBACK(_tree_selection_change), list);
+    g_signal_connect(list->treeview, "button-press-event", (GCallback)_tree_button_pressed, list);
+
+    /* Each half is a titled column of its own: with two trees side by side and no headers, a
+     * label is the only thing saying which is which. */
+    GtkWidget *half = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_GUI_BOX_SPACING);
+    GtkWidget *title = dt_ui_label_new(_(list_defs[i].title));
+    gtk_widget_set_tooltip_text(title, _(list_defs[i].tooltip));
+    gtk_box_pack_start(GTK_BOX(half), title, FALSE, FALSE, 0);
+
+    // Auto-grows to its content (the window scrolls) up to a user-set, persisted height.
+    GtkWidget *wrapper = dt_ui_scroll_wrap(list->treeview, 90, list_defs[i].height_key,
+                                           DT_UI_RESIZE_DYNAMIC);
+
+    /* The width floor is set here rather than on the window: a tree in a scrolled window has
+     * almost no minimum width of its own, so without this the paned would let either half be
+     * dragged down to nothing, and the window would have no sensible minimum either. Names
+     * ellipsize in the middle, so a narrow half stays readable at both ends. */
+    GtkWidget *scrolled = dt_ui_scroll_wrap_get_scrolled_window(wrapper);
+    if(GTK_IS_SCROLLED_WINDOW(scrolled))
+      gtk_scrolled_window_set_min_content_width(GTK_SCROLLED_WINDOW(scrolled), DT_PIXEL_APPLY_DPI(190));
+
+    gtk_box_pack_start(GTK_BOX(half), wrapper, TRUE, TRUE, 0);
+
+    if(i == 0)
+      gtk_paned_pack1(GTK_PANED(lists_paned), half, TRUE, FALSE);
+    else
+      gtk_paned_pack2(GTK_PANED(lists_paned), half, TRUE, FALSE);
+  }
+
+  gtk_box_pack_start(GTK_BOX(shape_manager_container), lists_paned, TRUE, TRUE, 0);
 
   DT_DEBUG_CONTROL_SIGNAL_CONNECT(dt_control_signal_get_global(), DT_SIGNAL_MASK_CHANGED, G_CALLBACK(_shape_manager_handler_callback), self);
 

--- a/src/libs/shape_manager.c
+++ b/src/libs/shape_manager.c
@@ -825,6 +825,28 @@ static gboolean _modchooser_button_pressed(GtkWidget *treeview, GdkEventButton *
   return TRUE;
 }
 
+/* Clicking past this window dismisses it, applying nothing -- the same as Cancel, which is what
+ * dismissing a window by clicking past it means everywhere else.
+ *
+ * Tested against the press itself rather than against the keyboard focus. Focus is too coarse a
+ * signal for this: it also moves when the window manager hands the pointer over a frame edge, so
+ * a focus-out handler closed the dialog on a click on its OWN border.
+ *
+ * The window is modal, so GTK routes every button press in the application to it; a press landing
+ * on one of its own GdkWindows is inside it and is left to the widget under the pointer. */
+static gboolean _modchooser_button_press(GtkWidget *dialog, GdkEventButton *event,
+                                         gpointer user_data __attribute__((unused)))
+{
+  if(event->type != GDK_BUTTON_PRESS) return FALSE;
+
+  GdkWindow *const toplevel = gtk_widget_get_window(dialog);
+  for(GdkWindow *w = event->window; !IS_NULL_PTR(w); w = gdk_window_get_parent(w))
+    if(w == toplevel) return FALSE;
+
+  gtk_dialog_response(GTK_DIALOG(dialog), GTK_RESPONSE_CANCEL);
+  return TRUE;
+}
+
 /* Runs the attachment manager modally and answers with what the user changed: the modules to
  * attach the shape to, and the ones to detach it from. Both lists are in the order the modules
  * were listed, borrow their modules, and are freed by the caller with g_list_free().
@@ -877,6 +899,13 @@ static gboolean _modchooser_run(const dt_masks_form_t *form, GList **to_attach, 
                                                   _("Cancel"), GTK_RESPONSE_CANCEL,
                                                   _("Apply"), GTK_RESPONSE_ACCEPT, NULL);
   gtk_dialog_set_default_response(GTK_DIALOG(dialog), GTK_RESPONSE_ACCEPT);
+
+  /* Above everything, because the window it is about -- the shape manager's own panel -- is a
+   * toplevel of its own and would otherwise be free to cover it. */
+  gtk_window_set_keep_above(GTK_WINDOW(dialog), TRUE);
+
+  gtk_widget_add_events(dialog, GDK_BUTTON_PRESS_MASK);
+  g_signal_connect(dialog, "button-press-event", G_CALLBACK(_modchooser_button_press), NULL);
 
   GtkWidget *content = gtk_dialog_get_content_area(GTK_DIALOG(dialog));
   gtk_container_set_border_width(GTK_CONTAINER(content), DT_GUI_BOX_SPACING);

--- a/src/libs/shape_manager.c
+++ b/src/libs/shape_manager.c
@@ -670,53 +670,6 @@ static int _selected_group_in_module_list(const dt_shape_manager_t *lm)
   return group_id;
 }
 
-/* Whether container_id holds needle_id, at any depth. A group added to a group that already
- * contains it would make the membership graph cyclic, and every walk over it -- the tree build
- * first of all -- would not terminate. */
-static gboolean _group_contains(const dt_develop_t *dev, const int container_id, const int needle_id)
-{
-  if(container_id == needle_id) return TRUE;
-
-  const dt_masks_form_t *container = dt_masks_get_from_id((dt_develop_t *)dev, container_id);
-  if(IS_NULL_PTR(container) || !(container->type & DT_MASKS_GROUP)) return FALSE;
-
-  for(const GList *pts = container->points; pts; pts = g_list_next(pts))
-  {
-    const dt_masks_form_group_t *pt = (const dt_masks_form_group_t *)pts->data;
-    if(_group_contains(dev, pt->formid, needle_id)) return TRUE;
-  }
-
-  return FALSE;
-}
-
-/* Whether every shape the group ultimately holds is already rendered by the target, directly or
- * through one of its own sub-groups. Sets *any as soon as it meets a leaf shape, so a caller can
- * tell "all covered" from "nothing in it to cover". */
-static gboolean _group_leaves_all_in(dt_develop_t *dev, const int group_id, const int target_id,
-                                     gboolean *any)
-{
-  const dt_masks_form_t *group = dt_masks_get_from_id(dev, group_id);
-  if(IS_NULL_PTR(group) || !(group->type & DT_MASKS_GROUP)) return TRUE;
-
-  for(const GList *pts = group->points; pts; pts = g_list_next(pts))
-  {
-    const dt_masks_form_group_t *pt = (const dt_masks_form_group_t *)pts->data;
-    const dt_masks_form_t *member = dt_masks_get_from_id(dev, pt->formid);
-    if(IS_NULL_PTR(member)) continue;
-
-    if(member->type & DT_MASKS_GROUP)
-    {
-      if(!_group_leaves_all_in(dev, pt->formid, target_id, any)) return FALSE;
-      continue;
-    }
-
-    *any = TRUE;
-    if(!_group_contains(dev, target_id, pt->formid)) return FALSE;
-  }
-
-  return TRUE;
-}
-
 /* Whether this row's "+" can do anything. Three ways it cannot: nothing is selected in the module
  * list, so there is nowhere to add to; the form is already a member of that group, and re-adding
  * it would write an undo step for a no-op; or the row is a group that already contains the
@@ -738,16 +691,16 @@ static gboolean _row_can_be_added(const dt_shape_manager_t *lm, GtkTreeModel *mo
   if(IS_NULL_PTR(grp) || !(grp->type & DT_MASKS_GROUP)) return FALSE;
 
   if(dt_masks_group_get_member(dev, group_id, fid, NULL) == DT_MASKS_OK) return FALSE;
-  if(_group_contains(dev, fid, group_id)) return FALSE;
+  if(dt_masks_group_contains(dev, fid, group_id) == DT_MASKS_OK) return FALSE;
 
   /* A group every one of whose shapes the target already renders would add nothing: nesting it
-   * duplicates coverage the mask already has. Checked leaf by leaf and at any depth on both
-   * sides, so it holds for a group of groups too. */
+   * duplicates coverage the mask already has. */
   const dt_masks_form_t *row_form = dt_masks_get_from_id(dev, fid);
   if(!IS_NULL_PTR(row_form) && (row_form->type & DT_MASKS_GROUP))
   {
-    gboolean any = FALSE;
-    if(_group_leaves_all_in(dev, fid, group_id, &any) && any) return FALSE;
+    gboolean has_shapes = FALSE;
+    if(dt_masks_group_covers_shapes(dev, fid, group_id, &has_shapes) == DT_MASKS_OK && has_shapes)
+      return FALSE;
   }
 
   return TRUE;
@@ -1017,7 +970,7 @@ static void _tree_row_assign_to_modules(dt_shape_manager_list_t *list, GtkTreeMo
   GList *to_detach = NULL;
   if(!_modchooser_run(form, &to_attach, &to_detach)) return;
 
-  dt_masks_form_t *shared = NULL;
+  int shared_id = 0;
   gboolean changed = FALSE;
 
   /* Detaching first, so a module the user unticked and a module they ticked cannot fight over
@@ -1039,13 +992,14 @@ static void _tree_row_assign_to_modules(dt_shape_manager_list_t *list, GtkTreeMo
   for(const GList *m = to_attach; m; m = g_list_next(m))
   {
     dt_iop_module_t *module = (dt_iop_module_t *)m->data;
-    dt_masks_form_t *own = dt_masks_get_from_id(dev, module->blend_params->mask_id);
+    const int own_id = module->blend_params->mask_id;
+    dt_masks_form_t *own = dt_masks_get_from_id(dev, own_id);
 
     if(!IS_NULL_PTR(own) && (own->type & DT_MASKS_GROUP))
     {
       // The module already renders a mask: add the shape to it rather than replacing it.
-      if(dt_masks_group_get_member(dev, own->formid, fid, NULL) == DT_MASKS_OK) continue;
-      if(_group_contains(dev, fid, own->formid)) continue;
+      if(dt_masks_group_get_member(dev, own_id, fid, NULL) == DT_MASKS_OK) continue;
+      if(dt_masks_group_contains(dev, fid, own_id) == DT_MASKS_OK) continue;
 
       own = dt_masks_cow_touch(dev, own);
       if(IS_NULL_PTR(dt_masks_group_add_form(dev, own, form))) continue;
@@ -1055,24 +1009,28 @@ static void _tree_row_assign_to_modules(dt_shape_manager_list_t *list, GtkTreeMo
       continue;
     }
 
-    if(IS_NULL_PTR(shared))
+    if(shared_id <= 0)
     {
       /* Named after the first module that needs it, which is the first ticked one in pipeline
        * order -- the name is the user's to change, and the rename below opens on it. */
-      shared = dt_masks_create_ext(dev, DT_MASKS_GROUP);
+      dt_masks_form_t *shared = dt_masks_create_ext(dev, DT_MASKS_GROUP);
       if(IS_NULL_PTR(shared)) break;
 
       gchar *name = dt_dev_get_masks_group_name(module);
       g_strlcpy(shared->name, name, sizeof(shared->name));
       dt_free(name);
 
-      dt_masks_group_add_form_with_state(dev, shared, form, shared->formid,
+      dt_masks_form_info_t shared_info = { 0 };
+      if(!dt_masks_form_get_info(shared, &shared_info)) break;
+      shared_id = shared_info.formid;
+
+      dt_masks_group_add_form_with_state(dev, shared, form, shared_id,
                                          DT_MASKS_STATE_USE | DT_MASKS_STATE_UNION, 1.0f);
       dt_masks_append_form(dev, shared);
       changed = TRUE;
     }
 
-    if(dt_iop_gui_blend_set_drawn_mask_group(module, shared))
+    if(dt_iop_gui_blend_set_drawn_mask_group(module, shared_id))
     {
       // A module's blend_params are its own history entry; the forms get one of their own below.
       dt_dev_add_history_item(dev, module, TRUE, TRUE);
@@ -1089,7 +1047,7 @@ static void _tree_row_assign_to_modules(dt_shape_manager_list_t *list, GtkTreeMo
   _shape_manager_broadcast(self, 0, 0, DT_MASKS_EVENT_CHANGE);
 
   // A group the user has just conjured wants a name, so its row opens straight into editing.
-  if(!IS_NULL_PTR(shared)) _tree_edit_group_name(self, shared->formid);
+  if(shared_id > 0) _tree_edit_group_name(self, shared_id);
 }
 
 /* The inventory's "+": add this row's form to the group the module list points at. */
@@ -1773,7 +1731,7 @@ static gboolean _tree_query_tooltip(GtkWidget *widget, gint x, gint y, gboolean 
             text = g_strdup_printf(_("Add this shape to the mask '%s'."), grp->name);
           else if(member)
             text = g_strdup_printf(_("This shape is already part of the mask '%s'."), grp->name);
-          else if(_group_contains(dt_dev_get_global(), fid, group_id))
+          else if(dt_masks_group_contains(dt_dev_get_global(), fid, group_id) == DT_MASKS_OK)
             text = g_strdup_printf(_("This group cannot be added to the mask '%s': it already contains it."),
                                    grp->name);
           else
@@ -1886,46 +1844,6 @@ static dt_iop_module_t *_module_owning_group(const dt_masks_form_t *group)
   return first;
 }
 
-/* Where the module's mask FIRST applies this shape, walked the way the tree shows it: members in
- * their own order, descending into a member group at the position that group sits at.
- *
- * A shape can legitimately be applied twice inside one mask, and the second application is not
- * always a no-op -- union and intersection are idempotent, but difference squares its own
- * factor and exclusion does not settle either (develop/masks/group.c). So neither instance can
- * be treated as void; what the list can say is which one came first, since that is the one the
- * later ones are read against.
- *
- * @return FALSE if the shape is not in this mask at all. */
-static gboolean _first_use_in_mask(dt_develop_t *dev, const int group_id, const int formid,
-                                   int *parent_id, int *index, const char **group_name)
-{
-  const dt_masks_form_t *group = dt_masks_get_from_id(dev, group_id);
-  if(IS_NULL_PTR(group) || !(group->type & DT_MASKS_GROUP)) return FALSE;
-
-  int i = 0;
-  for(const GList *pts = group->points; pts; pts = g_list_next(pts))
-  {
-    const dt_masks_form_group_t *pt = (const dt_masks_form_group_t *)pts->data;
-
-    if(pt->formid == formid)
-    {
-      *parent_id = group_id;
-      *index = i;
-      *group_name = group->name;
-      return TRUE;
-    }
-
-    const dt_masks_form_t *member = dt_masks_get_from_id(dev, pt->formid);
-    if(!IS_NULL_PTR(member) && (member->type & DT_MASKS_GROUP)
-       && _first_use_in_mask(dev, pt->formid, formid, parent_id, index, group_name))
-      return TRUE;
-
-    i++;
-  }
-
-  return FALSE;
-}
-
 /* Appends the row and returns its iter, which a group needs to hang its members from. Shapes and
  * groups are described identically here; only what happens afterwards differs. */
 static void _tree_append_row(GtkTreeStore *treestore, GtkTreeIter *toplevel, dt_shape_manager_t *lm,
@@ -1943,10 +1861,16 @@ static void _tree_append_row(GtkTreeStore *treestore, GtkTreeIter *toplevel, dt_
 
   GdkPixbuf *icinv = (row->gstate & DT_MASKS_STATE_INVERSE) ? lm->ic_inverse : NULL;
 
+  /* One by-value description of the form, which every field below is taken from. The name it
+   * carries is copied rather than borrowed, so nothing here holds a pointer into a refcounted
+   * form across a call that could clone it. */
+  dt_masks_form_info_t info = { 0 };
+  if(!dt_masks_form_get_info(row->form, &info)) return;
+
   // Only a top-level row asks who else uses the shape: a row under a group already says so.
   char used_by[1000] = "";
   int nbuse = 0;
-  if(row->grp_id == 0) _is_form_used(row->form->formid, used_by, sizeof(used_by), &nbuse);
+  if(row->grp_id == 0) _is_form_used(info.formid, used_by, sizeof(used_by), &nbuse);
 
   /* Only inside a module's mask, and only for a shape sitting under a group: a top-level row is
    * not reached through anything, and a group's own duplication is a different question.
@@ -1954,21 +1878,21 @@ static void _tree_append_row(GtkTreeStore *treestore, GtkTreeIter *toplevel, dt_
    * Only the instances AFTER the first are marked. Both used to be, symmetrically, which said
    * that the shape appears twice but not which application the other is measured against. */
   gchar *note = NULL;
-  if(row->root_id > 0 && row->grp_id > 0 && !(row->form->type & DT_MASKS_GROUP))
+  if(row->root_id > 0 && row->grp_id > 0 && !info.is_group)
   {
-    int first_parent = 0;
-    int first_index = 0;
-    const char *first_group = NULL;
-    if(_first_use_in_mask(dt_dev_get_global(), row->root_id, row->form->formid, &first_parent,
-                          &first_index, &first_group)
-       && (first_parent != row->grp_id || first_index != row->index))
+    int holder_id = 0;
+    guint holder_index = 0;
+    char holder_name[DT_MASKS_FORM_NAME_LEN] = "";
+    if(dt_masks_group_first_use(dt_dev_get_global(), row->root_id, info.formid, &holder_id,
+                                &holder_index, holder_name, sizeof(holder_name)) == DT_MASKS_OK
+       && (holder_id != row->grp_id || (int)holder_index != row->index))
       // Same wording the Drawn tab's shape list already uses for the same kind of remark.
-      note = g_strdup_printf(_("Already in '%s'"), first_group);
+      note = g_strdup_printf(_("Already in '%s'"), holder_name);
   }
 
   gtk_tree_store_append(treestore, child, toplevel);
-  gtk_tree_store_set(treestore, child, TREE_TEXT, row->form->name, TREE_MODULE, row->module,
-                     TREE_GROUPID, row->grp_id, TREE_FORMID, row->form->formid,
+  gtk_tree_store_set(treestore, child, TREE_TEXT, info.name, TREE_MODULE, row->module,
+                     TREE_GROUPID, row->grp_id, TREE_FORMID, info.formid,
                      TREE_EDITABLE, (row->grp_id == 0), TREE_IC_OP, icop,
                      TREE_IC_OP_VISIBLE, (!IS_NULL_PTR(icop)), TREE_IC_INVERSE, icinv,
                      TREE_IC_INVERSE_VISIBLE, (!IS_NULL_PTR(icinv)),

--- a/src/libs/shape_manager.c
+++ b/src/libs/shape_manager.c
@@ -710,7 +710,7 @@ static void _show_masks_on_owning_module(GtkTreeModel *model, GtkTreeIter *iter)
   _shape_manager_get_values(model, iter, &module, NULL, NULL);
 
   if(IS_NULL_PTR(module) || IS_NULL_PTR(module->gui) || IS_NULL_PTR(module->gui->blend_data)
-     || !(module->flags() & IOP_FLAGS_SUPPORTS_BLENDING) || (module->flags() & IOP_FLAGS_NO_MASKS))
+     || !dt_iop_module_supports_drawn_mask(module))
     return;
 
   dt_iop_gui_blend_data_t *bd = (dt_iop_gui_blend_data_t *)module->gui->blend_data;
@@ -1246,18 +1246,39 @@ typedef struct _tree_row_t
   int index;               // rank inside the parent, which _set_iter_name() shows
 } _tree_row_t;
 
-/* The module whose drawn mask is this group, if any. A group listed at top level with no module
- * yet is the only case worth asking about: a nested one inherits its parent's. */
-static dt_iop_module_t *_module_owning_group(const dt_masks_form_t *group)
+/* Every module whose drawn mask is this group, in pipeline order.
+ *
+ * The link between a group and a module is blend_params->mask_id, which lives in each module's
+ * own params blob, so nothing stops several modules from naming the same group -- and that is
+ * what a group shared between modules is. There is no stored back-reference to keep in step:
+ * the answer is derived here, from the one place the truth is, on a walk over ~80 modules.
+ *
+ * Returns a GList of dt_iop_module_t* the caller frees with g_list_free(), borrowing the
+ * modules themselves; NULL when no module uses the group. */
+static GList *_modules_owning_group(const dt_masks_form_t *group)
 {
+  if(IS_NULL_PTR(group)) return NULL;
+
+  GList *owners = NULL;
   for(const GList *iops = dt_dev_get_global()->iop; iops; iops = g_list_next(iops))
   {
     dt_iop_module_t *iop = (dt_iop_module_t *)iops->data;
-    if((iop->flags() & IOP_FLAGS_SUPPORTS_BLENDING) && !(iop->flags() & IOP_FLAGS_NO_MASKS)
-       && iop->blend_params->mask_id == group->formid)
-      return iop;
+    if(dt_iop_module_supports_drawn_mask(iop) && iop->blend_params->mask_id == group->formid)
+      owners = g_list_prepend(owners, iop);
   }
-  return NULL;
+
+  return g_list_reverse(owners);
+}
+
+/* The first module using this group, for the callers that need one module to speak for the row --
+ * the tree stores a single module per row. A group listed at top level with no module yet is the
+ * only case worth asking about: a nested one inherits its parent's. */
+static dt_iop_module_t *_module_owning_group(const dt_masks_form_t *group)
+{
+  GList *owners = _modules_owning_group(group);
+  dt_iop_module_t *first = IS_NULL_PTR(owners) ? NULL : (dt_iop_module_t *)owners->data;
+  g_list_free(owners);
+  return first;
 }
 
 /* Appends the row and returns its iter, which a group needs to hang its members from. Shapes and
@@ -1491,11 +1512,7 @@ static gboolean _tree_select_module_group(dt_shape_manager_t *lm, GtkTreeModel *
                                           const dt_masks_form_gui_t *gui)
 {
   dt_iop_module_t *const module = dt_dev_get_global()->gui_module;
-  const int group_id = (!IS_NULL_PTR(module) && module->blend_params
-                        && (module->flags() & IOP_FLAGS_SUPPORTS_BLENDING)
-                        && !(module->flags() & IOP_FLAGS_NO_MASKS))
-                           ? module->blend_params->mask_id
-                           : 0;
+  const int group_id = dt_iop_module_supports_drawn_mask(module) ? module->blend_params->mask_id : 0;
 
   if(group_id <= 0) return FALSE;
   // Mid-creation the tree follows the shape being drawn, not the module.

--- a/src/libs/shape_manager.c
+++ b/src/libs/shape_manager.c
@@ -950,11 +950,17 @@ static gboolean _modchooser_run(const dt_masks_form_t *form, GList **to_attach, 
 
 /* Puts the row's form to work in the modules the user picks.
  *
- * One group is created and SHARED by every picked module that has no mask of its own -- the link
- * is each module's own blend_params->mask_id, so several naming the same group is exactly what a
- * shared mask is, and nothing else has to be stored for it. A module that already has a mask
- * keeps it and receives the shape into it instead: repointing it at the shared group would
- * orphan the shapes it already carries. */
+ * Every module renders its OWN mask group -- created here, named "Mask <module>", if it has none
+ * yet -- and the row's form is nested as a member of each. What is shared between the modules is
+ * that form, not the mask holding it: one shape or shape group, referenced by as many module
+ * masks as tick it.
+ *
+ * That is what keeps each module independent. A module's own mask carries its own combine
+ * operators, opacities and order, so attaching the same shape group to a second module cannot
+ * disturb the first -- and unticking one removes the form from THAT module's mask alone. The
+ * alternative, pointing several modules at one mask group, would make every one of those
+ * settings, and every detach, common to all of them.
+ */
 static void _tree_row_assign_to_modules(dt_shape_manager_list_t *list, GtkTreeModel *model,
                                         GtkTreeIter *iter)
 {
@@ -970,20 +976,19 @@ static void _tree_row_assign_to_modules(dt_shape_manager_list_t *list, GtkTreeMo
   GList *to_detach = NULL;
   if(!_modchooser_run(form, &to_attach, &to_detach)) return;
 
-  int shared_id = 0;
+  int created_id = 0;
+  int created_count = 0;
   gboolean changed = FALSE;
 
-  /* Detaching first, so a module the user unticked and a module they ticked cannot fight over
-   * the same group within one validation. Note what a shared group means here: the shape is
-   * removed from the GROUP, so every module rendering that group stops using it -- there is one
-   * membership, not one per module. Reopening the dialog shows exactly that. */
+  /* Detaching first, so a module the user unticked and one they ticked cannot fight over the
+   * same mask within one validation. */
   for(const GList *m = to_detach; m; m = g_list_next(m))
   {
     dt_iop_module_t *module = (dt_iop_module_t *)m->data;
     dt_masks_form_t *own = dt_masks_get_from_id(dev, module->blend_params->mask_id);
     if(IS_NULL_PTR(own) || !(own->type & DT_MASKS_GROUP)) continue;
 
-    // Empties the group and deletes it if nothing is left, which dt_masks_form_delete() handles.
+    // Empties the mask and deletes it if nothing is left, which dt_masks_form_delete() handles.
     dt_masks_form_delete(dev, module, own, form);
     dt_iop_gui_blend_masks_update(module);
     changed = TRUE;
@@ -992,50 +997,45 @@ static void _tree_row_assign_to_modules(dt_shape_manager_list_t *list, GtkTreeMo
   for(const GList *m = to_attach; m; m = g_list_next(m))
   {
     dt_iop_module_t *module = (dt_iop_module_t *)m->data;
-    const int own_id = module->blend_params->mask_id;
+    int own_id = module->blend_params->mask_id;
     dt_masks_form_t *own = dt_masks_get_from_id(dev, own_id);
 
-    if(!IS_NULL_PTR(own) && (own->type & DT_MASKS_GROUP))
+    if(IS_NULL_PTR(own) || !(own->type & DT_MASKS_GROUP))
     {
-      // The module already renders a mask: add the shape to it rather than replacing it.
-      if(dt_masks_group_get_member(dev, own_id, fid, NULL) == DT_MASKS_OK) continue;
-      if(dt_masks_group_contains(dev, fid, own_id) == DT_MASKS_OK) continue;
-
-      own = dt_masks_cow_touch(dev, own);
-      if(IS_NULL_PTR(dt_masks_group_add_form(dev, own, form))) continue;
-
-      dt_iop_gui_blend_masks_update(module);
-      changed = TRUE;
-      continue;
-    }
-
-    if(shared_id <= 0)
-    {
-      /* Named after the first module that needs it, which is the first ticked one in pipeline
-       * order -- the name is the user's to change, and the rename below opens on it. */
-      dt_masks_form_t *shared = dt_masks_create_ext(dev, DT_MASKS_GROUP);
-      if(IS_NULL_PTR(shared)) break;
+      // No mask of its own yet: give it one, named after it, and switch drawn blending on.
+      own = dt_masks_create_ext(dev, DT_MASKS_GROUP);
+      if(IS_NULL_PTR(own)) break;
 
       gchar *name = dt_dev_get_masks_group_name(module);
-      g_strlcpy(shared->name, name, sizeof(shared->name));
+      g_strlcpy(own->name, name, sizeof(own->name));
       dt_free(name);
 
-      dt_masks_form_info_t shared_info = { 0 };
-      if(!dt_masks_form_get_info(shared, &shared_info)) break;
-      shared_id = shared_info.formid;
+      dt_masks_form_info_t own_info = { 0 };
+      if(!dt_masks_form_get_info(own, &own_info)) break;
+      own_id = own_info.formid;
 
-      dt_masks_group_add_form_with_state(dev, shared, form, shared_id,
-                                         DT_MASKS_STATE_USE | DT_MASKS_STATE_UNION, 1.0f);
-      dt_masks_append_form(dev, shared);
+      dt_masks_append_form(dev, own);
+
+      if(dt_iop_gui_blend_set_drawn_mask_group(module, own_id))
+      {
+        // A module's blend_params are its own history entry; the forms get one of their own below.
+        dt_dev_add_history_item(dev, module, TRUE, TRUE);
+      }
+
+      created_id = own_id;
+      created_count++;
       changed = TRUE;
     }
 
-    if(dt_iop_gui_blend_set_drawn_mask_group(module, shared_id))
-    {
-      // A module's blend_params are its own history entry; the forms get one of their own below.
-      dt_dev_add_history_item(dev, module, TRUE, TRUE);
-      changed = TRUE;
-    }
+    // Already there, or it would close a cycle: leave the mask alone.
+    if(dt_masks_group_get_member(dev, own_id, fid, NULL) == DT_MASKS_OK) continue;
+    if(dt_masks_group_contains(dev, fid, own_id) == DT_MASKS_OK) continue;
+
+    own = dt_masks_cow_touch(dev, own);
+    if(IS_NULL_PTR(dt_masks_group_add_form(dev, own, form))) continue;
+
+    dt_iop_gui_blend_masks_update(module);
+    changed = TRUE;
   }
 
   g_list_free(to_attach);
@@ -1046,8 +1046,10 @@ static void _tree_row_assign_to_modules(dt_shape_manager_list_t *list, GtkTreeMo
   _shape_manager_recreate_list(self);
   _shape_manager_broadcast(self, 0, 0, DT_MASKS_EVENT_CHANGE);
 
-  // A group the user has just conjured wants a name, so its row opens straight into editing.
-  if(shared_id > 0) _tree_edit_group_name(self, shared_id);
+  /* A mask the user has just conjured wants a name, so its row opens straight into editing --
+   * but only when exactly one was made. With several there is no "the" one to open, and each
+   * already carries its module's name, which is the answer most of the time anyway. */
+  if(created_count == 1) _tree_edit_group_name(self, created_id);
 }
 
 /* The inventory's "+": add this row's form to the group the module list points at. */
@@ -2040,8 +2042,15 @@ static gboolean _tree_store_add_forms(GtkTreeStore *treestore, dt_shape_manager_
 
     /* The mask this row and everything under it belongs to. Only the module list has one: the
      * inventory's groups are nobody's mask, so a shape under them is reached once and there is
-     * nothing to warn about. */
-    const int root_id = (which == DT_SHAPE_LIST_MODULES && groups) ? form->formid : 0;
+     * nothing to warn about. A module owns its mask group, so one row per group is already one
+     * row per module. */
+    int root_id = 0;
+    if(which == DT_SHAPE_LIST_MODULES && groups)
+    {
+      dt_masks_form_info_t info = { 0 };
+      if(!dt_masks_form_get_info(form, &info)) continue;
+      root_id = info.formid;
+    }
 
     const _tree_row_t row = { .form = form, .opacity = 1.0f, .root_id = root_id };
     _shape_manager_list_recurs(treestore, NULL, lm, &row);

--- a/src/libs/shape_manager.c
+++ b/src/libs/shape_manager.c
@@ -58,6 +58,7 @@
 #include "libs/lib_api.h"
 #include "views/view.h"
 #include "widgets/scroll_wrap.h"
+#include "widgets/widget_settings.h"  // dt_widget_root_window(), dt_widget_store_int()
 #include "common/conf.h"          // dt_conf_get_int(), dt_conf_key_exists()
 
 #include "widgets/label.h"   // dt_gui_symbolic_icon_pixbuf()
@@ -82,14 +83,16 @@ static void _shape_manager_broadcast(dt_lib_module_t *self, const int formid, co
                                      const dt_masks_event_t event);
 
 /* The panel splits the forms by the one question that separates them: is this group some
- * module's drawn mask, or nobody's yet? The left list is the inventory -- every shape, plus the
- * groups no module uses -- and the right one is the assignment: the groups modules actually
- * render, members underneath. A shape a module uses therefore appears in both, once as itself
- * and once as a member, which is the arrangement a module's own Drawn tab already uses. */
+ * module's drawn mask, or nobody's yet? The left list is the inventory -- every shape and every
+ * group, module masks included, so any of them can be picked up and reused -- and the right one
+ * is the assignment: only the groups modules actually render, members underneath. A module mask
+ * therefore appears in both, once in the inventory as an ordinary reusable group and once in the
+ * assignment under the module rendering it, the same way a shape a module uses appears in both
+ * its own row and as a member -- the arrangement a module's own Drawn tab already uses. */
 typedef enum dt_shape_list_t
 {
-  DT_SHAPE_LIST_SHAPES = 0,   // every shape, plus the groups no module uses
-  DT_SHAPE_LIST_MODULES,      // the groups that are some module's drawn mask
+  DT_SHAPE_LIST_SHAPES = 0,   // every shape and every group, module masks included
+  DT_SHAPE_LIST_MODULES,      // only the groups that are some module's drawn mask
   DT_SHAPE_LIST_COUNT
 } dt_shape_list_t;
 
@@ -118,6 +121,11 @@ typedef struct dt_shape_manager_list_t
 
   dt_shape_list_t which;
   dt_lib_module_t *self;   // the module both lists belong to
+
+  /* The conf key dt_ui_scroll_wrap() persists this list's dragged height under. Kept so the
+   * popup can raise the ceiling on it at show time, independently of whatever gui_init built the
+   * wrapper with -- see _shape_manager_relax_height_caps(). */
+  const char *height_key;
 } dt_shape_manager_list_t;
 
 typedef struct dt_shape_manager_t
@@ -641,6 +649,20 @@ static void _tree_delete_shape(GtkButton *button __attribute__((unused)), dt_sha
  * parent, so clicking "+" after selecting a shape inside a module's mask adds to that mask
  * rather than doing nothing. Returns 0 when nothing usable is selected, which is also what
  * greys the button out. */
+/* The top-level ancestor of a row -- itself, if it has none. The module list holds one row per
+ * module and that row's whole subtree, so nothing below the top level is its own destination:
+ * selecting a sub-group or a shape nested inside a module's mask still means "this mask". */
+static int _tree_root_formid(GtkTreeModel *model, GtkTreeIter iter)
+{
+  GtkTreeIter parent;
+  while(gtk_tree_model_iter_parent(model, &parent, &iter))
+    iter = parent;
+
+  int formid = 0;
+  gtk_tree_model_get(model, &iter, TREE_FORMID, &formid, -1);
+  return formid;
+}
+
 static int _selected_group_in_module_list(const dt_shape_manager_t *lm)
 {
   const dt_shape_manager_list_t *list = &lm->lists[DT_SHAPE_LIST_MODULES];
@@ -654,27 +676,20 @@ static int _selected_group_in_module_list(const dt_shape_manager_t *lm)
   int group_id = 0;
   GtkTreeIter iter;
   if(gtk_tree_model_get_iter(model, &iter, (GtkTreePath *)rows->data))
-  {
-    int grid = -1;
-    int fid = -1;
-    _shape_manager_get_values(model, &iter, NULL, &grid, &fid);
-
-    const dt_masks_form_t *form = dt_masks_get_from_id(dt_dev_get_global(), fid);
-    if(!IS_NULL_PTR(form) && (form->type & DT_MASKS_GROUP))
-      group_id = fid;
-    else if(grid > 0)
-      group_id = grid;
-  }
+    group_id = _tree_root_formid(model, iter);
 
   g_list_free_full(rows, (GDestroyNotify)gtk_tree_path_free);
   return group_id;
 }
 
-/* Whether this row's "+" can do anything. Three ways it cannot: nothing is selected in the module
- * list, so there is nowhere to add to; the form is already a member of that group, and re-adding
- * it would write an undo step for a no-op; or the row is a group that already contains the
- * target, and adding it would close a cycle in the membership graph -- every walk over it, the
- * tree build first of all, would then stop terminating.
+/* Whether this row's "+" can do anything. Four ways it cannot: nothing is selected in the module
+ * list, so there is nowhere to add to; the target mask -- always resolved to its top level, never
+ * to whatever sub-group or shape happens to be selected inside it -- already reaches this form,
+ * directly or through one of its own sub-groups, so adding it again would write an undo step for
+ * a no-op; the row is a group that already contains the target, and adding it would close a cycle
+ * in the membership graph -- every walk over it, the tree build first of all, would then stop
+ * terminating; or the row is a group every one of whose shapes the target already renders, adding
+ * nothing new.
  *
  * The icon and the click both ask this one function, so a button that looks available always is. */
 static gboolean _row_can_be_added(const dt_shape_manager_t *lm, GtkTreeModel *model, GtkTreeIter *iter)
@@ -690,7 +705,10 @@ static gboolean _row_can_be_added(const dt_shape_manager_t *lm, GtkTreeModel *mo
   const dt_masks_form_t *grp = dt_masks_get_from_id(dev, group_id);
   if(IS_NULL_PTR(grp) || !(grp->type & DT_MASKS_GROUP)) return FALSE;
 
-  if(dt_masks_group_get_member(dev, group_id, fid, NULL) == DT_MASKS_OK) return FALSE;
+  /* Subsumes "it is the same group" (trivial at depth 0) and "it is already a direct member": a
+   * mask that already reaches this form ANYWHERE in its own subtree gains nothing from reaching
+   * it again at the top. */
+  if(dt_masks_group_contains(dev, group_id, fid) == DT_MASKS_OK) return FALSE;
   if(dt_masks_group_contains(dev, fid, group_id) == DT_MASKS_OK) return FALSE;
 
   /* A group every one of whose shapes the target already renders would add nothing: nesting it
@@ -790,7 +808,9 @@ typedef enum dt_modchooser_col_t
 {
   MODCHOOSER_CHECKED = 0,
   MODCHOOSER_WAS_CHECKED,   // as the dialog opened, so validation can act on the difference
+  MODCHOOSER_SENSITIVE,     // FALSE for a row ticking could not act on -- the module's own mask
   MODCHOOSER_NAME,
+  MODCHOOSER_NOTE,          // why an insensitive row is insensitive; empty otherwise
   MODCHOOSER_MODULE,
   MODCHOOSER_COUNT
 } dt_modchooser_col_t;
@@ -802,7 +822,13 @@ static void _modchooser_toggled(GtkCellRendererToggle *cell __attribute__((unuse
   if(!gtk_tree_model_get_iter_from_string(GTK_TREE_MODEL(store), &iter, path_string)) return;
 
   gboolean checked = FALSE;
-  gtk_tree_model_get(GTK_TREE_MODEL(store), &iter, MODCHOOSER_CHECKED, &checked, -1);
+  gboolean sensitive = TRUE;
+  gtk_tree_model_get(GTK_TREE_MODEL(store), &iter, MODCHOOSER_CHECKED, &checked,
+                     MODCHOOSER_SENSITIVE, &sensitive, -1);
+
+  // A row ticking could not change stays where it is, whichever way it was reached.
+  if(!sensitive) return;
+
   gtk_list_store_set(store, &iter, MODCHOOSER_CHECKED, !checked, -1);
 }
 
@@ -862,9 +888,17 @@ static gboolean _modchooser_run(const dt_masks_form_t *form, GList **to_attach, 
   *to_attach = NULL;
   *to_detach = NULL;
 
+  // One by-value description of the form: every field below is taken from it, not from a raw
+  // reach into the struct.
+  dt_masks_form_info_t info = { 0 };
+  if(!dt_masks_form_get_info(form, &info)) return FALSE;
+
   dt_develop_t *const dev = dt_dev_get_global();
   GtkListStore *store = gtk_list_store_new(MODCHOOSER_COUNT, G_TYPE_BOOLEAN, G_TYPE_BOOLEAN,
-                                           G_TYPE_STRING, G_TYPE_POINTER);
+                                           G_TYPE_BOOLEAN, G_TYPE_STRING, G_TYPE_STRING, G_TYPE_POINTER);
+
+  // What the dialog's title, intro and tooltip call the thing being managed.
+  const char *noun = info.is_group ? _("group") : _("shape");
 
   gboolean any = FALSE;
   for(const GList *iops = g_list_last(dt_dev_get_global()->iop); iops; iops = g_list_previous(iops))
@@ -872,14 +906,23 @@ static gboolean _modchooser_run(const dt_masks_form_t *form, GList **to_attach, 
     dt_iop_module_t *module = (dt_iop_module_t *)iops->data;
     if(!dt_iop_module_is_in_pipeline(module) || !dt_iop_module_supports_drawn_mask(module)) continue;
 
+    /* A module cannot render its own mask as a member of itself -- ticking this would ask
+     * dt_masks_group_add_form() to nest a group inside itself, which _row_can_be_added()'s
+     * equivalent, dt_masks_group_contains(), already refuses trivially at depth 0. Surfacing it
+     * here instead of letting the tick silently do nothing on validation. */
+    const gboolean is_self_mask = (module->blend_params->mask_id == info.formid);
     const gboolean attached
-        = (dt_masks_group_get_member(dev, module->blend_params->mask_id, form->formid, NULL) == DT_MASKS_OK);
+        = !is_self_mask
+          && (dt_masks_group_get_member(dev, module->blend_params->mask_id, info.formid, NULL)
+              == DT_MASKS_OK);
 
     gchar *label = dt_history_item_get_name(module);
     GtkTreeIter iter;
     gtk_list_store_append(store, &iter);
     gtk_list_store_set(store, &iter, MODCHOOSER_CHECKED, attached, MODCHOOSER_WAS_CHECKED, attached,
-                       MODCHOOSER_NAME, label, MODCHOOSER_MODULE, module, -1);
+                       MODCHOOSER_SENSITIVE, !is_self_mask, MODCHOOSER_NAME, label,
+                       MODCHOOSER_NOTE, is_self_mask ? _("this is the module's own mask") : "",
+                       MODCHOOSER_MODULE, module, -1);
     dt_free(label);
     any = TRUE;
   }
@@ -894,10 +937,12 @@ static gboolean _modchooser_run(const dt_masks_form_t *form, GList **to_attach, 
   /* Parented to the main window rather than to the shape manager's own panel: that panel is a
    * UTILITY window that declines focus, which is not something to hang a modal dialog off. */
   GtkWindow *parent = GTK_WINDOW(dt_gui_main_window());
-  GtkWidget *dialog = gtk_dialog_new_with_buttons(_("Modules using this shape"), parent,
+  gchar *title = g_strdup_printf(_("Modules using this %s"), noun);
+  GtkWidget *dialog = gtk_dialog_new_with_buttons(title, parent,
                                                   GTK_DIALOG_DESTROY_WITH_PARENT | GTK_DIALOG_MODAL,
                                                   _("Cancel"), GTK_RESPONSE_CANCEL,
                                                   _("Apply"), GTK_RESPONSE_ACCEPT, NULL);
+  dt_free(title);   // gtk_window_set_title() (called internally) copies it
   gtk_dialog_set_default_response(GTK_DIALOG(dialog), GTK_RESPONSE_ACCEPT);
 
   /* Above everything, because the window it is about -- the shape manager's own panel -- is a
@@ -911,8 +956,8 @@ static gboolean _modchooser_run(const dt_masks_form_t *form, GList **to_attach, 
   gtk_container_set_border_width(GTK_CONTAINER(content), DT_GUI_BOX_SPACING);
   gtk_box_set_spacing(GTK_BOX(content), DT_GUI_BOX_SPACING);
 
-  gchar *intro = g_strdup_printf(_("Tick the modules that should use the shape '%s', untick the ones "
-                                   "that should stop."), form->name);
+  gchar *intro = g_strdup_printf(_("Tick the modules that should use the %s '%s', untick the ones "
+                                   "that should stop."), noun, info.name);
   GtkWidget *label = dt_ui_label_new(intro);
   dt_free(intro);
   gtk_box_pack_start(GTK_BOX(content), label, FALSE, FALSE, 0);
@@ -922,15 +967,29 @@ static gboolean _modchooser_run(const dt_masks_form_t *form, GList **to_attach, 
   gtk_tree_selection_set_mode(gtk_tree_view_get_selection(GTK_TREE_VIEW(treeview)), GTK_SELECTION_NONE);
 
   GtkTreeViewColumn *col = gtk_tree_view_column_new();
+  gtk_tree_view_column_set_expand(col, TRUE);
+
   GtkCellRenderer *renderer = gtk_cell_renderer_toggle_new();
   g_object_set(renderer, "activatable", TRUE, NULL);
   g_signal_connect(renderer, "toggled", G_CALLBACK(_modchooser_toggled), store);
   gtk_tree_view_column_pack_start(col, renderer, FALSE);
   gtk_tree_view_column_add_attribute(col, renderer, "active", MODCHOOSER_CHECKED);
+  gtk_tree_view_column_add_attribute(col, renderer, "sensitive", MODCHOOSER_SENSITIVE);
 
   renderer = gtk_cell_renderer_text_new();
   gtk_tree_view_column_pack_start(col, renderer, TRUE);
   gtk_tree_view_column_add_attribute(col, renderer, "text", MODCHOOSER_NAME);
+  gtk_tree_view_column_add_attribute(col, renderer, "sensitive", MODCHOOSER_SENSITIVE);
+
+  /* The reason a row is dead, said on the row itself: italic and against the right edge, so it
+   * reads as an annotation rather than part of the module's name. Empty on every live row, which
+   * costs it no space. */
+  renderer = gtk_cell_renderer_text_new();
+  g_object_set(renderer, "style", PANGO_STYLE_ITALIC, "xalign", 1.0f, NULL);
+  gtk_cell_renderer_set_sensitive(renderer, FALSE);
+  gtk_tree_view_column_pack_end(col, renderer, FALSE);
+  gtk_tree_view_column_add_attribute(col, renderer, "text", MODCHOOSER_NOTE);
+
   gtk_tree_view_append_column(GTK_TREE_VIEW(treeview), col);
 
   g_signal_connect(treeview, "button-press-event", G_CALLBACK(_modchooser_button_pressed), store);
@@ -1303,6 +1362,15 @@ static void _tree_selection_change(GtkTreeSelection *selection, dt_shape_manager
   // unlike grp_dest, whose reference passes to form_visible below.
   dt_masks_form_unref(grp);
   dt_masks_change_form_gui(dev, grp_dest);
+  /* dt_masks_change_form_gui() is NULL-safe on dev->form_gui throughout -- it is only ever
+   * allocated by dt_masks_gui_init(), on entering darkroom, and freed back to NULL on leaving it
+   * (views/darkroom.c, views/studio_capture.c's own dev teardown). This panel's window is a
+   * standalone toplevel that can outlive that: switching away from darkroom while it stays open,
+   * then selecting a row here, reached this point with dev->form_gui NULL and no guard (SIGSEGV,
+   * observed live). edit_mode has nothing to record it into then, and there is no "current form"
+   * for the pipeline to preview either -- the whole point of a view with no darkroom -- so this
+   * simply has nothing to do. */
+  if(IS_NULL_PTR(dev->form_gui)) return;
   dev->form_gui->edit_mode = DT_MASKS_EDIT_FULL;
   if(nb == 1 && !IS_NULL_PTR(selected_form))
     dt_masks_center_view_on_form(dev, selected_form);
@@ -1733,8 +1801,16 @@ static gboolean _tree_query_tooltip(GtkWidget *widget, gint x, gint y, gboolean 
 
       if(got && on_assign)
       {
-        gtk_tooltip_set_text(tooltip, _("Manage which modules use this shape. A mask is created for the "
-                                        "ticked ones that have none, and shared between them."));
+        int fid = -1;
+        _shape_manager_get_values(model, &action_iter, NULL, NULL, &fid);
+        dt_masks_form_info_t row_info = { 0 };
+        dt_masks_form_get_info(dt_masks_get_from_id(dt_dev_get_global(), fid), &row_info);
+
+        gchar *text = g_strdup_printf(_("Manage which modules use this %s. A mask is created for the "
+                                        "ticked ones that have none, and shared between them."),
+                                      row_info.is_group ? _("group") : _("shape"));
+        gtk_tooltip_set_text(tooltip, text);
+        dt_free(text);
         return TRUE;
       }
 
@@ -1754,15 +1830,18 @@ static gboolean _tree_query_tooltip(GtkWidget *widget, gint x, gint y, gboolean 
         {
           int fid = -1;
           _shape_manager_get_values(model, &action_iter, NULL, NULL, &fid);
-          const gboolean member
-              = (dt_masks_group_get_member(dt_dev_get_global(), group_id, fid, NULL) == DT_MASKS_OK);
+          dt_develop_t *const dev = dt_dev_get_global();
+
+          // Same reasoning _row_can_be_added() applies, so the wording never disagrees with it.
+          const gboolean already_in = (dt_masks_group_contains(dev, group_id, fid) == DT_MASKS_OK);
+          const gboolean would_cycle = (dt_masks_group_contains(dev, fid, group_id) == DT_MASKS_OK);
 
           gchar *text;
           if(_row_can_be_added(lm, model, &action_iter))
-            text = g_strdup_printf(_("Add this shape to the mask '%s'."), grp->name);
-          else if(member)
-            text = g_strdup_printf(_("This shape is already part of the mask '%s'."), grp->name);
-          else if(dt_masks_group_contains(dt_dev_get_global(), fid, group_id) == DT_MASKS_OK)
+            text = g_strdup_printf(_("Add this to the mask '%s'."), grp->name);
+          else if(already_in)
+            text = g_strdup_printf(_("This is already part of the mask '%s'."), grp->name);
+          else if(would_cycle)
             text = g_strdup_printf(_("This group cannot be added to the mask '%s': it already contains it."),
                                    grp->name);
           else
@@ -1838,6 +1917,9 @@ typedef struct _tree_row_t
   int index;               // rank inside the parent, which _set_iter_name() shows
   int root_id;             /* the module mask this row sits somewhere inside, 0 outside the
                             * module list -- the scope the note below is searched in */
+  gboolean flat;           /* TRUE to append this row without descending into its own members --
+                            * a module mask shown in the inventory: a single, non-expandable row
+                            * there, its full subtree still shown, expandable, in the module list */
 } _tree_row_t;
 
 /* Every module whose drawn mask is this group, in pipeline order.
@@ -1948,6 +2030,9 @@ static void _shape_manager_list_recurs(GtkTreeStore *treestore, GtkTreeIter *top
   GtkTreeIter child;
   _tree_append_row(treestore, toplevel, lm, &self, &child);
 
+  // A flat row is a single line by request: no expander, no children appended under it.
+  if(self.flat) return;
+
   if(!(self.form->type & DT_MASKS_GROUP)) return;
 
   int index = 0;
@@ -2043,18 +2128,41 @@ static void _tree_reveal_row(dt_shape_manager_list_t *list, GtkTreeModel *model,
   gtk_tree_path_free(path);
 }
 
-/* Which of the two lists a top-level form belongs in. Only a group can be claimed by a module,
- * so a plain shape is always in the inventory -- including one a module's group holds, which is
- * then listed twice, once here and once as that group's member. */
-static dt_shape_list_t _form_belongs_to(const dt_masks_form_t *form)
+/* Whether this group is some module's drawn mask, which is what the module list holds. */
+static gboolean _group_is_module_mask(const dt_masks_form_t *form)
 {
-  if(IS_NULL_PTR(form) || !(form->type & DT_MASKS_GROUP)) return DT_SHAPE_LIST_SHAPES;
+  if(IS_NULL_PTR(form) || !(form->type & DT_MASKS_GROUP)) return FALSE;
 
   GList *owners = _modules_owning_group(form);
   const gboolean assigned = !IS_NULL_PTR(owners);
   g_list_free(owners);
 
-  return assigned ? DT_SHAPE_LIST_MODULES : DT_SHAPE_LIST_SHAPES;
+  return assigned;
+}
+
+/* Appends one group's row (and, recursively, everything under it, unless @p flat) and answers
+ * whether it did -- FALSE only when a module-mask row's own id could not be read, which leaves
+ * the row unlisted rather than mislabelled. root_id is a property of the row's SCOPE (see
+ * _tree_row_t), not of the group itself: it is only ever set for a module mask, so the "applied
+ * twice in this mask" note has something to search.
+ *
+ * @param flat the inventory's own copy of a module mask: a single row, no expander, no members
+ *             appended under it -- that subtree is the module list's to show, not shown twice. */
+static gboolean _tree_store_append_group_row(GtkTreeStore *treestore, dt_shape_manager_t *lm,
+                                             dt_masks_form_t *form, const gboolean is_module_mask,
+                                             const gboolean flat)
+{
+  int root_id = 0;
+  if(is_module_mask)
+  {
+    dt_masks_form_info_t info = { 0 };
+    if(!dt_masks_form_get_info(form, &info)) return FALSE;
+    root_id = info.formid;
+  }
+
+  const _tree_row_t row = { .form = form, .opacity = 1.0f, .root_id = root_id, .flat = flat };
+  _shape_manager_list_recurs(treestore, NULL, lm, &row);
+  return TRUE;
 }
 
 /* Returns whether it added anything, which is what tells the caller a separator is worth having. */
@@ -2063,27 +2171,47 @@ static gboolean _tree_store_add_forms(GtkTreeStore *treestore, dt_shape_manager_
 {
   gboolean any = FALSE;
 
+  /* Module masks are walked in pipeline order rather than in creation order, in both lists --
+   * the inventory holds them too (see _group_is_module_mask()'s own comment).
+   * Reverse iop_order, the "bottom of the stack first" convention _modchooser_run() and the
+   * module groups panel's Pipeline tab already use for the same kind of module list, so a
+   * module's mask lands at the same relative position here as its own row does everywhere else
+   * in the darkroom.
+   *
+   * Scoped exactly like _modules_owning_group() -- every module in dev->iop, not just the ones
+   * dt_iop_module_is_in_pipeline() currently shows -- so a mask belonging to a hidden or
+   * not-yet-reached instance is still found here rather than silently dropped from both this
+   * loop and the "unclaimed groups" one below, which skips it on the assumption it was already
+   * handled. */
+  if(groups)
+  {
+    dt_develop_t *const dev = dt_dev_get_global();
+    for(const GList *iops = g_list_last(dev->iop); iops; iops = g_list_previous(iops))
+    {
+      dt_iop_module_t *module = (dt_iop_module_t *)iops->data;
+      if(!dt_iop_module_supports_drawn_mask(module)) continue;
+
+      dt_masks_form_t *mask = dt_masks_get_from_id(dev, module->blend_params->mask_id);
+      if(IS_NULL_PTR(mask) || !(mask->type & DT_MASKS_GROUP)) continue;
+
+      // Expandable in the module list (its own home), a single flat row in the inventory.
+      if(_tree_store_append_group_row(treestore, lm, mask, TRUE, which == DT_SHAPE_LIST_SHAPES))
+        any = TRUE;
+    }
+
+    // The module list holds nothing else.
+    if(which == DT_SHAPE_LIST_MODULES) return any;
+  }
+
   for(const GList *forms = dt_dev_get_global()->forms; forms; forms = g_list_next(forms))
   {
     dt_masks_form_t *form = (dt_masks_form_t *)forms->data;
     if(!!(form->type & DT_MASKS_GROUP) != groups) continue;
-    if(_form_belongs_to(form) != which) continue;
 
-    /* The mask this row and everything under it belongs to. Only the module list has one: the
-     * inventory's groups are nobody's mask, so a shape under them is reached once and there is
-     * nothing to warn about. A module owns its mask group, so one row per group is already one
-     * row per module. */
-    int root_id = 0;
-    if(which == DT_SHAPE_LIST_MODULES && groups)
-    {
-      dt_masks_form_info_t info = { 0 };
-      if(!dt_masks_form_get_info(form, &info)) continue;
-      root_id = info.formid;
-    }
+    // Already appended above, in pipeline order: this pass is unclaimed groups (and shapes) only.
+    if(groups && _group_is_module_mask(form)) continue;
 
-    const _tree_row_t row = { .form = form, .opacity = 1.0f, .root_id = root_id };
-    _shape_manager_list_recurs(treestore, NULL, lm, &row);
-    any = TRUE;
+    if(_tree_store_append_group_row(treestore, lm, form, FALSE, FALSE)) any = TRUE;
   }
 
   return any;
@@ -2432,12 +2560,28 @@ static gboolean _shape_manager_selection_change_in(dt_shape_manager_t *lm, const
     return FALSE;
   }
 
+  /* The recursive search below walks the MODEL (gtk_tree_model_iter_children()), which holds
+   * every row regardless of the view's own expand/collapse display state -- it needs nothing
+   * expanded to find its target. Expanding the WHOLE tree first, as this used to, was only ever
+   * about making the match visible afterward, and it did that by exploding every OTHER group
+   * open too, module masks and unclaimed groups alike, for a search that had nothing to do with
+   * them. Revealing just the path to the row actually found -- the same targeted
+   * expand-to-path/scroll _tree_reveal_row() already uses elsewhere -- gets the same visibility
+   * without the side effect. */
   gboolean found = FALSE;
   if(gtk_tree_model_get_iter_first(model, &iter))
-  {
-    gtk_tree_view_expand_all(GTK_TREE_VIEW(list->treeview));
     found = _shape_manager_selection_change_r(model, selection, &iter, module, selectid, throw_event, 1);
-    if(!found) gtk_tree_view_collapse_all(GTK_TREE_VIEW(list->treeview));
+
+  if(found)
+  {
+    GList *rows = gtk_tree_selection_get_selected_rows(selection, NULL);
+    if(!IS_NULL_PTR(rows))
+    {
+      GtkTreePath *path = (GtkTreePath *)rows->data;
+      gtk_tree_view_expand_to_path(GTK_TREE_VIEW(list->treeview), path);
+      gtk_tree_view_scroll_to_cell(GTK_TREE_VIEW(list->treeview), path, NULL, TRUE, 0.5, 0.5);
+    }
+    g_list_free_full(rows, (GDestroyNotify)gtk_tree_path_free);
   }
 
   lm->gui_reset = 0;
@@ -2673,6 +2817,57 @@ static void _shape_manager_popup_restore_geometry(dt_shape_manager_t *d)
 /** @brief The toolbox button is the panel's only state: showing and hiding both go through its
  * active flag, so every way of closing the panel leaves the button un-pressed. Re-entrant by
  * design -- the window-manager close path toggles the button, which comes back here. */
+/** @brief The room a fresh, un-dragged dt_ui_scroll_wrap area is allowed to grow to -- the same
+ * ceiling scroll_wrap.c's own ungated case uses, so raising a list's cap to this number is
+ * indistinguishable from that list never having been dragged at all. */
+static gint _shape_manager_height_ceiling(void)
+{
+  GtkWidget *win = dt_widget_root_window();
+  return win ? gtk_widget_get_allocated_height(win) : DT_PIXEL_APPLY_DPI(1000);
+}
+
+/** @brief Forget how far the user last dragged each list, so the auto-sizing pass that follows
+ * measures true, full content instead of stopping at a small stale cap from a previous session.
+ *
+ * There is no "erase this conf key" call, so the ceiling itself is stored in its place: as far as
+ * dt_ui_scroll_wrap()'s own sizing rule can tell, that is exactly what an un-dragged list looks
+ * like. A later manual drag overwrites it with a real choice again, same as always -- this only
+ * resets what STARTUP sees. */
+static void _shape_manager_relax_height_caps(const dt_shape_manager_t *d)
+{
+  const gint ceiling = _shape_manager_height_ceiling();
+  for(int i = 0; i < DT_SHAPE_LIST_COUNT; i++)
+  {
+    const dt_shape_manager_list_t *list = &d->lists[i];
+    if(!IS_NULL_PTR(list->height_key)) dt_widget_store_int(list->height_key, ceiling);
+  }
+}
+
+/** @brief Grows the just-shown window by one row past whatever height the (now uncapped) lists
+ * settled on, so the longer one reads as complete rather than filled edge-to-edge -- and so a
+ * list exactly as tall as the window doesn't look like it might have one more row hidden below.
+ *
+ * Must run AFTER gtk_widget_show_all(): the row-height query works on an empty model, but the
+ * window's OWN height only reflects the lists' true content once they have been realized and
+ * dt_ui_scroll_wrap's sizing rule has run against the raised ceiling. */
+static void _shape_manager_grow_by_one_row(const dt_shape_manager_t *d)
+{
+  if(!GTK_IS_WINDOW(d->popup_window)) return;
+
+  gint row = 0;
+  for(int i = 0; i < DT_SHAPE_LIST_COUNT; i++)
+  {
+    const gint h = dt_ui_scroll_wrap_row_height(d->lists[i].treeview);
+    if(h > row) row = h;
+  }
+  if(row <= 0) return;
+
+  gint width = 0;
+  gint height = 0;
+  gtk_window_get_size(GTK_WINDOW(d->popup_window), &width, &height);
+  gtk_window_resize(GTK_WINDOW(d->popup_window), width, height + row);
+}
+
 static void _shape_manager_popup_button_toggled_cb(GtkWidget *button, gpointer user_data)
 {
   dt_shape_manager_t *d = (dt_shape_manager_t *)user_data;
@@ -2685,7 +2880,15 @@ static void _shape_manager_popup_button_toggled_cb(GtkWidget *button, gpointer u
   {
     // before mapping: a move applied to a mapped window makes it jump in view
     _shape_manager_popup_restore_geometry(d);
+
+    // Also before mapping: dt_ui_scroll_wrap's sizing rule reads this the moment each treeview
+    // realizes, which show_all() triggers below.
+    _shape_manager_relax_height_caps(d);
+
     gtk_widget_show_all(d->popup_window);
+
+    // Only after: needs the lists' post-realize, freshly-uncapped height to add one row to it.
+    _shape_manager_grow_by_one_row(d);
   }
   else
   {
@@ -2764,9 +2967,11 @@ void gui_init(dt_lib_module_t *self)
   // first mapping only, so a panel the user has dragged elsewhere keeps its place.
   gtk_window_set_position(GTK_WINDOW(d->popup_window), GTK_WIN_POS_CENTER_ON_PARENT);
 
-  /* No width request of its own: the two lists below each carry a min-content-width, so the
-   * window's own minimum is what they add up to, and it grows with whatever the user drags the
-   * paned or the frame to. Heights come from each list's dt_ui_scroll_wrap() rule. */
+  /* No width request of its own: the window's own minimum is whatever the two lists below need
+   * -- their own content (names are never ellipsized, so a long one raises that floor) or their
+   * min-content-width default when there is none -- added together, and it grows further with
+   * whatever the user drags the paned or the frame to. Heights come from each list's
+   * dt_ui_scroll_wrap() rule. */
 
 #ifdef GDK_WINDOWING_QUARTZ
   dt_osx_disallow_fullscreen(d->popup_window);
@@ -2862,7 +3067,8 @@ void gui_init(dt_lib_module_t *self)
     const char *height_key;
   } list_defs[DT_SHAPE_LIST_COUNT] = {
     [DT_SHAPE_LIST_SHAPES] = { N_("All shapes"),
-                               N_("Every shape drawn on this image, and the groups no module uses yet."),
+                               N_("Every shape and group drawn on this image, including the masks "
+                                  "modules already use -- pick any of them up to reuse."),
                                "plugins/darkroom/masks/windowheight" },
     [DT_SHAPE_LIST_MODULES] = { N_("Module groups"),
                                 N_("The masks modules actually render, and the shapes each one is made of."),
@@ -2874,6 +3080,7 @@ void gui_init(dt_lib_module_t *self)
     dt_shape_manager_list_t *list = &d->lists[i];
     list->which = (dt_shape_list_t)i;
     list->self = self;
+    list->height_key = list_defs[i].height_key;
     list->treeview = gtk_tree_view_new();
 
     GtkTreeViewColumn *col = gtk_tree_view_column_new();
@@ -2889,8 +3096,15 @@ void gui_init(dt_lib_module_t *self)
     gtk_tree_view_column_set_attributes(col, renderer, "pixbuf", TREE_IC_INVERSE, NULL);
     gtk_tree_view_column_add_attribute(col, renderer, "visible", TREE_IC_INVERSE_VISIBLE);
 
+    /* No ellipsize: a name that does not fit is not something to shorten, it is something the
+     * column has to make room for. Measured offscreen -- with no ellipsize set, a GtkTreeView
+     * reports its true, full-content preferred width, and that width propagates all the way up
+     * through a GTK_POLICY_NEVER scrolled window to the window itself; gtk_window_resize() (used
+     * to restore a persisted width below) cannot force the window narrower than that reported
+     * minimum, GTK clamps it back up. So the name is simply never compressed, in either list, by
+     * a narrow paned split or a narrow restored window -- both floors hold at the content's own
+     * minimum instead. */
     renderer = gtk_cell_renderer_text_new();
-    g_object_set(renderer, "ellipsize", PANGO_ELLIPSIZE_MIDDLE, NULL);
     gtk_tree_view_column_pack_start(col, renderer, TRUE);
     gtk_tree_view_column_add_attribute(col, renderer, "text", TREE_TEXT);
     gtk_tree_view_column_add_attribute(col, renderer, "editable", TREE_EDITABLE);
@@ -2899,15 +3113,10 @@ void gui_init(dt_lib_module_t *self)
     list->name_col = col;
     list->name_renderer = renderer;
 
-    /* What the row has to say about itself, in italics against the right end of the name column,
-     * so it reads as an annotation rather than as part of the shape's name. Empty on every row
-     * that has nothing to add, which costs those no space. */
-    renderer = gtk_cell_renderer_text_new();
-    g_object_set(renderer, "style", PANGO_STYLE_ITALIC, "xalign", 1.0f, NULL);
-    gtk_cell_renderer_set_sensitive(renderer, FALSE);
-    gtk_tree_view_column_pack_end(col, renderer, FALSE);
-    gtk_tree_view_column_add_attribute(col, renderer, "text", TREE_NOTE);
-
+    /* Measured offscreen: of two renderers packed at a column's end, the FIRST one packed lands
+     * at the true right edge, and each renderer packed after it sits closer to the main content
+     * instead -- so the icon has to be packed before the note text, not after, to end up to the
+     * note's right. */
     renderer = gtk_cell_renderer_pixbuf_new();
     // A theme with no symbolic variant of that icon leaves the pixbuf NULL: name the icon instead
     // and let GTK draw it, untinted, rather than show nothing.
@@ -2917,6 +3126,16 @@ void gui_init(dt_lib_module_t *self)
       g_object_set(renderer, "pixbuf", d->ic_used, NULL);
     gtk_tree_view_column_pack_end(col, renderer, FALSE);
     gtk_tree_view_column_add_attribute(col, renderer, "visible", TREE_IC_USED_VISIBLE);
+
+    /* What the row has to say about itself, in italics, sitting to the LEFT of the "used by" icon
+     * above (packed after it, per the same measurement) so it reads as an annotation on the name
+     * rather than as part of it. Empty on every row that has nothing to add, which costs those no
+     * space. */
+    renderer = gtk_cell_renderer_text_new();
+    g_object_set(renderer, "style", PANGO_STYLE_ITALIC, "xalign", 1.0f, NULL);
+    gtk_cell_renderer_set_sensitive(renderer, FALSE);
+    gtk_tree_view_column_pack_end(col, renderer, FALSE);
+    gtk_tree_view_column_add_attribute(col, renderer, "text", TREE_NOTE);
 
     /* The per-row action icon, to the right of everything the name column carries -- the "used
      * by" icon included, since that one is packed at that column's end. Both renderers live in
@@ -3006,18 +3225,24 @@ void gui_init(dt_lib_module_t *self)
     GtkWidget *wrapper = dt_ui_scroll_wrap(list->treeview, 90, list_defs[i].height_key,
                                            DT_UI_RESIZE_DYNAMIC);
 
-    /* The width floor is set here rather than on the window: a tree in a scrolled window has
-     * almost no minimum width of its own, so without this the paned would let either half be
-     * dragged down to nothing, and the window would have no sensible minimum either. Names
-     * ellipsize in the middle, so a narrow half stays readable at both ends. */
+    /* A default floor for an EMPTY list, where the treeview's own content-derived minimum is
+     * near zero: without this, an empty paned half could be dragged down to nothing. It never
+     * shrinks a list below its actual content, though -- gtk_scrolled_window_set_min_content_width()
+     * only raises the reported minimum when it is the larger of the two; a longer name simply
+     * wins on its own, per the name renderer's own comment above. */
     GtkWidget *scrolled = dt_ui_scroll_wrap_get_scrolled_window(wrapper);
     if(GTK_IS_SCROLLED_WINDOW(scrolled))
       gtk_scrolled_window_set_min_content_width(GTK_SCROLLED_WINDOW(scrolled), DT_PIXEL_APPLY_DPI(190));
 
     gtk_box_pack_start(GTK_BOX(half), wrapper, TRUE, TRUE, 0);
 
+    /* Measured offscreen: with both sides resize=TRUE, GtkPaned splits any width the window
+     * gains between the two -- the divider drifts to keep an even split, rather than staying
+     * where it was left. The inventory (pack1) is pinned instead (resize=FALSE) so growing the
+     * window hands all of the new width to the module list (pack2, resize=TRUE) and the divider
+     * itself does not move; a manual drag still repositions it normally either way. */
     if(i == 0)
-      gtk_paned_pack1(GTK_PANED(lists_paned), half, TRUE, FALSE);
+      gtk_paned_pack1(GTK_PANED(lists_paned), half, FALSE, FALSE);
     else
       gtk_paned_pack2(GTK_PANED(lists_paned), half, TRUE, FALSE);
   }

--- a/src/libs/shape_manager.c
+++ b/src/libs/shape_manager.c
@@ -102,10 +102,9 @@ typedef struct dt_shape_manager_list_t
   GtkTreeViewColumn *action_col;
 
   /* The "add to the selected module group" column, on the inventory list only -- NULL on the
-   * module list. Its renderer is kept because whether the button is available is not a property
-   * of the row but of the other list's selection, and that is a renderer-wide sensitivity. */
+   * module list. Kept for the same reason as action_col: a click and a tooltip are both answered
+   * by comparing against the column the pointer is over. */
   GtkTreeViewColumn *add_col;
-  GtkCellRenderer *add_renderer;
 
   dt_shape_list_t which;
   dt_lib_module_t *self;   // the module both lists belong to
@@ -120,6 +119,11 @@ typedef struct dt_shape_manager_t
   GtkWidget *popup_button;
 
   GdkPixbuf *ic_used;
+  /* The "+" in its two states. A cell renderer has no colour of its own and its insensitive
+   * rendering is far too faint to read as disabled (measured: at most 49 of 255 on a channel),
+   * so availability is shown by swapping the icon for a differently tinted one. */
+  GdkPixbuf *ic_add;
+  GdkPixbuf *ic_add_off;
   GdkPixbuf *ic_inverse;
   GdkPixbuf *ic_union;
   GdkPixbuf *ic_intersection;
@@ -671,19 +675,66 @@ static gboolean _group_contains(const dt_develop_t *dev, const int container_id,
   return FALSE;
 }
 
-/* The "+" is available exactly when the module list points at a group. That is a property of the
- * other list's selection rather than of any row, so it is the renderer's own sensitivity, and
- * the inventory has to be redrawn when it changes. */
+/* Whether this row's "+" can do anything. Three ways it cannot: nothing is selected in the module
+ * list, so there is nowhere to add to; the form is already a member of that group, and re-adding
+ * it would write an undo step for a no-op; or the row is a group that already contains the
+ * target, and adding it would close a cycle in the membership graph -- every walk over it, the
+ * tree build first of all, would then stop terminating.
+ *
+ * The icon and the click both ask this one function, so a button that looks available always is. */
+static gboolean _row_can_be_added(const dt_shape_manager_t *lm, GtkTreeModel *model, GtkTreeIter *iter)
+{
+  const int group_id = _selected_group_in_module_list(lm);
+  if(group_id <= 0) return FALSE;
+
+  int fid = -1;
+  _shape_manager_get_values(model, iter, NULL, NULL, &fid);
+  if(fid <= 0) return FALSE;
+
+  dt_develop_t *const dev = dt_dev_get_global();
+  const dt_masks_form_t *grp = dt_masks_get_from_id(dev, group_id);
+  if(IS_NULL_PTR(grp) || !(grp->type & DT_MASKS_GROUP)) return FALSE;
+
+  if(dt_masks_group_get_member(dev, group_id, fid, NULL) == DT_MASKS_OK) return FALSE;
+  if(_group_contains(dev, fid, group_id)) return FALSE;
+
+  return TRUE;
+}
+
+/* Availability is per row and depends on the OTHER list's selection, so it is recomputed at draw
+ * time rather than stored: nothing can go stale, and there is no model column to keep in step.
+ *
+ * The renderer's sensitivity carries the meaning but not the look -- measured on this exact
+ * renderer, offscreen, an insensitive icon-name pixbuf cell differs from a sensitive one by at
+ * most 49 of 255 on a channel, a faint dim rather than a grey-out -- so the icon is swapped for
+ * a differently tinted one, the same answer the "used by" icon got.
+ *
+ * A cell data func replaces the column's attribute mapping rather than adding to it, so this
+ * sets "visible" too instead of leaving it to gtk_tree_view_column_add_attribute(). */
+static void _add_cell_data_func(GtkTreeViewColumn *col __attribute__((unused)), GtkCellRenderer *renderer,
+                                GtkTreeModel *model, GtkTreeIter *iter, gpointer data)
+{
+  const dt_shape_manager_t *lm = (const dt_shape_manager_t *)data;
+
+  gboolean on_row = FALSE;
+  gtk_tree_model_get(model, iter, TREE_IC_DELETE_VISIBLE, &on_row, -1);
+  g_object_set(renderer, "visible", on_row, NULL);
+  if(!on_row) return;
+
+  const gboolean available = _row_can_be_added(lm, model, iter);
+  gtk_cell_renderer_set_sensitive(renderer, available);
+
+  GdkPixbuf *icon = available ? lm->ic_add : lm->ic_add_off;
+  if(!IS_NULL_PTR(icon)) g_object_set(renderer, "pixbuf", icon, NULL);
+}
+
+/* The module list's selection decides every inventory row's "+", so a change there redraws the
+ * inventory and the data func above answers again. */
 static void _shape_manager_sync_add_sensitivity(const dt_shape_manager_t *lm)
 {
   const dt_shape_manager_list_t *list = &lm->lists[DT_SHAPE_LIST_SHAPES];
-  if(IS_NULL_PTR(list->add_renderer)) return;
-
-  const gboolean available = (_selected_group_in_module_list(lm) > 0);
-  if(gtk_cell_renderer_get_sensitive(list->add_renderer) == available) return;
-
-  gtk_cell_renderer_set_sensitive(list->add_renderer, available);
-  if(!IS_NULL_PTR(list->treeview)) gtk_widget_queue_draw(list->treeview);
+  if(IS_NULL_PTR(list->add_col) || IS_NULL_PTR(list->treeview)) return;
+  gtk_widget_queue_draw(list->treeview);
 }
 
 /* The inventory's "+": add this row's form to the group the module list points at. */
@@ -693,21 +744,15 @@ static void _tree_row_add_to_group(dt_shape_manager_list_t *list, GtkTreeModel *
   dt_shape_manager_t *lm = (dt_shape_manager_t *)self->data;
   dt_develop_t *const dev = dt_dev_get_global();
 
-  const int group_id = _selected_group_in_module_list(lm);
-  if(group_id <= 0) return;
+  // The same question the icon was drawn from, so a greyed "+" cannot act.
+  if(!_row_can_be_added(lm, model, iter)) return;
 
   int fid = -1;
   _shape_manager_get_values(model, iter, NULL, NULL, &fid);
 
   dt_masks_form_t *form = dt_masks_get_from_id(dev, fid);
-  dt_masks_form_t *grp = dt_masks_get_from_id(dev, group_id);
-  if(IS_NULL_PTR(form) || IS_NULL_PTR(grp) || !(grp->type & DT_MASKS_GROUP)) return;
-
-  // Adding a group to itself, or to one of its own descendants, would close a cycle.
-  if(_group_contains(dev, fid, group_id)) return;
-
-  // Already a member: nothing to add, and a no-op must not write an undo step.
-  if(dt_masks_group_get_member(dev, group_id, fid, NULL) == DT_MASKS_OK) return;
+  dt_masks_form_t *grp = dt_masks_get_from_id(dev, _selected_group_in_module_list(lm));
+  if(IS_NULL_PTR(form) || IS_NULL_PTR(grp)) return;
 
   grp = dt_masks_cow_touch(dev, grp);
   if(IS_NULL_PTR(dt_masks_group_add_form(dev, grp, form))) return;
@@ -1337,7 +1382,8 @@ static gboolean _tree_query_tooltip(GtkWidget *widget, gint x, gint y, gboolean 
 
       if(got && on_add)
       {
-        // The button says what it will do, so it has to name what is selected right now.
+        // The button says what it will do, so it has to name what is selected right now -- and
+        // when it is dead, which of the reasons it is dead for.
         const dt_shape_manager_t *lm = (const dt_shape_manager_t *)list->self->data;
         const int group_id = _selected_group_in_module_list(lm);
         const dt_masks_form_t *grp = dt_masks_get_from_id(dt_dev_get_global(), group_id);
@@ -1348,7 +1394,20 @@ static gboolean _tree_query_tooltip(GtkWidget *widget, gint x, gint y, gboolean 
         }
         else
         {
-          gchar *text = g_strdup_printf(_("Add this shape to the mask '%s'."), grp->name);
+          int fid = -1;
+          _shape_manager_get_values(model, &action_iter, NULL, NULL, &fid);
+          const gboolean member
+              = (dt_masks_group_get_member(dt_dev_get_global(), group_id, fid, NULL) == DT_MASKS_OK);
+
+          gchar *text;
+          if(_row_can_be_added(lm, model, &action_iter))
+            text = g_strdup_printf(_("Add this shape to the mask '%s'."), grp->name);
+          else if(member)
+            text = g_strdup_printf(_("This shape is already part of the mask '%s'."), grp->name);
+          else
+            // The remaining refusal: this group already holds the mask, at some depth.
+            text = g_strdup_printf(_("This group cannot be added to the mask '%s': it already contains it."),
+                                   grp->name);
           gtk_tooltip_set_text(tooltip, text);
           dt_free(text);
         }
@@ -2375,6 +2434,16 @@ void gui_init(dt_lib_module_t *self)
 
   d->ic_used = dt_gui_symbolic_icon_pixbuf("mail-attachment-symbolic", GTK_ICON_SIZE_MENU, &used_color, NULL);
 
+  // The "+" in its available and unavailable tints: the plain foreground against the same
+  // disabled grey the "used by" icon uses, which is the contrast that reads as a dead button.
+  GdkRGBA fg_color;
+  if(!gtk_style_context_lookup_color(gtk_widget_get_style_context(shape_manager_container),
+                                     "fg_color", &fg_color))
+    fg_color = (GdkRGBA){ 1.0, 1.0, 1.0, 1.0 };
+
+  d->ic_add = dt_gui_symbolic_icon_pixbuf("list-add-symbolic", GTK_ICON_SIZE_MENU, &fg_color, NULL);
+  d->ic_add_off = dt_gui_symbolic_icon_pixbuf("list-add-symbolic", GTK_ICON_SIZE_MENU, &used_color, NULL);
+
   /* The two lists sit side by side in a paned, so the split is the user's and persists. Each
    * half is built identically -- the only thing that differs between them is which forms their
    * store holds, which _tree_store_build() decides from list->which. */
@@ -2450,11 +2519,15 @@ void gui_init(dt_lib_module_t *self)
       gtk_tree_view_column_set_sizing(list->add_col, GTK_TREE_VIEW_COLUMN_FIXED);
       gtk_tree_view_column_set_fixed_width(list->add_col, DT_PIXEL_APPLY_DPI(24));
 
-      list->add_renderer = gtk_cell_renderer_pixbuf_new();
-      g_object_set(list->add_renderer, "icon-name", "list-add-symbolic", "stock-size", GTK_ICON_SIZE_MENU, NULL);
-      gtk_cell_renderer_set_sensitive(list->add_renderer, FALSE);
-      gtk_tree_view_column_pack_start(list->add_col, list->add_renderer, FALSE);
-      gtk_tree_view_column_add_attribute(list->add_col, list->add_renderer, "visible", TREE_IC_DELETE_VISIBLE);
+      renderer = gtk_cell_renderer_pixbuf_new();
+      // Same fallback as the "used by" icon: a theme with no symbolic variant gets the plain
+      // named icon, untinted, rather than nothing. The data func swaps the tinted pixbufs in
+      // when they exist, and sets visibility, so no attribute is bound on this column.
+      if(IS_NULL_PTR(d->ic_add_off))
+        g_object_set(renderer, "icon-name", "list-add-symbolic", "stock-size", GTK_ICON_SIZE_MENU, NULL);
+      gtk_cell_renderer_set_sensitive(renderer, FALSE);
+      gtk_tree_view_column_pack_start(list->add_col, renderer, FALSE);
+      gtk_tree_view_column_set_cell_data_func(list->add_col, renderer, _add_cell_data_func, d, NULL);
 
       gtk_tree_view_append_column(GTK_TREE_VIEW(list->treeview), list->add_col);
     }
@@ -2548,6 +2621,8 @@ void gui_cleanup(dt_lib_module_t *self)
     }
 
     if(!IS_NULL_PTR(d->ic_used)) g_object_unref(d->ic_used);
+    if(!IS_NULL_PTR(d->ic_add)) g_object_unref(d->ic_add);
+    if(!IS_NULL_PTR(d->ic_add_off)) g_object_unref(d->ic_add_off);
     if(!IS_NULL_PTR(d->ic_inverse)) g_object_unref(d->ic_inverse);
     if(!IS_NULL_PTR(d->ic_union)) g_object_unref(d->ic_union);
     if(!IS_NULL_PTR(d->ic_intersection)) g_object_unref(d->ic_intersection);
@@ -2555,6 +2630,8 @@ void gui_cleanup(dt_lib_module_t *self)
     if(!IS_NULL_PTR(d->ic_exclusion)) g_object_unref(d->ic_exclusion);
 
     d->ic_used = NULL;
+    d->ic_add = NULL;
+    d->ic_add_off = NULL;
     d->ic_inverse = NULL;
     d->ic_union = NULL;
     d->ic_intersection = NULL;

--- a/src/libs/shape_manager.c
+++ b/src/libs/shape_manager.c
@@ -1021,7 +1021,7 @@ static void _menu_append_existing_shapes(GtkMenuShell *menu, dt_masks_form_t *gr
 /* One entry per combine mode, plus the reordering pair. The same Invert/Union/Intersection/
  * Difference/Exclusion grouping the darkroom canvas and the blend module offer; all five differ
  * by a constant, so they ride on the menu item under "masks-operation". */
-static void _menu_append_operations(GtkMenuShell *menu, dt_lib_module_t *self, const int nb)
+static void _menu_append_operations(GtkMenuShell *menu, dt_shape_manager_list_t *list, const int nb)
 {
   static const struct
   {
@@ -1043,7 +1043,7 @@ static void _menu_append_operations(GtkMenuShell *menu, dt_lib_module_t *self, c
 
   item = gtk_menu_item_new_with_label(_("Invert shape"));
   g_object_set_data(G_OBJECT(item), "masks-operation", GINT_TO_POINTER(DT_MASKS_STATE_INVERSE));
-  g_signal_connect(item, "activate", (GCallback)_tree_apply_operation, self);
+  g_signal_connect(item, "activate", (GCallback)_tree_apply_operation, list);
   gtk_menu_shell_append(GTK_MENU_SHELL(op_submenu), item);
 
   // Combining is a question about one shape against its group; several at once has no answer.
@@ -1054,23 +1054,23 @@ static void _menu_append_operations(GtkMenuShell *menu, dt_lib_module_t *self, c
     {
       item = gtk_menu_item_new_with_label(_(combine[i].label));
       g_object_set_data(G_OBJECT(item), "masks-operation", GINT_TO_POINTER(combine[i].state));
-      g_signal_connect(item, "activate", (GCallback)_tree_apply_operation, self);
+      g_signal_connect(item, "activate", (GCallback)_tree_apply_operation, list);
       gtk_menu_shell_append(GTK_MENU_SHELL(op_submenu), item);
     }
   }
 
   gtk_menu_shell_append(menu, gtk_separator_menu_item_new());
   item = gtk_menu_item_new_with_label(_("Move up"));
-  g_signal_connect(item, "activate", (GCallback)_tree_moveup, self);
+  g_signal_connect(item, "activate", (GCallback)_tree_moveup, list);
   gtk_menu_shell_append(menu, item);
   item = gtk_menu_item_new_with_label(_("Move down"));
-  g_signal_connect(item, "activate", (GCallback)_tree_movedown, self);
+  g_signal_connect(item, "activate", (GCallback)_tree_movedown, list);
   gtk_menu_shell_append(menu, item);
   gtk_menu_shell_append(menu, gtk_separator_menu_item_new());
 }
 
 static GtkWidget *_tree_context_menu(GtkTreeSelection *selection, GtkTreeModel *model,
-                                     dt_lib_module_t *self, dt_iop_module_t *module)
+                                     dt_shape_manager_list_t *list, dt_iop_module_t *module)
 {
   GtkTreeIter iter;
   GtkMenuShell *menu = GTK_MENU_SHELL(gtk_menu_new());
@@ -1119,7 +1119,7 @@ static GtkWidget *_tree_context_menu(GtkTreeSelection *selection, GtkTreeModel *
   {
     gtk_menu_shell_append(menu, gtk_separator_menu_item_new());
     item = gtk_menu_item_new_with_label(_("Group the forms"));
-    g_signal_connect(item, "activate", (GCallback)_tree_group, self);
+    g_signal_connect(item, "activate", (GCallback)_tree_group, list);
     gtk_menu_shell_append(menu, item);
   }
 
@@ -1141,12 +1141,12 @@ static GtkWidget *_tree_context_menu(GtkTreeSelection *selection, GtkTreeModel *
     }
   }
 
-  if(from_group && depth < 3) _menu_append_operations(menu, self, nb);
+  if(from_group && depth < 3) _menu_append_operations(menu, list, nb);
 
   if(!from_group && !grp_is_group && nb == 1)
   {
     item = gtk_menu_item_new_with_label(_("Duplicate shape"));
-    g_signal_connect(item, "activate", (GCallback)_tree_duplicate_shape, self);
+    g_signal_connect(item, "activate", (GCallback)_tree_duplicate_shape, list);
     gtk_menu_shell_append(menu, item);
     gtk_menu_shell_append(menu, gtk_separator_menu_item_new());
   }
@@ -1155,18 +1155,18 @@ static GtkWidget *_tree_context_menu(GtkTreeSelection *selection, GtkTreeModel *
   {
     // One entry, named for what the row holds -- the whole mask when it is a group.
     item = gtk_menu_item_new_with_label(grp_is_group ? _("Delete mask") : _("Delete shape"));
-    g_signal_connect(item, "activate", (GCallback)_tree_delete_shape, self);
+    g_signal_connect(item, "activate", (GCallback)_tree_delete_shape, list);
     gtk_menu_shell_append(menu, item);
   }
   else if(nb > 0 && depth < 3)
   {
     item = gtk_menu_item_new_with_label(_("Remove shape from mask"));
-    g_signal_connect(item, "activate", (GCallback)_tree_delete_shape, self);
+    g_signal_connect(item, "activate", (GCallback)_tree_delete_shape, list);
     gtk_menu_shell_append(menu, item);
   }
 
   item = gtk_menu_item_new_with_label(_("Delete unused shapes"));
-  g_signal_connect(item, "activate", (GCallback)_tree_delete_unused, self);
+  g_signal_connect(item, "activate", (GCallback)_tree_delete_unused, list);
   gtk_menu_shell_append(menu, item);
   
   return GTK_WIDGET(menu);
@@ -1222,7 +1222,6 @@ static int _tree_apply_click_selection(GtkWidget *treeview, GtkTreeSelection *se
  * that so much as the place this widget already adjusts its own selection. */
 static int _tree_button_pressed(GtkWidget *treeview, GdkEventButton *event, dt_shape_manager_list_t *list)
 {
-  dt_lib_module_t *self = list->self;
   // we first need to adjust selection
   GtkTreeSelection *selection = gtk_tree_view_get_selection(GTK_TREE_VIEW(treeview));
   GtkTreeModel *model = gtk_tree_view_get_model(GTK_TREE_VIEW(treeview));
@@ -1278,7 +1277,7 @@ static int _tree_button_pressed(GtkWidget *treeview, GdkEventButton *event, dt_s
     }
 
     // and we display the context-menu
-    GtkWidget *menu = _tree_context_menu(selection, model, self, module);
+    GtkWidget *menu = _tree_context_menu(selection, model, list, module);
 
     gtk_widget_show_all(menu);
 

--- a/src/widgets/scroll_wrap.c
+++ b/src/widgets/scroll_wrap.c
@@ -537,7 +537,7 @@ static void _widget_auto_height_free(gpointer data)
  * @param config_str conf key persisting the user-chosen height (copied internally)
  * @param mode DT_UI_RESIZE_DYNAMIC (auto-fit) or DT_UI_RESIZE_STATIC (fixed height)
  */
-GtkWidget *dt_ui_scroll_wrap(GtkWidget *w, gint min_size, char *config_str, dt_ui_resize_mode_t mode)
+GtkWidget *dt_ui_scroll_wrap(GtkWidget *w, gint min_size, const char *config_str, dt_ui_resize_mode_t mode)
 {
   GtkWidget *sw = gtk_scrolled_window_new(NULL, NULL);
   gtk_scrolled_window_set_policy(GTK_SCROLLED_WINDOW(sw), GTK_POLICY_NEVER, GTK_POLICY_AUTOMATIC);

--- a/src/widgets/scroll_wrap.c
+++ b/src/widgets/scroll_wrap.c
@@ -616,6 +616,11 @@ GtkWidget *dt_ui_scroll_wrap_get_scrolled_window(GtkWidget *wrapper)
   return sw;
 }
 
+gint dt_ui_scroll_wrap_row_height(GtkWidget *content_widget)
+{
+  return _get_container_row_heigth(content_widget);
+}
+
 static void _resizable_area_free(gpointer data)
 {
   dt_ui_resizable_area_t *state = (dt_ui_resizable_area_t *)data;

--- a/src/widgets/scroll_wrap.h
+++ b/src/widgets/scroll_wrap.h
@@ -80,7 +80,7 @@ typedef struct dt_gui_widget_auto_height_t
  *             height regardless of content (avoids layout shifts for hover-/selection-driven
  *             widgets).
  */
-GtkWidget *dt_ui_scroll_wrap(GtkWidget *w, gint min_size, char *config_str, dt_ui_resize_mode_t mode);
+GtkWidget *dt_ui_scroll_wrap(GtkWidget *w, gint min_size, const char *config_str, dt_ui_resize_mode_t mode);
 
 /**
  * @brief Return the inner GtkScrolledWindow of a dt_ui_scroll_wrap() wrapper, or NULL.

--- a/src/widgets/scroll_wrap.h
+++ b/src/widgets/scroll_wrap.h
@@ -88,6 +88,17 @@ GtkWidget *dt_ui_scroll_wrap(GtkWidget *w, gint min_size, const char *config_str
 GtkWidget *dt_ui_scroll_wrap_get_scrolled_window(GtkWidget *wrapper);
 
 /**
+ * @brief One row's height for @p content_widget, the same measurement dt_ui_scroll_wrap()'s own
+ * dynamic sizing is built on -- a GtkTreeView's tallest column cell plus its vertical-separator
+ * style property, or a GtkTextView's line height. Works on an empty model: it reads renderer and
+ * font metrics, not actual rows.
+ *
+ * For a caller that needs to reserve room for one more row than the content itself requires (a
+ * trailing blank line, say) without re-deriving this measurement by hand.
+ */
+gint dt_ui_scroll_wrap_row_height(GtkWidget *content_widget);
+
+/**
  * @brief Make a self-drawing widget (typically a GtkDrawingArea graph or scope) vertically
  * resizable.
  *

--- a/tools/check_module_boundaries.sh
+++ b/tools/check_module_boundaries.sh
@@ -411,7 +411,7 @@ fi
 #                  are excluded; naming the type there is the design, not the leak.
 masks_include_baseline=19
 masks_gui_include_baseline=11
-masks_member_baseline=77
+masks_member_baseline=76
 masks_write_baseline=16
 masks_alloc_baseline=1
 masks_forms_baseline=74

--- a/tools/check_module_boundaries.sh
+++ b/tools/check_module_boundaries.sh
@@ -411,7 +411,7 @@ fi
 #                  are excluded; naming the type there is the design, not the leak.
 masks_include_baseline=19
 masks_gui_include_baseline=11
-masks_member_baseline=76
+masks_member_baseline=75
 masks_write_baseline=16
 masks_alloc_baseline=1
 masks_forms_baseline=74


### PR DESCRIPTION
The shape manager showed one tree that answered two different questions at once: what shapes exist, and which module renders what. This branch splits it in two and gives the panel the operations that arrangement makes obvious.

## The two lists

**Left, the inventory**: every shape and every group, module masks included, groups first then shapes. **Right, the assignment**: only the groups a module actually renders, each under its module.

A module mask therefore appears in both — once in the inventory where it can be picked up and reused like any other group, once in the assignment under its module. Membership is derived per rebuild by `_group_is_module_mask()` and never stored, so a group's assignment row appears the moment a module claims it and disappears the moment one releases it.

In the inventory a module mask is shown flat: one row, no expander, members not appended under it. That subtree belongs to the assignment list, which is where it is expandable.

Both lists order module masks by reverse `iop_order` — bottom of the stack first, the convention the module chooser and the Pipeline tab already use, so a mask sits where its module does everywhere else.

## Attaching a shape

Every inventory row carries a "+" before the trash. With a module-group row selected on the right, it adds the shape to that group, resolving the destination to the **top level** — never nesting into the sub-group the cursor happens to be on. With nothing selected it opens a chooser listing the pipeline modules that accept a drawn mask, bottom-to-top, modules already holding the shape pre-checked. On validation each chosen module gets its own mask group if it has none, the shape is nested into each of them, blending is enabled, and inline renaming opens on the new name.

The "+" answers per row and looks it: disabled when the shape is already in the selected group, or when adding it would build a cycle.

Each module owns **one** group of its own; what modules share is the shape nested inside each of their masks. That keeps their combine operators, opacities and member order independent — pointing several modules at one group would make every one of those settings, and every detach, common to all of them. Shapes already covered by a group of the same module say so in place ("Already in \<group\>").

## Graph questions moved into the masks module

`dt_masks_group_contains()`, `dt_masks_group_covers_shapes()` and `dt_masks_group_first_use()` join `develop/masks_group.h`, id-keyed and by value like the rest of that header. Asking them from `libs/` by hand is exactly what `tools/check_module_boundaries.sh` section 9 counts; the masks ratchet **falls** here (76 → 75 external member reads), lowered in the same commit.

New public predicates: `dt_iop_module_instance_exists()`, `dt_iop_module_is_in_pipeline()`, `dt_iop_module_supports_drawn_mask()` (`develop/imageop.h`), and `dt_iop_gui_blend_set_drawn_mask_group()` (`develop/blend_gui.h`), which points `mask_id` at a group and raises the blend flags without assuming the module's blending GUI was ever built.

## Three GTK behaviours measured offscreen, each contradicting the obvious guess

- **Names carry no `ellipsize`, and that is what guarantees they are never compressed.** A treeview with no ellipsize reports its true full-content preferred width, that width propagates through a `GTK_POLICY_NEVER` scrolled window, and `gtk_window_resize()` cannot force a window below its content minimum. The width floor is structural, not computed.
- **A `GtkPaned` with `resize=TRUE` on both children splits new width between them**, drifting the divider on every resize. The inventory is packed `resize=FALSE` so the divider holds; a manual drag still repositions it.
- **Of two renderers packed with `pack_end()`, the first packed lands at the true right edge.** The "used by" icon is packed before the note so it ends up to its right.

Also fixed: `_shape_manager_selection_change_in()` revealed its match with `gtk_tree_view_expand_all()`, which blew every unrelated group open — visible as "creating a shape expands all the groups". The recursive search walks the model and needs nothing expanded, so `gtk_tree_view_expand_to_path()` on the found row does the same job.

And `dev->form_gui` can be NULL while this panel is open — it is freed on leaving the darkroom and this panel is a standalone toplevel that outlives that. `_tree_selection_change()` dereferenced it unguarded and crashed (SIGSEGV, observed live).

`dt_ui_scroll_wrap_row_height()` publishes the row height `scroll_wrap` already measures, so the panel can size itself to the longest list plus one empty row at startup.

## Verification

Built with clang. All eight static gates pass at baseline — `check_layering.sh` 183/183, `check_module_boundaries.sh` with masks lowered to 75/34 — `ctest` 25/25, `check_it_runs.sh` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
