### PR TITLE
masks overlay: rasterise the outlines directly, and composite only what was painted

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1903,8 +1903,14 @@ for any other target. `masks_gui.c` draws everything into a persistent device-pi
 composites only the painted rectangle. Nodes, handles, arrows and the creation trace stay with
 cairo, on the same canvas. `doc/overlay-raster.md` is the account; the numbers and the pixel
 comparison come from `ansel-test-masks-geometry --time-overlay` (add `MASKS_DEBUG=1` for the
-per-stage traces). Two traps: stamping discs instead of capsules scallops thin lines, and inside
-a pushed group the writable surface is `cairo_get_group_target()`, not `cairo_get_target()`.
+per-stage traces). Three traps: stamping discs instead of capsules scallops thin lines; inside
+a pushed group the writable surface is `cairo_get_group_target()`, not `cairo_get_target()`; and
+**cairo's device space is not the pixel grid** — `cairo_user_to_device()` stops before the
+surface's own transform (pixel = device × device_scale + device_offset), so on a 2x screen every
+pixel derived from it must be multiplied by `cairo_surface_get_device_scale()`. The first version
+did not, was correct on every 1x screen and every unit test, and drew the whole overlay at half
+size in the top-left quadrant of a HiDPI darkroom; `test_stroke_raster` and the harness's
+`hidpi placement` check now paint on device-scaled surfaces.
 
 ### A rotated GtkLabel sizes the column it sits in
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1150,19 +1150,37 @@ rules that were each paid for by a reported defect:
   spoke with its range) — and an argument added to the evaluator by regex landed before the
   radius instead of after it on two of five callers, which zeroed every segment end's spoke,
   killed every cap, and read for an hour like a cap defect the tilt had exposed.
-- **A copy of a boundary stretch is not a boundary sample.** The walk stamps a full disc at a
+- **A repeat of a boundary sample is not a boundary sample.** The walk stamps a full disc at a
   node whose radius steps in BOTH passes and bridges joints with arcs about the same node, so a
   flaring node's circle was traced two or three times, each copy dashed from its own phase, and
   the copies filled each other's gaps: a near-solid line (`_MG_1074.CR2` brush #4, 4,020 kept
-  samples on a 2,114 px circumference). `_outline_sample_repeats()` drops a sample that repeats
-  an earlier one: the same SPINE POINT to a hundredth of a pixel, a border position within three
-  quarters of a pixel, and at least sixteen samples earlier along the walk. Each clause was paid
-  for by a corpus round: keyed on the disc instead of the spine point it never fired (a disc's
-  centre is its first sample's, half a pixel off and differently per pass); at half a pixel of
-  centre tolerance it fused consecutive segment discs and thinned every segment; without the
-  index exclusion a dense arc filler matched its own predecessor and shredded every arc. The
-  other side of the stroke, which the backward pass lays on the same spine points, is a diameter
-  away and never matches. Polygons and constant-radius brushes stay bit-identical.
+  samples on a 2,114 px circumference); and where a segment leaves such a node its envelope runs
+  within the boundary tolerance of the circle for tens of pixels, a second dash over the first.
+  `_outline_sample_repeats()` drops a sample within three quarters of a pixel of an earlier one
+  that is at least `OUTLINE_REPEAT_MIN_WALK` (4 px) of border BEHIND it along the walk, whatever
+  discs the two belong to: for drawing, two boundary samples that close are one line. Five corpus
+  rounds shaped it, each measured by the harness's skipped/ranges counts before the next: keyed
+  on the disc it never fired (a disc's centre is its first sample's, half a pixel off and
+  differently per pass); on the spine point it missed the junctions; a half-pixel centre
+  tolerance fused consecutive segment discs and thinned every segment; an exclusion by sixteen
+  SAMPLES shredded every arc, because the recursion samples a hundredth of a pixel apart around
+  every integer crossing, where sixteen samples are less than a pixel — only the walked length
+  tells a run from its copy, a copy being the other pass or another stamp, thousands of pixels
+  away along it. The other side of the stroke, which the backward pass lays on the same spine
+  points, is a diameter away and never matches; `_outline_keep_specks()` keeps a dropped run of
+  one or two samples between kept ones, since hiding it changes nothing and cuts the run.
+- **The dash phase is the arc length along the whole stroke, not along each sub-path.** An
+  outline is one cairo path of many sub-paths, one per kept run between skips, and cairo (and
+  the rasteriser, at first) restarts the dash pattern at every sub-path, so dashes bunched and
+  stretched at every run boundary. `dt_stroke_raster_path()` now carries one `_dash_t` across
+  all its sub-paths: a dash is a function of the pixels of border drawn before it. A dash cut by
+  a hidden stretch shows as a stub, which that metric owes.
+- **`MASKS_DUMP_OVERLAY=<dir>` makes the darkroom write what each frame drew**: the canvas
+  before it is composited and cleared, the frame and dirty rectangles, and every cached outline
+  with its skip ranges (`outline-<n>.txt`, the harness's format). It exists because a darkroom
+  cannot be driven from this machine, and a report the harness cannot reproduce needs the
+  darkroom's own frame, not a guess at it.
+
 - **`ansel-test-masks-geometry --time-overlay` renders at fit zoom; `MASKS_OVERLAY_VIEW=
   "scale,ox,oy[,ppd]"` renders the view the darkroom shows**, in user units with the surface's
   device scale, which is how the 1074 report was reproduced at 100% on a 2x screen. When adding

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1142,9 +1142,14 @@ rules that were each paid for by a reported defect:
   shoulders of a fat node as a flat shelf tens of pixels deep. `dt_masks_outline_envelope_offset()`
   (`masks_outline.c`) places every brush and polygon sample; the rate is the smoothstep's
   derivative, zero at both ends of a segment, so caps and joint arcs are untouched and every
-  constant-radius corpus case stayed bit-identical. The tilt is capped at
-  `DT_MASKS_OUTLINE_TILT_MAX` (0.7): past it the spokes would lean too far along the spine to paint
-  the width. Two traps from the round that landed it: the corpus judges only the samples that were
+  constant-radius corpus case stayed bit-identical. `DT_MASKS_OUTLINE_TILT_MAX` is 1.0, the exact
+  envelope: a first version capped the tilt at 0.7 to keep the spokes painting across the width,
+  and that cap cost a real defect — a segment whose rate peaks near 1 (a 132 px node flaring to
+  342 px over 287 px, `_MG_1074.CR2` brush #4 as the user drew it) has its union's top on the
+  rear envelope, 40 px outside the wide node's circle at a 64° tilt, which no capped sample
+  reached, so the outline lost the whole top of the shape; at the exact envelope the raster oracle
+  reports no missing pixel anywhere in the corpus. Two traps from the round that landed it: the
+  corpus judges only the samples that were
   KEPT, so a boundary stretch the skips swallow whole passes it — measure the skipped fraction
   (`ansel-test-masks-geometry --time-overlay` now prints it; `MASKS_DUMP_SKIPS=<dir>` dumps every
   spoke with its range) — and an argument added to the evaluator by regex landed before the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1132,6 +1132,24 @@ rules that were each paid for by a reported defect:
   went the long way round on one side of every turn. Do not "fix" the cusp tie-break to
   shortest-path: the two passes each cover one half of the tip disc, and which half is which
   is the pass's rotation. The #1313 cusp corpus, at all eight frame sizes, is the check.
+- **A border sample lies on the ENVELOPE of the discs, not on the normal.** Where the radius
+  changes along the spine, the boundary of the union is `c + r·(−r′ T + √(1 − r′²) N)`, r′ being
+  dr/ds: tilted off the normal by asin(r′). The normal sample sits inside the union by about
+  r′² r / 2 — a fraction of a pixel at a pen's rates, invisible to the eye and exactly what the
+  boundary detector (rightly) rejects, so the outline of any stroke whose radius varied lost
+  whole stretches of both sides (37% of the #1313 brush's border, reported as "discontinuities
+  in the dashed border"), and the raster's spokes, which end on the same samples, left the
+  shoulders of a fat node as a flat shelf tens of pixels deep. `dt_masks_outline_envelope_offset()`
+  (`masks_outline.c`) places every brush and polygon sample; the rate is the smoothstep's
+  derivative, zero at both ends of a segment, so caps and joint arcs are untouched and every
+  constant-radius corpus case stayed bit-identical. The tilt is capped at
+  `DT_MASKS_OUTLINE_TILT_MAX` (0.7): past it the spokes would lean too far along the spine to paint
+  the width. Two traps from the round that landed it: the corpus judges only the samples that were
+  KEPT, so a boundary stretch the skips swallow whole passes it — measure the skipped fraction
+  (`ansel-test-masks-geometry --time-overlay` now prints it; `MASKS_DUMP_SKIPS=<dir>` dumps every
+  spoke with its range) — and an argument added to the evaluator by regex landed before the
+  radius instead of after it on two of five callers, which zeroed every segment end's spoke,
+  killed every cap, and read for an hour like a cap defect the tilt had exposed.
 
 The corpus (`tests/masks/masks_geometry.c`) judges a brush and a polygon in **both directions** — owed
 coverage missing, and coverage no disc owes — and judges the drawn outline against the same

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1150,6 +1150,25 @@ rules that were each paid for by a reported defect:
   spoke with its range) — and an argument added to the evaluator by regex landed before the
   radius instead of after it on two of five callers, which zeroed every segment end's spoke,
   killed every cap, and read for an hour like a cap defect the tilt had exposed.
+- **A copy of a boundary stretch is not a boundary sample.** The walk stamps a full disc at a
+  node whose radius steps in BOTH passes and bridges joints with arcs about the same node, so a
+  flaring node's circle was traced two or three times, each copy dashed from its own phase, and
+  the copies filled each other's gaps: a near-solid line (`_MG_1074.CR2` brush #4, 4,020 kept
+  samples on a 2,114 px circumference). `_outline_sample_repeats()` drops a sample that repeats
+  an earlier one: the same SPINE POINT to a hundredth of a pixel, a border position within three
+  quarters of a pixel, and at least sixteen samples earlier along the walk. Each clause was paid
+  for by a corpus round: keyed on the disc instead of the spine point it never fired (a disc's
+  centre is its first sample's, half a pixel off and differently per pass); at half a pixel of
+  centre tolerance it fused consecutive segment discs and thinned every segment; without the
+  index exclusion a dense arc filler matched its own predecessor and shredded every arc. The
+  other side of the stroke, which the backward pass lays on the same spine points, is a diameter
+  away and never matches. Polygons and constant-radius brushes stay bit-identical.
+- **`ansel-test-masks-geometry --time-overlay` renders at fit zoom; `MASKS_OVERLAY_VIEW=
+  "scale,ox,oy[,ppd]"` renders the view the darkroom shows**, in user units with the surface's
+  device scale, which is how the 1074 report was reproduced at 100% on a 2x screen. When adding
+  a comparison surface to that harness, give it the same device scale: the first leftover check
+  at ppd 2 compared a scaled frame against an unscaled one and reported 50,000 ghost pixels that
+  were the harness's own.
 
 The corpus (`tests/masks/masks_geometry.c`) judges a brush and a polygon in **both directions** — owed
 coverage missing, and coverage no disc owes — and judges the drawn outline against the same

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1891,6 +1891,21 @@ policy must be `GTK_POLICY_EXTERNAL` + `set_min_content_height(1)` +
 reconfigures (the table persists across view enter/leave; the guard would otherwise skip the
 reconfigure on same-size re-entry).
 
+### The mask overlay's outlines are rasterised directly, not stroked by cairo
+
+A shape's outline reaches the drawing code already sampled at one point per device pixel;
+handing it to cairo as a path to stroke twice was raster → vector → raster, 7–18 ms per shape
+per frame at fit zoom. `widgets/stroke_raster.c` paints the polyline itself (a per-segment
+capsule distance field, two passes, dashes cut by arc length, the same one-pixel ramp as
+`CAIRO_ANTIALIAS_FAST`) into the ARGB32 surface `cr` draws on — the current group's surface,
+offset included — and `dt_draw_shape_lines()` tries it before falling back to the cairo strokes
+for any other target. `masks_gui.c` draws everything into a persistent device-pixel canvas and
+composites only the painted rectangle. Nodes, handles, arrows and the creation trace stay with
+cairo, on the same canvas. `doc/overlay-raster.md` is the account; the numbers and the pixel
+comparison come from `ansel-test-masks-geometry --time-overlay` (add `MASKS_DEBUG=1` for the
+per-stage traces). Two traps: stamping discs instead of capsules scallops thin lines, and inside
+a pushed group the writable surface is `cairo_get_group_target()`, not `cairo_get_target()`.
+
 ### A rotated GtkLabel sizes the column it sits in
 
 A `GtkLabel` with `gtk_label_set_angle()` requests the width of its *slanted* bounding box, so a

--- a/doc/brush-boundary.md
+++ b/doc/brush-boundary.md
@@ -223,21 +223,34 @@ copy is stroked as its own run with its own dash phase, so the copies fill each 
 the circle comes out as a near-solid line — `_MG_1074.CR2` brush #4, reported as a missing
 dashed border: 4,020 kept samples on a 2,114 px circumference.
 
-`_outline_sample_repeats()` drops a sample that repeats an earlier one: the same spine point to
-a hundredth of a pixel, a border position within three quarters of a pixel, and at least sixteen
-samples earlier along the walk. The other side of the stroke, which the backward pass lays on
-the very same spine points, is a diameter away and never matches; polygons, which bridge each
-joint once, and constant-radius brushes are bit-identical.
+`_outline_sample_repeats()` drops a sample within three quarters of a pixel of an earlier one
+that lies at least four pixels of border behind it along the walk, whatever discs the two belong
+to: for drawing, two boundary samples that close are one line. The other side of the stroke,
+which the backward pass lays on the very same spine points, is a diameter away and never
+matches. The same rule takes the stretch where a segment leaves a stamped node, whose envelope
+runs within the boundary tolerance of the node's circle for tens of pixels — a second dash over
+the first — which no identity of discs or spine points could pair. A dropped run of one or two
+samples between kept ones is kept again (`_outline_keep_specks()`): hiding it changes nothing on
+screen and cuts the run in two.
 
-Three corpus rounds shaped the clauses. Keyed on the disc rather than the sample's spine point
-the rule never fired, because a disc's centre is its first sample's and a stamp's samples merge
-into the disc the last moving sample opened, half a pixel off and differently in each pass. With
-half a pixel of centre tolerance it fused consecutive discs of a segment, which the builder
-separates by exactly that much, and thinned every segment to fragments. Without the index
-exclusion a dense arc filler matched its own predecessor and shredded every arc. The
-measurements that told those apart were the harness's skipped-sample counts per case — 2,821
-ranges on the zigzag against 4 — and the kept-sample count on the node's circle: 4,020, then
-3,980, then 1,804.
+Five corpus rounds shaped the clauses, each measured by the harness's skipped-sample and range
+counts per case before the next. Keyed on the disc the rule never fired, because a disc's centre
+is its first sample's and a stamp's samples merge into the disc the last moving sample opened,
+half a pixel off and differently in each pass. Keyed on the spine point it dropped the copies
+and missed the junctions. With half a pixel of centre tolerance it fused consecutive discs of a
+segment, which the builder separates by exactly that much, and thinned every segment to
+fragments. Excluding the sample's own run by a count of sixteen samples shredded every arc,
+because the recursion samples a hundredth of a pixel apart around every integer crossing, where
+sixteen samples are less than a pixel; only the length of border walked between two samples
+tells a run from its copy, a copy being the other pass or another stamp, thousands of pixels
+away along the walk. The kept-sample count on the node's circle went 4,020, 3,980, 1,804; the
+zigzag's ranges 4, 2,821, 4.
+
+The dashes are the other half of the same report. The rasteriser cut them by arc length but
+restarted the pattern at every sub-path, and an outline is one sub-path per kept run, so every
+run boundary bunched or stretched a dash. The pattern's state now travels across all the
+sub-paths of one stroke: a dash is a function of the pixels of border drawn before it, and a
+dash cut by a hidden stretch shows as a stub, which that metric owes.
 
 ## What is unified, and what is not
 

--- a/doc/brush-boundary.md
+++ b/doc/brush-boundary.md
@@ -214,6 +214,31 @@ callers: every segment end was evaluated at radius zero, every cap collapsed int
 through its centre, and the result read for an hour like a cap defect the tilt had exposed.
 Trace the helper's inputs before theorising about its geometry.
 
+## A copy of a boundary stretch is not a boundary sample
+
+The walk stamps a full disc at a node whose radius steps, in both passes, and bridges every
+joint with an arc about the node at the same radius. On a flaring node all of those trace the
+same circle, and the boundary pass kept them all: a copy is not strictly inside any disc. Each
+copy is stroked as its own run with its own dash phase, so the copies fill each other's gaps and
+the circle comes out as a near-solid line — `_MG_1074.CR2` brush #4, reported as a missing
+dashed border: 4,020 kept samples on a 2,114 px circumference.
+
+`_outline_sample_repeats()` drops a sample that repeats an earlier one: the same spine point to
+a hundredth of a pixel, a border position within three quarters of a pixel, and at least sixteen
+samples earlier along the walk. The other side of the stroke, which the backward pass lays on
+the very same spine points, is a diameter away and never matches; polygons, which bridge each
+joint once, and constant-radius brushes are bit-identical.
+
+Three corpus rounds shaped the clauses. Keyed on the disc rather than the sample's spine point
+the rule never fired, because a disc's centre is its first sample's and a stamp's samples merge
+into the disc the last moving sample opened, half a pixel off and differently in each pass. With
+half a pixel of centre tolerance it fused consecutive discs of a segment, which the builder
+separates by exactly that much, and thinned every segment to fragments. Without the index
+exclusion a dense arc filler matched its own predecessor and shredded every arc. The
+measurements that told those apart were the harness's skipped-sample counts per case — 2,821
+ranges on the zigzag against 4 — and the kept-sample count on the node's circle: 4,020, then
+3,980, then 1,804.
+
 ## What is unified, and what is not
 
 The API did not change shape: `dt_masks_functions_t.get_points_border` still returns

--- a/doc/brush-boundary.md
+++ b/doc/brush-boundary.md
@@ -197,13 +197,17 @@ carries no speed and is given rate zero. Every constant-radius corpus case staye
 bit-identical; the two whose radius varies moved by the crescents above and their baselines
 were regenerated.
 
-The tilt is capped at `DT_MASKS_OUTLINE_TILT_MAX = 0.7` (the sine of the angle). At a rate
-of 1 the discs nest and there is no envelope; between 0.7 and 1 the spokes of a family tilted
-to the envelope lean so far along the spine that nothing paints the width. With the cap, every
-point across the width at a sample is reached by the spoke of a sample one radius further on
-(r_j ≥ 1.41 r_i whenever the rate exceeds 0.41), so the union stays painted whatever the rate;
-past the cap the sample is a little inside the union and the outline skips it, which is the
-right answer for a radius growing almost as fast as the pen moves.
+`DT_MASKS_OUTLINE_TILT_MAX` is 1.0: the exact envelope, the clamp only keeping the square root
+real where the discs nest. A first version capped the tilt at 0.7, reasoning that a family of
+spokes tilted further leans too far along the spine to paint the width. That reasoning was not
+measured, and it cost a real defect. `_MG_1074.CR2` brush #4, as the user drew it, flares from
+a 132 px node to a 342 px one over 287 px, and the radius rate along that segment peaks near 1:
+the discs almost nest, and the union's top is the rear envelope of the flare, 40 px outside the
+wide node's circle at a tilt of 64°. No capped sample reached it, the wide node's circle was
+correctly found inside, and the outline lost the whole top of the shape — found only from the
+darkroom's own frame dump (`MASKS_DUMP_OVERLAY`), since the sidecar on disk no longer held the
+shape. At the exact envelope the raster oracle reports no missing pixel on any corpus case,
+this one included, and the top closes.
 
 Two traps from the round that landed it. The corpus judges only the samples that were KEPT —
 a stretch the skips swallow whole passes the outline band check, so the skipped fraction has

--- a/doc/brush-boundary.md
+++ b/doc/brush-boundary.md
@@ -164,6 +164,56 @@ and boundary pass. Before the rework, kept outline samples that sat two to five 
 inside the union numbered 47 to 206 per case; the old display cut through self-crossings
 without stopping at all.
 
+## The border sample is on the envelope, not on the normal
+
+The boundary pass decides per sample, and it is only as good as the samples it is given. A
+border sample was placed on the normal of its spine sample, `c + r N`, and that point is on
+the boundary of the union only while the radius is constant. Where the radius changes along
+the spine the union's boundary is the envelope of the discs,
+
+    c + r · ( −r′ T ± √(1 − r′²) N ),   r′ = dr/ds
+
+tilted off the normal by asin(r′) toward the smaller radius, and the normal sample sits
+inside the union by about r′² r / 2. At the rates a pen draws that is a fraction of a pixel:
+invisible to the eye, and precisely what the boundary pass rejects. Measured on the #1313
+corpus brush at the darkroom's fit zoom, 19,785 of 53,709 border samples were skipped in 25
+ranges, most of them along both long sides of the stroke, and the dashed outline was simply
+absent there — reported as "discontinuities in the dashed border". The pixels around every
+sample were checked in the cairo render and in the rasterised one: kept samples painted,
+skipped ones not, both renders 18 pixels apart, so the drawing was never the suspect.
+
+The raster had the same defect with the same cause and nobody had noticed: the spokes end on
+the same samples, so the shoulders of a fat node — where the radius grows fastest — were
+painted only out to the normal offset, a flat shelf tens of pixels short of the round lobe
+the union of discs actually is (the #1313 brush again: 13,333 pixels brighter after, none
+darker).
+
+`dt_masks_outline_envelope_offset()` in `masks_outline.c` now places every border sample of
+the brush and of the polygon, from the tangent and the radius rate by the same parameter. The
+rate is the derivative of the smoothstep the radius follows along a segment,
+`(r2 − r1) · 6t(1 − t)`, zero at both ends, so a segment's end samples stay on the normal and
+every cap, joint arc and stamp built from them is unchanged; a limit direction (a cusp end)
+carries no speed and is given rate zero. Every constant-radius corpus case stayed
+bit-identical; the two whose radius varies moved by the crescents above and their baselines
+were regenerated.
+
+The tilt is capped at `DT_MASKS_OUTLINE_TILT_MAX = 0.7` (the sine of the angle). At a rate
+of 1 the discs nest and there is no envelope; between 0.7 and 1 the spokes of a family tilted
+to the envelope lean so far along the spine that nothing paints the width. With the cap, every
+point across the width at a sample is reached by the spoke of a sample one radius further on
+(r_j ≥ 1.41 r_i whenever the rate exceeds 0.41), so the union stays painted whatever the rate;
+past the cap the sample is a little inside the union and the outline skips it, which is the
+right answer for a radius growing almost as fast as the pen moves.
+
+Two traps from the round that landed it. The corpus judges only the samples that were KEPT —
+a stretch the skips swallow whole passes the outline band check, so the skipped fraction has
+to be measured: `ansel-test-masks-geometry --time-overlay` prints it per case and
+`MASKS_DUMP_SKIPS=<dir>` dumps every spoke with the range that skips it. And a parameter added
+to the evaluator landed, by regex, before the radius instead of after it on two of its five
+callers: every segment end was evaluated at radius zero, every cap collapsed into two spirals
+through its centre, and the result read for an hour like a cap defect the tilt had exposed.
+Trace the helper's inputs before theorising about its geometry.
+
 ## What is unified, and what is not
 
 The API did not change shape: `dt_masks_functions_t.get_points_border` still returns

--- a/doc/overlay-raster.md
+++ b/doc/overlay-raster.md
@@ -46,12 +46,15 @@ the same numbers they always passed to cairo — widths in user units, the dash 
 ## The canvas
 
 `dt_masks_events_post_expose_with()` no longer pushes a group. It keeps one ARGB32 image
-surface the size of the clip in device pixels (created once, kept across frames, given the
-target's device scale), draws every shape into it through a `cairo_t` carrying `cr`'s matrix
-shifted to the clip's origin, and composites onto the view only the rectangle that was painted:
-the rasteriser's own record, plus the node header of every outline — node and both control
-points, three per node — with a margin for a node's disc and an arrow head, which bounds what
-cairo drew on top. That rectangle is then cleared by hand for the next frame. A creation
+surface the size of the clip in pixels (created once, kept across frames, given the target's
+device scale), draws every shape into it through a `cairo_t` carrying `cr`'s matrix shifted to
+the clip's origin, and composites onto the view only the rectangle that was painted: the
+rasteriser's own record, plus a bound on what cairo may draw on top — the node header of every
+outline, node and both control points, three per node, with a margin for a node's disc and an
+arrow head. That bound is computed *before* anything is drawn and the canvas context is clipped
+to it, so a handle that lands outside the estimate is not painted rather than left behind for
+the next frame (the harness draws a panned frame after every state and fails on any pixel a
+fresh surface would not show). The rectangle is then cleared by hand for the next frame. A creation
 session, which paints through its own cached pattern, takes the whole canvas.
 
 ## Measured
@@ -82,11 +85,23 @@ baseline moved at all. The 23 overlay baselines were regenerated.
   between vertices `s` apart; at the bright pass's half-width that shows. The capsule per
   segment is the fix, and per-pixel it costs a dot product more than the disc.
 - **Inside a pushed group, `cairo_get_target()` is the ORIGINAL target.** The group's surface
-  is `cairo_get_group_target()`, and it carries a device offset: pixel = device + offset. The
-  unit test paints inside a clipped group and checks the composite lands where cairo puts it.
-- **A widget context has a device scale, so an identity matrix is not device pixels.** The
-  canvas takes the target's device scale, its matrix is `cr`'s followed by a translation in
-  device units divided by that scale, and the composite positions the canvas in the same units.
+  is `cairo_get_group_target()`, and it carries a device offset. The unit test paints inside a
+  clipped group and checks the composite lands where cairo puts it.
+- **Cairo's device space is NOT the pixel grid, and `cairo_user_to_device()` stops there.** A
+  surface applies its own device transform after the CTM: pixel = device × device_scale +
+  device_offset, the scale being what a HiDPI widget carries (2 on a 2x screen) and the offset
+  what a pushed group carries (minus its clip's origin, already in pixels). Measured with
+  pycairo: on a surface with device scale 2, `user_to_device(10, 10)` is `(10, 10)` and
+  `get_matrix()` is the identity; a group pushed under a clip at (20, 20) reports offset
+  (−40, −40). The first version mapped device units straight to pixels, which is invisible on
+  every 1x screen and every unit test, and put the whole overlay at half size in the top-left
+  quadrant of a 2x darkroom. So every place that derives a pixel from `cairo_user_to_device()`
+  — the rasteriser's vertices and widths, the canvas frame, the cairo bound — multiplies by the
+  surface's device scale and adds its offset; the canvas takes the target's device scale, its
+  matrix is `cr`'s followed by a translation of the pixel shift divided by that scale, and the
+  composite positions it in the same units. `test_stroke_raster` paints on a device-scaled
+  surface, plain and inside a clipped group, and the harness renders every case at device
+  scale 2 and compares the painted bounding box with the 1x render's.
 - **`cairo_copy_path_flat()` is the cheap bridge.** The shapes' path builders are unchanged;
   extracting the flattened path costs microseconds and keeps one implementation of every
   outline walk.

--- a/doc/overlay-raster.md
+++ b/doc/overlay-raster.md
@@ -1,0 +1,92 @@
+# The mask overlay is rasterised, not stroked
+
+Status: implemented on `overlay-raster`. Measured with `tests/masks/masks_geometry.c --time-overlay`;
+every number below comes from that harness at a 2560×1440 view, fit zoom, 30 frames per figure.
+
+## What the overlay asked of cairo
+
+A shape's outline arrives at the drawing code already sampled at the resolution it is shown
+at: the producers walk it one point per raw pixel, the drawer keeps one per device pixel
+(`dt_draw_min_emit_step()`). Until now that polyline was handed to cairo as a path and
+stroked twice — a wide dark pass under a narrow bright one — with fast antialiasing, one of
+two dash patterns, round or flat caps. Raster in, vector path, raster out: cairo tessellated
+a few thousand one-pixel segments into trapezoids and rasterised them, twice, for every shape,
+every frame. Then the whole thing was composited from a `cairo_push_group()` the size of the
+view, painted or not.
+
+Of everything cairo offers, the overlays use exactly that: two widths, two colours with
+alpha, `DASH_STICK` (12/12 px) and `DASH_ROUND` (3/12 px), `CAIRO_LINE_CAP_ROUND` or
+`BUTT`, `CAIRO_ANTIALIAS_FAST`. Nodes, handles, arrows, the clone source shape, the brush's
+creation trace and cursor discs are a handful of small primitives each, and stay with cairo.
+
+## The rasteriser
+
+`src/widgets/stroke_raster.{h,c}` — a widget-layer primitive, cairo and glib only, no masks
+vocabulary. `dt_stroke_raster_path(cr, style)` takes cairo's current path (already built by
+the shape's own `draw_shape_func`), flattens it, maps it through `cr`'s matrix into the pixels
+of the surface `cr` draws on — the current group's, if one is pushed, offset included — and
+strokes it; the path is consumed as `cairo_stroke()` would consume it. When that surface is
+not an ARGB32 image the call returns FALSE with the path intact and the caller strokes with
+cairo, so nothing changes for a target this cannot write.
+
+The coverage model is a distance field over the polyline's bounding box: each segment stamps
+`reach² − d²` (MAX, so the nearest point wins; no square root until compositing) into a
+scratch plane whose resting state is zero, over the pixels within `reach` — the widest pass's
+half-width plus the antialiasing pixel. Joins and caps are the capsule's own, round; a flat
+cap drops the pixels past the segment's end plane. Dashes are cut along the polyline's arc
+length before stamping, so a dash end is a cap exactly as cairo's is. Compositing walks only
+the spans each row wrote — `clamp(R + ½ − d, 0, 1)` per pass, dark then bright, premultiplied
+OVER — then zeroes those spans again, so the plane is never cleared as a whole. The surface
+records what was touched as cairo user data, for whoever composites it.
+
+`dt_draw_shape_lines()` and `dt_draw_stroke_line()` (`widgets/draw.h`) build the style from
+the same numbers they always passed to cairo — widths in user units, the dash lengths through
+`dt_draw_dash_lengths()`, the overlay colour and contrast — and try the rasteriser first.
+
+## The canvas
+
+`dt_masks_events_post_expose_with()` no longer pushes a group. It keeps one ARGB32 image
+surface the size of the clip in device pixels (created once, kept across frames, given the
+target's device scale), draws every shape into it through a `cairo_t` carrying `cr`'s matrix
+shifted to the clip's origin, and composites onto the view only the rectangle that was painted:
+the rasteriser's own record, plus the node header of every outline — node and both control
+points, three per node — with a margin for a node's disc and an arrow head, which bounds what
+cairo drew on top. That rectangle is then cleared by hand for the next frame. A creation
+session, which paints through its own cached pattern, takes the whole canvas.
+
+## Measured
+
+Per shape per frame, the two states a drag frame is made of:
+
+| case | member (path only) | selected (path, dashed border, nodes) |
+|---|---:|---:|
+| brush-1313-cusp (11 nodes) | 7.56 → **1.49** ms | 9.49 → **2.49** ms |
+| brush-1360-pressure-ramp (43 nodes) | 8.47 → **2.51** ms | 11.67 → **4.27** ms |
+| brush-zigzag (6 nodes, 98 k samples) | 12.37 → **2.88** ms | 17.99 → **5.33** ms |
+| polygon-1788045925 (15 nodes) | 7.01 → **1.72** ms | 8.97 → **2.65** ms |
+| polygon-comb (12 nodes) | 12.65 → **4.04** ms | 16.96 → **6.47** ms |
+
+The harness paints its own background each frame (~1 ms), which the darkroom pays as its
+image blit anyway; it is inside both columns. The steps, from the traces (`MASKS_DEBUG=1`):
+the strokes alone fell from ~6 ms to ~3 ms on the pressure ramp; the full-view composite of the
+group, 4 ms per frame, became a composite of the painted rectangle.
+
+The pixels: on the corpus's screen renders, painted-pixel counts agree within 1–3 %, no
+pixel differs by more than 51/255 except single end-cap pixels — a one-pixel stub under a
+node whose flat end is round now, the first pixel of one dash — and no raster (alpha)
+baseline moved at all. The 23 overlay baselines were regenerated.
+
+## Traps
+
+- **Disc stamping scallops thin lines.** Stamping a disc per vertex leaves necks of `s²/8R`
+  between vertices `s` apart; at the bright pass's half-width that shows. The capsule per
+  segment is the fix, and per-pixel it costs a dot product more than the disc.
+- **Inside a pushed group, `cairo_get_target()` is the ORIGINAL target.** The group's surface
+  is `cairo_get_group_target()`, and it carries a device offset: pixel = device + offset. The
+  unit test paints inside a clipped group and checks the composite lands where cairo puts it.
+- **A widget context has a device scale, so an identity matrix is not device pixels.** The
+  canvas takes the target's device scale, its matrix is `cr`'s followed by a translation in
+  device units divided by that scale, and the composite positions the canvas in the same units.
+- **`cairo_copy_path_flat()` is the cheap bridge.** The shapes' path builders are unchanged;
+  extracting the flattened path costs microseconds and keeps one implementation of every
+  outline walk.

--- a/src/develop/masks/brush.c
+++ b/src/develop/masks/brush.c
@@ -228,7 +228,7 @@ static void _brush_get_XY(float p0_x, float p0_y, float p1_x, float p1_y, float 
  * is supposed to hold geometry. It is a return value now, so the border is either written or
  * left exactly as the caller had it. Returns TRUE when a border point was produced. */
 static gboolean _brush_border_get_XY(float p0_x, float p0_y, float p1_x, float p1_y, float p2_x, float p2_y,
-                                     float p3_x, float p3_y, float t, float radius,
+                                     float p3_x, float p3_y, float t, float radius, float radius_rate,
                                      float *point_x, float *point_y, float *border_x, float *border_y)
 {
   // we get the point
@@ -288,11 +288,32 @@ static gboolean _brush_border_get_XY(float p0_x, float p0_y, float p1_x, float p
     if(fabsf(dx) < degenerate && fabsf(dy) < degenerate) { dx = p3_x - p0_x; dy = p3_y - p0_y; }
 
     if(dx == 0.0f && dy == 0.0f) return FALSE;   // a single point: no direction to offset along
+
+    /* a limit direction has a direction and no speed, so no rate can be taken against it */
+    radius_rate = 0.0f;
   }
-  const float l = 1.0f / dt_fast_hypotf(dx, dy);
-  *border_x = (*point_x) + radius * dy * l;
-  *border_y = (*point_y) - radius * dx * l;
+
+  /* on the envelope of the discs, not on the normal: see dt_masks_outline_envelope_offset() */
+  const float centre[2] = { *point_x, *point_y };
+  float border[2];
+  dt_masks_outline_envelope_offset(centre, dx, dy, radius, radius_rate, border);
+  *border_x = border[0];
+  *border_y = border[1];
   return TRUE;
+}
+
+/* The radius along a segment eases from one node's to the other's, r1 + (r2 - r1) * t^2 (3 - 2t),
+ * and its rate by t is what the envelope needs: (r2 - r1) * 6 t (1 - t), zero at both ends, so a
+ * segment's end samples stay on the normal and the caps and joint arcs built from them are
+ * unchanged. */
+static inline float _brush_radius_at(const float r1, const float r2, const double t)
+{
+  return r1 + (r2 - r1) * t * t * (3.0 - 2.0 * t);
+}
+
+static inline float _brush_radius_rate_at(const float r1, const float r2, const double t)
+{
+  return (r2 - r1) * 6.0 * t * (1.0 - t);
 }
 
 /**
@@ -756,11 +777,13 @@ static void _brush_points_recurs(float *p1, float *p2, double tmin, double tmax,
   // we calculate points if needed
   if(!have_min)
     have_border_min = _brush_border_get_XY(p1[0], p1[1], p1[2], p1[3], p2[2], p2[3], p2[0], p2[1], tmin,
-                                           p1[4] + (p2[4] - p1[4]) * tmin * tmin * (3.0 - 2.0 * tmin), points_min,
+                                           _brush_radius_at(p1[4], p2[4], tmin),
+                                           _brush_radius_rate_at(p1[4], p2[4], tmin), points_min,
                                            points_min + 1, border_min, border_min + 1);
   if(!have_max)
     have_border_max = _brush_border_get_XY(p1[0], p1[1], p1[2], p1[3], p2[2], p2[3], p2[0], p2[1], tmax,
-                                           p1[4] + (p2[4] - p1[4]) * tmax * tmax * (3.0 - 2.0 * tmax), points_max,
+                                           _brush_radius_at(p1[4], p2[4], tmax),
+                                           _brush_radius_rate_at(p1[4], p2[4], tmax), points_max,
                                            points_max + 1, border_max, border_max + 1);
 
   if(!_brush_span_is_leaf(tmin, tmax, points_min, points_max, withborder ? border_min : NULL, border_max,
@@ -790,7 +813,7 @@ static void _brush_points_recurs(float *p1, float *p2, double tmin, double tmax,
 
   if(withborder)
   {
-    const float radius = p1[4] + (p2[4] - p1[4]) * tmax * tmax * (3.0 - 2.0 * tmax);
+    const float radius = _brush_radius_at(p1[4], p2[4], tmax);
     const float chord[2] = { p2[0] - p1[0], p2[1] - p1[1] };
     _brush_leaf_borrow_border(border_min, border_max, have_border_min, have_border_max, points_max, chord, radius);
 
@@ -965,9 +988,9 @@ static gboolean _brush_walk_segment(const _brush_walk_t *const w, _brush_walk_st
   float c1[2];
   float b1[2];
   const gboolean have_b0 = _brush_border_get_XY(p1[0], p1[1], p1[2], p1[3], p2[2], p2[3], p2[0], p2[1], 0.0f,
-                                                p1[4], c0, c0 + 1, b0, b0 + 1);
+                                                p1[4], 0.0f, c0, c0 + 1, b0, b0 + 1);
   const gboolean have_b1 = _brush_border_get_XY(p1[0], p1[1], p1[2], p1[3], p2[2], p2[3], p2[0], p2[1], 1.0f,
-                                                p2[4], c1, c1 + 1, b1, b1 + 1);
+                                                p2[4], 0.0f, c1, c1 + 1, b1, b1 + 1);
   if(!have_b0 && !have_b1) return FALSE;
   if(!have_b0) dt_masks_outline_offset_along(c0, b1[0] - c1[0], b1[1] - c1[1], p1[4], b0);
   if(!have_b1) dt_masks_outline_offset_along(c1, b0[0] - c0[0], b0[1] - c0[1], p2[4], b1);
@@ -998,6 +1021,7 @@ static gboolean _brush_walk_segment(const _brush_walk_t *const w, _brush_walk_st
   s->b[0] = rb[0];
   s->b[1] = rb[1];
   s->r = p2[4];
+
   s->payload[0] = rp[0];
   s->payload[1] = rp[1];
   s->have_prev = TRUE;

--- a/src/develop/masks/masks_functions.h
+++ b/src/develop/masks/masks_functions.h
@@ -175,6 +175,34 @@ gboolean dt_masks_outline_short_way(const float *const centre, const float *cons
 void dt_masks_outline_offset_along(const float *const centre, float dx, float dy, const float radius,
                                    float *const border);
 
+/** How far off the normal a border sample may tilt, as the sine of the angle: the rate of the
+ * radius along the spine, |dr/ds|, up to which the envelope is followed exactly. Beyond it the
+ * sample stays at that tilt, which puts it a little inside the union -- so the outline skips it
+ * there -- but keeps the spoke painted from it reaching across the stroke. At a rate of 1 the
+ * discs nest and there is no envelope to follow at all; between 0.7 and 1 the spokes of a
+ * family tilted to the envelope would lean so far along the spine that nothing paints the
+ * width, and the raster would open. With this cap every point across the width at a sample is
+ * reached by the spoke of a sample one radius further on (r_j >= 1.41 r_i whenever the rate
+ * exceeds 0.41), which is what keeps the union painted whatever the rate. */
+#define DT_MASKS_OUTLINE_TILT_MAX 0.7f
+
+/** Place the border sample of a disc of @p radius centred at @p centre, when the disc belongs
+ * to a family whose centre moves along the tangent (@p dx, @p dy) -- any length, the derivative
+ * of the spine by its parameter -- and whose radius changes by @p radius_rate per unit of that
+ * same parameter.
+ *
+ * A border sample on the NORMAL of its spine sample is on the boundary of the union only while
+ * the radius is constant. Where the radius grows or shrinks along the spine the boundary is the
+ * envelope of the discs, c + r * (-r' T + sqrt(1 - r'^2) N) with r' = dr/ds, tilted off the
+ * normal by asin(r'); the normal sample sits inside the union by about r'^2 r / 2 -- a fraction
+ * of a pixel at the rates a pen draws, invisible to the eye and exactly what the boundary
+ * detector rejects, so the outline of a stroke whose radius varied lost whole stretches of both
+ * sides (a 37% skipped border on the #1313 corpus brush, most of it along the sides). The
+ * tilt is capped at DT_MASKS_OUTLINE_TILT_MAX. The normal is (dy, -dx), the side every
+ * border in this module offsets to. */
+void dt_masks_outline_envelope_offset(const float *centre, float dx, float dy, float radius, float radius_rate,
+                                      float *out);
+
 
 /** Is @p index inside one of the excluded spans? For a consumer that SEARCHES the outline rather
  * than walking it; a forward walk should use dt_masks_draw_outline_runs() instead. */

--- a/src/develop/masks/masks_functions.h
+++ b/src/develop/masks/masks_functions.h
@@ -176,15 +176,16 @@ void dt_masks_outline_offset_along(const float *const centre, float dx, float dy
                                    float *const border);
 
 /** How far off the normal a border sample may tilt, as the sine of the angle: the rate of the
- * radius along the spine, |dr/ds|, up to which the envelope is followed exactly. Beyond it the
- * sample stays at that tilt, which puts it a little inside the union -- so the outline skips it
- * there -- but keeps the spoke painted from it reaching across the stroke. At a rate of 1 the
- * discs nest and there is no envelope to follow at all; between 0.7 and 1 the spokes of a
- * family tilted to the envelope would lean so far along the spine that nothing paints the
- * width, and the raster would open. With this cap every point across the width at a sample is
- * reached by the spoke of a sample one radius further on (r_j >= 1.41 r_i whenever the rate
- * exceeds 0.41), which is what keeps the union painted whatever the rate. */
-#define DT_MASKS_OUTLINE_TILT_MAX 0.7f
+ * radius along the spine, |dr/ds|, up to which the envelope is followed. At 1 the discs nest
+ * and there is no envelope beyond it, so this is the exact envelope and the clamp only keeps
+ * the square root real. A first version capped it at 0.7 to keep the spokes painted from the
+ * samples reaching across the stroke, on the argument that a family tilted further leans too
+ * far along the spine to paint the width. Measured, the raster oracle reports no missing pixel
+ * anywhere in the corpus at the exact envelope, while the cap left a real hole: a segment whose
+ * rate peaks near 1 -- a brush flaring from a 132 px node to a 342 px one over 287 px -- has its
+ * union's top on the rear envelope of the flare, 40 px outside the wide node's circle at a tilt
+ * of 64 degrees, and no sample reached it, so the outline lost the whole top of the shape. */
+#define DT_MASKS_OUTLINE_TILT_MAX 1.0f
 
 /** Place the border sample of a disc of @p radius centred at @p centre, when the disc belongs
  * to a family whose centre moves along the tangent (@p dx, @p dy) -- any length, the derivative

--- a/src/develop/masks/masks_gui.c
+++ b/src/develop/masks/masks_gui.c
@@ -39,6 +39,7 @@
 #include "develop/masks_gui.h"
 #include "develop/masks_group.h"
 #include "develop/masks/masks_functions.h"
+#include "widgets/stroke_raster.h"
 #include "widgets/bauhaus.h"
 #include "common/conf.h"
 #include "control/signal.h"
@@ -3940,6 +3941,123 @@ void dt_masks_events_post_expose(dt_develop_t *dev, struct dt_iop_module_t *modu
 {
   dt_masks_events_post_expose_with(dev, module, cr, width, height, pointerx, pointery, NULL);
 }
+/* ---------------------------------------------------------------------------------------------
+ * THE CANVAS.
+ *
+ * The overlay is painted into an image surface of its own, in device pixels, and composited
+ * onto the view once. That is what cairo_push_group() did too, with two costs this avoids:
+ * the group is sized to the clip -- the whole view -- and both its pixels and its composite
+ * are paid over that whole area every frame whether one small shape is being dragged or not;
+ * and a group is cairo's, so nothing but cairo can paint into it. The canvas is ours: the
+ * stroke rasteriser writes its pixels directly (see widgets/stroke_raster.c), cairo still
+ * draws the nodes, handles and arrows into the same surface, and the composite covers only
+ * the rectangle that was painted, which the rasteriser reports and the node header bounds.
+ *
+ * It persists across frames -- an ARGB32 surface of the view's size is not something to
+ * allocate per frame; that is what the group had replaced an explicit surface for -- and is
+ * cleared after each composite over the same rectangle, so a frame starts from transparency
+ * without touching the rest. GUI thread only, like everything else in this file. */
+static cairo_surface_t *_canvas = NULL;
+static int _canvas_width = 0;
+static int _canvas_height = 0;
+
+static cairo_surface_t *_canvas_acquire(const int width, const int height, const double device_scale)
+{
+  if(!IS_NULL_PTR(_canvas) && (_canvas_width != width || _canvas_height != height))
+  {
+    cairo_surface_destroy(_canvas);
+    _canvas = NULL;
+  }
+  if(IS_NULL_PTR(_canvas))
+  {
+    _canvas = cairo_image_surface_create(CAIRO_FORMAT_ARGB32, width, height);
+    if(cairo_surface_status(_canvas) != CAIRO_STATUS_SUCCESS)
+    {
+      cairo_surface_destroy(_canvas);
+      _canvas = NULL;
+      return NULL;
+    }
+    _canvas_width = width;
+    _canvas_height = height;
+  }
+  cairo_surface_set_device_scale(_canvas, device_scale, device_scale);
+  return _canvas;
+}
+
+/* Clear @p rect of the canvas back to transparent, by hand: a handful of rows of a surface we
+ * own, where cairo's CLEAR would walk the same pixels with more ceremony. */
+static void _canvas_clear(cairo_surface_t *canvas, const cairo_rectangle_int_t *rect)
+{
+  cairo_surface_flush(canvas);
+  uint8_t *const data = cairo_image_surface_get_data(canvas);
+  const int stride = cairo_image_surface_get_stride(canvas);
+  const int x0 = MAX(rect->x, 0);
+  const int y0 = MAX(rect->y, 0);
+  const int x1 = MIN(rect->x + rect->width, _canvas_width);
+  const int y1 = MIN(rect->y + rect->height, _canvas_height);
+  if(x1 <= x0 || y1 <= y0) return;
+  for(int y = y0; y < y1; y++) memset(data + (size_t)y * stride + (size_t)x0 * 4, 0, (size_t)(x1 - x0) * 4);
+  cairo_surface_mark_dirty_rectangle(canvas, x0, y0, x1 - x0, y1 - y0);
+}
+
+/* Grow @p rect to hold the canvas pixel (x, y), with @p margin around it. */
+static void _rect_include(cairo_rectangle_int_t *rect, gboolean *any, const double x, const double y, const int margin)
+{
+  const int x0 = (int)floor(x) - margin;
+  const int y0 = (int)floor(y) - margin;
+  const int x1 = (int)ceil(x) + margin + 1;
+  const int y1 = (int)ceil(y) + margin + 1;
+  if(!*any)
+  {
+    rect->x = x0;
+    rect->y = y0;
+    rect->width = x1 - x0;
+    rect->height = y1 - y0;
+    *any = TRUE;
+    return;
+  }
+  const int rx1 = MAX(rect->x + rect->width, x1);
+  const int ry1 = MAX(rect->y + rect->height, y1);
+  rect->x = MIN(rect->x, x0);
+  rect->y = MIN(rect->y, y0);
+  rect->width = rx1 - rect->x;
+  rect->height = ry1 - rect->y;
+}
+
+/* What cairo, not the rasteriser, painted into the canvas this frame. The nodes and their
+ * handles sit on the node header of every outline -- three points per node: the node and its
+ * two control points -- and the clone arrow runs between a shape and its source, so the union
+ * of both headers, with a margin for a node's disc and an arrow head, bounds them all. The
+ * outlines themselves the rasteriser reports exactly. A buffer too short to have a header (a
+ * circle's, a source's) contributes its first points instead. */
+static void _canvas_dirty_from_headers(cairo_t *canvas_cr, const dt_masks_form_gui_t *gui, cairo_rectangle_int_t *rect,
+                                       gboolean *any)
+{
+  const int margin = (int)ceil(2.0 * DT_DRAW_RADIUS_NODE_SELECTED + DT_DRAW_SCALE_ARROW) + 2;
+  const dt_masks_form_t *form = dt_masks_get_visible_form(gui->dev);
+  const int nodes = IS_NULL_PTR(form) ? 0 : (int)g_list_length(form->points);
+  for(const GList *node = gui->points; node; node = g_list_next(node))
+  {
+    const dt_masks_form_gui_points_t *const pts = (const dt_masks_form_gui_points_t *)node->data;
+    if(IS_NULL_PTR(pts)) continue;
+    const float *const arrays[2] = { pts->points, pts->source };
+    const int counts[2] = { pts->points_count, pts->source_count };
+    for(int a = 0; a < 2; a++)
+    {
+      if(IS_NULL_PTR(arrays[a]) || counts[a] <= 0) continue;
+      const int header = MIN(nodes * 3, counts[a]);
+      const int limit = (header > 0) ? header : MIN(counts[a], 64);
+      for(int i = 0; i < limit; i++)
+      {
+        double x = arrays[a][2 * i];
+        double y = arrays[a][2 * i + 1];
+        cairo_user_to_device(canvas_cr, &x, &y);
+        _rect_include(rect, any, x, y, margin);
+      }
+    }
+  }
+}
+
 
 void dt_masks_events_post_expose_with(dt_develop_t *dev, struct dt_iop_module_t *module, cairo_t *cr,
                                       int32_t width, int32_t height, int32_t pointerx, int32_t pointery,
@@ -3977,16 +4095,49 @@ void dt_masks_events_post_expose_with(dt_develop_t *dev, struct dt_iop_module_t 
   const double group_start = dt_get_wtime();
   if(dt_get_debug_flags() & DT_DEBUG_PERF)
     dt_print(DT_DEBUG_MASKS, "[masks] overlay preamble took %0.04f sec\n", group_start - post_expose_start);
-  cairo_push_group(cr);
-  cairo_t *const mask_draw = cr;
-  if(dt_get_debug_flags() & DT_DEBUG_PERF)
-    dt_print(DT_DEBUG_MASKS, "[masks] overlay group pushed in %0.04f sec\n", dt_get_wtime() - group_start);
 
-  // Apply the same transformation to the mask drawing context
-  /*cairo_matrix_t m;
-  cairo_get_matrix(cr, &m);
-  cairo_set_matrix(mask_draw, &m);*/
-  
+  /* The canvas covers the clip, in the device pixels of cr's target. */
+  double clip_x0 = 0.0;
+  double clip_y0 = 0.0;
+  double clip_x1 = 0.0;
+  double clip_y1 = 0.0;
+  cairo_clip_extents(cr, &clip_x0, &clip_y0, &clip_x1, &clip_y1);
+  double device_x0 = clip_x0;
+  double device_y0 = clip_y0;
+  double device_x1 = clip_x1;
+  double device_y1 = clip_y1;
+  cairo_user_to_device(cr, &device_x0, &device_y0);
+  cairo_user_to_device(cr, &device_x1, &device_y1);
+  const int canvas_x = (int)floor(MIN(device_x0, device_x1));
+  const int canvas_y = (int)floor(MIN(device_y0, device_y1));
+  const int canvas_width = (int)ceil(MAX(device_x0, device_x1)) - canvas_x;
+  const int canvas_height = (int)ceil(MAX(device_y0, device_y1)) - canvas_y;
+  if(canvas_width <= 0 || canvas_height <= 0) return;
+  double device_scale_x = 1.0;
+  double device_scale_y = 1.0;
+  cairo_surface_get_device_scale(cairo_get_target(cr), &device_scale_x, &device_scale_y);
+  const double device_scale = (device_scale_x > 0.0) ? device_scale_x : 1.0;
+
+  cairo_surface_t *canvas = _canvas_acquire(canvas_width, canvas_height, device_scale);
+  if(IS_NULL_PTR(canvas)) return;
+  dt_stroke_raster_touched_reset(canvas);
+  cairo_t *const mask_draw = cairo_create(canvas);
+  if(dt_get_debug_flags() & DT_DEBUG_PERF)
+    dt_print(DT_DEBUG_MASKS, "[masks] overlay canvas %dx%d ready in %0.04f sec\n", canvas_width, canvas_height,
+             dt_get_wtime() - group_start);
+
+  /* The canvas draws in cr's coordinates, shifted so that its pixel (0, 0) is the clip's
+   * device origin: cr's matrix, then a device-space translation -- in the units the device
+   * scale multiplies, so divided by it. */
+  {
+    cairo_matrix_t matrix;
+    cairo_matrix_t shift;
+    cairo_matrix_t canvas_matrix;
+    cairo_get_matrix(cr, &matrix);
+    cairo_matrix_init_translate(&shift, -canvas_x / device_scale, -canvas_y / device_scale);
+    cairo_matrix_multiply(&canvas_matrix, &matrix, &shift);
+    cairo_set_matrix(mask_draw, &canvas_matrix);
+  }
   cairo_save(mask_draw);
 
   // We rescale to input space -- from the viewport, or from the caller's own mapping when it
@@ -3996,7 +4147,7 @@ void dt_masks_events_post_expose_with(dt_develop_t *dev, struct dt_iop_module_t 
     if(dt_dev_rescale_roi_to_input(develop, mask_draw, width, height))
     {
       cairo_restore(mask_draw);
-      cairo_pattern_destroy(cairo_pop_group(cr));   // discard: nothing was drawn
+      cairo_destroy(mask_draw);   // nothing was drawn
       return;
     }
   }
@@ -4035,20 +4186,51 @@ void dt_masks_events_post_expose_with(dt_develop_t *dev, struct dt_iop_module_t 
     mask_gui->type = mask_form->type;
     mask_form->functions->post_expose(mask_draw, zoom_scale, mask_gui, 0, point_count);
   }
+  /* What was painted: the rasteriser's own record, and the bounds of what cairo drew on top.
+   * The transform is still in effect here, which is what the header bounds need; a creation
+   * session paints through its own cached pattern and takes the whole canvas. */
+  cairo_rectangle_int_t dirty = { 0, 0, 0, 0 };
+  gboolean any = dt_stroke_raster_touched(canvas, &dirty);
+  if(mask_gui->creation || !IS_NULL_PTR(mask_gui->creation_formids))
+  {
+    dirty = (cairo_rectangle_int_t){ 0, 0, canvas_width, canvas_height };
+    any = TRUE;
+  }
+  else
+    _canvas_dirty_from_headers(mask_draw, mask_gui, &dirty, &any);
   cairo_restore(mask_draw);
+  cairo_destroy(mask_draw);
 
   if(dt_get_debug_flags() & DT_DEBUG_MASKS)
     dt_show_times(&draw_start, "[masks] overlay drawn");
 
-  /* Composite the group. pop_group_to_source() hands back a pattern already carrying the matrix
-   * that was in effect at push time, so a plain paint reproduces exactly what the explicit
-   * full-window surface did -- the save/restore pair above balances the one taken after the
-   * push. */
+  /* Composite the dirty rectangle of the canvas onto the view, one pixel to one device pixel,
+   * then clear it so the next frame starts from transparency there. */
   const double composite_start = dt_get_wtime();
-  cairo_pop_group_to_source(cr);
-  cairo_paint(cr);
+  if(any)
+  {
+    const int x0 = CLAMP(dirty.x, 0, canvas_width);
+    const int y0 = CLAMP(dirty.y, 0, canvas_height);
+    const int x1 = CLAMP(dirty.x + dirty.width, 0, canvas_width);
+    const int y1 = CLAMP(dirty.y + dirty.height, 0, canvas_height);
+    if(x1 > x0 && y1 > y0)
+    {
+      cairo_surface_flush(canvas);
+      cairo_save(cr);
+      cairo_identity_matrix(cr);
+      cairo_set_source_surface(cr, canvas, canvas_x / device_scale, canvas_y / device_scale);
+      cairo_rectangle(cr, (canvas_x + x0) / device_scale, (canvas_y + y0) / device_scale,
+                      (x1 - x0) / device_scale, (y1 - y0) / device_scale);
+      cairo_fill(cr);
+      cairo_restore(cr);
+      const cairo_rectangle_int_t painted = { x0, y0, x1 - x0, y1 - y0 };
+      _canvas_clear(canvas, &painted);
+    }
+  }
   if(dt_get_debug_flags() & DT_DEBUG_PERF)
-    dt_print(DT_DEBUG_MASKS, "[masks] overlay composited in %0.04f sec\n", dt_get_wtime() - composite_start);
+    dt_print(DT_DEBUG_MASKS, "[masks] overlay composited (%dx%d of %dx%d) in %0.04f sec\n",
+             any ? dirty.width : 0, any ? dirty.height : 0, canvas_width, canvas_height,
+             dt_get_wtime() - composite_start);
 }
 
 void dt_masks_clear_form_gui(dt_develop_t *develop)

--- a/src/develop/masks/masks_gui.c
+++ b/src/develop/masks/masks_gui.c
@@ -4048,6 +4048,10 @@ static void _canvas_cairo_bound(cairo_t *canvas_cr, const dt_masks_form_gui_t *g
 {
   const dt_masks_form_t *form = dt_masks_get_visible_form(gui->dev);
   const int nodes = IS_NULL_PTR(form) ? 0 : (int)g_list_length(form->points);
+  double scale = 1.0;
+  double scale_y = 1.0;
+  cairo_surface_get_device_scale(cairo_get_target(canvas_cr), &scale, &scale_y);
+  if(scale <= 0.0) scale = 1.0;
   double reach = 0.0;
   for(const GList *node = gui->points; node; node = g_list_next(node))
   {
@@ -4065,7 +4069,7 @@ static void _canvas_cairo_bound(cairo_t *canvas_cr, const dt_masks_form_gui_t *g
         double x = arrays[a][2 * i];
         double y = arrays[a][2 * i + 1];
         cairo_user_to_device(canvas_cr, &x, &y);
-        _rect_include(rect, any, x, y, 0);
+        _rect_include(rect, any, x * scale, y * scale, 0);   /* device units to canvas pixels */
       }
     }
     /* the longest control vector of this outline's header, in device pixels */
@@ -4081,7 +4085,7 @@ static void _canvas_cairo_bound(cairo_t *canvas_cr, const dt_masks_form_gui_t *g
           double cx = pts->points[k * 6 + (c ? 4 : 0)];
           double cy = pts->points[k * 6 + (c ? 5 : 1)];
           cairo_user_to_device(canvas_cr, &cx, &cy);
-          reach = MAX(reach, hypot(cx - nx, cy - ny));
+          reach = MAX(reach, hypot(cx - nx, cy - ny) * scale);
         }
       }
     }
@@ -4122,30 +4126,41 @@ static gboolean _canvas_begin(cairo_t *cr, _canvas_frame_t *frame)
   double device_y1 = clip_y1;
   cairo_user_to_device(cr, &device_x0, &device_y0);
   cairo_user_to_device(cr, &device_x1, &device_y1);
-  frame->x = (int)floor(MIN(device_x0, device_x1));
-  frame->y = (int)floor(MIN(device_y0, device_y1));
-  frame->width = (int)ceil(MAX(device_x0, device_x1)) - frame->x;
-  frame->height = (int)ceil(MAX(device_y0, device_y1)) - frame->y;
-  if(frame->width <= 0 || frame->height <= 0) return FALSE;
 
+  /* cairo's device space stops short of the pixel grid: a pixel is device * device_scale +
+   * device_offset, the scale being what a HiDPI widget carries. The frame is in pixels. */
   double device_scale_x = 1.0;
   double device_scale_y = 1.0;
+  double device_offset_x = 0.0;
+  double device_offset_y = 0.0;
   cairo_surface_get_device_scale(cairo_get_target(cr), &device_scale_x, &device_scale_y);
+  cairo_surface_get_device_offset(cairo_get_target(cr), &device_offset_x, &device_offset_y);
   frame->device_scale = (device_scale_x > 0.0) ? device_scale_x : 1.0;
+  const double px0 = MIN(device_x0, device_x1) * frame->device_scale + device_offset_x;
+  const double px1 = MAX(device_x0, device_x1) * frame->device_scale + device_offset_x;
+  const double py0 = MIN(device_y0, device_y1) * frame->device_scale + device_offset_y;
+  const double py1 = MAX(device_y0, device_y1) * frame->device_scale + device_offset_y;
+  frame->x = (int)floor(px0);
+  frame->y = (int)floor(py0);
+  frame->width = (int)ceil(px1) - frame->x;
+  frame->height = (int)ceil(py1) - frame->y;
+  if(frame->width <= 0 || frame->height <= 0) return FALSE;
 
   frame->canvas = _canvas_acquire(frame->width, frame->height, frame->device_scale);
   if(IS_NULL_PTR(frame->canvas)) return FALSE;
   dt_stroke_raster_touched_reset(frame->canvas);
   frame->cr = cairo_create(frame->canvas);
 
-  /* The canvas draws in cr's coordinates, shifted so that its pixel (0, 0) is the clip's
-   * device origin: cr's matrix, then a device-space translation -- in the units the device
-   * scale multiplies, so divided by it. */
+  /* The canvas draws in cr's coordinates, shifted so that its pixel (0, 0) is the frame's
+   * origin: cr's matrix, then a device-space translation. The canvas has the target's device
+   * scale, so a pixel shift is that many device units, and the target's own device offset is
+   * taken back out. */
   cairo_matrix_t matrix;
   cairo_matrix_t shift;
   cairo_matrix_t canvas_matrix;
   cairo_get_matrix(cr, &matrix);
-  cairo_matrix_init_translate(&shift, -frame->x / frame->device_scale, -frame->y / frame->device_scale);
+  cairo_matrix_init_translate(&shift, (device_offset_x - frame->x) / frame->device_scale,
+                              (device_offset_y - frame->y) / frame->device_scale);
   cairo_matrix_multiply(&canvas_matrix, &matrix, &shift);
   cairo_set_matrix(frame->cr, &canvas_matrix);
   return TRUE;
@@ -4160,12 +4175,19 @@ static void _canvas_end(cairo_t *cr, const _canvas_frame_t *frame, const cairo_r
   const int x1 = CLAMP(dirty->x + dirty->width, 0, frame->width);
   const int y1 = CLAMP(dirty->y + dirty->height, 0, frame->height);
   if(x1 <= x0 || y1 <= y0) return;
+  /* With the identity matrix a user unit is one device unit, and the target maps those to
+   * pixels through its device scale and offset; the canvas, carrying the same device scale,
+   * then lands pixel on pixel. */
   const double s = frame->device_scale;
+  double offset_x = 0.0;
+  double offset_y = 0.0;
+  cairo_surface_get_device_offset(cairo_get_target(cr), &offset_x, &offset_y);
   cairo_surface_flush(frame->canvas);
   cairo_save(cr);
   cairo_identity_matrix(cr);
-  cairo_set_source_surface(cr, frame->canvas, frame->x / s, frame->y / s);
-  cairo_rectangle(cr, (frame->x + x0) / s, (frame->y + y0) / s, (x1 - x0) / s, (y1 - y0) / s);
+  cairo_set_source_surface(cr, frame->canvas, (frame->x - offset_x) / s, (frame->y - offset_y) / s);
+  cairo_rectangle(cr, (frame->x + x0 - offset_x) / s, (frame->y + y0 - offset_y) / s, (x1 - x0) / s,
+                  (y1 - y0) / s);
   cairo_fill(cr);
   cairo_restore(cr);
   const cairo_rectangle_int_t painted = { x0, y0, x1 - x0, y1 - y0 };

--- a/src/develop/masks/masks_gui.c
+++ b/src/develop/masks/masks_gui.c
@@ -4024,25 +4024,38 @@ static void _rect_include(cairo_rectangle_int_t *rect, gboolean *any, const doub
   rect->height = ry1 - rect->y;
 }
 
-/* What cairo, not the rasteriser, painted into the canvas this frame. The nodes and their
- * handles sit on the node header of every outline -- three points per node: the node and its
- * two control points -- and the clone arrow runs between a shape and its source, so the union
- * of both headers, with a margin for a node's disc and an arrow head, bounds them all. The
- * outlines themselves the rasteriser reports exactly. A buffer too short to have a header (a
- * circle's, a source's) contributes its first points instead. */
-static void _canvas_dirty_from_headers(cairo_t *canvas_cr, const dt_masks_form_gui_t *gui, cairo_rectangle_int_t *rect,
-                                       gboolean *any)
+/* Where cairo may paint this frame -- the nodes, their handles, the clone arrow -- as a
+ * rectangle the canvas context is CLIPPED to before anything is drawn, so that what cairo
+ * paints is bounded by construction rather than by an estimate made afterwards. What escapes
+ * a too-small rectangle is clipped, which is seen at once; what escaped an estimate was
+ * neither composited nor cleared, and stayed in the canvas to reappear in a later frame's
+ * rectangle, possibly after a pan -- a ghost, which is seen much later and understood never.
+ *
+ * The bound: every header point of every outline -- node and both control points, three per
+ * node, plus the border's own header, where the border handle sits, and the source's --
+ * grown by the longest control vector, because a curvature handle is that vector rotated a
+ * quarter turn about its node (same length, any direction), by a node's disc and by an arrow
+ * head. A buffer too short to have a header (a circle's, a source's) contributes its first
+ * points. The outlines themselves the rasteriser reports exactly, on top of this. */
+/* Does this buffer carry a node header at all: three points per node, ahead of the samples. */
+static inline gboolean header_reach_wanted(const int nodes, const int points_count)
 {
-  const int margin = (int)ceil(2.0 * DT_DRAW_RADIUS_NODE_SELECTED + DT_DRAW_SCALE_ARROW) + 2;
+  return nodes > 0 && points_count >= nodes * 3;
+}
+
+static void _canvas_cairo_bound(cairo_t *canvas_cr, const dt_masks_form_gui_t *gui, cairo_rectangle_int_t *rect,
+                                gboolean *any)
+{
   const dt_masks_form_t *form = dt_masks_get_visible_form(gui->dev);
   const int nodes = IS_NULL_PTR(form) ? 0 : (int)g_list_length(form->points);
+  double reach = 0.0;
   for(const GList *node = gui->points; node; node = g_list_next(node))
   {
     const dt_masks_form_gui_points_t *const pts = (const dt_masks_form_gui_points_t *)node->data;
     if(IS_NULL_PTR(pts)) continue;
-    const float *const arrays[2] = { pts->points, pts->source };
-    const int counts[2] = { pts->points_count, pts->source_count };
-    for(int a = 0; a < 2; a++)
+    const float *const arrays[3] = { pts->points, pts->border, pts->source };
+    const int counts[3] = { pts->points_count, pts->border_count, pts->source_count };
+    for(int a = 0; a < 3; a++)
     {
       if(IS_NULL_PTR(arrays[a]) || counts[a] <= 0) continue;
       const int header = MIN(nodes * 3, counts[a]);
@@ -4052,12 +4065,34 @@ static void _canvas_dirty_from_headers(cairo_t *canvas_cr, const dt_masks_form_g
         double x = arrays[a][2 * i];
         double y = arrays[a][2 * i + 1];
         cairo_user_to_device(canvas_cr, &x, &y);
-        _rect_include(rect, any, x, y, margin);
+        _rect_include(rect, any, x, y, 0);
+      }
+    }
+    /* the longest control vector of this outline's header, in device pixels */
+    if(!IS_NULL_PTR(pts->points) && header_reach_wanted(nodes, pts->points_count))
+    {
+      for(int k = 0; k < nodes; k++)
+      {
+        double nx = pts->points[k * 6 + 2];
+        double ny = pts->points[k * 6 + 3];
+        cairo_user_to_device(canvas_cr, &nx, &ny);
+        for(int c = 0; c < 2; c++)
+        {
+          double cx = pts->points[k * 6 + (c ? 4 : 0)];
+          double cy = pts->points[k * 6 + (c ? 5 : 1)];
+          cairo_user_to_device(canvas_cr, &cx, &cy);
+          reach = MAX(reach, hypot(cx - nx, cy - ny));
+        }
       }
     }
   }
+  if(!*any) return;
+  const int margin = (int)ceil(reach + 2.0 * DT_DRAW_RADIUS_NODE_SELECTED + DT_DRAW_SCALE_ARROW) + 2;
+  rect->x -= margin;
+  rect->y -= margin;
+  rect->width += 2 * margin;
+  rect->height += 2 * margin;
 }
-
 
 /* A frame of the canvas: where it sits in cr's device space, and the context that draws
  * into it in cr's coordinates. */
@@ -4158,17 +4193,23 @@ static void _overlay_draw_form(cairo_t *cr, const float zoom_scale, dt_masks_for
  * on top. The transform must still be in effect on @p canvas_cr, which is what the header
  * bounds need; a creation session paints through its own cached pattern and takes the whole
  * canvas. Returns FALSE when nothing was painted. */
-static gboolean _overlay_dirty(cairo_t *canvas_cr, const _canvas_frame_t *frame, const dt_masks_form_gui_t *mask_gui,
-                               cairo_rectangle_int_t *dirty)
+static gboolean _overlay_dirty(const _canvas_frame_t *frame, const cairo_rectangle_int_t *cairo_bound,
+                               const gboolean cairo_bounded, cairo_rectangle_int_t *dirty)
 {
-  if(mask_gui->creation || !IS_NULL_PTR(mask_gui->creation_formids))
+  gboolean any = dt_stroke_raster_touched(frame->canvas, dirty);
+  if(!cairo_bounded) return any;
+  if(!any)
   {
-    *dirty = (cairo_rectangle_int_t){ 0, 0, frame->width, frame->height };
+    *dirty = *cairo_bound;
     return TRUE;
   }
-  gboolean any = dt_stroke_raster_touched(frame->canvas, dirty);
-  _canvas_dirty_from_headers(canvas_cr, mask_gui, dirty, &any);
-  return any;
+  const int x1 = MAX(dirty->x + dirty->width, cairo_bound->x + cairo_bound->width);
+  const int y1 = MAX(dirty->y + dirty->height, cairo_bound->y + cairo_bound->height);
+  dirty->x = MIN(dirty->x, cairo_bound->x);
+  dirty->y = MIN(dirty->y, cairo_bound->y);
+  dirty->width = x1 - dirty->x;
+  dirty->height = y1 - dirty->y;
+  return TRUE;
 }
 
 void dt_masks_events_post_expose_with(dt_develop_t *dev, struct dt_iop_module_t *module, cairo_t *cr,
@@ -4242,6 +4283,25 @@ void dt_masks_events_post_expose_with(dt_develop_t *dev, struct dt_iop_module_t 
   if(!((mask_form->type & DT_MASKS_IS_PRIMITIVE_SHAPE) && mask_gui->creation))
     dt_masks_gui_form_test_create(mask_form, mask_gui, module);
 
+  /* The rectangle cairo may paint in, and the clip that holds it to that. A creation session
+   * paints through its own cached pattern and takes the whole canvas instead. */
+  cairo_rectangle_int_t cairo_bound = { 0, 0, frame.width, frame.height };
+  gboolean cairo_bounded = TRUE;
+  if(!mask_gui->creation && IS_NULL_PTR(mask_gui->creation_formids))
+  {
+    cairo_bounded = FALSE;
+    _canvas_cairo_bound(mask_draw, mask_gui, &cairo_bound, &cairo_bounded);
+    if(cairo_bounded)
+    {
+      cairo_save(mask_draw);
+      cairo_identity_matrix(mask_draw);
+      cairo_rectangle(mask_draw, cairo_bound.x / frame.device_scale, cairo_bound.y / frame.device_scale,
+                      cairo_bound.width / frame.device_scale, cairo_bound.height / frame.device_scale);
+      cairo_restore(mask_draw);
+      cairo_clip(mask_draw);
+    }
+  }
+
   if(dt_get_debug_flags() & DT_DEBUG_MASKS)
     dt_show_times(&rebuild_start, "[masks] overlay outline refresh");
 
@@ -4260,7 +4320,7 @@ void dt_masks_events_post_expose_with(dt_develop_t *dev, struct dt_iop_module_t 
    * The transform is still in effect here, which is what the header bounds need; a creation
    * session paints through its own cached pattern and takes the whole canvas. */
   cairo_rectangle_int_t dirty = { 0, 0, 0, 0 };
-  const gboolean any = _overlay_dirty(mask_draw, &frame, mask_gui, &dirty);
+  const gboolean any = _overlay_dirty(&frame, &cairo_bound, cairo_bounded, &dirty);
   cairo_restore(mask_draw);
   cairo_destroy(mask_draw);
 

--- a/src/develop/masks/masks_gui.c
+++ b/src/develop/masks/masks_gui.c
@@ -4037,67 +4037,6 @@ static void _rect_include(cairo_rectangle_int_t *rect, gboolean *any, const doub
  * quarter turn about its node (same length, any direction), by a node's disc and by an arrow
  * head. A buffer too short to have a header (a circle's, a source's) contributes its first
  * points. The outlines themselves the rasteriser reports exactly, on top of this. */
-/* Does this buffer carry a node header at all: three points per node, ahead of the samples. */
-static inline gboolean header_reach_wanted(const int nodes, const int points_count)
-{
-  return nodes > 0 && points_count >= nodes * 3;
-}
-
-static void _canvas_cairo_bound(cairo_t *canvas_cr, const dt_masks_form_gui_t *gui, cairo_rectangle_int_t *rect,
-                                gboolean *any)
-{
-  const dt_masks_form_t *form = dt_masks_get_visible_form(gui->dev);
-  const int nodes = IS_NULL_PTR(form) ? 0 : (int)g_list_length(form->points);
-  double scale = 1.0;
-  double scale_y = 1.0;
-  cairo_surface_get_device_scale(cairo_get_target(canvas_cr), &scale, &scale_y);
-  if(scale <= 0.0) scale = 1.0;
-  double reach = 0.0;
-  for(const GList *node = gui->points; node; node = g_list_next(node))
-  {
-    const dt_masks_form_gui_points_t *const pts = (const dt_masks_form_gui_points_t *)node->data;
-    if(IS_NULL_PTR(pts)) continue;
-    const float *const arrays[3] = { pts->points, pts->border, pts->source };
-    const int counts[3] = { pts->points_count, pts->border_count, pts->source_count };
-    for(int a = 0; a < 3; a++)
-    {
-      if(IS_NULL_PTR(arrays[a]) || counts[a] <= 0) continue;
-      const int header = MIN(nodes * 3, counts[a]);
-      const int limit = (header > 0) ? header : MIN(counts[a], 64);
-      for(int i = 0; i < limit; i++)
-      {
-        double x = arrays[a][2 * i];
-        double y = arrays[a][2 * i + 1];
-        cairo_user_to_device(canvas_cr, &x, &y);
-        _rect_include(rect, any, x * scale, y * scale, 0);   /* device units to canvas pixels */
-      }
-    }
-    /* the longest control vector of this outline's header, in device pixels */
-    if(!IS_NULL_PTR(pts->points) && header_reach_wanted(nodes, pts->points_count))
-    {
-      for(int k = 0; k < nodes; k++)
-      {
-        double nx = pts->points[k * 6 + 2];
-        double ny = pts->points[k * 6 + 3];
-        cairo_user_to_device(canvas_cr, &nx, &ny);
-        for(int c = 0; c < 2; c++)
-        {
-          double cx = pts->points[k * 6 + (c ? 4 : 0)];
-          double cy = pts->points[k * 6 + (c ? 5 : 1)];
-          cairo_user_to_device(canvas_cr, &cx, &cy);
-          reach = MAX(reach, hypot(cx - nx, cy - ny) * scale);
-        }
-      }
-    }
-  }
-  if(!*any) return;
-  const int margin = (int)ceil(reach + 2.0 * DT_DRAW_RADIUS_NODE_SELECTED + DT_DRAW_SCALE_ARROW) + 2;
-  rect->x -= margin;
-  rect->y -= margin;
-  rect->width += 2 * margin;
-  rect->height += 2 * margin;
-}
-
 /* A frame of the canvas: where it sits in cr's device space, and the context that draws
  * into it in cr's coordinates. */
 typedef struct _canvas_frame_t
@@ -4110,6 +4049,115 @@ typedef struct _canvas_frame_t
   int height;
   double device_scale;    /* the target's, copied to the canvas */
 } _canvas_frame_t;
+
+/* Does this buffer carry a node header at all: three points per node, ahead of the samples. */
+static inline gboolean header_reach_wanted(const int nodes, const int points_count)
+{
+  return nodes > 0 && points_count >= nodes * 3;
+}
+
+/* The device scale of the surface @p cr draws on: pixel = device unit * scale. */
+static double _canvas_device_scale(cairo_t *cr)
+{
+  double scale_x = 1.0;
+  double scale_y = 1.0;
+  cairo_surface_get_device_scale(cairo_get_target(cr), &scale_x, &scale_y);
+  return (scale_x > 0.0) ? scale_x : 1.0;
+}
+
+/* Include the first @p limit points of @p array, taken through @p canvas_cr's matrix to canvas
+ * pixels, in @p rect. */
+static void _bound_include_points(cairo_t *canvas_cr, const float *const array, const int limit,
+                                  const double scale, cairo_rectangle_int_t *rect, gboolean *any)
+{
+  for(int i = 0; i < limit; i++)
+  {
+    double x = array[2 * i];
+    double y = array[2 * i + 1];
+    cairo_user_to_device(canvas_cr, &x, &y);
+    _rect_include(rect, any, x * scale, y * scale, 0);   /* device units to canvas pixels */
+  }
+}
+
+/* Include the node header of each of an outline's three buffers -- or, for a buffer with no
+ * header, its first samples -- in @p rect. */
+static void _bound_include_headers(cairo_t *canvas_cr, const dt_masks_form_gui_points_t *const pts, const int nodes,
+                                   const double scale, cairo_rectangle_int_t *rect, gboolean *any)
+{
+  const float *const arrays[3] = { pts->points, pts->border, pts->source };
+  const int counts[3] = { pts->points_count, pts->border_count, pts->source_count };
+  for(int a = 0; a < 3; a++)
+  {
+    if(IS_NULL_PTR(arrays[a]) || counts[a] <= 0) continue;
+    const int header = MIN(nodes * 3, counts[a]);
+    const int limit = (header > 0) ? header : MIN(counts[a], 64);
+    _bound_include_points(canvas_cr, arrays[a], limit, scale, rect, any);
+  }
+}
+
+/* The longest control vector of an outline's node header, in canvas pixels: how far from a
+ * node its curvature handle can be drawn. */
+static double _bound_header_reach(cairo_t *canvas_cr, const dt_masks_form_gui_points_t *const pts, const int nodes,
+                                  const double scale)
+{
+  if(IS_NULL_PTR(pts->points) || !header_reach_wanted(nodes, pts->points_count)) return 0.0;
+  double reach = 0.0;
+  for(int k = 0; k < nodes; k++)
+  {
+    double nx = pts->points[k * 6 + 2];
+    double ny = pts->points[k * 6 + 3];
+    cairo_user_to_device(canvas_cr, &nx, &ny);
+    for(int c = 0; c < 2; c++)
+    {
+      double cx = pts->points[k * 6 + (c ? 4 : 0)];
+      double cy = pts->points[k * 6 + (c ? 5 : 1)];
+      cairo_user_to_device(canvas_cr, &cx, &cy);
+      reach = MAX(reach, hypot(cx - nx, cy - ny) * scale);
+    }
+  }
+  return reach;
+}
+
+static void _canvas_cairo_bound(cairo_t *canvas_cr, const dt_masks_form_gui_t *gui, cairo_rectangle_int_t *rect,
+                                gboolean *any)
+{
+  const dt_masks_form_t *form = dt_masks_get_visible_form(gui->dev);
+  const int nodes = IS_NULL_PTR(form) ? 0 : (int)g_list_length(form->points);
+  const double scale = _canvas_device_scale(canvas_cr);
+  double reach = 0.0;
+  for(const GList *node = gui->points; node; node = g_list_next(node))
+  {
+    const dt_masks_form_gui_points_t *const pts = (const dt_masks_form_gui_points_t *)node->data;
+    if(IS_NULL_PTR(pts)) continue;
+    _bound_include_headers(canvas_cr, pts, nodes, scale, rect, any);
+    reach = MAX(reach, _bound_header_reach(canvas_cr, pts, nodes, scale));
+  }
+  if(!*any) return;
+  const int margin = (int)ceil(reach + 2.0 * DT_DRAW_RADIUS_NODE_SELECTED + DT_DRAW_SCALE_ARROW) + 2;
+  rect->x -= margin;
+  rect->y -= margin;
+  rect->width += 2 * margin;
+  rect->height += 2 * margin;
+}
+
+/* Bound what cairo may paint on top of the outlines and clip the canvas context to it. A
+ * creation session paints through its own cached pattern and keeps @p bound as the caller set
+ * it, the whole canvas, unclipped. Returns whether @p bound holds a rectangle at all. */
+static gboolean _overlay_clip_to_bound(cairo_t *mask_draw, const dt_masks_form_gui_t *gui,
+                                       const _canvas_frame_t *const frame, cairo_rectangle_int_t *bound)
+{
+  if(gui->creation || !IS_NULL_PTR(gui->creation_formids)) return TRUE;
+  gboolean bounded = FALSE;
+  _canvas_cairo_bound(mask_draw, gui, bound, &bounded);
+  if(!bounded) return FALSE;
+  const double s = frame->device_scale;
+  cairo_save(mask_draw);
+  cairo_identity_matrix(mask_draw);
+  cairo_rectangle(mask_draw, bound->x / s, bound->y / s, bound->width / s, bound->height / s);
+  cairo_restore(mask_draw);
+  cairo_clip(mask_draw);
+  return TRUE;
+}
 
 /* Open a frame covering cr's clip. Returns FALSE with nothing to draw into when the clip is
  * empty or the canvas cannot be had. */
@@ -4305,24 +4353,9 @@ void dt_masks_events_post_expose_with(dt_develop_t *dev, struct dt_iop_module_t 
   if(!((mask_form->type & DT_MASKS_IS_PRIMITIVE_SHAPE) && mask_gui->creation))
     dt_masks_gui_form_test_create(mask_form, mask_gui, module);
 
-  /* The rectangle cairo may paint in, and the clip that holds it to that. A creation session
-   * paints through its own cached pattern and takes the whole canvas instead. */
+  /* The rectangle cairo may paint in, and the clip that holds it to that. */
   cairo_rectangle_int_t cairo_bound = { 0, 0, frame.width, frame.height };
-  gboolean cairo_bounded = TRUE;
-  if(!mask_gui->creation && IS_NULL_PTR(mask_gui->creation_formids))
-  {
-    cairo_bounded = FALSE;
-    _canvas_cairo_bound(mask_draw, mask_gui, &cairo_bound, &cairo_bounded);
-    if(cairo_bounded)
-    {
-      cairo_save(mask_draw);
-      cairo_identity_matrix(mask_draw);
-      cairo_rectangle(mask_draw, cairo_bound.x / frame.device_scale, cairo_bound.y / frame.device_scale,
-                      cairo_bound.width / frame.device_scale, cairo_bound.height / frame.device_scale);
-      cairo_restore(mask_draw);
-      cairo_clip(mask_draw);
-    }
-  }
+  const gboolean cairo_bounded = _overlay_clip_to_bound(mask_draw, mask_gui, &frame, &cairo_bound);
 
   if(dt_get_debug_flags() & DT_DEBUG_MASKS)
     dt_show_times(&rebuild_start, "[masks] overlay outline refresh");

--- a/src/develop/masks/masks_gui.c
+++ b/src/develop/masks/masks_gui.c
@@ -4243,6 +4243,26 @@ static void _canvas_end(cairo_t *cr, const _canvas_frame_t *frame, const cairo_r
   _canvas_clear(frame->canvas, &painted);
 }
 
+/* The skip range that hides border sample @p i of @p pts, or -1. */
+static int _overlay_skip_of(const dt_masks_form_gui_points_t *const pts, const int i)
+{
+  for(int k = 0; k < pts->border_skip_count; k++)
+    if(i >= pts->border_skips[k].jump_from && i < pts->border_skips[k].resume_at) return k;
+  return -1;
+}
+
+/* One cached outline as the harness dumps it: index, border, the skip range hiding it, spine. */
+static void _overlay_dump_outline(const dt_masks_form_gui_points_t *const pts, const char *path)
+{
+  FILE *f = g_fopen(path, "w");
+  if(IS_NULL_PTR(f)) return;
+  const int count = MIN(pts->points_count, pts->border_count);
+  for(int i = 0; i < count; i++)
+    fprintf(f, "%d %.2f %.2f %d %.2f %.2f\n", i, pts->border[2 * i], pts->border[2 * i + 1], _overlay_skip_of(pts, i),
+            pts->points[2 * i], pts->points[2 * i + 1]);
+  fclose(f);
+}
+
 /* MASKS_DUMP_OVERLAY=<dir>: write what this frame drew -- the canvas before it is composited
  * and cleared, and every outline in the GUI cache with its skip ranges -- so a darkroom that
  * shows something the harness does not can be read from the files it leaves behind. Overwritten
@@ -4271,19 +4291,8 @@ static void _overlay_dump(const _canvas_frame_t *const frame, const dt_masks_for
     const dt_masks_form_gui_points_t *const pts = (const dt_masks_form_gui_points_t *)node->data;
     if(IS_NULL_PTR(pts) || IS_NULL_PTR(pts->border) || IS_NULL_PTR(pts->points)) continue;
     path = g_strdup_printf("%s/outline-%d.txt", dir, index);
-    FILE *f = g_fopen(path, "w");
+    _overlay_dump_outline(pts, path);
     g_free(path);
-    if(IS_NULL_PTR(f)) continue;
-    const int count = MIN(pts->points_count, pts->border_count);
-    for(int i = 0; i < count; i++)
-    {
-      int skip = -1;
-      for(int k = 0; k < pts->border_skip_count; k++)
-        if(i >= pts->border_skips[k].jump_from && i < pts->border_skips[k].resume_at) skip = k;
-      fprintf(f, "%d %.2f %.2f %d %.2f %.2f\n", i, pts->border[2 * i], pts->border[2 * i + 1], skip,
-              pts->points[2 * i], pts->points[2 * i + 1]);
-    }
-    fclose(f);
   }
 }
 

--- a/src/develop/masks/masks_gui.c
+++ b/src/develop/masks/masks_gui.c
@@ -4059,6 +4059,84 @@ static void _canvas_dirty_from_headers(cairo_t *canvas_cr, const dt_masks_form_g
 }
 
 
+/* A frame of the canvas: where it sits in cr's device space, and the context that draws
+ * into it in cr's coordinates. */
+typedef struct _canvas_frame_t
+{
+  cairo_surface_t *canvas;
+  cairo_t *cr;            /* draws into the canvas, in the caller's coordinates */
+  int x;                  /* the canvas's origin in the target's device pixels */
+  int y;
+  int width;
+  int height;
+  double device_scale;    /* the target's, copied to the canvas */
+} _canvas_frame_t;
+
+/* Open a frame covering cr's clip. Returns FALSE with nothing to draw into when the clip is
+ * empty or the canvas cannot be had. */
+static gboolean _canvas_begin(cairo_t *cr, _canvas_frame_t *frame)
+{
+  double clip_x0 = 0.0;
+  double clip_y0 = 0.0;
+  double clip_x1 = 0.0;
+  double clip_y1 = 0.0;
+  cairo_clip_extents(cr, &clip_x0, &clip_y0, &clip_x1, &clip_y1);
+  double device_x0 = clip_x0;
+  double device_y0 = clip_y0;
+  double device_x1 = clip_x1;
+  double device_y1 = clip_y1;
+  cairo_user_to_device(cr, &device_x0, &device_y0);
+  cairo_user_to_device(cr, &device_x1, &device_y1);
+  frame->x = (int)floor(MIN(device_x0, device_x1));
+  frame->y = (int)floor(MIN(device_y0, device_y1));
+  frame->width = (int)ceil(MAX(device_x0, device_x1)) - frame->x;
+  frame->height = (int)ceil(MAX(device_y0, device_y1)) - frame->y;
+  if(frame->width <= 0 || frame->height <= 0) return FALSE;
+
+  double device_scale_x = 1.0;
+  double device_scale_y = 1.0;
+  cairo_surface_get_device_scale(cairo_get_target(cr), &device_scale_x, &device_scale_y);
+  frame->device_scale = (device_scale_x > 0.0) ? device_scale_x : 1.0;
+
+  frame->canvas = _canvas_acquire(frame->width, frame->height, frame->device_scale);
+  if(IS_NULL_PTR(frame->canvas)) return FALSE;
+  dt_stroke_raster_touched_reset(frame->canvas);
+  frame->cr = cairo_create(frame->canvas);
+
+  /* The canvas draws in cr's coordinates, shifted so that its pixel (0, 0) is the clip's
+   * device origin: cr's matrix, then a device-space translation -- in the units the device
+   * scale multiplies, so divided by it. */
+  cairo_matrix_t matrix;
+  cairo_matrix_t shift;
+  cairo_matrix_t canvas_matrix;
+  cairo_get_matrix(cr, &matrix);
+  cairo_matrix_init_translate(&shift, -frame->x / frame->device_scale, -frame->y / frame->device_scale);
+  cairo_matrix_multiply(&canvas_matrix, &matrix, &shift);
+  cairo_set_matrix(frame->cr, &canvas_matrix);
+  return TRUE;
+}
+
+/* Composite @p dirty of the frame's canvas onto @p cr, one pixel to one device pixel, then
+ * clear it so the next frame starts from transparency there. */
+static void _canvas_end(cairo_t *cr, const _canvas_frame_t *frame, const cairo_rectangle_int_t *dirty)
+{
+  const int x0 = CLAMP(dirty->x, 0, frame->width);
+  const int y0 = CLAMP(dirty->y, 0, frame->height);
+  const int x1 = CLAMP(dirty->x + dirty->width, 0, frame->width);
+  const int y1 = CLAMP(dirty->y + dirty->height, 0, frame->height);
+  if(x1 <= x0 || y1 <= y0) return;
+  const double s = frame->device_scale;
+  cairo_surface_flush(frame->canvas);
+  cairo_save(cr);
+  cairo_identity_matrix(cr);
+  cairo_set_source_surface(cr, frame->canvas, frame->x / s, frame->y / s);
+  cairo_rectangle(cr, (frame->x + x0) / s, (frame->y + y0) / s, (x1 - x0) / s, (y1 - y0) / s);
+  cairo_fill(cr);
+  cairo_restore(cr);
+  const cairo_rectangle_int_t painted = { x0, y0, x1 - x0, y1 - y0 };
+  _canvas_clear(frame->canvas, &painted);
+}
+
 void dt_masks_events_post_expose_with(dt_develop_t *dev, struct dt_iop_module_t *module, cairo_t *cr,
                                       int32_t width, int32_t height, int32_t pointerx, int32_t pointery,
                                       const dt_masks_overlay_transform_t *transform)
@@ -4096,48 +4174,13 @@ void dt_masks_events_post_expose_with(dt_develop_t *dev, struct dt_iop_module_t 
   if(dt_get_debug_flags() & DT_DEBUG_PERF)
     dt_print(DT_DEBUG_MASKS, "[masks] overlay preamble took %0.04f sec\n", group_start - post_expose_start);
 
-  /* The canvas covers the clip, in the device pixels of cr's target. */
-  double clip_x0 = 0.0;
-  double clip_y0 = 0.0;
-  double clip_x1 = 0.0;
-  double clip_y1 = 0.0;
-  cairo_clip_extents(cr, &clip_x0, &clip_y0, &clip_x1, &clip_y1);
-  double device_x0 = clip_x0;
-  double device_y0 = clip_y0;
-  double device_x1 = clip_x1;
-  double device_y1 = clip_y1;
-  cairo_user_to_device(cr, &device_x0, &device_y0);
-  cairo_user_to_device(cr, &device_x1, &device_y1);
-  const int canvas_x = (int)floor(MIN(device_x0, device_x1));
-  const int canvas_y = (int)floor(MIN(device_y0, device_y1));
-  const int canvas_width = (int)ceil(MAX(device_x0, device_x1)) - canvas_x;
-  const int canvas_height = (int)ceil(MAX(device_y0, device_y1)) - canvas_y;
-  if(canvas_width <= 0 || canvas_height <= 0) return;
-  double device_scale_x = 1.0;
-  double device_scale_y = 1.0;
-  cairo_surface_get_device_scale(cairo_get_target(cr), &device_scale_x, &device_scale_y);
-  const double device_scale = (device_scale_x > 0.0) ? device_scale_x : 1.0;
-
-  cairo_surface_t *canvas = _canvas_acquire(canvas_width, canvas_height, device_scale);
-  if(IS_NULL_PTR(canvas)) return;
-  dt_stroke_raster_touched_reset(canvas);
-  cairo_t *const mask_draw = cairo_create(canvas);
+  _canvas_frame_t frame = { 0 };
+  if(!_canvas_begin(cr, &frame)) return;
+  cairo_t *const mask_draw = frame.cr;
   if(dt_get_debug_flags() & DT_DEBUG_PERF)
-    dt_print(DT_DEBUG_MASKS, "[masks] overlay canvas %dx%d ready in %0.04f sec\n", canvas_width, canvas_height,
+    dt_print(DT_DEBUG_MASKS, "[masks] overlay canvas %dx%d ready in %0.04f sec\n", frame.width, frame.height,
              dt_get_wtime() - group_start);
 
-  /* The canvas draws in cr's coordinates, shifted so that its pixel (0, 0) is the clip's
-   * device origin: cr's matrix, then a device-space translation -- in the units the device
-   * scale multiplies, so divided by it. */
-  {
-    cairo_matrix_t matrix;
-    cairo_matrix_t shift;
-    cairo_matrix_t canvas_matrix;
-    cairo_get_matrix(cr, &matrix);
-    cairo_matrix_init_translate(&shift, -canvas_x / device_scale, -canvas_y / device_scale);
-    cairo_matrix_multiply(&canvas_matrix, &matrix, &shift);
-    cairo_set_matrix(mask_draw, &canvas_matrix);
-  }
   cairo_save(mask_draw);
 
   // We rescale to input space -- from the viewport, or from the caller's own mapping when it
@@ -4190,10 +4233,10 @@ void dt_masks_events_post_expose_with(dt_develop_t *dev, struct dt_iop_module_t 
    * The transform is still in effect here, which is what the header bounds need; a creation
    * session paints through its own cached pattern and takes the whole canvas. */
   cairo_rectangle_int_t dirty = { 0, 0, 0, 0 };
-  gboolean any = dt_stroke_raster_touched(canvas, &dirty);
+  gboolean any = dt_stroke_raster_touched(frame.canvas, &dirty);
   if(mask_gui->creation || !IS_NULL_PTR(mask_gui->creation_formids))
   {
-    dirty = (cairo_rectangle_int_t){ 0, 0, canvas_width, canvas_height };
+    dirty = (cairo_rectangle_int_t){ 0, 0, frame.width, frame.height };
     any = TRUE;
   }
   else
@@ -4204,32 +4247,11 @@ void dt_masks_events_post_expose_with(dt_develop_t *dev, struct dt_iop_module_t 
   if(dt_get_debug_flags() & DT_DEBUG_MASKS)
     dt_show_times(&draw_start, "[masks] overlay drawn");
 
-  /* Composite the dirty rectangle of the canvas onto the view, one pixel to one device pixel,
-   * then clear it so the next frame starts from transparency there. */
   const double composite_start = dt_get_wtime();
-  if(any)
-  {
-    const int x0 = CLAMP(dirty.x, 0, canvas_width);
-    const int y0 = CLAMP(dirty.y, 0, canvas_height);
-    const int x1 = CLAMP(dirty.x + dirty.width, 0, canvas_width);
-    const int y1 = CLAMP(dirty.y + dirty.height, 0, canvas_height);
-    if(x1 > x0 && y1 > y0)
-    {
-      cairo_surface_flush(canvas);
-      cairo_save(cr);
-      cairo_identity_matrix(cr);
-      cairo_set_source_surface(cr, canvas, canvas_x / device_scale, canvas_y / device_scale);
-      cairo_rectangle(cr, (canvas_x + x0) / device_scale, (canvas_y + y0) / device_scale,
-                      (x1 - x0) / device_scale, (y1 - y0) / device_scale);
-      cairo_fill(cr);
-      cairo_restore(cr);
-      const cairo_rectangle_int_t painted = { x0, y0, x1 - x0, y1 - y0 };
-      _canvas_clear(canvas, &painted);
-    }
-  }
+  if(any) _canvas_end(cr, &frame, &dirty);
   if(dt_get_debug_flags() & DT_DEBUG_PERF)
     dt_print(DT_DEBUG_MASKS, "[masks] overlay composited (%dx%d of %dx%d) in %0.04f sec\n",
-             any ? dirty.width : 0, any ? dirty.height : 0, canvas_width, canvas_height,
+             any ? dirty.width : 0, any ? dirty.height : 0, frame.width, frame.height,
              dt_get_wtime() - composite_start);
 }
 

--- a/src/develop/masks/masks_gui.c
+++ b/src/develop/masks/masks_gui.c
@@ -52,6 +52,7 @@
 #include <math.h>
 #include <stdlib.h>
 #include "widgets/togglebutton.h"
+#include <glib/gstdio.h>
 
 #define DT_MASKS_SHAPE_BUTTON_COUNT 5
 
@@ -4242,6 +4243,50 @@ static void _canvas_end(cairo_t *cr, const _canvas_frame_t *frame, const cairo_r
   _canvas_clear(frame->canvas, &painted);
 }
 
+/* MASKS_DUMP_OVERLAY=<dir>: write what this frame drew -- the canvas before it is composited
+ * and cleared, and every outline in the GUI cache with its skip ranges -- so a darkroom that
+ * shows something the harness does not can be read from the files it leaves behind. Overwritten
+ * on every frame: the last one is the one on screen. */
+static void _overlay_dump(const _canvas_frame_t *const frame, const dt_masks_form_gui_t *const gui,
+                          const cairo_rectangle_int_t *const dirty)
+{
+  const char *dir = g_getenv("MASKS_DUMP_OVERLAY");
+  if(IS_NULL_PTR(dir)) return;
+  char *path = g_strdup_printf("%s/overlay-canvas.png", dir);
+  cairo_surface_flush(frame->canvas);
+  cairo_surface_write_to_png(frame->canvas, path);
+  g_free(path);
+  path = g_strdup_printf("%s/overlay-info.txt", dir);
+  FILE *info = g_fopen(path, "w");
+  g_free(path);
+  if(!IS_NULL_PTR(info))
+  {
+    fprintf(info, "canvas %d %d %dx%d device_scale %.3f dirty %d %d %dx%d\n", frame->x, frame->y, frame->width,
+            frame->height, frame->device_scale, dirty->x, dirty->y, dirty->width, dirty->height);
+    fclose(info);
+  }
+  int index = 0;
+  for(const GList *node = gui->points; node; node = g_list_next(node), index++)
+  {
+    const dt_masks_form_gui_points_t *const pts = (const dt_masks_form_gui_points_t *)node->data;
+    if(IS_NULL_PTR(pts) || IS_NULL_PTR(pts->border) || IS_NULL_PTR(pts->points)) continue;
+    path = g_strdup_printf("%s/outline-%d.txt", dir, index);
+    FILE *f = g_fopen(path, "w");
+    g_free(path);
+    if(IS_NULL_PTR(f)) continue;
+    const int count = MIN(pts->points_count, pts->border_count);
+    for(int i = 0; i < count; i++)
+    {
+      int skip = -1;
+      for(int k = 0; k < pts->border_skip_count; k++)
+        if(i >= pts->border_skips[k].jump_from && i < pts->border_skips[k].resume_at) skip = k;
+      fprintf(f, "%d %.2f %.2f %d %.2f %.2f\n", i, pts->border[2 * i], pts->border[2 * i + 1], skip,
+              pts->points[2 * i], pts->points[2 * i + 1]);
+    }
+    fclose(f);
+  }
+}
+
 /* Draw the visible form: a group member by member, anything else through its own drawer. */
 static void _overlay_draw_form(cairo_t *cr, const float zoom_scale, dt_masks_form_t *mask_form,
                                dt_masks_form_gui_t *mask_gui)
@@ -4376,6 +4421,7 @@ void dt_masks_events_post_expose_with(dt_develop_t *dev, struct dt_iop_module_t 
    * session paints through its own cached pattern and takes the whole canvas. */
   cairo_rectangle_int_t dirty = { 0, 0, 0, 0 };
   const gboolean any = _overlay_dirty(&frame, &cairo_bound, cairo_bounded, &dirty);
+  _overlay_dump(&frame, mask_gui, &dirty);
   cairo_restore(mask_draw);
   cairo_destroy(mask_draw);
 

--- a/src/develop/masks/masks_gui.c
+++ b/src/develop/masks/masks_gui.c
@@ -4137,6 +4137,40 @@ static void _canvas_end(cairo_t *cr, const _canvas_frame_t *frame, const cairo_r
   _canvas_clear(frame->canvas, &painted);
 }
 
+/* Draw the visible form: a group member by member, anything else through its own drawer. */
+static void _overlay_draw_form(cairo_t *cr, const float zoom_scale, dt_masks_form_t *mask_form,
+                               dt_masks_form_gui_t *mask_gui)
+{
+  if(mask_form->type & DT_MASKS_GROUP)
+  {
+    dt_group_events_post_expose(cr, zoom_scale, mask_form, mask_gui);
+    return;
+  }
+  if(mask_form->functions && mask_form->functions->post_expose)
+  {
+    const guint point_count = g_list_length(mask_form->points);
+    mask_gui->type = mask_form->type;
+    mask_form->functions->post_expose(cr, zoom_scale, mask_gui, 0, point_count);
+  }
+}
+
+/* What was painted this frame: the rasteriser's own record, and the bounds of what cairo drew
+ * on top. The transform must still be in effect on @p canvas_cr, which is what the header
+ * bounds need; a creation session paints through its own cached pattern and takes the whole
+ * canvas. Returns FALSE when nothing was painted. */
+static gboolean _overlay_dirty(cairo_t *canvas_cr, const _canvas_frame_t *frame, const dt_masks_form_gui_t *mask_gui,
+                               cairo_rectangle_int_t *dirty)
+{
+  if(mask_gui->creation || !IS_NULL_PTR(mask_gui->creation_formids))
+  {
+    *dirty = (cairo_rectangle_int_t){ 0, 0, frame->width, frame->height };
+    return TRUE;
+  }
+  gboolean any = dt_stroke_raster_touched(frame->canvas, dirty);
+  _canvas_dirty_from_headers(canvas_cr, mask_gui, dirty, &any);
+  return any;
+}
+
 void dt_masks_events_post_expose_with(dt_develop_t *dev, struct dt_iop_module_t *module, cairo_t *cr,
                                       int32_t width, int32_t height, int32_t pointerx, int32_t pointery,
                                       const dt_masks_overlay_transform_t *transform)
@@ -4221,26 +4255,12 @@ void dt_masks_events_post_expose_with(dt_develop_t *dev, struct dt_iop_module_t 
   const dt_times_t draw_start = { 0 };
   dt_get_times((dt_times_t *)&draw_start);
 
-  if(mask_form->type & DT_MASKS_GROUP)
-    dt_group_events_post_expose(mask_draw, zoom_scale, mask_form, mask_gui);
-  else if(mask_form->functions && mask_form->functions->post_expose)
-  {
-    const guint point_count = g_list_length(mask_form->points);
-    mask_gui->type = mask_form->type;
-    mask_form->functions->post_expose(mask_draw, zoom_scale, mask_gui, 0, point_count);
-  }
+  _overlay_draw_form(mask_draw, zoom_scale, mask_form, mask_gui);
   /* What was painted: the rasteriser's own record, and the bounds of what cairo drew on top.
    * The transform is still in effect here, which is what the header bounds need; a creation
    * session paints through its own cached pattern and takes the whole canvas. */
   cairo_rectangle_int_t dirty = { 0, 0, 0, 0 };
-  gboolean any = dt_stroke_raster_touched(frame.canvas, &dirty);
-  if(mask_gui->creation || !IS_NULL_PTR(mask_gui->creation_formids))
-  {
-    dirty = (cairo_rectangle_int_t){ 0, 0, frame.width, frame.height };
-    any = TRUE;
-  }
-  else
-    _canvas_dirty_from_headers(mask_draw, mask_gui, &dirty, &any);
+  const gboolean any = _overlay_dirty(mask_draw, &frame, mask_gui, &dirty);
   cairo_restore(mask_draw);
   cairo_destroy(mask_draw);
 

--- a/src/develop/masks/masks_outline.c
+++ b/src/develop/masks/masks_outline.c
@@ -57,6 +57,27 @@ void dt_masks_outline_offset_along(const float *const centre, float dx, float dy
   border[1] = centre[1] + radius * dy;
 }
 
+void dt_masks_outline_envelope_offset(const float *centre, float dx, float dy, float radius, float radius_rate,
+                                      float *out)
+{
+  const float length = dt_fast_hypotf(dx, dy);
+  if(!(length > 0.0f))
+  {
+    out[0] = centre[0];
+    out[1] = centre[1];
+    return;
+  }
+  const float l = 1.0f / length;
+  /* r' = dr/ds: the rate by the parameter over the speed by the parameter */
+  float along = -radius_rate * l;
+  along = CLAMP(along, -DT_MASKS_OUTLINE_TILT_MAX, DT_MASKS_OUTLINE_TILT_MAX);
+  const float across = sqrtf(1.0f - along * along);
+  const float tx = dx * l;
+  const float ty = dy * l;
+  out[0] = centre[0] + radius * (along * tx + across * ty);
+  out[1] = centre[1] + radius * (along * ty - across * tx);
+}
+
 /* Which way round a joint arc goes: from @p from to @p to about @p centre, the SHORT way.
  *
  * On the convex side of a turn the short way is the exterior wedge the spokes leave open, which

--- a/src/develop/masks/masks_outline.c
+++ b/src/develop/masks/masks_outline.c
@@ -174,7 +174,7 @@ typedef struct _outline_boundary_t
   int ndisc;
   const int *disc_of;   /* per sample, the disc it belongs to */
   const float *border_h;   /* the border samples, past the header */
-  const float *points_h;   /* their spine points */
+  const float *walk;       /* per sample, the length of the border walked to reach it */
   int window;           /* discs either side of a sample's own that can reach it along the walk */
   float reach;          /* how far a block's first disc may be for the block to matter */
   float eps;            /* boundary tolerance, in pixels */
@@ -182,47 +182,58 @@ typedef struct _outline_boundary_t
   gboolean have_grid;
 } _outline_boundary_t;
 
-/* One border sample being probed: its index, its disc, its spine point and its position. */
+/* One border sample being probed: its index, its disc and its position. */
 typedef struct _outline_probe_t
 {
   int i;
   int own;
-  float px;
-  float py;
   float bx;
   float by;
+  float walk;   /* the border length walked to this sample */
 } _outline_probe_t;
 
-/* Does the probed sample repeat an earlier sample of disc @p j: one with the same spine point,
- * to a hundredth of a pixel, and a border position within three quarters of a pixel.
+/* How far back along the walk a sample may match: closer than this it is the sample's own
+ * run. Sixteen samples was the first guess, and the recursion samples a border a hundredth of
+ * a pixel apart around every integer crossing, where sixteen samples are less than a pixel. */
+#define OUTLINE_REPEAT_MIN_WALK 4.0f
+
+/* Does the probed sample repeat an earlier sample of disc @p j: a border position within three
+ * quarters of a pixel, at least sixteen samples earlier along the walk.
  *
  * The walk stamps a full disc at a node whose radius steps in BOTH passes, and bridges a joint
  * with an arc about the same node at the same radius; every copy after the first traces a
  * boundary the first already traces, and drawn on top of it with its own dash phase it fills
  * the gaps of the dashes -- measured on a flaring brush: 3,171 samples per pass centred on the
  * node to the float, 4,020 kept on a 2,114 px circumference, drawn as a near-solid line. A copy
- * is not a boundary sample.
+ * is not a boundary sample. Neither is the stretch where a segment leaves such a node: its
+ * envelope runs within the boundary tolerance of the node's circle for tens of pixels, and both
+ * were kept, a second dash over the first from a different phase.
  *
- * Two things this test is careful about, each paid for by a corpus round. The spine point, not
- * the disc: a disc's centre is its FIRST sample's, and a stamp's samples merge into the disc the
- * last moving sample opened, up to half a pixel off and differently in each pass. And the
- * three-quarter pixel: a copy of any phase has one of the original's within half a pixel, and
- * the other side of the stroke -- the backward pass revisits every spine point of the forward
- * one -- is a diameter away. A sample's own run is excluded by index instead: an arc filler can
- * sample closer than the tolerance, and matching a predecessor thinned every arc to fragments. */
+ * Position alone decides, whatever discs the two samples belong to: for drawing, two boundary
+ * samples within three quarters of a pixel are one line. The other side of the stroke -- the
+ * backward pass revisits every spine point of the forward one -- is a diameter away and never
+ * matches. A sample's own run is excluded by the length of border walked between the two,
+ * OUTLINE_REPEAT_MIN_WALK: an arc filler can sample closer than the tolerance, and the
+ * recursion samples a hundredth of a pixel apart around every integer crossing, so neither a
+ * count of samples nor a predecessor test can tell a run from its copy -- the walk can, a copy
+ * being the other pass or another stamp, thousands of pixels away along it. Keyed on the
+ * sample's disc or its spine point instead, this test missed the copies (a disc's centre is
+ * its first sample's, half a pixel off and differently per pass) or the junctions; each round
+ * was measured on the corpus before the next. The annulus test on the disc is what keeps it
+ * cheap: a disc's samples lie a radius from its centre, give or take the half pixel its spine
+ * may have moved. */
 static inline gboolean _outline_sample_repeats(const _outline_boundary_t *const b, const int j,
                                                const _outline_probe_t *const probe)
 {
   if(j > probe->own) return FALSE;
   const _outline_disc_t *const d = &b->discs[j];
-  /* a sample joins a disc whose centre is within half a pixel of its own spine point */
-  if(fabsf(d->x - probe->px) > 0.6f || fabsf(d->y - probe->py) > 0.6f) return FALSE;
-  /* never the probe's own neighbours: an arc filler can sample closer than the tolerance, and
-   * a copy is always far along the walk -- the other pass, or another stamp or arc */
-  const int last = MIN(d->last, probe->i - 16);
-  for(int k = d->first; k <= last; k++)
+  const float cx = d->x - probe->bx;
+  const float cy = d->y - probe->by;
+  const float distance = dt_fast_hypotf(cx, cy);
+  if(fabsf(distance - d->r) > 1.3f) return FALSE;   /* no sample of this disc can be within reach */
+  const float walk_limit = probe->walk - OUTLINE_REPEAT_MIN_WALK;
+  for(int k = d->first; k <= d->last && b->walk[k] <= walk_limit; k++)
   {
-    if(fabsf(b->points_h[2 * k] - probe->px) > 0.01f || fabsf(b->points_h[2 * k + 1] - probe->py) > 0.01f) continue;
     const float dx = b->border_h[2 * k] - probe->bx;
     const float dy = b->border_h[2 * k + 1] - probe->by;
     if(dx * dx + dy * dy <= 0.5625f) return TRUE;
@@ -357,8 +368,7 @@ static inline gboolean _outline_sample_inside(const _outline_boundary_t *const b
   const int d0 = b->disc_of[i];
   const int lo = MAX(d0 - b->window, 0);
   const int hi = MIN(d0 + b->window, b->ndisc - 1);
-  const _outline_probe_t probe = { .i = i, .own = d0, .px = b->points_h[2 * i], .py = b->points_h[2 * i + 1],
-                                   .bx = bx, .by = by };
+  const _outline_probe_t probe = { .i = i, .own = d0, .bx = bx, .by = by, .walk = b->walk[i] };
   if(_outline_discs_contain(b, lo, hi, &probe)) return TRUE;
   return b->have_grid && _outline_far_contains(b, lo, hi, &probe);
 }
@@ -433,7 +443,6 @@ static float _outline_discs_from_outline(const float *const points_h, const floa
   b->ndisc = ndisc;
   b->disc_of = disc_of;
   b->border_h = border_h;
-  b->points_h = points_h;
   b->window = (int)(4.0f * r_max) + 8;
   b->reach = r_max + 8.0f * fmaxf(step_max, 1.0f);
   b->eps = 0.5f;
@@ -464,6 +473,32 @@ static inline gboolean _outline_next_dropped_run(const uint8_t *const dropped, c
   *to = j;
   *cursor = j;
   return TRUE;
+}
+
+/* A dropped run of one or two samples between kept ones is kept again. Such a speck is a
+ * sample that coincides with a neighbour -- a gap filler's first point over the previous leaf's
+ * border, a sample a hair inside the next disc -- and hiding it changes nothing on screen while
+ * it cuts the run in two: every cut is a sub-path of its own to stroke, and a corpus brush went
+ * from one run to forty-seven for nothing. The mirror rule, a kept speck between dropped runs,
+ * lives in _outline_next_dropped_run(). */
+static void _outline_keep_specks(uint8_t *const dropped, const int n)
+{
+  int i = 0;
+  while(i < n)
+  {
+    if(!dropped[i])
+    {
+      i++;
+      continue;
+    }
+    int j = i;
+    while(j < n && dropped[j]) j++;
+    const gboolean kept_before = (i > 0) && !dropped[i - 1];
+    const gboolean kept_after = (j < n) && !dropped[j];
+    if(j - i <= 2 && kept_before && kept_after)
+      for(int k = i; k < j; k++) dropped[k] = 0;
+    i = j;
+  }
 }
 
 /* Runs of dropped samples become skip ranges, indices offset back past the header. */
@@ -505,18 +540,24 @@ int dt_masks_outline_boundary_skips(const float *const points, const float *cons
   _outline_disc_t *discs = dt_alloc_align((size_t)n * sizeof(_outline_disc_t));
   int *disc_of = dt_alloc_align((size_t)n * sizeof(int));
   uint8_t *dropped = dt_alloc_align((size_t)n);
-  if(IS_NULL_PTR(discs) || IS_NULL_PTR(disc_of) || IS_NULL_PTR(dropped))
+  float *walk = dt_alloc_align((size_t)n * sizeof(float));
+  if(IS_NULL_PTR(discs) || IS_NULL_PTR(disc_of) || IS_NULL_PTR(dropped) || IS_NULL_PTR(walk))
   {
     dt_free_align(discs);
     dt_free_align(disc_of);
     dt_free_align(dropped);
+    dt_free_align(walk);
     return 0;
   }
   memset(dropped, 0, (size_t)n);
+  walk[0] = 0.0f;
+  for(int i = 1; i < n; i++)
+    walk[i] = walk[i - 1] + dt_fast_hypotf(border_h[2 * i] - border_h[2 * i - 2], border_h[2 * i + 1] - border_h[2 * i - 1]);
 
   _outline_boundary_t b = { 0 };
   float bbox[4];
   const float r_max = _outline_discs_from_outline(points_h, border_h, n, discs, disc_of, &b, bbox);
+  b.walk = walk;
   b.have_grid = _outline_grid_build(&b, bbox, r_max);
 
   /* The probes.
@@ -560,7 +601,9 @@ int dt_masks_outline_boundary_skips(const float *const points, const float *cons
   dt_free_align(discs);
   dt_free_align(disc_of);
 
+  if(ndropped > 0) _outline_keep_specks(dropped, n);
   const int nskips = (ndropped > 0) ? _outline_skips_from_dropped(dropped, n, header, skips_out) : 0;
   dt_free_align(dropped);
+  dt_free_align(walk);
   return nskips;
 }

--- a/src/develop/masks/masks_outline.c
+++ b/src/develop/masks/masks_outline.c
@@ -147,36 +147,9 @@ typedef struct _outline_disc_t
   float x;
   float y;
   float r;
+  int first;   /* the disc's samples: consecutive along the walk, [first, last] */
+  int last;
 } _outline_disc_t;
-
-/* is @p b strictly inside disc @p d, by more than the boundary tolerance */
-static inline gboolean _outline_disc_contains(const _outline_disc_t *const d, const float bx, const float by,
-                                            const float eps)
-{
-  const float jx = d->x - bx;
-  const float jy = d->y - by;
-  const float rin = d->r - eps;
-  return (rin > 0.0f && jx * jx + jy * jy < rin * rin);
-}
-
-/* test the discs [lo, hi] against the probe, in blocks: consecutive discs move at most
- * @p step_max, so a block whose first disc is further than reach + block * step_max away
- * holds nothing that can contain the probe */
-static inline gboolean _outline_discs_contain(const _outline_disc_t *const discs, const int lo, const int hi,
-                                     const float bx, const float by, const float reach, const float eps)
-{
-  const int block = 8;
-  for(int d = lo; d <= hi; d += block)
-  {
-    const float ddx = discs[d].x - bx;
-    const float ddy = discs[d].y - by;
-    if(ddx * ddx + ddy * ddy > reach * reach) continue;
-    const int e = MIN(d + block - 1, hi);
-    for(int j = d; j <= e; j++)
-      if(_outline_disc_contains(&discs[j], bx, by, eps)) return TRUE;
-  }
-  return FALSE;
-}
 
 /* The bucket grid over the discs: one reach per cell, each bucket a linked list of RUNS of
  * consecutive disc indices, so that a run inside the walk's window can be dismissed with two
@@ -200,12 +173,94 @@ typedef struct _outline_boundary_t
   const _outline_disc_t *discs;
   int ndisc;
   const int *disc_of;   /* per sample, the disc it belongs to */
+  const float *border_h;   /* the border samples, past the header */
+  const float *points_h;   /* their spine points */
   int window;           /* discs either side of a sample's own that can reach it along the walk */
   float reach;          /* how far a block's first disc may be for the block to matter */
   float eps;            /* boundary tolerance, in pixels */
   _outline_disc_grid_t grid;
   gboolean have_grid;
 } _outline_boundary_t;
+
+/* One border sample being probed: its index, its disc, its spine point and its position. */
+typedef struct _outline_probe_t
+{
+  int i;
+  int own;
+  float px;
+  float py;
+  float bx;
+  float by;
+} _outline_probe_t;
+
+/* Does the probed sample repeat an earlier sample of disc @p j: one with the same spine point,
+ * to a hundredth of a pixel, and a border position within three quarters of a pixel.
+ *
+ * The walk stamps a full disc at a node whose radius steps in BOTH passes, and bridges a joint
+ * with an arc about the same node at the same radius; every copy after the first traces a
+ * boundary the first already traces, and drawn on top of it with its own dash phase it fills
+ * the gaps of the dashes -- measured on a flaring brush: 3,171 samples per pass centred on the
+ * node to the float, 4,020 kept on a 2,114 px circumference, drawn as a near-solid line. A copy
+ * is not a boundary sample.
+ *
+ * Two things this test is careful about, each paid for by a corpus round. The spine point, not
+ * the disc: a disc's centre is its FIRST sample's, and a stamp's samples merge into the disc the
+ * last moving sample opened, up to half a pixel off and differently in each pass. And the
+ * three-quarter pixel: a copy of any phase has one of the original's within half a pixel, and
+ * the other side of the stroke -- the backward pass revisits every spine point of the forward
+ * one -- is a diameter away. A sample's own run is excluded by index instead: an arc filler can
+ * sample closer than the tolerance, and matching a predecessor thinned every arc to fragments. */
+static inline gboolean _outline_sample_repeats(const _outline_boundary_t *const b, const int j,
+                                               const _outline_probe_t *const probe)
+{
+  if(j > probe->own) return FALSE;
+  const _outline_disc_t *const d = &b->discs[j];
+  /* a sample joins a disc whose centre is within half a pixel of its own spine point */
+  if(fabsf(d->x - probe->px) > 0.6f || fabsf(d->y - probe->py) > 0.6f) return FALSE;
+  /* never the probe's own neighbours: an arc filler can sample closer than the tolerance, and
+   * a copy is always far along the walk -- the other pass, or another stamp or arc */
+  const int last = MIN(d->last, probe->i - 16);
+  for(int k = d->first; k <= last; k++)
+  {
+    if(fabsf(b->points_h[2 * k] - probe->px) > 0.01f || fabsf(b->points_h[2 * k + 1] - probe->py) > 0.01f) continue;
+    const float dx = b->border_h[2 * k] - probe->bx;
+    const float dy = b->border_h[2 * k + 1] - probe->by;
+    if(dx * dx + dy * dy <= 0.5625f) return TRUE;
+  }
+  return FALSE;
+}
+
+/* is @p b strictly inside disc @p d, by more than the boundary tolerance */
+static inline gboolean _outline_disc_contains(const _outline_disc_t *const d, const float bx, const float by,
+                                            const float eps)
+{
+  const float jx = d->x - bx;
+  const float jy = d->y - by;
+  const float rin = d->r - eps;
+  return (rin > 0.0f && jx * jx + jy * jy < rin * rin);
+}
+
+/* test the discs [lo, hi] against the probe, in blocks: consecutive discs move at most
+ * @p step_max, so a block whose first disc is further than reach + block * step_max away
+ * holds nothing that can contain the probe */
+static inline gboolean _outline_discs_contain(const _outline_boundary_t *const b, const int lo, const int hi,
+                                              const _outline_probe_t *const probe)
+{
+  const int block = 8;
+  const float reach2 = b->reach * b->reach;
+  for(int d = lo; d <= hi; d += block)
+  {
+    const float ddx = b->discs[d].x - probe->bx;
+    const float ddy = b->discs[d].y - probe->by;
+    if(ddx * ddx + ddy * ddy > reach2) continue;
+    const int e = MIN(d + block - 1, hi);
+    for(int j = d; j <= e; j++)
+      if(_outline_disc_contains(&b->discs[j], probe->bx, probe->by, b->eps) || _outline_sample_repeats(b, j, probe))
+        return TRUE;
+  }
+  return FALSE;
+}
+
 
 static void _outline_grid_free(_outline_disc_grid_t *const g)
 {
@@ -272,11 +327,11 @@ static gboolean _outline_grid_build(_outline_boundary_t *const b, const float *c
 /* The far test: every run in reach of the probe, but only the parts of it OUTSIDE the walk's
  * window [lo, hi] -- the part inside is the near test's, already answered. */
 static inline gboolean _outline_far_contains(const _outline_boundary_t *const b, const int lo, const int hi,
-                                    const float bx, const float by)
+                                    const _outline_probe_t *const probe)
 {
   const _outline_disc_grid_t *const g = &b->grid;
-  const int gx = CLAMP((int)((bx - g->minx) / g->bucket) + 1, 0, g->bw - 1);
-  const int gy = CLAMP((int)((by - g->miny) / g->bucket) + 1, 0, g->bh - 1);
+  const int gx = CLAMP((int)((probe->bx - g->minx) / g->bucket) + 1, 0, g->bw - 1);
+  const int gy = CLAMP((int)((probe->by - g->miny) / g->bucket) + 1, 0, g->bh - 1);
 
   for(int neighbour = 0; neighbour < 9; neighbour++)
   {
@@ -288,10 +343,8 @@ static inline gboolean _outline_far_contains(const _outline_boundary_t *const b,
     {
       const int start = g->run_start[r];
       const int end = g->run_end[r];
-      if(start < lo && _outline_discs_contain(b->discs, start, MIN(end, lo - 1), bx, by, b->reach, b->eps))
-        return TRUE;
-      if(end > hi && _outline_discs_contain(b->discs, MAX(start, hi + 1), end, bx, by, b->reach, b->eps))
-        return TRUE;
+      if(start < lo && _outline_discs_contain(b, start, MIN(end, lo - 1), probe)) return TRUE;
+      if(end > hi && _outline_discs_contain(b, MAX(start, hi + 1), end, probe)) return TRUE;
     }
   }
   return FALSE;
@@ -304,8 +357,10 @@ static inline gboolean _outline_sample_inside(const _outline_boundary_t *const b
   const int d0 = b->disc_of[i];
   const int lo = MAX(d0 - b->window, 0);
   const int hi = MIN(d0 + b->window, b->ndisc - 1);
-  if(_outline_discs_contain(b->discs, lo, hi, bx, by, b->reach, b->eps)) return TRUE;
-  return b->have_grid && _outline_far_contains(b, lo, hi, bx, by);
+  const _outline_probe_t probe = { .i = i, .own = d0, .px = b->points_h[2 * i], .py = b->points_h[2 * i + 1],
+                                   .bx = bx, .by = by };
+  if(_outline_discs_contain(b, lo, hi, &probe)) return TRUE;
+  return b->have_grid && _outline_far_contains(b, lo, hi, &probe);
 }
 
 /* Settle the samples [from, to) between two probes: when both probes agreed, the samples take
@@ -367,14 +422,18 @@ static float _outline_discs_from_outline(const float *const points_h, const floa
       discs[ndisc].x = px;
       discs[ndisc].y = py;
       discs[ndisc].r = r;
+      discs[ndisc].first = i;
       ndisc++;
       r_max = fmaxf(r_max, r);
     }
+    discs[ndisc - 1].last = i;
     disc_of[i] = ndisc - 1;
   }
   b->discs = discs;
   b->ndisc = ndisc;
   b->disc_of = disc_of;
+  b->border_h = border_h;
+  b->points_h = points_h;
   b->window = (int)(4.0f * r_max) + 8;
   b->reach = r_max + 8.0f * fmaxf(step_max, 1.0f);
   b->eps = 0.5f;

--- a/src/develop/masks/polygon.c
+++ b/src/develop/masks/polygon.c
@@ -96,7 +96,7 @@ static void _polygon_get_XY(const float p0_x, const float p0_y, const float p1_x
  */
 static gboolean _polygon_border_get_XY(const float p0_x, const float p0_y, const float p1_x, const float p1_y,
                                    const float p2_x, const float p2_y, const float p3_x, const float p3_y,
-                                   const float t, const float radius,
+                                   const float t, const float radius, float radius_rate,
                                    float *center_x, float *center_y, float *border_x, float *border_y)
 {
   // we get the point
@@ -153,12 +153,32 @@ static gboolean _polygon_border_get_XY(const float p0_x, const float p0_y, const
     }
     /* only a curve collapsed to a single point has no direction at all */
     if(dx == 0.0 && dy == 0.0) return FALSE;
+
+    /* a limit direction has a direction and no speed, so no rate can be taken against it */
+    radius_rate = 0.0f;
   }
 
-  const double l = 1.0 / sqrt(dx * dx + dy * dy);
-  *border_x = (*center_x) + radius * dy * l;
-  *border_y = (*center_y) - radius * dx * l;
+  /* on the envelope of the feather's discs, not on the normal: see
+   * dt_masks_outline_envelope_offset() */
+  const float centre[2] = { *center_x, *center_y };
+  float border[2];
+  dt_masks_outline_envelope_offset(centre, (float)dx, (float)dy, radius, radius_rate, border);
+  *border_x = border[0];
+  *border_y = border[1];
   return TRUE;
+}
+
+/* The feather along a segment eases from one node's to the other's, r1 + (r2 - r1) * t^2 (3 - 2t);
+ * its rate by t, (r2 - r1) * 6 t (1 - t), is zero at both ends, so the end samples stay on the
+ * normal and the joints built from them are unchanged. */
+static inline float _polygon_radius_at(const float r1, const float r2, const double t)
+{
+  return r1 + (r2 - r1) * t * t * (3.0 - 2.0 * t);
+}
+
+static inline float _polygon_radius_rate_at(const float r1, const float r2, const double t)
+{
+  return (r2 - r1) * 6.0 * t * (1.0 - t);
 }
 
 /**
@@ -408,8 +428,8 @@ static void _polygon_points_recurs(float *segment_start, float *segment_end,
     have_border_min =
     _polygon_border_get_XY(segment_start[0], segment_start[1], segment_start[2], segment_start[3],
                            segment_end[2], segment_end[3], segment_end[0], segment_end[1], t_min,
-                           segment_start[4]
-                               + (segment_end[4] - segment_start[4]) * t_min * t_min * (3.0 - 2.0 * t_min),
+                           _polygon_radius_at(segment_start[4], segment_end[4], t_min),
+                           _polygon_radius_rate_at(segment_start[4], segment_end[4], t_min),
                            polygon_min, polygon_min + 1, border_min, border_min + 1);
   }
   if(!have_max)
@@ -417,8 +437,8 @@ static void _polygon_points_recurs(float *segment_start, float *segment_end,
     have_border_max =
     _polygon_border_get_XY(segment_start[0], segment_start[1], segment_start[2], segment_start[3],
                            segment_end[2], segment_end[3], segment_end[0], segment_end[1], t_max,
-                           segment_start[4]
-                               + (segment_end[4] - segment_start[4]) * t_max * t_max * (3.0 - 2.0 * t_max),
+                           _polygon_radius_at(segment_start[4], segment_end[4], t_max),
+                           _polygon_radius_rate_at(segment_start[4], segment_end[4], t_max),
                            polygon_max, polygon_max + 1, border_max, border_max + 1);
   }
 
@@ -448,8 +468,7 @@ static void _polygon_points_recurs(float *segment_start, float *segment_end,
          * at the top level and (0, 0) -- the image origin -- below it, written to the buffer
          * as geometry. A spoke of the right LENGTH along the chord's normal is always a valid
          * piece of the disc union. */
-        const float radius = segment_start[4]
-                             + (segment_end[4] - segment_start[4]) * t_max * t_max * (3.0 - 2.0 * t_max);
+        const float radius = _polygon_radius_at(segment_start[4], segment_end[4], t_max);
         dt_masks_outline_offset_along(polygon_max, segment_end[1] - segment_start[1],
                                       -(segment_end[0] - segment_start[0]), radius, border_max);
         have_border_max = TRUE;
@@ -586,9 +605,9 @@ static gboolean _polygon_walk_segment(const _polygon_walk_t *const w, _polygon_w
   float c1[2];
   float b1[2];
   const gboolean have_b0 = _polygon_border_get_XY(p1[0], p1[1], p1[2], p1[3], p2[2], p2[3], p2[0], p2[1], 0.0f,
-                                                  p1[4], c0, c0 + 1, b0, b0 + 1);
+                                                  p1[4], 0.0f, c0, c0 + 1, b0, b0 + 1);
   const gboolean have_b1 = _polygon_border_get_XY(p1[0], p1[1], p1[2], p1[3], p2[2], p2[3], p2[0], p2[1], 1.0f,
-                                                  p2[4], c1, c1 + 1, b1, b1 + 1);
+                                                  p2[4], 0.0f, c1, c1 + 1, b1, b1 + 1);
   if(!have_b0 && !have_b1) return FALSE;
   if(!have_b0) dt_masks_outline_offset_along(c0, b1[0] - c1[0], b1[1] - c1[1], p1[4], b0);
   if(!have_b1) dt_masks_outline_offset_along(c1, b0[0] - c0[0], b0[1] - c0[1], p2[4], b1);

--- a/src/widgets/CMakeLists.txt
+++ b/src/widgets/CMakeLists.txt
@@ -30,6 +30,7 @@ set(ANSEL_WIDGETS_SOURCES
   resetlabel.c
   scroll_wrap.c
   sidepanel.c
+  stroke_raster.c
   thumbnail_btn.c
   togglebutton.c
   widget_settings.c

--- a/src/widgets/draw.h
+++ b/src/widgets/draw.h
@@ -55,6 +55,7 @@
 #include "system/mem_alloc.h"
 #include "system/openmp.h"        // __OMP_DECLARE_SIMD__, __OMP_PARALLEL_FOR_SIMD__
 #include "widgets/paint.h"          // DTGTKCairoPaintIconFunc
+#include "widgets/stroke_raster.h"  // dt_stroke_raster_path()
 #include "widgets/widget_settings.h"
 
 #include <cairo.h>
@@ -597,6 +598,26 @@ static void _fill_clear_preserve(cairo_t *cr)
   _draw_fill_clear(cr, TRUE);
 }
 
+/** The dash pattern of @p type in user units at @p zoom_scale: 0 and 0 for a solid line. */
+static inline void dt_draw_dash_lengths(const dt_draw_dash_type_t type, const float zoom_scale, double *on, double *off)
+{
+  *on = 0.0;
+  *off = 0.0;
+  switch(type)
+  {
+    case DT_MASKS_DASH_STICK:
+      *on = DT_DRAW_SCALE_DASH / zoom_scale;
+      *off = DT_DRAW_SCALE_DASH / zoom_scale;
+      break;
+    case DT_MASKS_DASH_ROUND:
+      *on = (DT_DRAW_SCALE_DASH * 0.25f) / zoom_scale;
+      *off = DT_DRAW_SCALE_DASH / zoom_scale;
+      break;
+    default:
+      break;
+  }
+}
+
 static inline void dt_draw_set_dash_style(cairo_t *cr, dt_draw_dash_type_t type, float zoom_scale)
 {
   // return early if no dash is needed
@@ -840,20 +861,48 @@ static inline void dt_draw_shape_lines(struct dt_develop_t *dev, const dt_draw_d
   const float line_width_bright = selected
                   ? DT_DRAW_SIZE_LINE_SELECTED / zoom_scale
                   : DT_DRAW_SIZE_LINE / zoom_scale;
-  
-  // OUTLINE (dark)
-  cairo_set_line_width(cr, line_width_dark);
+
   float alpha = dash_type ? 0.3f : 0.9f;
   if(source) alpha *= 0.5f;
+  const float alpha_bright = source ? 0.4f : 0.8f;
+
+  /* The path is pixels already: the outline was sampled at the resolution it is drawn at.
+   * Paint it as such wherever the surface allows -- the overlay's own canvas, any image
+   * surface, the group cairo pushed on one -- and keep the cairo strokes below for every other
+   * target. The rasteriser reproduces exactly these: the same two passes, widths, colours,
+   * dashes and caps. */
+  dt_stroke_style_t style = { 0 };
+  const dt_widget_overlay_color_t *overlay = dt_widget_overlay_color();
+  const double dark_amount = (1.0 - overlay->contrast) * 0.5;
+  const double bright_amount = 0.5 + overlay->contrast * 0.5;
+  style.dark = (dt_stroke_pass_t){ .width = line_width_dark,
+                                   .red = overlay->red * dark_amount,
+                                   .green = overlay->green * dark_amount,
+                                   .blue = overlay->blue * dark_amount,
+                                   .alpha = alpha };
+  style.bright = (dt_stroke_pass_t){ .width = line_width_bright,
+                                     .red = overlay->red * bright_amount,
+                                     .green = overlay->green * bright_amount,
+                                     .blue = overlay->blue * bright_amount,
+                                     .alpha = alpha_bright };
+  dt_draw_dash_lengths(dash, zoom_scale, &style.dash_on, &style.dash_off);
+  style.round_caps = (line_cap == CAIRO_LINE_CAP_ROUND);
+  if(dt_stroke_raster_path(cr, &style))
+  {
+    cairo_restore(cr);
+    return;
+  }
+
+  // OUTLINE (dark)
+  cairo_set_line_width(cr, line_width_dark);
   dt_draw_set_color_overlay(cr, FALSE, alpha);
   cairo_stroke_preserve(cr);
 
   // NORMAL (bright)
   cairo_set_line_width(cr, line_width_bright);
-  dt_draw_set_color_overlay(cr, TRUE, source ? 0.4f : 0.8f);
+  dt_draw_set_color_overlay(cr, TRUE, alpha_bright);
   cairo_stroke(cr);
 
-  
   cairo_restore(cr);
 }
 

--- a/src/widgets/stroke_raster.c
+++ b/src/widgets/stroke_raster.c
@@ -1,0 +1,548 @@
+/*
+    This file is part of Ansel,
+    Copyright (C) 2026 Aurélien PIERRE.
+
+    Ansel is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Ansel is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Ansel.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "widgets/stroke_raster.h"
+
+#include <float.h>
+#include <limits.h>
+#include <math.h>
+#include <stdint.h>
+#include <string.h>
+
+/* ---------------------------------------------------------------------------------------------
+ * The touched rectangle, kept on the surface it describes.
+ *
+ * A surface carries its own record of what was painted into it here, as cairo user data, so a
+ * caller that owns the surface can composite or clear exactly that much: the rasteriser is the
+ * one thing that knows where its pixels went. Half-open pixel ranges, [x0, x1) x [y0, y1). */
+typedef struct _touched_t
+{
+  gboolean any;
+  int x0;
+  int y0;
+  int x1;
+  int y1;
+} _touched_t;
+
+static const cairo_user_data_key_t _touched_key = { 0 };
+
+static _touched_t *_touched_of(cairo_surface_t *surface, const gboolean create)
+{
+  _touched_t *touched = (_touched_t *)cairo_surface_get_user_data(surface, &_touched_key);
+  if(touched || !create) return touched;
+  touched = g_malloc0(sizeof(_touched_t));
+  if(cairo_surface_set_user_data(surface, &_touched_key, touched, g_free) != CAIRO_STATUS_SUCCESS)
+  {
+    g_free(touched);
+    return NULL;
+  }
+  return touched;
+}
+
+static void _touched_add(cairo_surface_t *surface, const int x0, const int y0, const int x1, const int y1)
+{
+  if(x1 <= x0 || y1 <= y0) return;
+  _touched_t *touched = _touched_of(surface, TRUE);
+  if(!touched) return;
+  if(!touched->any)
+  {
+    touched->x0 = x0;
+    touched->y0 = y0;
+    touched->x1 = x1;
+    touched->y1 = y1;
+    touched->any = TRUE;
+    return;
+  }
+  touched->x0 = MIN(touched->x0, x0);
+  touched->y0 = MIN(touched->y0, y0);
+  touched->x1 = MAX(touched->x1, x1);
+  touched->y1 = MAX(touched->y1, y1);
+}
+
+gboolean dt_stroke_raster_touched(cairo_surface_t *surface, cairo_rectangle_int_t *touched)
+{
+  if(!surface || !touched) return FALSE;
+  const _touched_t *record = _touched_of(surface, FALSE);
+  if(!record || !record->any) return FALSE;
+  touched->x = record->x0;
+  touched->y = record->y0;
+  touched->width = record->x1 - record->x0;
+  touched->height = record->y1 - record->y0;
+  return TRUE;
+}
+
+void dt_stroke_raster_touched_reset(cairo_surface_t *surface)
+{
+  if(!surface) return;
+  _touched_t *record = _touched_of(surface, FALSE);
+  if(record) record->any = FALSE;
+}
+
+gboolean dt_stroke_raster_can_paint(cairo_surface_t *surface)
+{
+  return surface && cairo_surface_status(surface) == CAIRO_STATUS_SUCCESS
+         && cairo_surface_get_type(surface) == CAIRO_SURFACE_TYPE_IMAGE
+         && cairo_image_surface_get_format(surface) == CAIRO_FORMAT_ARGB32;
+}
+
+/* ---------------------------------------------------------------------------------------------
+ * The distance plane.
+ *
+ * One scratch plane over the polyline's bounding box, holding per pixel not the distance but
+ * `reach^2 - d^2', where reach is the widest pass's half-width plus the antialiasing pixel:
+ * positive inside the stroke's reach, zero outside and for anything never stamped. Zero being
+ * the resting state is what makes the plane cheap to keep: it is never cleared as a whole, only
+ * the spans a stroke actually wrote are zeroed again once composited, and a plane that only ever
+ * grows starts every new byte at zero. Stamping is MAX, which for this quantity is the nearest
+ * point of the polyline, and squared distances need no square root until compositing, which
+ * touches only the pixels of the stroke's band and not the box around it.
+ *
+ * Per row, the extent that was written, so compositing and the clearing after it walk the band
+ * rather than the box. Overlays are drawn from one thread at a time; the lock says so. */
+typedef struct _plane_t
+{
+  float *value;      /* reach^2 - d^2, zero at rest */
+  int *span_min;     /* per row of the box: first column written, or INT_MAX */
+  int *span_max;     /* per row of the box: last column written, or -1 */
+  int width;         /* the box's, in pixels */
+  int height;
+  int x0;            /* the box's origin in the surface's pixel grid */
+  int y0;
+} _plane_t;
+
+static GMutex _scratch_lock;
+static float *_scratch_value = NULL;
+static size_t _scratch_value_count = 0;
+static int *_scratch_span_min = NULL;
+static int *_scratch_span_max = NULL;
+static int _scratch_span_rows = 0;
+
+/* Take the scratch for a box of @p width x @p height, growing it -- zeroed -- as needed. */
+static gboolean _plane_acquire(_plane_t *plane, const int x0, const int y0, const int width, const int height)
+{
+  const size_t count = (size_t)width * (size_t)height;
+  if(count > _scratch_value_count)
+  {
+    float *grown = g_try_malloc0(count * sizeof(float));
+    if(!grown) return FALSE;
+    g_free(_scratch_value);
+    _scratch_value = grown;
+    _scratch_value_count = count;
+  }
+  if(height > _scratch_span_rows)
+  {
+    int *min_grown = g_try_malloc(sizeof(int) * (size_t)height);
+    int *max_grown = g_try_malloc(sizeof(int) * (size_t)height);
+    if(!min_grown || !max_grown)
+    {
+      g_free(min_grown);
+      g_free(max_grown);
+      return FALSE;
+    }
+    g_free(_scratch_span_min);
+    g_free(_scratch_span_max);
+    _scratch_span_min = min_grown;
+    _scratch_span_max = max_grown;
+    _scratch_span_rows = height;
+  }
+  for(int y = 0; y < height; y++)
+  {
+    _scratch_span_min[y] = INT_MAX;
+    _scratch_span_max[y] = -1;
+  }
+  plane->value = _scratch_value;
+  plane->span_min = _scratch_span_min;
+  plane->span_max = _scratch_span_max;
+  plane->width = width;
+  plane->height = height;
+  plane->x0 = x0;
+  plane->y0 = y0;
+  return TRUE;
+}
+
+/* Stamp the capsule of half-width @p reach around the segment (ax, ay)-(bx, by), in surface
+ * pixels, into the plane. A capped end is round; an uncapped one is cut flat at the segment's
+ * end plane, which is what a butt cap is. */
+static inline void _plane_stamp_capsule(_plane_t *const plane, const double ax, const double ay, const double bx,
+                                        const double by, const double reach, const gboolean cap_a,
+                                        const gboolean cap_b)
+{
+  const double dx = bx - ax;
+  const double dy = by - ay;
+  const double len2 = dx * dx + dy * dy;
+  const double reach2 = reach * reach;
+
+  int x_first = (int)floor(MIN(ax, bx) - reach) - plane->x0;
+  int x_last = (int)ceil(MAX(ax, bx) + reach) - plane->x0;
+  int y_first = (int)floor(MIN(ay, by) - reach) - plane->y0;
+  int y_last = (int)ceil(MAX(ay, by) + reach) - plane->y0;
+  x_first = MAX(x_first, 0);
+  y_first = MAX(y_first, 0);
+  x_last = MIN(x_last, plane->width - 1);
+  y_last = MIN(y_last, plane->height - 1);
+  if(x_first > x_last || y_first > y_last) return;
+
+  for(int y = y_first; y <= y_last; y++)
+  {
+    const double py = (double)(y + plane->y0) + 0.5;
+    float *const row = plane->value + (size_t)y * plane->width;
+    gboolean wrote = FALSE;
+    for(int x = x_first; x <= x_last; x++)
+    {
+      const double px = (double)(x + plane->x0) + 0.5;
+      double t = (len2 > 0.0) ? ((px - ax) * dx + (py - ay) * dy) / len2 : 0.0;
+      if(t < 0.0)
+      {
+        if(!cap_a) continue;
+        t = 0.0;
+      }
+      else if(t > 1.0)
+      {
+        if(!cap_b) continue;
+        t = 1.0;
+      }
+      const double ex = ax + t * dx - px;
+      const double ey = ay + t * dy - py;
+      const double d2 = ex * ex + ey * ey;
+      if(d2 >= reach2) continue;
+      const float inside = (float)(reach2 - d2);
+      if(inside > row[x])
+      {
+        row[x] = inside;
+        wrote = TRUE;
+      }
+    }
+    if(wrote)
+    {
+      plane->span_min[y] = MIN(plane->span_min[y], x_first);
+      plane->span_max[y] = MAX(plane->span_max[y], x_last);
+    }
+  }
+}
+
+/* ---------------------------------------------------------------------------------------------
+ * Compositing: the two passes from the distance, premultiplied OVER, into ARGB32.
+ *
+ * ARGB32 is one native-endian uint32 per pixel, alpha in the top byte, colour premultiplied by
+ * alpha. The dark pass goes first and the bright pass over it, each with coverage
+ * clamp(R + 1/2 - d, 0, 1) for its own half-width R -- the one-pixel ramp of a fast antialiased
+ * cairo stroke. A pass with alpha or width at zero contributes nothing. */
+static inline uint32_t _pixel_pack(const double a, const double r, const double g, const double b)
+{
+  const uint32_t ia = (uint32_t)(a * 255.0 + 0.5);
+  const uint32_t ir = (uint32_t)(r * 255.0 + 0.5);
+  const uint32_t ig = (uint32_t)(g * 255.0 + 0.5);
+  const uint32_t ib = (uint32_t)(b * 255.0 + 0.5);
+  return (ia << 24) | (ir << 16) | (ig << 8) | ib;
+}
+
+static inline void _pixel_over(uint32_t *const pixel, const dt_stroke_pass_t *const pass, const double coverage)
+{
+  const double src_a = pass->alpha * coverage;
+  if(src_a <= 0.0) return;
+  const uint32_t dst = *pixel;
+  const double keep = 1.0 - src_a;
+  const double a = src_a + ((dst >> 24) & 0xff) / 255.0 * keep;
+  const double r = pass->red * src_a + ((dst >> 16) & 0xff) / 255.0 * keep;
+  const double g = pass->green * src_a + ((dst >> 8) & 0xff) / 255.0 * keep;
+  const double b = pass->blue * src_a + (dst & 0xff) / 255.0 * keep;
+  *pixel = _pixel_pack(MIN(a, 1.0), MIN(r, 1.0), MIN(g, 1.0), MIN(b, 1.0));
+}
+
+static void _plane_composite_and_clear(_plane_t *const plane, cairo_surface_t *surface, const dt_stroke_style_t *style,
+                                       const double reach, cairo_rectangle_int_t *touched)
+{
+  const double reach2 = reach * reach;
+  const double half_dark = 0.5 * style->dark.width;
+  const double half_bright = 0.5 * style->bright.width;
+  const gboolean with_dark = style->dark.width > 0.0 && style->dark.alpha > 0.0;
+  const gboolean with_bright = style->bright.width > 0.0 && style->bright.alpha > 0.0;
+
+  cairo_surface_flush(surface);
+  uint8_t *const data = cairo_image_surface_get_data(surface);
+  const int stride = cairo_image_surface_get_stride(surface);
+  const int surface_width = cairo_image_surface_get_width(surface);
+  const int surface_height = cairo_image_surface_get_height(surface);
+
+  int tx0 = INT_MAX;
+  int ty0 = INT_MAX;
+  int tx1 = -1;
+  int ty1 = -1;
+  for(int y = 0; y < plane->height; y++)
+  {
+    if(plane->span_max[y] < plane->span_min[y]) continue;
+    const int sy = y + plane->y0;
+    float *const row = plane->value + (size_t)y * plane->width;
+    if(sy >= 0 && sy < surface_height)
+    {
+      uint32_t *const pixels = (uint32_t *)(data + (size_t)sy * stride);
+      for(int x = plane->span_min[y]; x <= plane->span_max[y]; x++)
+      {
+        const float inside = row[x];
+        if(inside <= 0.0f) continue;
+        const int sx = x + plane->x0;
+        if(sx < 0 || sx >= surface_width) continue;
+        const double d = sqrt(MAX(reach2 - (double)inside, 0.0));
+        if(with_dark) _pixel_over(&pixels[sx], &style->dark, CLAMP(half_dark + 0.5 - d, 0.0, 1.0));
+        if(with_bright) _pixel_over(&pixels[sx], &style->bright, CLAMP(half_bright + 0.5 - d, 0.0, 1.0));
+        tx0 = MIN(tx0, sx);
+        tx1 = MAX(tx1, sx);
+        ty0 = MIN(ty0, sy);
+        ty1 = MAX(ty1, sy);
+      }
+    }
+    /* back to rest: only what was written */
+    memset(row + plane->span_min[y], 0, sizeof(float) * (size_t)(plane->span_max[y] - plane->span_min[y] + 1));
+  }
+
+  if(tx1 >= tx0 && ty1 >= ty0)
+  {
+    cairo_surface_mark_dirty_rectangle(surface, tx0, ty0, tx1 - tx0 + 1, ty1 - ty0 + 1);
+    _touched_add(surface, tx0, ty0, tx1 + 1, ty1 + 1);
+    if(touched)
+    {
+      touched->x = tx0;
+      touched->y = ty0;
+      touched->width = tx1 - tx0 + 1;
+      touched->height = ty1 - ty0 + 1;
+    }
+  }
+}
+
+/* ---------------------------------------------------------------------------------------------
+ * The walk along a polyline: dashes cut by arc length, capsules stamped. */
+typedef struct _dash_state_t
+{
+  gboolean on;        /* inside a dash rather than a gap */
+  double left;        /* what remains of the current dash or gap */
+} _dash_state_t;
+
+static void _polyline_stamp(_plane_t *const plane, const double *xy, const int count, const dt_stroke_style_t *style,
+                            const double reach, const gboolean closed)
+{
+  const gboolean dashed = style->dash_on > 0.0 && style->dash_off > 0.0;
+  _dash_state_t dash = { .on = TRUE, .left = dashed ? style->dash_on : DBL_MAX };
+  /* The ends of the polyline: round when asked, flat otherwise; a closed polyline has none.
+   * Every other piece end is a join or a dash cut inside the line, always capped so the joins
+   * between consecutive segments are round and seamless. */
+  const gboolean caps = style->round_caps;
+  const int last = count - 1;
+  /* a dash cut is a piece end; whether it is capped follows the cap style */
+  for(int i = 0; i < last; i++)
+  {
+    const double ax = xy[2 * i];
+    const double ay = xy[2 * i + 1];
+    const double bx = xy[2 * i + 2];
+    const double by = xy[2 * i + 3];
+    const double length = hypot(bx - ax, by - ay);
+    const gboolean starts_line = (i == 0) && !closed;
+    const gboolean ends_line = (i == last - 1) && !closed;
+
+    if(!dashed)
+    {
+      _plane_stamp_capsule(plane, ax, ay, bx, by, reach, caps || !starts_line, caps || !ends_line);
+      continue;
+    }
+
+    double pos = 0.0;
+    gboolean piece_begins_here = starts_line;   /* the current on-piece started at the line's start */
+    while(pos < length)
+    {
+      const double run = MIN(dash.left, length - pos);
+      const double end = pos + run;
+      if(dash.on)
+      {
+        const double t0 = pos / length;
+        const double t1 = end / length;
+        const gboolean piece_starts = (pos == 0.0) ? piece_begins_here : TRUE;   /* a cut: a dash start */
+        const gboolean piece_ends_at_cut = (end < length) || (ends_line && end >= length);
+        const gboolean cap_a = caps || !(piece_starts);
+        const gboolean cap_b = caps || !piece_ends_at_cut;
+        _plane_stamp_capsule(plane, ax + t0 * (bx - ax), ay + t0 * (by - ay), ax + t1 * (bx - ax),
+                             ay + t1 * (by - ay), reach, cap_a, cap_b);
+      }
+      dash.left -= run;
+      pos = end;
+      if(dash.left <= 0.0)
+      {
+        dash.on = !dash.on;
+        dash.left = dash.on ? style->dash_on : style->dash_off;
+        piece_begins_here = TRUE;
+      }
+      else
+        piece_begins_here = FALSE;
+    }
+  }
+  if(count == 1 && caps)
+    _plane_stamp_capsule(plane, xy[0], xy[1], xy[0], xy[1], reach, TRUE, TRUE);   /* a dot */
+}
+
+static gboolean _stroke_polyline(cairo_surface_t *surface, const double *xy, const int count,
+                                 const dt_stroke_style_t *style, const gboolean closed)
+{
+  if(count < 1) return FALSE;
+  const double widest = MAX(style->dark.width, style->bright.width);
+  if(widest <= 0.0) return FALSE;
+  const double reach = 0.5 * widest + 1.0;   /* the antialiasing pixel beyond the widest pass */
+
+  double x_min = DBL_MAX;
+  double y_min = DBL_MAX;
+  double x_max = -DBL_MAX;
+  double y_max = -DBL_MAX;
+  for(int i = 0; i < count; i++)
+  {
+    x_min = MIN(x_min, xy[2 * i]);
+    x_max = MAX(x_max, xy[2 * i]);
+    y_min = MIN(y_min, xy[2 * i + 1]);
+    y_max = MAX(y_max, xy[2 * i + 1]);
+  }
+  if(!isfinite(x_min) || !isfinite(x_max) || !isfinite(y_min) || !isfinite(y_max)) return FALSE;
+
+  /* the box: the polyline's, grown by the reach, clipped to the surface */
+  const int surface_width = cairo_image_surface_get_width(surface);
+  const int surface_height = cairo_image_surface_get_height(surface);
+  const int x0 = MAX((int)floor(x_min - reach) - 1, 0);
+  const int y0 = MAX((int)floor(y_min - reach) - 1, 0);
+  const int x1 = MIN((int)ceil(x_max + reach) + 1, surface_width - 1);
+  const int y1 = MIN((int)ceil(y_max + reach) + 1, surface_height - 1);
+  if(x1 < x0 || y1 < y0) return FALSE;   /* entirely off the surface */
+
+  g_mutex_lock(&_scratch_lock);
+  _plane_t plane;
+  gboolean ok = _plane_acquire(&plane, x0, y0, x1 - x0 + 1, y1 - y0 + 1);
+  if(ok)
+  {
+    _polyline_stamp(&plane, xy, count, style, reach, closed);
+    _plane_composite_and_clear(&plane, surface, style, reach, NULL);
+  }
+  g_mutex_unlock(&_scratch_lock);
+  return ok;
+}
+
+gboolean dt_stroke_raster_polyline(cairo_surface_t *surface, const double *xy, int count,
+                                   const dt_stroke_style_t *style)
+{
+  if(!dt_stroke_raster_can_paint(surface) || !xy || !style || count < 1) return FALSE;
+  return _stroke_polyline(surface, xy, count, style, FALSE);
+}
+
+/* ---------------------------------------------------------------------------------------------
+ * From a cairo path. */
+
+/* How much cr's matrix scales a length, taken as the geometric mean of the two axes so an
+ * anisotropic matrix -- which no overlay has -- degrades gracefully. */
+static double _matrix_scale(cairo_t *cr)
+{
+  double ax = 1.0;
+  double ay = 0.0;
+  double bx = 0.0;
+  double by = 1.0;
+  cairo_user_to_device_distance(cr, &ax, &ay);
+  cairo_user_to_device_distance(cr, &bx, &by);
+  const double scale = sqrt(hypot(ax, ay) * hypot(bx, by));
+  return isfinite(scale) ? scale : 1.0;
+}
+
+gboolean dt_stroke_raster_path(cairo_t *cr, const dt_stroke_style_t *style)
+{
+  if(!cr || !style) return FALSE;
+  cairo_surface_t *surface = cairo_get_group_target(cr);
+  if(!dt_stroke_raster_can_paint(surface)) return FALSE;
+
+  cairo_path_t *path = cairo_copy_path_flat(cr);
+  if(!path || path->status != CAIRO_STATUS_SUCCESS)
+  {
+    if(path) cairo_path_destroy(path);
+    return FALSE;
+  }
+
+  /* the surface's pixel grid is device space shifted by the surface's device offset: for the
+   * group cairo pushed, that is the clip's origin */
+  double offset_x = 0.0;
+  double offset_y = 0.0;
+  cairo_surface_get_device_offset(surface, &offset_x, &offset_y);
+
+  const double scale = _matrix_scale(cr);
+  dt_stroke_style_t device_style = *style;
+  device_style.dark.width *= scale;
+  device_style.bright.width *= scale;
+  device_style.dash_on *= scale;
+  device_style.dash_off *= scale;
+
+  GArray *vertices = g_array_sized_new(FALSE, FALSE, sizeof(double), 2 * 1024);
+  gboolean closed = FALSE;
+  double first_x = 0.0;
+  double first_y = 0.0;
+  for(int i = 0; i < path->num_data; i += path->data[i].header.length)
+  {
+    const cairo_path_data_t *const element = &path->data[i];
+    const cairo_path_data_type_t type = element->header.type;
+    if(type == CAIRO_PATH_MOVE_TO)
+    {
+      /* a move ends the polyline before it and starts the next one at its point */
+      if(vertices->len >= 2)
+        _stroke_polyline(surface, (const double *)vertices->data, (int)(vertices->len / 2), &device_style, closed);
+      g_array_set_size(vertices, 0);
+      closed = FALSE;
+    }
+    switch(type)
+    {
+      case CAIRO_PATH_MOVE_TO:
+      case CAIRO_PATH_LINE_TO:
+      {
+        double x = element[1].point.x;
+        double y = element[1].point.y;
+        cairo_user_to_device(cr, &x, &y);
+        x += offset_x;
+        y += offset_y;
+        if(vertices->len == 0)
+        {
+          first_x = x;
+          first_y = y;
+        }
+        g_array_append_val(vertices, x);
+        g_array_append_val(vertices, y);
+        break;
+      }
+      case CAIRO_PATH_CLOSE_PATH:
+        if(vertices->len >= 2)
+        {
+          g_array_append_val(vertices, first_x);
+          g_array_append_val(vertices, first_y);
+          closed = TRUE;
+        }
+        break;
+      case CAIRO_PATH_CURVE_TO:
+      default:
+        break;   /* a flattened path has no curves */
+    }
+  }
+  if(vertices->len >= 2)
+    _stroke_polyline(surface, (const double *)vertices->data, (int)(vertices->len / 2), &device_style, closed);
+
+  g_array_free(vertices, TRUE);
+  cairo_path_destroy(path);
+  cairo_new_path(cr);
+  return TRUE;
+}
+
+// clang-format off
+// modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py
+// vim: shiftwidth=2 expandtab tabstop=2 cindent
+// kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;
+// clang-format on

--- a/src/widgets/stroke_raster.c
+++ b/src/widgets/stroke_raster.c
@@ -330,7 +330,7 @@ static void _plane_stamp_dashed(_plane_t *const plane, const _segment_t *const s
 }
 
 static void _polyline_stamp(_plane_t *const plane, const double *xy, const int count, const dt_stroke_style_t *style,
-                            const double reach, const gboolean closed)
+                            const double reach, const gboolean closed, _dash_t *const dash)
 {
   const gboolean caps = style->round_caps;
   if(count == 1)
@@ -341,7 +341,6 @@ static void _polyline_stamp(_plane_t *const plane, const double *xy, const int c
     return;
   }
   const gboolean dashed = style->dash_on > 0.0 && style->dash_off > 0.0;
-  _dash_t dash = { .on = TRUE, .left = style->dash_on, .fresh = TRUE };
   const int last = count - 1;
   for(int i = 0; i < last; i++)
   {
@@ -355,10 +354,17 @@ static void _polyline_stamp(_plane_t *const plane, const double *xy, const int c
                              .cap_a = caps || !starts_line,
                              .cap_b = caps || !ends_line };
     if(dashed)
-      _plane_stamp_dashed(plane, &seg, style, reach, &dash);
+      _plane_stamp_dashed(plane, &seg, style, reach, dash);
     else
       _plane_stamp_capsule(plane, &seg, reach);
   }
+}
+
+/* The dash pattern at the start of a stroke: a dash, with its whole length ahead. */
+static _dash_t _dash_start(const dt_stroke_style_t *const style)
+{
+  const _dash_t dash = { .on = TRUE, .left = style->dash_on, .fresh = TRUE };
+  return dash;
 }
 
 /* ---------------------------------------------------------------------------------------------
@@ -472,8 +478,13 @@ static void _plane_composite_and_clear(_plane_t *const plane, cairo_surface_t *s
 /* ---------------------------------------------------------------------------------------------
  * A polyline, and a path's worth of them. */
 
+/* Stroke one polyline; @p dash is the pattern's state, carried across the sub-paths of one
+ * stroke so that a dash is a function of the arc length along everything drawn and not of
+ * where a sub-path happened to start. An outline is many sub-paths -- one per run between the
+ * stretches the boundary pass hides -- and restarting the pattern at each bunched and stretched
+ * the dashes at every run boundary. */
 static gboolean _stroke_polyline(cairo_surface_t *surface, const double *xy, const int count,
-                                 const dt_stroke_style_t *style, const gboolean closed)
+                                 const dt_stroke_style_t *style, const gboolean closed, _dash_t *const dash)
 {
   if(count < 1) return FALSE;
   const double widest = MAX(style->dark.width, style->bright.width);
@@ -504,7 +515,7 @@ static gboolean _stroke_polyline(cairo_surface_t *surface, const double *xy, con
 
   _plane_t plane;
   if(!_plane_acquire(surface, &plane, x0, y0, x1 - x0 + 1, y1 - y0 + 1)) return FALSE;
-  _polyline_stamp(&plane, xy, count, style, reach, closed);
+  _polyline_stamp(&plane, xy, count, style, reach, closed, dash);
   _plane_composite_and_clear(&plane, surface, style, reach);
   return TRUE;
 }
@@ -513,7 +524,8 @@ gboolean dt_stroke_raster_polyline(cairo_surface_t *surface, const double *xy, i
                                    const dt_stroke_style_t *style)
 {
   if(!dt_stroke_raster_can_paint(surface) || !xy || !style || count < 1) return FALSE;
-  return _stroke_polyline(surface, xy, count, style, FALSE);
+  _dash_t dash = _dash_start(style);
+  return _stroke_polyline(surface, xy, count, style, FALSE, &dash);
 }
 
 /* How much cr's matrix scales a length, taken as the geometric mean of the two axes so an
@@ -552,10 +564,11 @@ typedef struct _gather_t
   double offset_y;
 } _gather_t;
 
-static void _gather_flush(_gather_t *const g, cairo_surface_t *surface, const dt_stroke_style_t *style)
+static void _gather_flush(_gather_t *const g, cairo_surface_t *surface, const dt_stroke_style_t *style,
+                          _dash_t *const dash)
 {
   if(g->vertices->len >= 2)
-    _stroke_polyline(surface, (const double *)g->vertices->data, (int)(g->vertices->len / 2), style, g->closed);
+    _stroke_polyline(surface, (const double *)g->vertices->data, (int)(g->vertices->len / 2), style, g->closed, dash);
   g_array_set_size(g->vertices, 0);
   g->closed = FALSE;
 }
@@ -605,6 +618,7 @@ gboolean dt_stroke_raster_path(cairo_t *cr, const dt_stroke_style_t *style)
   device_style.bright.width *= scale;
   device_style.dash_on *= scale;
   device_style.dash_off *= scale;
+  _dash_t dash = _dash_start(&device_style);   /* one pattern for the whole path */
 
   for(int i = 0; i < path->num_data; i += path->data[i].header.length)
   {
@@ -612,7 +626,7 @@ gboolean dt_stroke_raster_path(cairo_t *cr, const dt_stroke_style_t *style)
     switch(element->header.type)
     {
       case CAIRO_PATH_MOVE_TO:
-        _gather_flush(&gather, surface, &device_style);
+        _gather_flush(&gather, surface, &device_style, &dash);
         _gather_point(&gather, cr, &element[1]);
         break;
       case CAIRO_PATH_LINE_TO:
@@ -630,7 +644,7 @@ gboolean dt_stroke_raster_path(cairo_t *cr, const dt_stroke_style_t *style)
         break;   /* a flattened path has no curves */
     }
   }
-  _gather_flush(&gather, surface, &device_style);
+  _gather_flush(&gather, surface, &device_style, &dash);
 
   g_array_free(gather.vertices, TRUE);
   cairo_path_destroy(path);

--- a/src/widgets/stroke_raster.c
+++ b/src/widgets/stroke_raster.c
@@ -531,14 +531,24 @@ static double _matrix_scale(cairo_t *cr)
 }
 
 /* The polyline being gathered from a path: its vertices in surface pixels, and its first one
- * for a close. */
+ * for a close.
+ *
+ * Cairo's "device space" is not the pixel grid. It is the space the CTM maps user space into,
+ * and the surface then applies its own device transform: pixel = device * device_scale +
+ * device_offset, the scale being what a HiDPI widget carries (2 on a 2x screen) and the offset
+ * what a pushed group carries (minus its clip's origin, in pixels). cairo_user_to_device()
+ * stops at device space -- measured: on a surface with device scale 2, (10, 10) maps to
+ * (10, 10) -- so both factors are applied here. Leaving the scale out put every overlay at half
+ * size in the top-left quadrant of a HiDPI view. */
 typedef struct _gather_t
 {
   GArray *vertices;
   double first_x;
   double first_y;
   gboolean closed;
-  double offset_x;   /* the surface's device offset: pixel = device + offset */
+  double scale_x;    /* the surface's device scale */
+  double scale_y;
+  double offset_x;   /* the surface's device offset, in pixels */
   double offset_y;
 } _gather_t;
 
@@ -555,8 +565,8 @@ static void _gather_point(_gather_t *const g, cairo_t *cr, const cairo_path_data
   double x = point->point.x;
   double y = point->point.y;
   cairo_user_to_device(cr, &x, &y);
-  x += g->offset_x;
-  y += g->offset_y;
+  x = x * g->scale_x + g->offset_x;
+  y = y * g->scale_y + g->offset_y;
   if(g->vertices->len == 0)
   {
     g->first_x = x;
@@ -579,17 +589,22 @@ gboolean dt_stroke_raster_path(cairo_t *cr, const dt_stroke_style_t *style)
     return FALSE;
   }
 
-  const double scale = _matrix_scale(cr);
+  /* the surface's pixel grid is device space scaled by the surface's device scale and shifted
+   * by its device offset: for the group cairo pushed, that is the clip's origin */
+  _gather_t gather = { .vertices = g_array_sized_new(FALSE, FALSE, sizeof(double), 2 * 1024),
+                       .scale_x = 1.0,
+                       .scale_y = 1.0 };
+  cairo_surface_get_device_scale(surface, &gather.scale_x, &gather.scale_y);
+  cairo_surface_get_device_offset(surface, &gather.offset_x, &gather.offset_y);
+  if(gather.scale_x <= 0.0) gather.scale_x = 1.0;
+  if(gather.scale_y <= 0.0) gather.scale_y = 1.0;
+
+  const double scale = _matrix_scale(cr) * sqrt(gather.scale_x * gather.scale_y);
   dt_stroke_style_t device_style = *style;
   device_style.dark.width *= scale;
   device_style.bright.width *= scale;
   device_style.dash_on *= scale;
   device_style.dash_off *= scale;
-
-  /* the surface's pixel grid is device space shifted by the surface's device offset: for the
-   * group cairo pushed, that is the clip's origin */
-  _gather_t gather = { .vertices = g_array_sized_new(FALSE, FALSE, sizeof(double), 2 * 1024) };
-  cairo_surface_get_device_offset(surface, &gather.offset_x, &gather.offset_y);
 
   for(int i = 0; i < path->num_data; i += path->data[i].header.length)
   {

--- a/src/widgets/stroke_raster.c
+++ b/src/widgets/stroke_raster.c
@@ -24,12 +24,17 @@
 #include <stdint.h>
 #include <string.h>
 
+/* This file holds no state of its own: src/widgets keeps none outside its two registries, and
+ * a rasteriser has no business remembering anything between two strokes. What it needs across
+ * a call -- a scratch plane -- and across a frame -- what was touched -- lives on the surface
+ * being painted, as cairo user data, and dies with it. */
+
 /* ---------------------------------------------------------------------------------------------
  * The touched rectangle, kept on the surface it describes.
  *
- * A surface carries its own record of what was painted into it here, as cairo user data, so a
- * caller that owns the surface can composite or clear exactly that much: the rasteriser is the
- * one thing that knows where its pixels went. Half-open pixel ranges, [x0, x1) x [y0, y1). */
+ * A surface carries its own record of what was painted into it here, so a caller that owns the
+ * surface can composite or clear exactly that much: the rasteriser is the one thing that knows
+ * where its pixels went. Half-open pixel ranges, [x0, x1) x [y0, y1). */
 typedef struct _touched_t
 {
   gboolean any;
@@ -101,19 +106,54 @@ gboolean dt_stroke_raster_can_paint(cairo_surface_t *surface)
 }
 
 /* ---------------------------------------------------------------------------------------------
- * The distance plane.
+ * The distance plane, and the scratch it is cut from.
  *
- * One scratch plane over the polyline's bounding box, holding per pixel not the distance but
+ * One plane over the polyline's bounding box, holding per pixel not the distance but
  * `reach^2 - d^2', where reach is the widest pass's half-width plus the antialiasing pixel:
  * positive inside the stroke's reach, zero outside and for anything never stamped. Zero being
- * the resting state is what makes the plane cheap to keep: it is never cleared as a whole, only
- * the spans a stroke actually wrote are zeroed again once composited, and a plane that only ever
- * grows starts every new byte at zero. Stamping is MAX, which for this quantity is the nearest
- * point of the polyline, and squared distances need no square root until compositing, which
- * touches only the pixels of the stroke's band and not the box around it.
+ * the resting state is what makes the scratch cheap to keep: it is never cleared as a whole,
+ * only the spans a stroke actually wrote are zeroed again once composited, and memory that
+ * only ever grows starts every new byte at zero. Stamping is MAX, which for this quantity is
+ * the nearest point of the polyline, and squared distances need no square root until
+ * compositing, which touches only the pixels of the stroke's band and not the box around it.
  *
  * Per row, the extent that was written, so compositing and the clearing after it walk the band
- * rather than the box. Overlays are drawn from one thread at a time; the lock says so. */
+ * rather than the box. The scratch belongs to the surface, grows to the largest box that
+ * surface ever asked for, and is freed with it. */
+typedef struct _scratch_t
+{
+  float *value;
+  size_t count;
+  int *span_min;
+  int *span_max;
+  int rows;
+} _scratch_t;
+
+static const cairo_user_data_key_t _scratch_key = { 0 };
+
+static void _scratch_free(void *data)
+{
+  _scratch_t *scratch = (_scratch_t *)data;
+  if(!scratch) return;
+  g_free(scratch->value);
+  g_free(scratch->span_min);
+  g_free(scratch->span_max);
+  g_free(scratch);
+}
+
+static _scratch_t *_scratch_of(cairo_surface_t *surface)
+{
+  _scratch_t *scratch = (_scratch_t *)cairo_surface_get_user_data(surface, &_scratch_key);
+  if(scratch) return scratch;
+  scratch = g_malloc0(sizeof(_scratch_t));
+  if(cairo_surface_set_user_data(surface, &_scratch_key, scratch, _scratch_free) != CAIRO_STATUS_SUCCESS)
+  {
+    g_free(scratch);
+    return NULL;
+  }
+  return scratch;
+}
+
 typedef struct _plane_t
 {
   float *value;      /* reach^2 - d^2, zero at rest */
@@ -125,26 +165,23 @@ typedef struct _plane_t
   int y0;
 } _plane_t;
 
-static GMutex _scratch_lock;
-static float *_scratch_value = NULL;
-static size_t _scratch_value_count = 0;
-static int *_scratch_span_min = NULL;
-static int *_scratch_span_max = NULL;
-static int _scratch_span_rows = 0;
-
-/* Take the scratch for a box of @p width x @p height, growing it -- zeroed -- as needed. */
-static gboolean _plane_acquire(_plane_t *plane, const int x0, const int y0, const int width, const int height)
+/* Cut a plane for a box of @p width x @p height from the surface's scratch, growing it --
+ * zeroed -- as needed. */
+static gboolean _plane_acquire(cairo_surface_t *surface, _plane_t *plane, const int x0, const int y0,
+                               const int width, const int height)
 {
+  _scratch_t *scratch = _scratch_of(surface);
+  if(!scratch) return FALSE;
   const size_t count = (size_t)width * (size_t)height;
-  if(count > _scratch_value_count)
+  if(count > scratch->count)
   {
     float *grown = g_try_malloc0(count * sizeof(float));
     if(!grown) return FALSE;
-    g_free(_scratch_value);
-    _scratch_value = grown;
-    _scratch_value_count = count;
+    g_free(scratch->value);
+    scratch->value = grown;
+    scratch->count = count;
   }
-  if(height > _scratch_span_rows)
+  if(height > scratch->rows)
   {
     int *min_grown = g_try_malloc(sizeof(int) * (size_t)height);
     int *max_grown = g_try_malloc(sizeof(int) * (size_t)height);
@@ -154,20 +191,20 @@ static gboolean _plane_acquire(_plane_t *plane, const int x0, const int y0, cons
       g_free(max_grown);
       return FALSE;
     }
-    g_free(_scratch_span_min);
-    g_free(_scratch_span_max);
-    _scratch_span_min = min_grown;
-    _scratch_span_max = max_grown;
-    _scratch_span_rows = height;
+    g_free(scratch->span_min);
+    g_free(scratch->span_max);
+    scratch->span_min = min_grown;
+    scratch->span_max = max_grown;
+    scratch->rows = height;
   }
   for(int y = 0; y < height; y++)
   {
-    _scratch_span_min[y] = INT_MAX;
-    _scratch_span_max[y] = -1;
+    scratch->span_min[y] = INT_MAX;
+    scratch->span_max[y] = -1;
   }
-  plane->value = _scratch_value;
-  plane->span_min = _scratch_span_min;
-  plane->span_max = _scratch_span_max;
+  plane->value = scratch->value;
+  plane->span_min = scratch->span_min;
+  plane->span_max = scratch->span_max;
   plane->width = width;
   plane->height = height;
   plane->x0 = x0;
@@ -175,63 +212,152 @@ static gboolean _plane_acquire(_plane_t *plane, const int x0, const int y0, cons
   return TRUE;
 }
 
-/* Stamp the capsule of half-width @p reach around the segment (ax, ay)-(bx, by), in surface
- * pixels, into the plane. A capped end is round; an uncapped one is cut flat at the segment's
- * end plane, which is what a butt cap is. */
-static inline void _plane_stamp_capsule(_plane_t *const plane, const double ax, const double ay, const double bx,
-                                        const double by, const double reach, const gboolean cap_a,
-                                        const gboolean cap_b)
-{
-  const double dx = bx - ax;
-  const double dy = by - ay;
-  const double len2 = dx * dx + dy * dy;
-  const double reach2 = reach * reach;
+/* ---------------------------------------------------------------------------------------------
+ * Stamping: the capsule of a segment. */
 
-  int x_first = (int)floor(MIN(ax, bx) - reach) - plane->x0;
-  int x_last = (int)ceil(MAX(ax, bx) + reach) - plane->x0;
-  int y_first = (int)floor(MIN(ay, by) - reach) - plane->y0;
-  int y_last = (int)ceil(MAX(ay, by) + reach) - plane->y0;
-  x_first = MAX(x_first, 0);
-  y_first = MAX(y_first, 0);
-  x_last = MIN(x_last, plane->width - 1);
-  y_last = MIN(y_last, plane->height - 1);
+/* One segment of a polyline, in surface pixels, with what its ends are: a capped end is round,
+ * an uncapped one is cut flat at the segment's end plane, which is what a butt cap is. Every
+ * end inside a polyline is capped, so consecutive segments join round and seamless. */
+typedef struct _segment_t
+{
+  double ax;
+  double ay;
+  double bx;
+  double by;
+  gboolean cap_a;
+  gboolean cap_b;
+} _segment_t;
+
+/* One row of the capsule: every pixel of [x_first, x_last] within reach of the segment takes
+ * the nearest distance. Returns whether any did. */
+static inline gboolean _plane_stamp_row(_plane_t *const plane, const int y, const int x_first, const int x_last,
+                                        const _segment_t *const seg, const double reach2)
+{
+  const double dx = seg->bx - seg->ax;
+  const double dy = seg->by - seg->ay;
+  const double len2 = dx * dx + dy * dy;
+  const double py = (double)(y + plane->y0) + 0.5;
+  float *const row = plane->value + (size_t)y * plane->width;
+  gboolean wrote = FALSE;
+  for(int x = x_first; x <= x_last; x++)
+  {
+    const double px = (double)(x + plane->x0) + 0.5;
+    double t = (len2 > 0.0) ? ((px - seg->ax) * dx + (py - seg->ay) * dy) / len2 : 0.0;
+    if(t < 0.0 && !seg->cap_a) continue;
+    if(t > 1.0 && !seg->cap_b) continue;
+    t = CLAMP(t, 0.0, 1.0);
+    const double ex = seg->ax + t * dx - px;
+    const double ey = seg->ay + t * dy - py;
+    const double d2 = ex * ex + ey * ey;
+    if(d2 >= reach2) continue;
+    const float inside = (float)(reach2 - d2);
+    if(inside <= row[x]) continue;
+    row[x] = inside;
+    wrote = TRUE;
+  }
+  return wrote;
+}
+
+/* Stamp the capsule of half-width @p reach around @p seg into the plane. */
+static inline void _plane_stamp_capsule(_plane_t *const plane, const _segment_t *const seg, const double reach)
+{
+  const double reach2 = reach * reach;
+  const int x_first = MAX((int)floor(MIN(seg->ax, seg->bx) - reach) - plane->x0, 0);
+  const int x_last = MIN((int)ceil(MAX(seg->ax, seg->bx) + reach) - plane->x0, plane->width - 1);
+  const int y_first = MAX((int)floor(MIN(seg->ay, seg->by) - reach) - plane->y0, 0);
+  const int y_last = MIN((int)ceil(MAX(seg->ay, seg->by) + reach) - plane->y0, plane->height - 1);
   if(x_first > x_last || y_first > y_last) return;
 
   for(int y = y_first; y <= y_last; y++)
   {
-    const double py = (double)(y + plane->y0) + 0.5;
-    float *const row = plane->value + (size_t)y * plane->width;
-    gboolean wrote = FALSE;
-    for(int x = x_first; x <= x_last; x++)
+    if(!_plane_stamp_row(plane, y, x_first, x_last, seg, reach2)) continue;
+    plane->span_min[y] = MIN(plane->span_min[y], x_first);
+    plane->span_max[y] = MAX(plane->span_max[y], x_last);
+  }
+}
+
+/* ---------------------------------------------------------------------------------------------
+ * The walk along a polyline: dashes cut by arc length, capsules stamped. */
+
+/* Where the walk is in the dash pattern. */
+typedef struct _dash_t
+{
+  gboolean on;          /* inside a dash rather than a gap */
+  double left;          /* what remains of the current dash or gap */
+  gboolean fresh;       /* the current dash started at a cut, not at the line's start */
+} _dash_t;
+
+/* The dashed pieces of one segment. A piece that starts at a cut, or ends at one, gets the
+ * cap style's end there; one that continues from or into the neighbouring segment is a join,
+ * always capped so the two halves meet round. */
+static void _plane_stamp_dashed(_plane_t *const plane, const _segment_t *const seg, const dt_stroke_style_t *style,
+                                const double reach, _dash_t *const dash)
+{
+  const double length = hypot(seg->bx - seg->ax, seg->by - seg->ay);
+  const gboolean caps = style->round_caps;
+  double pos = 0.0;
+  gboolean piece_starts_at_cut = dash->fresh;   /* the line's own start counts as a cut */
+  while(pos < length)
+  {
+    const double run = MIN(dash->left, length - pos);
+    const double end = pos + run;
+    if(dash->on)
     {
-      const double px = (double)(x + plane->x0) + 0.5;
-      double t = (len2 > 0.0) ? ((px - ax) * dx + (py - ay) * dy) / len2 : 0.0;
-      if(t < 0.0)
-      {
-        if(!cap_a) continue;
-        t = 0.0;
-      }
-      else if(t > 1.0)
-      {
-        if(!cap_b) continue;
-        t = 1.0;
-      }
-      const double ex = ax + t * dx - px;
-      const double ey = ay + t * dy - py;
-      const double d2 = ex * ex + ey * ey;
-      if(d2 >= reach2) continue;
-      const float inside = (float)(reach2 - d2);
-      if(inside > row[x])
-      {
-        row[x] = inside;
-        wrote = TRUE;
-      }
+      const double t0 = pos / length;
+      const double t1 = end / length;
+      const gboolean ends_at_cut = (end < length) || seg->cap_b == FALSE;
+      const _segment_t piece = { .ax = seg->ax + t0 * (seg->bx - seg->ax),
+                                 .ay = seg->ay + t0 * (seg->by - seg->ay),
+                                 .bx = seg->ax + t1 * (seg->bx - seg->ax),
+                                 .by = seg->ay + t1 * (seg->by - seg->ay),
+                                 .cap_a = caps || !(piece_starts_at_cut || (pos == 0.0 && !seg->cap_a)),
+                                 .cap_b = caps || !ends_at_cut };
+      _plane_stamp_capsule(plane, &piece, reach);
     }
-    if(wrote)
+    dash->left -= run;
+    pos = end;
+    if(dash->left <= 0.0)
     {
-      plane->span_min[y] = MIN(plane->span_min[y], x_first);
-      plane->span_max[y] = MAX(plane->span_max[y], x_last);
+      dash->on = !dash->on;
+      dash->left = dash->on ? style->dash_on : style->dash_off;
+      piece_starts_at_cut = TRUE;
     }
+    else
+      piece_starts_at_cut = FALSE;
+  }
+  /* the next segment continues whatever this one was in, unless a cut fell exactly at its end */
+  dash->fresh = piece_starts_at_cut;
+}
+
+static void _polyline_stamp(_plane_t *const plane, const double *xy, const int count, const dt_stroke_style_t *style,
+                            const double reach, const gboolean closed)
+{
+  const gboolean caps = style->round_caps;
+  if(count == 1)
+  {
+    if(!caps) return;
+    const _segment_t dot = { xy[0], xy[1], xy[0], xy[1], TRUE, TRUE };
+    _plane_stamp_capsule(plane, &dot, reach);
+    return;
+  }
+  const gboolean dashed = style->dash_on > 0.0 && style->dash_off > 0.0;
+  _dash_t dash = { .on = TRUE, .left = style->dash_on, .fresh = TRUE };
+  const int last = count - 1;
+  for(int i = 0; i < last; i++)
+  {
+    /* the polyline's own two ends take the cap style; a closed one has none */
+    const gboolean starts_line = (i == 0) && !closed;
+    const gboolean ends_line = (i == last - 1) && !closed;
+    const _segment_t seg = { .ax = xy[2 * i],
+                             .ay = xy[2 * i + 1],
+                             .bx = xy[2 * i + 2],
+                             .by = xy[2 * i + 3],
+                             .cap_a = caps || !starts_line,
+                             .cap_b = caps || !ends_line };
+    if(dashed)
+      _plane_stamp_dashed(plane, &seg, style, reach, &dash);
+    else
+      _plane_stamp_capsule(plane, &seg, reach);
   }
 }
 
@@ -242,6 +368,19 @@ static inline void _plane_stamp_capsule(_plane_t *const plane, const double ax, 
  * alpha. The dark pass goes first and the bright pass over it, each with coverage
  * clamp(R + 1/2 - d, 0, 1) for its own half-width R -- the one-pixel ramp of a fast antialiased
  * cairo stroke. A pass with alpha or width at zero contributes nothing. */
+typedef struct _composite_t
+{
+  const dt_stroke_pass_t *dark;     /* NULL when the pass contributes nothing */
+  const dt_stroke_pass_t *bright;
+  double reach2;
+  double half_dark;
+  double half_bright;
+  uint8_t *data;
+  int stride;
+  int surface_width;
+  int surface_height;
+} _composite_t;
+
 static inline uint32_t _pixel_pack(const double a, const double r, const double g, const double b)
 {
   const uint32_t ia = (uint32_t)(a * 255.0 + 0.5);
@@ -264,133 +403,74 @@ static inline void _pixel_over(uint32_t *const pixel, const dt_stroke_pass_t *co
   *pixel = _pixel_pack(MIN(a, 1.0), MIN(r, 1.0), MIN(g, 1.0), MIN(b, 1.0));
 }
 
-static void _plane_composite_and_clear(_plane_t *const plane, cairo_surface_t *surface, const dt_stroke_style_t *style,
-                                       const double reach, cairo_rectangle_int_t *touched)
+/* One row's span: composite what was stamped, and widen the touched range [tx0, tx1) to it.
+ * Returns whether any pixel was painted. */
+static inline gboolean _composite_row(const _plane_t *const plane, const int y, const _composite_t *const c,
+                                      int *const tx0, int *const tx1)
 {
-  const double reach2 = reach * reach;
-  const double half_dark = 0.5 * style->dark.width;
-  const double half_bright = 0.5 * style->bright.width;
+  const int sy = y + plane->y0;
+  if(sy < 0 || sy >= c->surface_height) return FALSE;
+  const float *const row = plane->value + (size_t)y * plane->width;
+  uint32_t *const pixels = (uint32_t *)(c->data + (size_t)sy * c->stride);
+  gboolean painted = FALSE;
+  for(int x = plane->span_min[y]; x <= plane->span_max[y]; x++)
+  {
+    const float inside = row[x];
+    if(inside <= 0.0f) continue;
+    const int sx = x + plane->x0;
+    if(sx < 0 || sx >= c->surface_width) continue;
+    const double d = sqrt(MAX(c->reach2 - (double)inside, 0.0));
+    if(c->dark) _pixel_over(&pixels[sx], c->dark, CLAMP(c->half_dark + 0.5 - d, 0.0, 1.0));
+    if(c->bright) _pixel_over(&pixels[sx], c->bright, CLAMP(c->half_bright + 0.5 - d, 0.0, 1.0));
+    *tx0 = MIN(*tx0, sx);
+    *tx1 = MAX(*tx1, sx + 1);
+    painted = TRUE;
+  }
+  return painted;
+}
+
+static void _plane_composite_and_clear(_plane_t *const plane, cairo_surface_t *surface, const dt_stroke_style_t *style,
+                                       const double reach)
+{
+  cairo_surface_flush(surface);
   const gboolean with_dark = style->dark.width > 0.0 && style->dark.alpha > 0.0;
   const gboolean with_bright = style->bright.width > 0.0 && style->bright.alpha > 0.0;
-
-  cairo_surface_flush(surface);
-  uint8_t *const data = cairo_image_surface_get_data(surface);
-  const int stride = cairo_image_surface_get_stride(surface);
-  const int surface_width = cairo_image_surface_get_width(surface);
-  const int surface_height = cairo_image_surface_get_height(surface);
+  const _composite_t c = { .dark = with_dark ? &style->dark : NULL,
+                           .bright = with_bright ? &style->bright : NULL,
+                           .reach2 = reach * reach,
+                           .half_dark = 0.5 * style->dark.width,
+                           .half_bright = 0.5 * style->bright.width,
+                           .data = cairo_image_surface_get_data(surface),
+                           .stride = cairo_image_surface_get_stride(surface),
+                           .surface_width = cairo_image_surface_get_width(surface),
+                           .surface_height = cairo_image_surface_get_height(surface) };
 
   int tx0 = INT_MAX;
-  int ty0 = INT_MAX;
   int tx1 = -1;
+  int ty0 = INT_MAX;
   int ty1 = -1;
   for(int y = 0; y < plane->height; y++)
   {
     if(plane->span_max[y] < plane->span_min[y]) continue;
-    const int sy = y + plane->y0;
-    float *const row = plane->value + (size_t)y * plane->width;
-    if(sy >= 0 && sy < surface_height)
+    if(_composite_row(plane, y, &c, &tx0, &tx1))
     {
-      uint32_t *const pixels = (uint32_t *)(data + (size_t)sy * stride);
-      for(int x = plane->span_min[y]; x <= plane->span_max[y]; x++)
-      {
-        const float inside = row[x];
-        if(inside <= 0.0f) continue;
-        const int sx = x + plane->x0;
-        if(sx < 0 || sx >= surface_width) continue;
-        const double d = sqrt(MAX(reach2 - (double)inside, 0.0));
-        if(with_dark) _pixel_over(&pixels[sx], &style->dark, CLAMP(half_dark + 0.5 - d, 0.0, 1.0));
-        if(with_bright) _pixel_over(&pixels[sx], &style->bright, CLAMP(half_bright + 0.5 - d, 0.0, 1.0));
-        tx0 = MIN(tx0, sx);
-        tx1 = MAX(tx1, sx);
-        ty0 = MIN(ty0, sy);
-        ty1 = MAX(ty1, sy);
-      }
+      ty0 = MIN(ty0, y + plane->y0);
+      ty1 = MAX(ty1, y + plane->y0 + 1);
     }
     /* back to rest: only what was written */
-    memset(row + plane->span_min[y], 0, sizeof(float) * (size_t)(plane->span_max[y] - plane->span_min[y] + 1));
+    memset(plane->value + (size_t)y * plane->width + plane->span_min[y], 0,
+           sizeof(float) * (size_t)(plane->span_max[y] - plane->span_min[y] + 1));
   }
 
-  if(tx1 >= tx0 && ty1 >= ty0)
+  if(tx1 > tx0 && ty1 > ty0)
   {
-    cairo_surface_mark_dirty_rectangle(surface, tx0, ty0, tx1 - tx0 + 1, ty1 - ty0 + 1);
-    _touched_add(surface, tx0, ty0, tx1 + 1, ty1 + 1);
-    if(touched)
-    {
-      touched->x = tx0;
-      touched->y = ty0;
-      touched->width = tx1 - tx0 + 1;
-      touched->height = ty1 - ty0 + 1;
-    }
+    cairo_surface_mark_dirty_rectangle(surface, tx0, ty0, tx1 - tx0, ty1 - ty0);
+    _touched_add(surface, tx0, ty0, tx1, ty1);
   }
 }
 
 /* ---------------------------------------------------------------------------------------------
- * The walk along a polyline: dashes cut by arc length, capsules stamped. */
-typedef struct _dash_state_t
-{
-  gboolean on;        /* inside a dash rather than a gap */
-  double left;        /* what remains of the current dash or gap */
-} _dash_state_t;
-
-static void _polyline_stamp(_plane_t *const plane, const double *xy, const int count, const dt_stroke_style_t *style,
-                            const double reach, const gboolean closed)
-{
-  const gboolean dashed = style->dash_on > 0.0 && style->dash_off > 0.0;
-  _dash_state_t dash = { .on = TRUE, .left = dashed ? style->dash_on : DBL_MAX };
-  /* The ends of the polyline: round when asked, flat otherwise; a closed polyline has none.
-   * Every other piece end is a join or a dash cut inside the line, always capped so the joins
-   * between consecutive segments are round and seamless. */
-  const gboolean caps = style->round_caps;
-  const int last = count - 1;
-  /* a dash cut is a piece end; whether it is capped follows the cap style */
-  for(int i = 0; i < last; i++)
-  {
-    const double ax = xy[2 * i];
-    const double ay = xy[2 * i + 1];
-    const double bx = xy[2 * i + 2];
-    const double by = xy[2 * i + 3];
-    const double length = hypot(bx - ax, by - ay);
-    const gboolean starts_line = (i == 0) && !closed;
-    const gboolean ends_line = (i == last - 1) && !closed;
-
-    if(!dashed)
-    {
-      _plane_stamp_capsule(plane, ax, ay, bx, by, reach, caps || !starts_line, caps || !ends_line);
-      continue;
-    }
-
-    double pos = 0.0;
-    gboolean piece_begins_here = starts_line;   /* the current on-piece started at the line's start */
-    while(pos < length)
-    {
-      const double run = MIN(dash.left, length - pos);
-      const double end = pos + run;
-      if(dash.on)
-      {
-        const double t0 = pos / length;
-        const double t1 = end / length;
-        const gboolean piece_starts = (pos == 0.0) ? piece_begins_here : TRUE;   /* a cut: a dash start */
-        const gboolean piece_ends_at_cut = (end < length) || (ends_line && end >= length);
-        const gboolean cap_a = caps || !(piece_starts);
-        const gboolean cap_b = caps || !piece_ends_at_cut;
-        _plane_stamp_capsule(plane, ax + t0 * (bx - ax), ay + t0 * (by - ay), ax + t1 * (bx - ax),
-                             ay + t1 * (by - ay), reach, cap_a, cap_b);
-      }
-      dash.left -= run;
-      pos = end;
-      if(dash.left <= 0.0)
-      {
-        dash.on = !dash.on;
-        dash.left = dash.on ? style->dash_on : style->dash_off;
-        piece_begins_here = TRUE;
-      }
-      else
-        piece_begins_here = FALSE;
-    }
-  }
-  if(count == 1 && caps)
-    _plane_stamp_capsule(plane, xy[0], xy[1], xy[0], xy[1], reach, TRUE, TRUE);   /* a dot */
-}
+ * A polyline, and a path's worth of them. */
 
 static gboolean _stroke_polyline(cairo_surface_t *surface, const double *xy, const int count,
                                  const dt_stroke_style_t *style, const gboolean closed)
@@ -422,16 +502,11 @@ static gboolean _stroke_polyline(cairo_surface_t *surface, const double *xy, con
   const int y1 = MIN((int)ceil(y_max + reach) + 1, surface_height - 1);
   if(x1 < x0 || y1 < y0) return FALSE;   /* entirely off the surface */
 
-  g_mutex_lock(&_scratch_lock);
   _plane_t plane;
-  gboolean ok = _plane_acquire(&plane, x0, y0, x1 - x0 + 1, y1 - y0 + 1);
-  if(ok)
-  {
-    _polyline_stamp(&plane, xy, count, style, reach, closed);
-    _plane_composite_and_clear(&plane, surface, style, reach, NULL);
-  }
-  g_mutex_unlock(&_scratch_lock);
-  return ok;
+  if(!_plane_acquire(surface, &plane, x0, y0, x1 - x0 + 1, y1 - y0 + 1)) return FALSE;
+  _polyline_stamp(&plane, xy, count, style, reach, closed);
+  _plane_composite_and_clear(&plane, surface, style, reach);
+  return TRUE;
 }
 
 gboolean dt_stroke_raster_polyline(cairo_surface_t *surface, const double *xy, int count,
@@ -440,9 +515,6 @@ gboolean dt_stroke_raster_polyline(cairo_surface_t *surface, const double *xy, i
   if(!dt_stroke_raster_can_paint(surface) || !xy || !style || count < 1) return FALSE;
   return _stroke_polyline(surface, xy, count, style, FALSE);
 }
-
-/* ---------------------------------------------------------------------------------------------
- * From a cairo path. */
 
 /* How much cr's matrix scales a length, taken as the geometric mean of the two axes so an
  * anisotropic matrix -- which no overlay has -- degrades gracefully. */
@@ -458,6 +530,42 @@ static double _matrix_scale(cairo_t *cr)
   return isfinite(scale) ? scale : 1.0;
 }
 
+/* The polyline being gathered from a path: its vertices in surface pixels, and its first one
+ * for a close. */
+typedef struct _gather_t
+{
+  GArray *vertices;
+  double first_x;
+  double first_y;
+  gboolean closed;
+  double offset_x;   /* the surface's device offset: pixel = device + offset */
+  double offset_y;
+} _gather_t;
+
+static void _gather_flush(_gather_t *const g, cairo_surface_t *surface, const dt_stroke_style_t *style)
+{
+  if(g->vertices->len >= 2)
+    _stroke_polyline(surface, (const double *)g->vertices->data, (int)(g->vertices->len / 2), style, g->closed);
+  g_array_set_size(g->vertices, 0);
+  g->closed = FALSE;
+}
+
+static void _gather_point(_gather_t *const g, cairo_t *cr, const cairo_path_data_t *const point)
+{
+  double x = point->point.x;
+  double y = point->point.y;
+  cairo_user_to_device(cr, &x, &y);
+  x += g->offset_x;
+  y += g->offset_y;
+  if(g->vertices->len == 0)
+  {
+    g->first_x = x;
+    g->first_y = y;
+  }
+  g_array_append_val(g->vertices, x);
+  g_array_append_val(g->vertices, y);
+}
+
 gboolean dt_stroke_raster_path(cairo_t *cr, const dt_stroke_style_t *style)
 {
   if(!cr || !style) return FALSE;
@@ -471,12 +579,6 @@ gboolean dt_stroke_raster_path(cairo_t *cr, const dt_stroke_style_t *style)
     return FALSE;
   }
 
-  /* the surface's pixel grid is device space shifted by the surface's device offset: for the
-   * group cairo pushed, that is the clip's origin */
-  double offset_x = 0.0;
-  double offset_y = 0.0;
-  cairo_surface_get_device_offset(surface, &offset_x, &offset_y);
-
   const double scale = _matrix_scale(cr);
   dt_stroke_style_t device_style = *style;
   device_style.dark.width *= scale;
@@ -484,58 +586,38 @@ gboolean dt_stroke_raster_path(cairo_t *cr, const dt_stroke_style_t *style)
   device_style.dash_on *= scale;
   device_style.dash_off *= scale;
 
-  GArray *vertices = g_array_sized_new(FALSE, FALSE, sizeof(double), 2 * 1024);
-  gboolean closed = FALSE;
-  double first_x = 0.0;
-  double first_y = 0.0;
+  /* the surface's pixel grid is device space shifted by the surface's device offset: for the
+   * group cairo pushed, that is the clip's origin */
+  _gather_t gather = { .vertices = g_array_sized_new(FALSE, FALSE, sizeof(double), 2 * 1024) };
+  cairo_surface_get_device_offset(surface, &gather.offset_x, &gather.offset_y);
+
   for(int i = 0; i < path->num_data; i += path->data[i].header.length)
   {
     const cairo_path_data_t *const element = &path->data[i];
-    const cairo_path_data_type_t type = element->header.type;
-    if(type == CAIRO_PATH_MOVE_TO)
-    {
-      /* a move ends the polyline before it and starts the next one at its point */
-      if(vertices->len >= 2)
-        _stroke_polyline(surface, (const double *)vertices->data, (int)(vertices->len / 2), &device_style, closed);
-      g_array_set_size(vertices, 0);
-      closed = FALSE;
-    }
-    switch(type)
+    switch(element->header.type)
     {
       case CAIRO_PATH_MOVE_TO:
+        _gather_flush(&gather, surface, &device_style);
+        _gather_point(&gather, cr, &element[1]);
+        break;
       case CAIRO_PATH_LINE_TO:
-      {
-        double x = element[1].point.x;
-        double y = element[1].point.y;
-        cairo_user_to_device(cr, &x, &y);
-        x += offset_x;
-        y += offset_y;
-        if(vertices->len == 0)
-        {
-          first_x = x;
-          first_y = y;
-        }
-        g_array_append_val(vertices, x);
-        g_array_append_val(vertices, y);
+        _gather_point(&gather, cr, &element[1]);
         break;
-      }
       case CAIRO_PATH_CLOSE_PATH:
-        if(vertices->len >= 2)
+        if(gather.vertices->len >= 2)
         {
-          g_array_append_val(vertices, first_x);
-          g_array_append_val(vertices, first_y);
-          closed = TRUE;
+          g_array_append_val(gather.vertices, gather.first_x);
+          g_array_append_val(gather.vertices, gather.first_y);
+          gather.closed = TRUE;
         }
         break;
-      case CAIRO_PATH_CURVE_TO:
       default:
         break;   /* a flattened path has no curves */
     }
   }
-  if(vertices->len >= 2)
-    _stroke_polyline(surface, (const double *)vertices->data, (int)(vertices->len / 2), &device_style, closed);
+  _gather_flush(&gather, surface, &device_style);
 
-  g_array_free(vertices, TRUE);
+  g_array_free(gather.vertices, TRUE);
   cairo_path_destroy(path);
   cairo_new_path(cr);
   return TRUE;

--- a/src/widgets/stroke_raster.h
+++ b/src/widgets/stroke_raster.h
@@ -1,0 +1,104 @@
+/*
+    This file is part of Ansel,
+    Copyright (C) 2026 Aurélien PIERRE.
+
+    Ansel is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Ansel is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Ansel.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef DT_WIDGETS_STROKE_RASTER_H
+#define DT_WIDGETS_STROKE_RASTER_H
+
+/* A stroke rasteriser for GUI overlays.
+ *
+ * An overlay line -- a mask's outline, its feather border -- arrives as a polyline already
+ * sampled at the resolution it is shown at: one vertex per device pixel or so. Handing that to
+ * cairo means turning pixels back into a vector path and asking a general-purpose stroker to
+ * tessellate and rasterise it, twice per line (a wide dark pass under a narrow bright one). What
+ * the overlays actually use of a stroker is small and fixed: two widths, two colours with alpha,
+ * two dash patterns, round or butt caps, and a one-pixel antialiasing ramp. This is that, and
+ * nothing more, painting straight into the ARGB32 pixels of the surface the overlay is drawn on.
+ *
+ * It knows nothing about masks, nodes or handles. Everything drawn with a cairo primitive that
+ * is NOT a long polyline -- discs, arcs, arrows, the CLEAR-operator punch under a node -- stays
+ * with cairo, on the same surface, before or after these strokes as the caller likes.
+ *
+ * The coverage model is a distance field: for every pixel within reach of a polyline, the
+ * distance to the nearest point of it (a union of capsules, one per segment, so joins and caps
+ * come out round with no seams). Coverage of a pass of half-width R is clamp(R + 1/2 - d, 0, 1),
+ * the same one-pixel ramp CAIRO_ANTIALIAS_FAST draws. Dashes are cut along the polyline's arc
+ * length before the capsules are stamped, so a dash end is a round cap exactly as cairo's
+ * CAIRO_LINE_CAP_ROUND makes it. Compositing is premultiplied OVER, dark pass then bright pass,
+ * which is what the two cairo_stroke() calls it replaces composed. */
+
+#include <cairo.h>
+#include <glib.h>
+
+G_BEGIN_DECLS
+
+/** One pass of a stroke: a width and a straight (not premultiplied) colour with alpha. */
+typedef struct dt_stroke_pass_t
+{
+  double width;
+  double red;
+  double green;
+  double blue;
+  double alpha;
+} dt_stroke_pass_t;
+
+/** How a polyline is stroked. Widths and dash lengths are in whatever space the entry point
+ * says: device pixels for dt_stroke_raster_polyline(), user units for dt_stroke_raster_path(). */
+typedef struct dt_stroke_style_t
+{
+  dt_stroke_pass_t dark;     /**< painted first, the wider of the two */
+  dt_stroke_pass_t bright;   /**< painted over it; width <= 0 means no second pass */
+  double dash_on;            /**< length of a dash; <= 0 means solid */
+  double dash_off;           /**< length of the gap after a dash */
+  gboolean round_caps;       /**< round ends on the polyline and on every dash; else flat ends */
+} dt_stroke_style_t;
+
+/** Is @p surface something this rasteriser can paint into: an ARGB32 image surface. */
+gboolean dt_stroke_raster_can_paint(cairo_surface_t *surface);
+
+/** Stroke @p count device-space vertices (x, y pairs, in the pixel grid of @p surface) as one
+ * open polyline into @p surface. The style's widths and dashes are device pixels. Returns FALSE,
+ * having painted nothing, when the surface is not one this can paint into (see
+ * dt_stroke_raster_can_paint()) or when there is nothing to draw. */
+gboolean dt_stroke_raster_polyline(cairo_surface_t *surface, const double *xy, int count,
+                                   const dt_stroke_style_t *style);
+
+/** Stroke the current path of @p cr with @p style, then consume the path, as a pair of
+ * cairo_stroke() calls would. The path is flattened and mapped through cr's matrix into the
+ * pixels of the surface cr is drawing on -- the current group's, if one is pushed -- and the
+ * style's widths and dashes, given in USER units as the cairo calls receive them, are mapped
+ * through the same matrix. Returns FALSE, leaving the path in place, when that surface is not
+ * one this can paint into; the caller then strokes it with cairo instead. */
+gboolean dt_stroke_raster_path(cairo_t *cr, const dt_stroke_style_t *style);
+
+/** The pixel rectangle everything painted into @p surface through this file has touched since
+ * the last reset, so a caller can composite or clear that much and no more. Returns FALSE when
+ * nothing was painted. */
+gboolean dt_stroke_raster_touched(cairo_surface_t *surface, cairo_rectangle_int_t *touched);
+
+/** Forget the touched rectangle of @p surface. */
+void dt_stroke_raster_touched_reset(cairo_surface_t *surface);
+
+G_END_DECLS
+
+#endif // DT_WIDGETS_STROKE_RASTER_H
+
+// clang-format off
+// modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py
+// vim: shiftwidth=2 expandtab tabstop=2 cindent
+// kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;
+// clang-format on

--- a/tests/masks/masks_geometry.c
+++ b/tests/masks/masks_geometry.c
@@ -1341,6 +1341,42 @@ static void _time_overlay_form(dt_develop_t *dev, dt_masks_form_t *form, const c
       cairo_surface_write_to_png(surface, png);
       g_free(png);
     }
+
+    /* A frame must leave nothing behind. Draw once more at a PANNED transform, then compare
+     * with the same frame drawn onto a fresh surface after a rebuild: anything the selected
+     * frame left in the canvas -- a handle painted outside the rectangle it composited and
+     * cleared -- would land in the panned frame as pixels the fresh one does not have. */
+    const dt_masks_overlay_transform_t panned
+        = { .scale = scale, .offset_x = transform.offset_x + 97.0, .offset_y = transform.offset_y - 61.0 };
+    cairo_surface_t *fresh = cairo_image_surface_create(CAIRO_FORMAT_ARGB32, OVERLAY_SCREEN_W, OVERLAY_SCREEN_H);
+    cairo_t *cr_panned = cairo_create(surface);
+    cairo_set_source_rgb(cr_panned, 0.12, 0.12, 0.12);
+    cairo_paint(cr_panned);
+    dt_masks_events_post_expose_with(dev, NULL, cr_panned, OVERLAY_SCREEN_W, OVERLAY_SCREEN_H, -1, -1, &panned);
+    cairo_destroy(cr_panned);
+    dev->form_gui->formid = 0;
+    dev->form_gui->geometry_generation = 0;
+    cairo_t *cr_fresh = cairo_create(fresh);
+    cairo_set_source_rgb(cr_fresh, 0.12, 0.12, 0.12);
+    cairo_paint(cr_fresh);
+    dt_masks_events_post_expose_with(dev, NULL, cr_fresh, OVERLAY_SCREEN_W, OVERLAY_SCREEN_H, -1, -1, &panned);
+    cairo_destroy(cr_fresh);
+    cairo_surface_flush(surface);
+    cairo_surface_flush(fresh);
+    const uint32_t *pa = (const uint32_t *)cairo_image_surface_get_data(surface);
+    const uint32_t *pb = (const uint32_t *)cairo_image_surface_get_data(fresh);
+    const int stride = cairo_image_surface_get_stride(surface) / 4;
+    long leftovers = 0;
+    for(int y = 0; y < OVERLAY_SCREEN_H; y++)
+      for(int x = 0; x < OVERLAY_SCREEN_W; x++)
+        if(pa[y * stride + x] != pb[y * stride + x]) leftovers++;
+    cairo_surface_destroy(fresh);
+    if(leftovers > 0)
+    {
+      printf("[FAIL] %-26s %-8s left %ld pixel(s) behind for the next, panned frame\n", name,
+             selected ? "selected" : "member", leftovers);
+      failures++;
+    }
   }
   cairo_surface_destroy(surface);
 }

--- a/tests/masks/masks_geometry.c
+++ b/tests/masks/masks_geometry.c
@@ -1267,6 +1267,94 @@ static void _run_case(dt_develop_t *dev, dt_masks_form_t *form, const char *name
 #define OVERLAY_SCREEN_W 2560
 #define OVERLAY_SCREEN_H 1440
 
+/* How much of an outline's border the boundary pass skipped: the sample count and the number
+ * of ranges. */
+static void _overlay_skipped(const dt_masks_form_gui_points_t *const gp, int *skipped, int *ranges)
+{
+  *skipped = 0;
+  *ranges = gp->border_skip_count;
+  for(int k = 0; k < gp->border_skip_count; k++)
+    *skipped += gp->border_skips[k].resume_at - gp->border_skips[k].jump_from;
+}
+
+/* The range that skips border sample @p i, or -1. */
+static int _overlay_skip_of(const dt_masks_form_gui_points_t *const gp, const int i)
+{
+  for(int k = 0; k < gp->border_skip_count; k++)
+    if(i >= gp->border_skips[k].jump_from && i < gp->border_skips[k].resume_at) return k;
+  return -1;
+}
+
+/* MASKS_DUMP_SKIPS=<dir>: every border sample of the selected state, raw coordinates, with the
+ * range that skips it and its spine point, as <dir>/<case>-border.txt; and every range on
+ * stdout with its ends on screen. This is what let the missing dashes be measured on the
+ * renders instead of judged by eye. */
+static void _overlay_dump_skips(const dt_masks_form_gui_points_t *const gp, const char *name,
+                                const dt_masks_overlay_transform_t *const transform)
+{
+  const char *dump_dir = g_getenv("MASKS_DUMP_SKIPS");
+  if(IS_NULL_PTR(dump_dir)) return;
+  const int border = gp->border_count;
+  char *path = g_strdup_printf("%s/%s-border.txt", dump_dir, name);
+  FILE *f = g_fopen(path, "w");
+  if(!IS_NULL_PTR(f))
+  {
+    for(int i = 0; i < border; i++)
+      fprintf(f, "%d %.2f %.2f %d %.2f %.2f\n", i, gp->border[2 * i], gp->border[2 * i + 1], _overlay_skip_of(gp, i),
+              gp->points[2 * i], gp->points[2 * i + 1]);
+    fclose(f);
+  }
+  g_free(path);
+  for(int k = 0; k < gp->border_skip_count; k++)
+  {
+    const int a = gp->border_skips[k].jump_from;
+    const int b = MIN(gp->border_skips[k].resume_at, border - 1);
+    printf("  skip %2d: [%6d, %6d) %6d samples  from (%.0f, %.0f) to (%.0f, %.0f) on screen\n", k, a,
+           gp->border_skips[k].resume_at, gp->border_skips[k].resume_at - a,
+           gp->border[2 * a] * transform->scale + transform->offset_x,
+           gp->border[2 * a + 1] * transform->scale + transform->offset_y,
+           gp->border[2 * b] * transform->scale + transform->offset_x,
+           gp->border[2 * b + 1] * transform->scale + transform->offset_y);
+  }
+}
+
+/* Paint the background and draw one overlay frame at @p transform. */
+static void _overlay_frame(dt_develop_t *dev, cairo_surface_t *surface, const dt_masks_overlay_transform_t *const transform)
+{
+  cairo_t *cr = cairo_create(surface);
+  cairo_set_source_rgb(cr, 0.12, 0.12, 0.12);
+  cairo_paint(cr);
+  dt_masks_events_post_expose_with(dev, NULL, cr, OVERLAY_SCREEN_W, OVERLAY_SCREEN_H, -1, -1, transform);
+  cairo_destroy(cr);
+}
+
+/* A frame must leave nothing behind. Draw once more at a PANNED transform, then compare with
+ * the same frame drawn onto a fresh surface after a rebuild: anything the frame left in the
+ * canvas -- a handle painted outside the rectangle it composited and cleared -- lands in the
+ * panned frame as pixels the fresh one does not have. Returns how many. */
+static long _overlay_leftovers(dt_develop_t *dev, cairo_surface_t *surface,
+                               const dt_masks_overlay_transform_t *const transform)
+{
+  const dt_masks_overlay_transform_t panned
+      = { .scale = transform->scale, .offset_x = transform->offset_x + 97.0, .offset_y = transform->offset_y - 61.0 };
+  _overlay_frame(dev, surface, &panned);
+  cairo_surface_t *fresh = cairo_image_surface_create(CAIRO_FORMAT_ARGB32, OVERLAY_SCREEN_W, OVERLAY_SCREEN_H);
+  dev->form_gui->formid = 0;
+  dev->form_gui->geometry_generation = 0;
+  _overlay_frame(dev, fresh, &panned);
+  cairo_surface_flush(surface);
+  cairo_surface_flush(fresh);
+  const uint32_t *pa = (const uint32_t *)cairo_image_surface_get_data(surface);
+  const uint32_t *pb = (const uint32_t *)cairo_image_surface_get_data(fresh);
+  const int stride = cairo_image_surface_get_stride(surface) / 4;
+  long leftovers = 0;
+  for(int y = 0; y < OVERLAY_SCREEN_H; y++)
+    for(int x = 0; x < OVERLAY_SCREEN_W; x++)
+      if(pa[y * stride + x] != pb[y * stride + x]) leftovers++;
+  cairo_surface_destroy(fresh);
+  return leftovers;
+}
+
 static void _time_overlay_form(dt_develop_t *dev, dt_masks_form_t *form, const char *name, const char *dir,
                                const int img_w, const int img_h, const int frames)
 {
@@ -1302,24 +1390,15 @@ static void _time_overlay_form(dt_develop_t *dev, dt_masks_form_t *form, const c
     dev->form_gui->group_selected = selected ? 0 : -1;
     dev->form_gui->form_selected = FALSE;
 
-    cairo_t *cr = cairo_create(surface);
-    cairo_set_source_rgb(cr, 0.12, 0.12, 0.12);
-    cairo_paint(cr);
     /* the first frame builds the outline, which the darkroom also does once per edit; it is
      * not the per-frame cost and is timed apart */
     const double build_start = dt_get_wtime();
-    dt_masks_events_post_expose_with(dev, NULL, cr, OVERLAY_SCREEN_W, OVERLAY_SCREEN_H, -1, -1, &transform);
+    _overlay_frame(dev, surface, &transform);
     const double build_ms = 1000.0 * (dt_get_wtime() - build_start);
 
     const double start = dt_get_wtime();
-    for(int f = 0; f < frames; f++)
-    {
-      cairo_set_source_rgb(cr, 0.12, 0.12, 0.12);
-      cairo_paint(cr);
-      dt_masks_events_post_expose_with(dev, NULL, cr, OVERLAY_SCREEN_W, OVERLAY_SCREEN_H, -1, -1, &transform);
-    }
+    for(int f = 0; f < frames; f++) _overlay_frame(dev, surface, &transform);
     const double per_frame_ms = 1000.0 * (dt_get_wtime() - start) / MAX(frames, 1);
-    cairo_destroy(cr);
 
     int points = 0;
     int border = 0;
@@ -1331,39 +1410,8 @@ static void _time_overlay_form(dt_develop_t *dev, dt_masks_form_t *form, const c
     {
       points = gp->points_count;
       border = gp->border_count;
-      skip_ranges = gp->border_skip_count;
-      for(int k = 0; k < gp->border_skip_count; k++)
-        skipped += gp->border_skips[k].resume_at - gp->border_skips[k].jump_from;
-      if(!IS_NULL_PTR(g_getenv("MASKS_DUMP_SKIPS")) && selected)
-      {
-        /* every border sample, raw coordinates, with the range that skips it or -1 */
-        char *path = g_strdup_printf("%s/%s-border.txt", g_getenv("MASKS_DUMP_SKIPS"), name);
-        FILE *f = g_fopen(path, "w");
-        if(f)
-        {
-          for(int i = 0; i < border; i++)
-          {
-            int in = -1;
-            for(int k = 0; k < gp->border_skip_count; k++)
-              if(i >= gp->border_skips[k].jump_from && i < gp->border_skips[k].resume_at) in = k;
-            fprintf(f, "%d %.2f %.2f %d %.2f %.2f\n", i, gp->border[2 * i], gp->border[2 * i + 1], in,
-                    gp->points[2 * i], gp->points[2 * i + 1]);
-          }
-          fclose(f);
-        }
-        g_free(path);
-      }
-      if(!IS_NULL_PTR(g_getenv("MASKS_DUMP_SKIPS")) && selected)
-        for(int k = 0; k < gp->border_skip_count; k++)
-        {
-          const int a = gp->border_skips[k].jump_from;
-          const int b = gp->border_skips[k].resume_at;
-          printf("  skip %2d: [%6d, %6d) %6d samples  from (%.0f, %.0f) to (%.0f, %.0f) on screen\n", k, a, b, b - a,
-                 gp->border[2 * a] * transform.scale + transform.offset_x,
-                 gp->border[2 * a + 1] * transform.scale + transform.offset_y,
-                 gp->border[2 * MIN(b, border - 1)] * transform.scale + transform.offset_x,
-                 gp->border[2 * MIN(b, border - 1) + 1] * transform.scale + transform.offset_y);
-        }
+      _overlay_skipped(gp, &skipped, &skip_ranges);
+      if(selected) _overlay_dump_skips(gp, name, &transform);
     }
     printf("[TIME] %-26s %5dx%-4d %-8s %7.2f ms/frame  (first frame incl. build %7.2f ms;"
            " %d outline samples, %d border samples, %d skipped in %d ranges)\n",
@@ -1378,35 +1426,7 @@ static void _time_overlay_form(dt_develop_t *dev, dt_masks_form_t *form, const c
       g_free(png);
     }
 
-    /* A frame must leave nothing behind. Draw once more at a PANNED transform, then compare
-     * with the same frame drawn onto a fresh surface after a rebuild: anything the selected
-     * frame left in the canvas -- a handle painted outside the rectangle it composited and
-     * cleared -- would land in the panned frame as pixels the fresh one does not have. */
-    const dt_masks_overlay_transform_t panned
-        = { .scale = scale, .offset_x = transform.offset_x + 97.0, .offset_y = transform.offset_y - 61.0 };
-    cairo_surface_t *fresh = cairo_image_surface_create(CAIRO_FORMAT_ARGB32, OVERLAY_SCREEN_W, OVERLAY_SCREEN_H);
-    cairo_t *cr_panned = cairo_create(surface);
-    cairo_set_source_rgb(cr_panned, 0.12, 0.12, 0.12);
-    cairo_paint(cr_panned);
-    dt_masks_events_post_expose_with(dev, NULL, cr_panned, OVERLAY_SCREEN_W, OVERLAY_SCREEN_H, -1, -1, &panned);
-    cairo_destroy(cr_panned);
-    dev->form_gui->formid = 0;
-    dev->form_gui->geometry_generation = 0;
-    cairo_t *cr_fresh = cairo_create(fresh);
-    cairo_set_source_rgb(cr_fresh, 0.12, 0.12, 0.12);
-    cairo_paint(cr_fresh);
-    dt_masks_events_post_expose_with(dev, NULL, cr_fresh, OVERLAY_SCREEN_W, OVERLAY_SCREEN_H, -1, -1, &panned);
-    cairo_destroy(cr_fresh);
-    cairo_surface_flush(surface);
-    cairo_surface_flush(fresh);
-    const uint32_t *pa = (const uint32_t *)cairo_image_surface_get_data(surface);
-    const uint32_t *pb = (const uint32_t *)cairo_image_surface_get_data(fresh);
-    const int stride = cairo_image_surface_get_stride(surface) / 4;
-    long leftovers = 0;
-    for(int y = 0; y < OVERLAY_SCREEN_H; y++)
-      for(int x = 0; x < OVERLAY_SCREEN_W; x++)
-        if(pa[y * stride + x] != pb[y * stride + x]) leftovers++;
-    cairo_surface_destroy(fresh);
+    const long leftovers = _overlay_leftovers(dev, surface, &transform);
     if(leftovers > 0)
     {
       printf("[FAIL] %-26s %-8s left %ld pixel(s) behind for the next, panned frame\n", name,
@@ -1432,8 +1452,18 @@ static gboolean _painted_bbox(cairo_surface_t *surface, int *x0, int *y0, int *x
     {
       const uint32_t p = px[y * stride + x];
       if(p == background) continue;
-      if(!any) { *x0 = *x1 = x; *y0 = *y1 = y; any = TRUE; }
-      *x0 = MIN(*x0, x); *x1 = MAX(*x1, x); *y0 = MIN(*y0, y); *y1 = MAX(*y1, y);
+      if(!any)
+      {
+        *x0 = x;
+        *x1 = x;
+        *y0 = y;
+        *y1 = y;
+        any = TRUE;
+      }
+      *x0 = MIN(*x0, x);
+      *x1 = MAX(*x1, x);
+      *y0 = MIN(*y0, y);
+      *y1 = MAX(*y1, y);
     }
   return any;
 }
@@ -1475,7 +1505,7 @@ static void _check_hidpi_placement(dt_develop_t *dev, dt_masks_form_t *form, con
   }
   const int tolerance = 12;   /* antialiasing plus the wider lines and handles of a 2x screen */
   gboolean ok = any[0] && any[1];
-  for(int i = 0; ok && i < 4; i++)
+  for(int i = 0; i < 4; i++)
     if(abs(bbox[0][i] - bbox[1][i]) > tolerance) ok = FALSE;
   printf("[%s] %-26s hidpi placement: 1x bbox (%d,%d)-(%d,%d)  2x bbox (%d,%d)-(%d,%d)\n", ok ? "PASS" : "FAIL", name,
          bbox[0][0], bbox[0][1], bbox[0][2], bbox[0][3], bbox[1][0], bbox[1][1], bbox[1][2], bbox[1][3]);

--- a/tests/masks/masks_geometry.c
+++ b/tests/masks/masks_geometry.c
@@ -1355,9 +1355,16 @@ static long _overlay_leftovers(dt_develop_t *dev, cairo_surface_t *surface,
   return leftovers;
 }
 
+/* What one state of one case cost: the frame, and the first frame that also built the outline. */
+typedef struct _overlay_timing_t
+{
+  double per_frame_ms;
+  double build_ms;
+} _overlay_timing_t;
+
 /* The measurement line of one state, with the outline's sample and skip counts. */
 static void _overlay_report(dt_develop_t *dev, const char *name, const int img_w, const int img_h,
-                            const gboolean selected, const double per_frame_ms, const double build_ms,
+                            const gboolean selected, const _overlay_timing_t *const timing,
                             const dt_masks_overlay_transform_t *const transform)
 {
   int points = 0;
@@ -1375,8 +1382,8 @@ static void _overlay_report(dt_develop_t *dev, const char *name, const int img_w
   }
   printf("[TIME] %-26s %5dx%-4d %-8s %7.2f ms/frame  (first frame incl. build %7.2f ms;"
          " %d outline samples, %d border samples, %d skipped in %d ranges)\n",
-         name, img_w, img_h, selected ? "selected" : "member", per_frame_ms, build_ms, points, border, skipped,
-         skip_ranges);
+         name, img_w, img_h, selected ? "selected" : "member", timing->per_frame_ms, timing->build_ms, points, border,
+         skipped, skip_ranges);
 }
 
 static void _time_overlay_form(dt_develop_t *dev, dt_masks_form_t *form, const char *name, const char *dir,
@@ -1416,14 +1423,15 @@ static void _time_overlay_form(dt_develop_t *dev, dt_masks_form_t *form, const c
 
     /* the first frame builds the outline, which the darkroom also does once per edit; it is
      * not the per-frame cost and is timed apart */
+    _overlay_timing_t timing = { 0 };
     const double build_start = dt_get_wtime();
     _overlay_frame(dev, surface, &transform);
-    const double build_ms = 1000.0 * (dt_get_wtime() - build_start);
+    timing.build_ms = 1000.0 * (dt_get_wtime() - build_start);
 
     const double start = dt_get_wtime();
     for(int f = 0; f < frames; f++) _overlay_frame(dev, surface, &transform);
-    const double per_frame_ms = 1000.0 * (dt_get_wtime() - start) / MAX(frames, 1);
-    _overlay_report(dev, name, img_w, img_h, selected, per_frame_ms, build_ms, &transform);
+    timing.per_frame_ms = 1000.0 * (dt_get_wtime() - start) / MAX(frames, 1);
+    _overlay_report(dev, name, img_w, img_h, selected, &timing, &transform);
 
     if(!IS_NULL_PTR(dir))
     {

--- a/tests/masks/masks_geometry.c
+++ b/tests/masks/masks_geometry.c
@@ -562,6 +562,24 @@ static const float _brush_1074[8][11] = {
   { 0.614701509f, 0.904702842f, 0.609275997f, 0.908323109f, 0.603850603f, 0.911943376f, 0.0375316516f, 0.0375316516f, 1.0f, 0.660000026f, 1 },
 };
 
+/* The same brush as the darkroom held it on the evening of 2026-09-08, rebuilt from the
+ * frame dump (MASKS_DUMP_OVERLAY) rather than the sidecar, which no longer matched: node 1 is
+ * 287 px from node 0 now, and the radius rate along that segment peaks near 1 -- the discs
+ * almost nest, and the union's top is the rear envelope of the flare, 40 px outside node 1's
+ * circle at a tilt of 64 degrees. Radii measured on the dump: 132 px everywhere, 342.5 at
+ * node 1; frame 5184x3456. */
+static const float _brush_1074b[8][11] = {
+  /* columns: node x y | ctrl1 x y | ctrl2 x y | border in out | density | fading | state */
+  { 0.751560571f, 0.636493056f, 0.749378858f, 0.628718171f, 0.753744213f, 0.64426794f, 0.0381944444f, 0.0381944444f, 1.0f, 0.660000026f, 1 },
+  { 0.745943287f, 0.718943866f, 0.742395833f, 0.674337384f, 0.749488812f, 0.763550347f, 0.0991030093f, 0.0991030093f, 1.0f, 0.660000026f, 1 },
+  { 0.722523148f, 0.958313079f, 0.722864583f, 0.915240162f, 0.722181713f, 1.001386f, 0.0381944444f, 0.0381944444f, 1.0f, 0.660000026f, 1 },
+  { 0.705744599f, 0.972430556f, 0.713929398f, 0.970590278f, 0.697559799f, 0.974273727f, 0.0381944444f, 0.0381944444f, 1.0f, 0.660000026f, 1 },
+  { 0.673414352f, 0.969363426f, 0.686442901f, 0.974068287f, 0.660387731f, 0.964655671f, 0.0381944444f, 0.0381944444f, 1.0f, 0.660000026f, 1 },
+  { 0.627581019f, 0.944195602f, 0.637197145f, 0.950434028f, 0.617962963f, 0.937954282f, 0.0381944444f, 0.0381944444f, 1.0f, 0.660000026f, 1 },
+  { 0.615711806f, 0.931918403f, 0.62048804f, 0.932120949f, 0.6109375f, 0.931712963f, 0.0381944444f, 0.0381944444f, 1.0f, 0.660000026f, 1 },
+  { 0.598933256f, 0.942965856f, 0.604527392f, 0.939282407f, 0.593341049f, 0.946649306f, 0.0381944444f, 0.0381944444f, 1.0f, 0.660000026f, 1 },
+};
+
 /* Point the dev's geometry at a given frame size. The chain must be rebuilt afterwards or it
  * stops being authoritative and every outline comes back empty, silently. */
 static void _set_frame(dt_develop_t *dev, const int w, const int h)
@@ -816,6 +834,7 @@ typedef struct _band_t
   int kept;
   int inside;
   int outside;
+  int off_frame;   /* kept samples past the edge of the frame, which no map can judge */
   double seconds;
 } _band_t;
 
@@ -845,7 +864,9 @@ static _band_t _outline_band_check(dt_develop_t *dev, dt_masks_form_t *form, con
     const int y = (int)lrintf(border[i * 2 + 1]);
     if(x < 0 || y < 0 || x >= w || y >= h)
     {
-      band.outside++;
+      /* a shape drawn past the edge of the image has a boundary there the maps cannot judge;
+       * it is drawn all the same, and not a spoke to nowhere */
+      band.off_frame++;
       continue;
     }
     const size_t at = (size_t)y * w + x;
@@ -925,8 +946,8 @@ static void _judge_raster(dt_develop_t *dev, dt_masks_form_t *form, const _brush
   if(missing.largest > 0) printf(" around (%d,%d)", missing.cx, missing.cy);
   printf(")  excess %7d px (largest run %7d px", excess.total, excess.largest);
   if(excess.largest > 0) printf(" around (%d,%d)", excess.cx, excess.cy);
-  printf(")  outline: %d kept, %d inside, %d outside, built in %.1f ms  budget %d  -> %s\n",
-         band.kept, band.inside, band.outside, 1000.0 * band.seconds, c->budget_px, alpha_path);
+  printf(")  outline: %d kept, %d inside, %d outside, %d off frame, built in %.1f ms  budget %d  -> %s\n",
+         band.kept, band.inside, band.outside, band.off_frame, 1000.0 * band.seconds, c->budget_px, alpha_path);
   if(!ok) failures++;
 
   g_free(alpha_path);
@@ -1613,6 +1634,7 @@ static void _time_overlay_all(dt_develop_t *dev, const char *dir, const int fram
   _time_overlay_brush(dev, _brush_from_table11(_brush_1360, 43), "brush-1360-pressure-ramp", dir, 5184, 3888, frames);
   _time_overlay_brush(dev, _brush_from_table11(_brush_1352, 7), "brush-1352-radius-step", dir, IMG_W, IMG_H, frames);
   _time_overlay_brush(dev, _brush_from_table11(_brush_1074, 8), "brush-1074-flare", dir, 5184, 3456, frames);
+  _time_overlay_brush(dev, _brush_from_table11(_brush_1074b, 8), "brush-1074-flare-b", dir, 5184, 3456, frames);
 
   {
     dt_masks_form_t form = { 0 };
@@ -1832,6 +1854,8 @@ int main(int argc, char *argv[])
     _run_brush_case11_at(&dev, _brush_1352, 7, &c1352_small);
     const _brush_case_t c1074 = { "brush-1074-flare", dir, 0, 5184, 3456 };
     _run_brush_case11_at(&dev, _brush_1074, 8, &c1074);
+    const _brush_case_t c1074b = { "brush-1074-flare-b", dir, 0, 5184, 3456 };
+    _run_brush_case11_at(&dev, _brush_1074b, 8, &c1074b);
   }
 
   /* 3b. THE SECOND REPORTED SHAPE, polygon #2. Two defects were reported against it: the outer

--- a/tests/masks/masks_geometry.c
+++ b/tests/masks/masks_geometry.c
@@ -1355,6 +1355,30 @@ static long _overlay_leftovers(dt_develop_t *dev, cairo_surface_t *surface,
   return leftovers;
 }
 
+/* The measurement line of one state, with the outline's sample and skip counts. */
+static void _overlay_report(dt_develop_t *dev, const char *name, const int img_w, const int img_h,
+                            const gboolean selected, const double per_frame_ms, const double build_ms,
+                            const dt_masks_overlay_transform_t *const transform)
+{
+  int points = 0;
+  int border = 0;
+  int skip_ranges = 0;
+  int skipped = 0;
+  const dt_masks_form_gui_points_t *const gp
+      = (const dt_masks_form_gui_points_t *)g_list_nth_data(dev->form_gui->points, 0);
+  if(!IS_NULL_PTR(gp))
+  {
+    points = gp->points_count;
+    border = gp->border_count;
+    _overlay_skipped(gp, &skipped, &skip_ranges);
+    if(selected) _overlay_dump_skips(gp, name, transform);
+  }
+  printf("[TIME] %-26s %5dx%-4d %-8s %7.2f ms/frame  (first frame incl. build %7.2f ms;"
+         " %d outline samples, %d border samples, %d skipped in %d ranges)\n",
+         name, img_w, img_h, selected ? "selected" : "member", per_frame_ms, build_ms, points, border, skipped,
+         skip_ranges);
+}
+
 static void _time_overlay_form(dt_develop_t *dev, dt_masks_form_t *form, const char *name, const char *dir,
                                const int img_w, const int img_h, const int frames)
 {
@@ -1399,24 +1423,7 @@ static void _time_overlay_form(dt_develop_t *dev, dt_masks_form_t *form, const c
     const double start = dt_get_wtime();
     for(int f = 0; f < frames; f++) _overlay_frame(dev, surface, &transform);
     const double per_frame_ms = 1000.0 * (dt_get_wtime() - start) / MAX(frames, 1);
-
-    int points = 0;
-    int border = 0;
-    int skip_ranges = 0;
-    int skipped = 0;
-    const dt_masks_form_gui_points_t *const gp
-        = (const dt_masks_form_gui_points_t *)g_list_nth_data(dev->form_gui->points, 0);
-    if(!IS_NULL_PTR(gp))
-    {
-      points = gp->points_count;
-      border = gp->border_count;
-      _overlay_skipped(gp, &skipped, &skip_ranges);
-      if(selected) _overlay_dump_skips(gp, name, &transform);
-    }
-    printf("[TIME] %-26s %5dx%-4d %-8s %7.2f ms/frame  (first frame incl. build %7.2f ms;"
-           " %d outline samples, %d border samples, %d skipped in %d ranges)\n",
-           name, img_w, img_h, selected ? "selected" : "member", per_frame_ms, build_ms, points, border, skipped,
-           skip_ranges);
+    _overlay_report(dev, name, img_w, img_h, selected, per_frame_ms, build_ms, &transform);
 
     if(!IS_NULL_PTR(dir))
     {

--- a/tests/masks/masks_geometry.c
+++ b/tests/masks/masks_geometry.c
@@ -1381,6 +1381,71 @@ static void _time_overlay_form(dt_develop_t *dev, dt_masks_form_t *form, const c
   cairo_surface_destroy(surface);
 }
 
+/* The painted pixels' bounding box of an overlay rendered onto @p surface. */
+static gboolean _painted_bbox(cairo_surface_t *surface, int *x0, int *y0, int *x1, int *y1)
+{
+  cairo_surface_flush(surface);
+  const uint32_t *px = (const uint32_t *)cairo_image_surface_get_data(surface);
+  const int stride = cairo_image_surface_get_stride(surface) / 4;
+  const int w = cairo_image_surface_get_width(surface);
+  const int h = cairo_image_surface_get_height(surface);
+  gboolean any = FALSE;
+  const uint32_t background = px[0];   /* the corner is letterboxed, never painted */
+  for(int y = 0; y < h; y++)
+    for(int x = 0; x < w; x++)
+    {
+      const uint32_t p = px[y * stride + x];
+      if(p == background) continue;
+      if(!any) { *x0 = *x1 = x; *y0 = *y1 = y; any = TRUE; }
+      *x0 = MIN(*x0, x); *x1 = MAX(*x1, x); *y0 = MIN(*y0, y); *y1 = MAX(*y1, y);
+    }
+  return any;
+}
+
+/* A HiDPI view: the same pixels, a device scale of 2 on the surface, half the user units. The
+ * overlay must land on the same pixels as at scale 1 -- measured as the painted bounding box,
+ * to within the antialiasing and the thicker lines a 2x screen is entitled to. This is the
+ * check the darkroom on a 2x screen made necessary: everything at half size in the top-left
+ * quadrant, because cairo's device space is not the pixel grid. */
+static void _check_hidpi_placement(dt_develop_t *dev, dt_masks_form_t *form, const char *name, const int img_w,
+                                   const int img_h)
+{
+  _set_frame(dev, img_w, img_h);
+  dev->form_gui->form_visible = form;
+  dt_dev_geometry_set_processed_size(dev, img_w, img_h);
+  const double scale = MIN((double)OVERLAY_SCREEN_W / img_w, (double)OVERLAY_SCREEN_H / img_h);
+  int bbox[2][4] = { { 0, 0, 0, 0 }, { 0, 0, 0, 0 } };
+  gboolean any[2] = { FALSE, FALSE };
+  for(int hidpi = 0; hidpi < 2; hidpi++)
+  {
+    const double ppd = hidpi ? 2.0 : 1.0;
+    cairo_surface_t *surface = cairo_image_surface_create(CAIRO_FORMAT_ARGB32, OVERLAY_SCREEN_W, OVERLAY_SCREEN_H);
+    cairo_surface_set_device_scale(surface, ppd, ppd);
+    const dt_masks_overlay_transform_t transform
+        = { .scale = scale / ppd,
+            .offset_x = 0.5 * (OVERLAY_SCREEN_W - scale * img_w) / ppd,
+            .offset_y = 0.5 * (OVERLAY_SCREEN_H - scale * img_h) / ppd };
+    dev->form_gui->formid = 0;
+    dev->form_gui->geometry_generation = 0;
+    dev->form_gui->group_selected = 0;
+    cairo_t *cr = cairo_create(surface);
+    cairo_set_source_rgb(cr, 0.12, 0.12, 0.12);
+    cairo_paint(cr);
+    dt_masks_events_post_expose_with(dev, NULL, cr, (int)(OVERLAY_SCREEN_W / ppd), (int)(OVERLAY_SCREEN_H / ppd), -1, -1,
+                                     &transform);
+    cairo_destroy(cr);
+    any[hidpi] = _painted_bbox(surface, &bbox[hidpi][0], &bbox[hidpi][1], &bbox[hidpi][2], &bbox[hidpi][3]);
+    cairo_surface_destroy(surface);
+  }
+  const int tolerance = 12;   /* antialiasing plus the wider lines and handles of a 2x screen */
+  gboolean ok = any[0] && any[1];
+  for(int i = 0; ok && i < 4; i++)
+    if(abs(bbox[0][i] - bbox[1][i]) > tolerance) ok = FALSE;
+  printf("[%s] %-26s hidpi placement: 1x bbox (%d,%d)-(%d,%d)  2x bbox (%d,%d)-(%d,%d)\n", ok ? "PASS" : "FAIL", name,
+         bbox[0][0], bbox[0][1], bbox[0][2], bbox[0][3], bbox[1][0], bbox[1][1], bbox[1][2], bbox[1][3]);
+  if(!ok) failures++;
+}
+
 static void _time_overlay_brush(dt_develop_t *dev, GList *nodes, const char *name, const char *dir,
                                 const int img_w, const int img_h, const int frames)
 {
@@ -1392,6 +1457,7 @@ static void _time_overlay_brush(dt_develop_t *dev, GList *nodes, const char *nam
   g_strlcpy(form.name, name, sizeof(form.name));
   form.points = nodes;
   _time_overlay_form(dev, &form, name, dir, img_w, img_h, frames);
+  _check_hidpi_placement(dev, &form, name, img_w, img_h);
   g_list_free_full(form.points, free);
 }
 
@@ -1421,6 +1487,7 @@ static void _time_overlay_all(dt_develop_t *dev, const char *dir, const int fram
       form.points = g_list_append(form.points, _polygon_node(r[0], r[1], r[2], r[3], r[4], r[5], r[6]));
     }
     _time_overlay_form(dev, &form, "polygon-1788045925", dir, 5198, 3904, frames);
+    _check_hidpi_placement(dev, &form, "polygon-1788045925", 5198, 3904);
     g_list_free_full(form.points, free);
   }
   {
@@ -1441,6 +1508,7 @@ static void _time_overlay_all(dt_develop_t *dev, const char *dir, const int fram
     form.points = g_list_append(form.points, _polygon_node(0.80f, 0.78f, 0.80f, 0.78f, 0.80f, 0.78f, radius));
     form.points = g_list_append(form.points, _polygon_node(0.20f, 0.78f, 0.20f, 0.78f, 0.20f, 0.78f, radius));
     _time_overlay_form(dev, &form, "polygon-comb", dir, IMG_W, IMG_H, frames);
+    _check_hidpi_placement(dev, &form, "polygon-comb", IMG_W, IMG_H);
     g_list_free_full(form.points, free);
   }
 }

--- a/tests/masks/masks_geometry.c
+++ b/tests/masks/masks_geometry.c
@@ -1445,7 +1445,7 @@ static void _time_overlay_form(dt_develop_t *dev, dt_masks_form_t *form, const c
   /* fit the image into the screen, centred: what the darkroom shows at zoom "fit" -- or, with
    * MASKS_OVERLAY_VIEW="scale,offset_x,offset_y[,ppd]", the view the darkroom is showing, in
    * user units, with the surface's device scale, to reproduce what a user sees at a zoom */
-  double scale = MIN((double)OVERLAY_SCREEN_W / img_w, (double)OVERLAY_SCREEN_H / img_h);
+  const double scale = MIN((double)OVERLAY_SCREEN_W / img_w, (double)OVERLAY_SCREEN_H / img_h);
   dt_masks_overlay_transform_t transform
       = { .scale = scale,
           .offset_x = 0.5 * (OVERLAY_SCREEN_W - scale * img_w),
@@ -1458,7 +1458,6 @@ static void _time_overlay_form(dt_develop_t *dev, dt_masks_form_t *form, const c
     gchar **parts = g_strsplit(view, ",", 4);
     for(int i = 0; i < 4 && !IS_NULL_PTR(parts[i]); i++) v[i] = g_ascii_strtod(parts[i], NULL);
     g_strfreev(parts);
-    scale = v[0];
     transform.scale = v[0];
     transform.offset_x = v[1];
     transform.offset_y = v[2];

--- a/tests/masks/masks_geometry.c
+++ b/tests/masks/masks_geometry.c
@@ -1323,16 +1323,52 @@ static void _time_overlay_form(dt_develop_t *dev, dt_masks_form_t *form, const c
 
     int points = 0;
     int border = 0;
+    int skip_ranges = 0;
+    int skipped = 0;
     const dt_masks_form_gui_points_t *const gp
         = (const dt_masks_form_gui_points_t *)g_list_nth_data(dev->form_gui->points, 0);
     if(!IS_NULL_PTR(gp))
     {
       points = gp->points_count;
       border = gp->border_count;
+      skip_ranges = gp->border_skip_count;
+      for(int k = 0; k < gp->border_skip_count; k++)
+        skipped += gp->border_skips[k].resume_at - gp->border_skips[k].jump_from;
+      if(!IS_NULL_PTR(g_getenv("MASKS_DUMP_SKIPS")) && selected)
+      {
+        /* every border sample, raw coordinates, with the range that skips it or -1 */
+        char *path = g_strdup_printf("%s/%s-border.txt", g_getenv("MASKS_DUMP_SKIPS"), name);
+        FILE *f = g_fopen(path, "w");
+        if(f)
+        {
+          for(int i = 0; i < border; i++)
+          {
+            int in = -1;
+            for(int k = 0; k < gp->border_skip_count; k++)
+              if(i >= gp->border_skips[k].jump_from && i < gp->border_skips[k].resume_at) in = k;
+            fprintf(f, "%d %.2f %.2f %d %.2f %.2f\n", i, gp->border[2 * i], gp->border[2 * i + 1], in,
+                    gp->points[2 * i], gp->points[2 * i + 1]);
+          }
+          fclose(f);
+        }
+        g_free(path);
+      }
+      if(!IS_NULL_PTR(g_getenv("MASKS_DUMP_SKIPS")) && selected)
+        for(int k = 0; k < gp->border_skip_count; k++)
+        {
+          const int a = gp->border_skips[k].jump_from;
+          const int b = gp->border_skips[k].resume_at;
+          printf("  skip %2d: [%6d, %6d) %6d samples  from (%.0f, %.0f) to (%.0f, %.0f) on screen\n", k, a, b, b - a,
+                 gp->border[2 * a] * transform.scale + transform.offset_x,
+                 gp->border[2 * a + 1] * transform.scale + transform.offset_y,
+                 gp->border[2 * MIN(b, border - 1)] * transform.scale + transform.offset_x,
+                 gp->border[2 * MIN(b, border - 1) + 1] * transform.scale + transform.offset_y);
+        }
     }
     printf("[TIME] %-26s %5dx%-4d %-8s %7.2f ms/frame  (first frame incl. build %7.2f ms;"
-           " %d outline samples, %d border samples)\n",
-           name, img_w, img_h, selected ? "selected" : "member", per_frame_ms, build_ms, points, border);
+           " %d outline samples, %d border samples, %d skipped in %d ranges)\n",
+           name, img_w, img_h, selected ? "selected" : "member", per_frame_ms, build_ms, points, border, skipped,
+           skip_ranges);
 
     if(!IS_NULL_PTR(dir))
     {

--- a/tests/masks/masks_geometry.c
+++ b/tests/masks/masks_geometry.c
@@ -546,6 +546,22 @@ static const float _brush_1352[7][11] = {
   { 0.36773169f, 0.193801045f, 0.375862241f, 0.187250778f, 0.35960114f, 0.200351343f, 0.0239629708f, 0.0239629708f, 1.0f, 0.660000026f, 1 },
 };
 
+/* _MG_1074.CR2, brush #4 of its sidecar (2026-09-08): eight nodes, the second with a radius
+ * 2.6 times its neighbours', so the stroke flares from node 0 into node 1 and back. Reported
+ * as "some dashed border missing near node 0" once the envelope samples had fixed the long
+ * sides elsewhere: the flare's rate sits near the tilt cap. Frame 5184x3456. */
+static const float _brush_1074[8][11] = {
+  /* columns: node x y | ctrl1 x y | ctrl2 x y | border in out | density | fading | state */
+  { 0.758693337f, 0.601638496f, 0.760810494f, 0.609281301f, 0.762927711f, 0.616924226f, 0.0375316516f, 0.0375316516f, 1.0f, 0.660000026f, 1 },
+  { 0.748442948f, 0.644278347f, 0.751883447f, 0.688123882f, 0.755324066f, 0.731969476f, 0.097397998f, 0.097397998f, 1.0f, 0.660000026f, 1 },
+  { 0.729495943f, 0.881070495f, 0.729165137f, 0.923407614f, 0.728834331f, 0.965744674f, 0.0375316516f, 0.0375316516f, 1.0f, 0.660000026f, 1 },
+  { 0.720828474f, 0.935475111f, 0.712888777f, 0.937285244f, 0.704949141f, 0.939095378f, 0.0375316516f, 0.0375316516f, 1.0f, 0.660000026f, 1 },
+  { 0.694164455f, 0.938894272f, 0.681527078f, 0.934268355f, 0.668889761f, 0.929642439f, 0.0375316516f, 0.0375316516f, 1.0f, 0.660000026f, 1 },
+  { 0.646394014f, 0.915664196f, 0.637064874f, 0.909529805f, 0.627735794f, 0.903395414f, 0.0375316516f, 0.0375316516f, 1.0f, 0.660000026f, 1 },
+  { 0.630183876f, 0.897663355f, 0.625552356f, 0.897462249f, 0.620920897f, 0.897261143f, 0.0375316516f, 0.0375316516f, 1.0f, 0.660000026f, 1 },
+  { 0.614701509f, 0.904702842f, 0.609275997f, 0.908323109f, 0.603850603f, 0.911943376f, 0.0375316516f, 0.0375316516f, 1.0f, 0.660000026f, 1 },
+};
+
 /* Point the dev's geometry at a given frame size. The chain must be rebuilt afterwards or it
  * stops being authoritative and every outline comes back empty, silently. */
 static void _set_frame(dt_develop_t *dev, const int w, const int h)
@@ -1339,6 +1355,11 @@ static long _overlay_leftovers(dt_develop_t *dev, cairo_surface_t *surface,
       = { .scale = transform->scale, .offset_x = transform->offset_x + 97.0, .offset_y = transform->offset_y - 61.0 };
   _overlay_frame(dev, surface, &panned);
   cairo_surface_t *fresh = cairo_image_surface_create(CAIRO_FORMAT_ARGB32, OVERLAY_SCREEN_W, OVERLAY_SCREEN_H);
+  /* the same device scale, or the two frames differ by construction */
+  double ppd_x = 1.0;
+  double ppd_y = 1.0;
+  cairo_surface_get_device_scale(surface, &ppd_x, &ppd_y);
+  cairo_surface_set_device_scale(fresh, ppd_x, ppd_y);
   dev->form_gui->formid = 0;
   dev->form_gui->geometry_generation = 0;
   _overlay_frame(dev, fresh, &panned);
@@ -1348,9 +1369,30 @@ static long _overlay_leftovers(dt_develop_t *dev, cairo_surface_t *surface,
   const uint32_t *pb = (const uint32_t *)cairo_image_surface_get_data(fresh);
   const int stride = cairo_image_surface_get_stride(surface) / 4;
   long leftovers = 0;
+  int bx0 = OVERLAY_SCREEN_W;
+  int by0 = OVERLAY_SCREEN_H;
+  int bx1 = -1;
+  int by1 = -1;
   for(int y = 0; y < OVERLAY_SCREEN_H; y++)
     for(int x = 0; x < OVERLAY_SCREEN_W; x++)
-      if(pa[y * stride + x] != pb[y * stride + x]) leftovers++;
+      if(pa[y * stride + x] != pb[y * stride + x])
+      {
+        leftovers++;
+        bx0 = MIN(bx0, x);
+        by0 = MIN(by0, y);
+        bx1 = MAX(bx1, x);
+        by1 = MAX(by1, y);
+      }
+  if(leftovers > 0 && !IS_NULL_PTR(g_getenv("MASKS_DUMP_SKIPS")))
+  {
+    printf("  leftovers within (%d,%d)-(%d,%d)\n", bx0, by0, bx1, by1);
+    char *path = g_strdup_printf("%s/leftover-panned.png", g_getenv("MASKS_DUMP_SKIPS"));
+    cairo_surface_write_to_png(surface, path);
+    g_free(path);
+    path = g_strdup_printf("%s/leftover-fresh.png", g_getenv("MASKS_DUMP_SKIPS"));
+    cairo_surface_write_to_png(fresh, path);
+    g_free(path);
+  }
   cairo_surface_destroy(fresh);
   return leftovers;
 }
@@ -1400,12 +1442,28 @@ static void _time_overlay_form(dt_develop_t *dev, dt_masks_form_t *form, const c
   dev->form_gui->form_visible = form;
   dt_dev_geometry_set_processed_size(dev, img_w, img_h);
 
-  /* fit the image into the screen, centred: what the darkroom shows at zoom "fit" */
-  const double scale = MIN((double)OVERLAY_SCREEN_W / img_w, (double)OVERLAY_SCREEN_H / img_h);
-  const dt_masks_overlay_transform_t transform
+  /* fit the image into the screen, centred: what the darkroom shows at zoom "fit" -- or, with
+   * MASKS_OVERLAY_VIEW="scale,offset_x,offset_y[,ppd]", the view the darkroom is showing, in
+   * user units, with the surface's device scale, to reproduce what a user sees at a zoom */
+  double scale = MIN((double)OVERLAY_SCREEN_W / img_w, (double)OVERLAY_SCREEN_H / img_h);
+  dt_masks_overlay_transform_t transform
       = { .scale = scale,
           .offset_x = 0.5 * (OVERLAY_SCREEN_W - scale * img_w),
           .offset_y = 0.5 * (OVERLAY_SCREEN_H - scale * img_h) };
+  double ppd = 1.0;
+  const char *view = g_getenv("MASKS_OVERLAY_VIEW");
+  if(!IS_NULL_PTR(view))
+  {
+    double v[4] = { scale, transform.offset_x, transform.offset_y, 1.0 };
+    gchar **parts = g_strsplit(view, ",", 4);
+    for(int i = 0; i < 4 && !IS_NULL_PTR(parts[i]); i++) v[i] = g_ascii_strtod(parts[i], NULL);
+    g_strfreev(parts);
+    scale = v[0];
+    transform.scale = v[0];
+    transform.offset_x = v[1];
+    transform.offset_y = v[2];
+    ppd = (v[3] > 0.0) ? v[3] : 1.0;
+  }
 
   cairo_surface_t *surface = cairo_image_surface_create(CAIRO_FORMAT_ARGB32, OVERLAY_SCREEN_W, OVERLAY_SCREEN_H);
   if(cairo_surface_status(surface) != CAIRO_STATUS_SUCCESS)
@@ -1413,6 +1471,7 @@ static void _time_overlay_form(dt_develop_t *dev, dt_masks_form_t *form, const c
     cairo_surface_destroy(surface);
     return;
   }
+  cairo_surface_set_device_scale(surface, ppd, ppd);
 
   for(int selected = 0; selected < 2; selected++)
   {
@@ -1554,6 +1613,7 @@ static void _time_overlay_all(dt_develop_t *dev, const char *dir, const int fram
   _time_overlay_brush(dev, _brush_from_table(_brush_concave_tbl, 5), "brush-concave", dir, IMG_W, IMG_H, frames);
   _time_overlay_brush(dev, _brush_from_table11(_brush_1360, 43), "brush-1360-pressure-ramp", dir, 5184, 3888, frames);
   _time_overlay_brush(dev, _brush_from_table11(_brush_1352, 7), "brush-1352-radius-step", dir, IMG_W, IMG_H, frames);
+  _time_overlay_brush(dev, _brush_from_table11(_brush_1074, 8), "brush-1074-flare", dir, 5184, 3456, frames);
 
   {
     dt_masks_form_t form = { 0 };
@@ -1771,6 +1831,8 @@ int main(int argc, char *argv[])
     _run_brush_case11_at(&dev, _brush_1360, 43, &c1360);
     _run_brush_case11_at(&dev, _brush_1352, 7, &c1352);
     _run_brush_case11_at(&dev, _brush_1352, 7, &c1352_small);
+    const _brush_case_t c1074 = { "brush-1074-flare", dir, 0, 5184, 3456 };
+    _run_brush_case11_at(&dev, _brush_1074, 8, &c1074);
   }
 
   /* 3b. THE SECOND REPORTED SHAPE, polygon #2. Two defects were reported against it: the outer

--- a/tests/masks/masks_geometry.c
+++ b/tests/masks/masks_geometry.c
@@ -648,6 +648,8 @@ static void _surface_diff(cairo_surface_t *const a, cairo_surface_t *const b,
 
 static const char *baseline_dir = NULL;
 static gboolean baseline_update = FALSE;
+static gboolean time_overlay = FALSE;
+static int time_overlay_frames = 30;
 static int baseline_missing = 0;
 
 /** Compare @p path against its baseline, or create the baseline when updating. Returns TRUE when
@@ -1250,6 +1252,163 @@ static void _run_case(dt_develop_t *dev, dt_masks_form_t *form, const char *name
 
 /* ------------------------------------------------------------------------------------- */
 
+
+/* ---------------------------------------------------------------------------------------------
+ * The overlay's per-frame cost, headless.
+ *
+ * What the darkroom pays on every motion event while a mask is being edited is the drawing of
+ * every shape's outline into the view: a cairo path of one vertex per device pixel, stroked
+ * twice. This mode reproduces that draw alone -- the outline buffers are built once and cached
+ * by the geometry generation exactly as in the darkroom -- on a screen-sized surface with the
+ * fit transform, and reports milliseconds per frame. Two states per case: the shape as one of
+ * a group's members (path only) and as the selected member (path, dashed border, nodes and
+ * handles), which are the two costs a drag frame is made of. The last frame is saved as
+ * <case>-screen[-selected].png, so the pixels a change produces can be compared as well. */
+#define OVERLAY_SCREEN_W 2560
+#define OVERLAY_SCREEN_H 1440
+
+static void _time_overlay_form(dt_develop_t *dev, dt_masks_form_t *form, const char *name, const char *dir,
+                               const int img_w, const int img_h, const int frames)
+{
+  _set_frame(dev, img_w, img_h);
+  if(IS_NULL_PTR(dev->form_gui))
+  {
+    dev->form_gui = (dt_masks_form_gui_t *)calloc(1, sizeof(dt_masks_form_gui_t));
+    if(IS_NULL_PTR(dev->form_gui)) return;
+    dt_masks_init_form_gui(dev, dev->form_gui);
+  }
+  dev->form_gui->dev = dev;
+  dev->form_gui->form_visible = form;
+  dt_dev_geometry_set_processed_size(dev, img_w, img_h);
+
+  /* fit the image into the screen, centred: what the darkroom shows at zoom "fit" */
+  const double scale = MIN((double)OVERLAY_SCREEN_W / img_w, (double)OVERLAY_SCREEN_H / img_h);
+  const dt_masks_overlay_transform_t transform
+      = { .scale = scale,
+          .offset_x = 0.5 * (OVERLAY_SCREEN_W - scale * img_w),
+          .offset_y = 0.5 * (OVERLAY_SCREEN_H - scale * img_h) };
+
+  cairo_surface_t *surface = cairo_image_surface_create(CAIRO_FORMAT_ARGB32, OVERLAY_SCREEN_W, OVERLAY_SCREEN_H);
+  if(cairo_surface_status(surface) != CAIRO_STATUS_SUCCESS)
+  {
+    cairo_surface_destroy(surface);
+    return;
+  }
+
+  for(int selected = 0; selected < 2; selected++)
+  {
+    dev->form_gui->formid = 0;                 /* rebuild the outline cache for this form */
+    dev->form_gui->geometry_generation = 0;
+    dev->form_gui->group_selected = selected ? 0 : -1;
+    dev->form_gui->form_selected = FALSE;
+
+    cairo_t *cr = cairo_create(surface);
+    cairo_set_source_rgb(cr, 0.12, 0.12, 0.12);
+    cairo_paint(cr);
+    /* the first frame builds the outline, which the darkroom also does once per edit; it is
+     * not the per-frame cost and is timed apart */
+    const double build_start = dt_get_wtime();
+    dt_masks_events_post_expose_with(dev, NULL, cr, OVERLAY_SCREEN_W, OVERLAY_SCREEN_H, -1, -1, &transform);
+    const double build_ms = 1000.0 * (dt_get_wtime() - build_start);
+
+    const double start = dt_get_wtime();
+    for(int f = 0; f < frames; f++)
+    {
+      cairo_set_source_rgb(cr, 0.12, 0.12, 0.12);
+      cairo_paint(cr);
+      dt_masks_events_post_expose_with(dev, NULL, cr, OVERLAY_SCREEN_W, OVERLAY_SCREEN_H, -1, -1, &transform);
+    }
+    const double per_frame_ms = 1000.0 * (dt_get_wtime() - start) / MAX(frames, 1);
+    cairo_destroy(cr);
+
+    int points = 0;
+    int border = 0;
+    const dt_masks_form_gui_points_t *const gp
+        = (const dt_masks_form_gui_points_t *)g_list_nth_data(dev->form_gui->points, 0);
+    if(!IS_NULL_PTR(gp))
+    {
+      points = gp->points_count;
+      border = gp->border_count;
+    }
+    printf("[TIME] %-26s %5dx%-4d %-8s %7.2f ms/frame  (first frame incl. build %7.2f ms;"
+           " %d outline samples, %d border samples)\n",
+           name, img_w, img_h, selected ? "selected" : "member", per_frame_ms, build_ms, points, border);
+
+    if(!IS_NULL_PTR(dir))
+    {
+      char *png = g_strdup_printf("%s/%s-screen%s.png", dir, name, selected ? "-selected" : "");
+      cairo_surface_flush(surface);
+      cairo_surface_write_to_png(surface, png);
+      g_free(png);
+    }
+  }
+  cairo_surface_destroy(surface);
+}
+
+static void _time_overlay_brush(dt_develop_t *dev, GList *nodes, const char *name, const char *dir,
+                                const int img_w, const int img_h, const int frames)
+{
+  dt_masks_form_t form = { 0 };
+  form.type = DT_MASKS_BRUSH;
+  form.functions = &dt_masks_functions_brush;
+  form.version = 6;
+  form.formid = 900;
+  g_strlcpy(form.name, name, sizeof(form.name));
+  form.points = nodes;
+  _time_overlay_form(dev, &form, name, dir, img_w, img_h, frames);
+  g_list_free_full(form.points, free);
+}
+
+static void _time_overlay_all(dt_develop_t *dev, const char *dir, const int frames)
+{
+  printf("overlay timing: %dx%d screen, fit zoom, %d frames per measurement\n", OVERLAY_SCREEN_W,
+         OVERLAY_SCREEN_H, frames);
+  _time_overlay_brush(dev, _brush_from_table(_brush_1313, 11), "brush-1313-cusp", dir, 5198, 3904, frames);
+  _time_overlay_brush(dev, _brush_from_table(_brush_cusp_tbl, 3), "brush-cusp", dir, IMG_W, IMG_H, frames);
+  _time_overlay_brush(dev, _brush_from_table(_brush_hairpin_tbl, 3), "brush-hairpin", dir, IMG_W, IMG_H, frames);
+  _time_overlay_brush(dev, _brush_from_table(_brush_zigzag_tbl, 6), "brush-zigzag", dir, IMG_W, IMG_H, frames);
+  _time_overlay_brush(dev, _brush_from_table(_brush_selfcross_tbl, 5), "brush-selfcross", dir, IMG_W, IMG_H, frames);
+  _time_overlay_brush(dev, _brush_from_table(_brush_concave_tbl, 5), "brush-concave", dir, IMG_W, IMG_H, frames);
+  _time_overlay_brush(dev, _brush_from_table11(_brush_1360, 43), "brush-1360-pressure-ramp", dir, 5184, 3888, frames);
+  _time_overlay_brush(dev, _brush_from_table11(_brush_1352, 7), "brush-1352-radius-step", dir, IMG_W, IMG_H, frames);
+
+  {
+    dt_masks_form_t form = { 0 };
+    form.type = DT_MASKS_POLYGON;
+    form.functions = &dt_masks_functions_polygon;
+    form.version = 6;
+    form.formid = 106;
+    g_strlcpy(form.name, "polygon-1788045925", sizeof(form.name));
+    for(int i = 0; i < 15; i++)
+    {
+      const float *r = _polygon_1788045925[i];
+      form.points = g_list_append(form.points, _polygon_node(r[0], r[1], r[2], r[3], r[4], r[5], r[6]));
+    }
+    _time_overlay_form(dev, &form, "polygon-1788045925", dir, 5198, 3904, frames);
+    g_list_free_full(form.points, free);
+  }
+  {
+    dt_masks_form_t form = { 0 };
+    form.type = DT_MASKS_POLYGON;
+    form.functions = &dt_masks_functions_polygon;
+    form.version = 6;
+    form.formid = 104;
+    g_strlcpy(form.name, "polygon-comb", sizeof(form.name));
+    const float radius = 0.028f;
+    for(int i = 0; i < 5; i++)
+    {
+      const float x = 0.20f + 0.13f * i;
+      form.points = g_list_append(form.points, _polygon_node(x, 0.35f, x, 0.35f, x, 0.35f, radius));
+      form.points = g_list_append(form.points,
+                                  _polygon_node(x + 0.05f, 0.62f, x + 0.05f, 0.62f, x + 0.05f, 0.62f, radius));
+    }
+    form.points = g_list_append(form.points, _polygon_node(0.80f, 0.78f, 0.80f, 0.78f, 0.80f, 0.78f, radius));
+    form.points = g_list_append(form.points, _polygon_node(0.20f, 0.78f, 0.20f, 0.78f, 0.20f, 0.78f, radius));
+    _time_overlay_form(dev, &form, "polygon-comb", dir, IMG_W, IMG_H, frames);
+    g_list_free_full(form.points, free);
+  }
+}
+
 int main(int argc, char *argv[])
 {
   /* Defaulting to "/tmp" wrote three dozen renders and CSVs to PREDICTABLE names in a
@@ -1289,6 +1448,11 @@ int main(int argc, char *argv[])
       g_free(default_baseline);
       default_baseline = g_strdup(argv[++i]);
     }
+    else if(!strcmp(argv[i], "--time-overlay"))
+    {
+      time_overlay = TRUE;
+      if(i + 1 < argc && argv[i + 1][0] != '-') time_overlay_frames = atoi(argv[++i]);
+    }
     else if(!strcmp(argv[i], "--no-baseline"))
     {
       g_free(default_baseline);
@@ -1312,8 +1476,13 @@ int main(int argc, char *argv[])
     return 1;
   }
 
+  /* MASKS_DEBUG=1 turns on the masks and perf traces, which is how the per-stage cost of an
+   * overlay frame is read; the corpus itself does not want them. */
+  const gboolean debug = !IS_NULL_PTR(g_getenv("MASKS_DEBUG"));
   char *argv_override[] = {
     "ansel-test-masks-geometry",
+    debug ? "-d" : "--conf", debug ? "masks" : "write_sidecar_files=FALSE",
+    debug ? "-d" : "--conf", debug ? "perf" : "write_sidecar_files=FALSE",
     "--library", ":memory:",
     "--datadir", ANSEL_TEST_SOURCE_DIR "/data",
     // the build tree keeps its modules under src/, laid out as the installed tree expects
@@ -1354,6 +1523,11 @@ int main(int argc, char *argv[])
   printf("geometry chain authoritative: %s\n",
          dt_geometry_chain_authoritative(dev.geometry_chain) ? "yes" : "NO -- outlines will be empty");
 
+  if(time_overlay)
+  {
+    _time_overlay_all(&dev, dir, MAX(time_overlay_frames, 1));
+    return 0;
+  }
   printf("mask geometry corpus -> %s\n", dir);
 
   /* 0. THE REPORTED SHAPE. Issue #1313's follow-up: brush #1, cusp at node 8. The stroke loses

--- a/tests/unittests/CMakeLists.txt
+++ b/tests/unittests/CMakeLists.txt
@@ -40,6 +40,7 @@ set(LIB_ANSEL_UNIT_TESTS
   test_dtpthread_recursive
   test_history_snapshot
   test_masks_raster_contract
+  test_stroke_raster
 )
 
 foreach(test ${LIB_ANSEL_UNIT_TESTS})

--- a/tests/unittests/test_stroke_raster.c
+++ b/tests/unittests/test_stroke_raster.c
@@ -56,6 +56,7 @@ static dt_stroke_style_t _solid(const double width, const double r, const double
 
 static void _a_horizontal_line_paints_a_band_of_its_width(void **state)
 {
+  (void)state;
   cairo_surface_t *s = cairo_image_surface_create(CAIRO_FORMAT_ARGB32, 100, 20);
   const double xy[] = { 10.5, 10.5, 90.5, 10.5 };   /* pixel centres */
   const dt_stroke_style_t style = _solid(4.0, 0.0, 0.0, 1.0);
@@ -85,6 +86,7 @@ static void _a_horizontal_line_paints_a_band_of_its_width(void **state)
 
 static void _flat_caps_stop_at_the_ends(void **state)
 {
+  (void)state;
   cairo_surface_t *s = cairo_image_surface_create(CAIRO_FORMAT_ARGB32, 100, 20);
   const double xy[] = { 10.5, 10.5, 90.5, 10.5 };
   dt_stroke_style_t style = _solid(4.0, 0.0, 0.0, 1.0);
@@ -98,6 +100,7 @@ static void _flat_caps_stop_at_the_ends(void **state)
 
 static void _dashes_leave_gaps_along_the_line(void **state)
 {
+  (void)state;
   cairo_surface_t *s = cairo_image_surface_create(CAIRO_FORMAT_ARGB32, 120, 20);
   const double xy[] = { 0.5, 10.5, 100.5, 10.5 };
   dt_stroke_style_t style = _solid(2.0, 1.0, 1.0, 1.0);
@@ -115,6 +118,7 @@ static void _dashes_leave_gaps_along_the_line(void **state)
 
 static void _the_bright_pass_paints_over_the_dark_one(void **state)
 {
+  (void)state;
   cairo_surface_t *s = cairo_image_surface_create(CAIRO_FORMAT_ARGB32, 100, 20);
   const double xy[] = { 10.5, 10.5, 90.5, 10.5 };
   dt_stroke_style_t style = _solid(6.0, 1.0, 0.0, 0.0);
@@ -129,6 +133,7 @@ static void _the_bright_pass_paints_over_the_dark_one(void **state)
 
 static void _a_surface_it_cannot_write_is_refused_and_the_path_kept(void **state)
 {
+  (void)state;
   cairo_surface_t *s = cairo_image_surface_create(CAIRO_FORMAT_RGB24, 100, 20);
   cairo_t *cr = cairo_create(s);
   cairo_move_to(cr, 10, 10);
@@ -146,6 +151,7 @@ static void _a_surface_it_cannot_write_is_refused_and_the_path_kept(void **state
 
 static void _a_path_in_a_pushed_group_lands_where_cairo_puts_it(void **state)
 {
+  (void)state;
   /* The group's surface is sized to the clip and offset to it; a stroke painted into that
    * surface must still appear at the path's device position once the group is composited. */
   cairo_surface_t *s = cairo_image_surface_create(CAIRO_FORMAT_ARGB32, 100, 100);
@@ -171,6 +177,7 @@ static void _a_path_in_a_pushed_group_lands_where_cairo_puts_it(void **state)
 
 static void _the_matrix_scales_widths_and_positions(void **state)
 {
+  (void)state;
   cairo_surface_t *s = cairo_image_surface_create(CAIRO_FORMAT_ARGB32, 120, 60);
   cairo_t *cr = cairo_create(s);
   cairo_scale(cr, 2.0, 2.0);
@@ -188,6 +195,7 @@ static void _the_matrix_scales_widths_and_positions(void **state)
 
 static void _the_touched_record_resets(void **state)
 {
+  (void)state;
   cairo_surface_t *s = cairo_image_surface_create(CAIRO_FORMAT_ARGB32, 100, 20);
   cairo_rectangle_int_t touched;
   assert_false(dt_stroke_raster_touched(s, &touched));

--- a/tests/unittests/test_stroke_raster.c
+++ b/tests/unittests/test_stroke_raster.c
@@ -1,0 +1,222 @@
+/*
+    This file is part of Ansel,
+    Copyright (C) 2026 Aurélien PIERRE.
+
+    Ansel is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Ansel is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Ansel.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+/* The stroke rasteriser, pixel by pixel.
+ *
+ * Every expectation here is a pixel value read back from an ARGB32 surface, because the
+ * rasteriser's whole contract is what it puts in pixels: a band of the right width at the
+ * right place, a round or flat end, a gap where a dash pattern says so, the bright pass over
+ * the dark one, and -- the one that bites -- the same place cairo would put it when drawing
+ * inside a pushed group, whose surface is offset from the target's device space. */
+
+#include "widgets/stroke_raster.h"
+
+#include <cairo.h>
+#include <setjmp.h>
+#include <stdarg.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <cmocka.h>
+
+static uint32_t _pixel(cairo_surface_t *surface, const int x, const int y)
+{
+  cairo_surface_flush(surface);
+  const uint8_t *data = cairo_image_surface_get_data(surface);
+  const int stride = cairo_image_surface_get_stride(surface);
+  return *(const uint32_t *)(data + (size_t)y * stride + (size_t)x * 4);
+}
+
+static int _alpha(cairo_surface_t *surface, const int x, const int y)
+{
+  return (int)(_pixel(surface, x, y) >> 24);
+}
+
+static dt_stroke_style_t _solid(const double width, const double r, const double g, const double b)
+{
+  dt_stroke_style_t style = { 0 };
+  style.dark = (dt_stroke_pass_t){ .width = width, .red = r, .green = g, .blue = b, .alpha = 1.0 };
+  style.round_caps = TRUE;
+  return style;
+}
+
+static void _a_horizontal_line_paints_a_band_of_its_width(void **state)
+{
+  cairo_surface_t *s = cairo_image_surface_create(CAIRO_FORMAT_ARGB32, 100, 20);
+  const double xy[] = { 10.5, 10.5, 90.5, 10.5 };   /* pixel centres */
+  const dt_stroke_style_t style = _solid(4.0, 0.0, 0.0, 1.0);
+  assert_true(dt_stroke_raster_polyline(s, xy, 2, &style));
+
+  /* on the centreline: opaque blue, premultiplied */
+  assert_int_equal(_pixel(s, 50, 10), 0xff0000ffu);
+  /* one pixel off the centreline is still inside a 4-wide band (distance 1 < 2) */
+  assert_int_equal(_alpha(s, 50, 11), 255);
+  /* the ramp: distance 2 sits on the edge, half covered */
+  const int edge = _alpha(s, 50, 12);
+  assert_in_range(edge, 100, 155);
+  /* distance 3 is beyond the ramp */
+  assert_int_equal(_alpha(s, 50, 13), 0);
+  /* a round cap: one pixel past the end is inside (distance 1), the pixel at distance 2 sits on
+   * the cap's edge, and distance 3 is beyond it */
+  assert_int_equal(_alpha(s, 9, 10), 255);
+  assert_in_range(_alpha(s, 8, 10), 100, 155);
+  assert_int_equal(_alpha(s, 7, 10), 0);
+
+  cairo_rectangle_int_t touched;
+  assert_true(dt_stroke_raster_touched(s, &touched));
+  assert_true(touched.x <= 8 && touched.x + touched.width >= 93);
+  assert_true(touched.y <= 8 && touched.y + touched.height >= 13);
+  cairo_surface_destroy(s);
+}
+
+static void _flat_caps_stop_at_the_ends(void **state)
+{
+  cairo_surface_t *s = cairo_image_surface_create(CAIRO_FORMAT_ARGB32, 100, 20);
+  const double xy[] = { 10.5, 10.5, 90.5, 10.5 };
+  dt_stroke_style_t style = _solid(4.0, 0.0, 0.0, 1.0);
+  style.round_caps = FALSE;
+  assert_true(dt_stroke_raster_polyline(s, xy, 2, &style));
+  assert_int_equal(_alpha(s, 50, 10), 255);
+  assert_int_equal(_alpha(s, 8, 10), 0);    /* nothing past the end */
+  assert_int_equal(_alpha(s, 11, 10), 255); /* the line itself is intact */
+  cairo_surface_destroy(s);
+}
+
+static void _dashes_leave_gaps_along_the_line(void **state)
+{
+  cairo_surface_t *s = cairo_image_surface_create(CAIRO_FORMAT_ARGB32, 120, 20);
+  const double xy[] = { 0.5, 10.5, 100.5, 10.5 };
+  dt_stroke_style_t style = _solid(2.0, 1.0, 1.0, 1.0);
+  style.dash_on = 10.0;
+  style.dash_off = 10.0;
+  style.round_caps = FALSE;
+  assert_true(dt_stroke_raster_polyline(s, xy, 2, &style));
+  assert_int_equal(_alpha(s, 5, 10), 255);    /* first dash, 0..10 */
+  assert_int_equal(_alpha(s, 15, 10), 0);     /* first gap, 10..20 */
+  assert_int_equal(_alpha(s, 25, 10), 255);   /* second dash */
+  assert_int_equal(_alpha(s, 35, 10), 0);
+  assert_int_equal(_alpha(s, 95, 10), 0);     /* 90..100 is a gap */
+  cairo_surface_destroy(s);
+}
+
+static void _the_bright_pass_paints_over_the_dark_one(void **state)
+{
+  cairo_surface_t *s = cairo_image_surface_create(CAIRO_FORMAT_ARGB32, 100, 20);
+  const double xy[] = { 10.5, 10.5, 90.5, 10.5 };
+  dt_stroke_style_t style = _solid(6.0, 1.0, 0.0, 0.0);
+  style.bright = (dt_stroke_pass_t){ .width = 2.0, .red = 0.0, .green = 1.0, .blue = 0.0, .alpha = 1.0 };
+  assert_true(dt_stroke_raster_polyline(s, xy, 2, &style));
+  /* centre: green won */
+  assert_int_equal(_pixel(s, 50, 10), 0xff00ff00u);
+  /* two pixels out: only the dark, red pass */
+  assert_int_equal(_pixel(s, 50, 12), 0xffff0000u);
+  cairo_surface_destroy(s);
+}
+
+static void _a_surface_it_cannot_write_is_refused_and_the_path_kept(void **state)
+{
+  cairo_surface_t *s = cairo_image_surface_create(CAIRO_FORMAT_RGB24, 100, 20);
+  cairo_t *cr = cairo_create(s);
+  cairo_move_to(cr, 10, 10);
+  cairo_line_to(cr, 90, 10);
+  const dt_stroke_style_t style = _solid(4.0, 0.0, 0.0, 1.0);
+  assert_false(dt_stroke_raster_path(cr, &style));
+  /* the path is still there for cairo to stroke */
+  assert_true(cairo_has_current_point(cr));
+  cairo_path_t *path = cairo_copy_path(cr);
+  assert_true(path->num_data > 0);
+  cairo_path_destroy(path);
+  cairo_destroy(cr);
+  cairo_surface_destroy(s);
+}
+
+static void _a_path_in_a_pushed_group_lands_where_cairo_puts_it(void **state)
+{
+  /* The group's surface is sized to the clip and offset to it; a stroke painted into that
+   * surface must still appear at the path's device position once the group is composited. */
+  cairo_surface_t *s = cairo_image_surface_create(CAIRO_FORMAT_ARGB32, 100, 100);
+  cairo_t *cr = cairo_create(s);
+  cairo_rectangle(cr, 20, 20, 60, 60);
+  cairo_clip(cr);
+  cairo_push_group(cr);
+  cairo_move_to(cr, 30, 50);
+  cairo_line_to(cr, 70, 50);
+  const dt_stroke_style_t style = _solid(4.0, 0.0, 0.0, 1.0);
+  assert_true(dt_stroke_raster_path(cr, &style));
+  assert_false(cairo_has_current_point(cr));   /* consumed, as a stroke would */
+  cairo_pop_group_to_source(cr);
+  cairo_paint(cr);
+  cairo_destroy(cr);
+
+  assert_int_equal(_alpha(s, 50, 50), 255);   /* on the line */
+  assert_int_equal(_alpha(s, 50, 45), 0);     /* well off it */
+  assert_int_equal(_alpha(s, 10, 50), 0);     /* outside the clip */
+  assert_int_equal(_alpha(s, 30, 50), 255);   /* the start, inside the clip */
+  cairo_surface_destroy(s);
+}
+
+static void _the_matrix_scales_widths_and_positions(void **state)
+{
+  cairo_surface_t *s = cairo_image_surface_create(CAIRO_FORMAT_ARGB32, 120, 60);
+  cairo_t *cr = cairo_create(s);
+  cairo_scale(cr, 2.0, 2.0);
+  cairo_move_to(cr, 10.25, 10.25);   /* device (20.5, 20.5): a pixel centre */
+  cairo_line_to(cr, 40.25, 10.25);
+  dt_stroke_style_t style = _solid(2.0, 0.0, 0.0, 1.0);   /* 2 user units = 4 device pixels */
+  assert_true(dt_stroke_raster_path(cr, &style));
+  cairo_destroy(cr);
+  assert_int_equal(_alpha(s, 50, 20), 255);
+  assert_int_equal(_alpha(s, 50, 21), 255);   /* still inside a 4-wide band */
+  assert_int_equal(_alpha(s, 50, 23), 0);     /* three pixels out: beyond it */
+  assert_int_equal(_alpha(s, 50, 10), 0);     /* the user-space y would have been wrong here */
+  cairo_surface_destroy(s);
+}
+
+static void _the_touched_record_resets(void **state)
+{
+  cairo_surface_t *s = cairo_image_surface_create(CAIRO_FORMAT_ARGB32, 100, 20);
+  cairo_rectangle_int_t touched;
+  assert_false(dt_stroke_raster_touched(s, &touched));
+  const double xy[] = { 10.5, 10.5, 20.5, 10.5 };
+  const dt_stroke_style_t style = _solid(2.0, 1.0, 1.0, 1.0);
+  assert_true(dt_stroke_raster_polyline(s, xy, 2, &style));
+  assert_true(dt_stroke_raster_touched(s, &touched));
+  dt_stroke_raster_touched_reset(s);
+  assert_false(dt_stroke_raster_touched(s, &touched));
+  cairo_surface_destroy(s);
+}
+
+int main(void)
+{
+  const struct CMUnitTest tests[] = {
+    cmocka_unit_test(_a_horizontal_line_paints_a_band_of_its_width),
+    cmocka_unit_test(_flat_caps_stop_at_the_ends),
+    cmocka_unit_test(_dashes_leave_gaps_along_the_line),
+    cmocka_unit_test(_the_bright_pass_paints_over_the_dark_one),
+    cmocka_unit_test(_a_surface_it_cannot_write_is_refused_and_the_path_kept),
+    cmocka_unit_test(_a_path_in_a_pushed_group_lands_where_cairo_puts_it),
+    cmocka_unit_test(_the_matrix_scales_widths_and_positions),
+    cmocka_unit_test(_the_touched_record_resets),
+  };
+  return cmocka_run_group_tests(tests, NULL, NULL);
+}
+
+// clang-format off
+// modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py
+// vim: shiftwidth=2 expandtab tabstop=2 cindent
+// kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;
+// clang-format on

--- a/tests/unittests/test_stroke_raster.c
+++ b/tests/unittests/test_stroke_raster.c
@@ -193,6 +193,49 @@ static void _the_matrix_scales_widths_and_positions(void **state)
   cairo_surface_destroy(s);
 }
 
+static void _a_device_scaled_surface_is_painted_in_its_pixels(void **state)
+{
+  (void)state;
+  /* A HiDPI widget's surface carries a device scale: cairo's device space is then half the
+   * pixel grid, and cairo_user_to_device() stops there. The line below is at user (10..40, 10)
+   * on a surface scaled by 2: it must land on pixel row 20, from column 20 to 80, four pixels
+   * wide for a width of 2 user units -- not on row 10 at half size. */
+  cairo_surface_t *s = cairo_image_surface_create(CAIRO_FORMAT_ARGB32, 120, 60);
+  cairo_surface_set_device_scale(s, 2.0, 2.0);
+  cairo_t *cr = cairo_create(s);
+  cairo_move_to(cr, 10.25, 10.25);
+  cairo_line_to(cr, 40.25, 10.25);
+  const dt_stroke_style_t style = _solid(2.0, 0.0, 0.0, 1.0);
+  assert_true(dt_stroke_raster_path(cr, &style));
+  cairo_destroy(cr);
+  assert_int_equal(_alpha(s, 50, 20), 255);   /* on the line, in pixels */
+  assert_int_equal(_alpha(s, 50, 21), 255);   /* four pixels wide */
+  assert_int_equal(_alpha(s, 50, 23), 0);
+  assert_int_equal(_alpha(s, 50, 10), 0);     /* where device units would have put it */
+  assert_int_equal(_alpha(s, 25, 10), 0);
+  assert_int_equal(_alpha(s, 79, 20), 255);   /* the end, in pixels */
+  assert_int_equal(_alpha(s, 86, 20), 0);
+  cairo_surface_destroy(s);
+
+  /* and inside a pushed group on such a surface, where the group's offset is in pixels */
+  s = cairo_image_surface_create(CAIRO_FORMAT_ARGB32, 120, 120);
+  cairo_surface_set_device_scale(s, 2.0, 2.0);
+  cr = cairo_create(s);
+  cairo_rectangle(cr, 10, 10, 40, 40);   /* pixels 20..100 */
+  cairo_clip(cr);
+  cairo_push_group(cr);
+  cairo_move_to(cr, 15, 30);             /* pixels (30, 60) .. (90, 60) */
+  cairo_line_to(cr, 45, 30);
+  assert_true(dt_stroke_raster_path(cr, &style));
+  cairo_pop_group_to_source(cr);
+  cairo_paint(cr);
+  cairo_destroy(cr);
+  assert_int_equal(_alpha(s, 60, 60), 255);
+  assert_int_equal(_alpha(s, 60, 30), 0);     /* device units would have put it here */
+  assert_int_equal(_alpha(s, 10, 60), 0);     /* outside the clip */
+  cairo_surface_destroy(s);
+}
+
 static void _the_touched_record_resets(void **state)
 {
   (void)state;
@@ -218,6 +261,7 @@ int main(void)
     cmocka_unit_test(_a_surface_it_cannot_write_is_refused_and_the_path_kept),
     cmocka_unit_test(_a_path_in_a_pushed_group_lands_where_cairo_puts_it),
     cmocka_unit_test(_the_matrix_scales_widths_and_positions),
+    cmocka_unit_test(_a_device_scaled_surface_is_painted_in_its_pixels),
     cmocka_unit_test(_the_touched_record_resets),
   };
   return cmocka_run_group_tests(tests, NULL, NULL);


### PR DESCRIPTION
The mask overlay's outlines are drawn from the pixel samples the producers already computed, instead of being turned back into a cairo path and stroked. Requested as: we rasterise, then vectorise, then re-rasterise — reimplement the minimum of cairo the overlays use and paint the coordinates we have.

## What the overlays used of cairo

Exactly this, and nothing else, for the long polylines: two widths (a wide dark pass under a narrow bright one), two colours with alpha, `DASH_STICK` (12/12 px) and `DASH_ROUND` (3/12 px), round or flat caps, `CAIRO_ANTIALIAS_FAST`. Nodes, handles, arrows, the clone source shape, the brush's creation trace and cursor discs are a handful of small primitives each — they stay with cairo, drawn into the same surface.

## What changes

- **`src/widgets/stroke_raster.{h,c}`** — a widget-layer primitive (cairo + glib, no masks vocabulary). `dt_stroke_raster_path(cr, style)` takes cairo's current path, flattens it, maps it through the matrix into the pixels of the surface `cr` draws on — the current *group's* surface if one is pushed, device offset included — and strokes it from a distance field: each segment stamps `reach² − d²` into a zero-at-rest scratch plane over its own box (MAX, so the nearest point wins; no square root until compositing); dashes are cut along the arc length before stamping, so a dash end is a cap as cairo's is; compositing walks only the spans each row wrote, `clamp(R + ½ − d, 0, 1)` per pass, premultiplied OVER, then zeroes them. A surface it cannot write (not ARGB32 image) is refused with the path intact, and the cairo strokes take over — nothing changes for any other target.
- **`widgets/draw.h`** — `dt_draw_shape_lines()` / `dt_draw_stroke_line()` build the style from the same numbers they always gave cairo (`dt_draw_dash_lengths()` factors the dash pattern out of `dt_draw_set_dash_style()`) and try the rasteriser first.
- **`masks_gui.c`** — no more `cairo_push_group()` the size of the view. One ARGB32 canvas in device pixels, kept across frames, drawn through a `cairo_t` carrying `cr`'s matrix shifted to the clip's origin; composited over **only the rectangle that was painted** — the rasteriser's own record plus the node header of every outline (three points per node, with a margin for a disc and an arrow head), then cleared by hand for the next frame.

## Measured

`ansel-test-masks-geometry --time-overlay 30`: a 2560×1440 view at fit zoom, per shape per frame, the two states a drag frame is made of.

| case | member (path only) | selected (path, dashed border, nodes) |
|---|---:|---:|
| brush-1313-cusp (11 nodes) | 7.56 → **1.49** ms | 9.49 → **2.49** ms |
| brush-1360-pressure-ramp (43 nodes) | 8.47 → **2.51** ms | 11.67 → **4.27** ms |
| brush-zigzag (98 k samples) | 12.37 → **2.88** ms | 17.99 → **5.33** ms |
| polygon-1788045925 (15 nodes) | 7.01 → **1.72** ms | 8.97 → **2.65** ms |
| polygon-comb (12 nodes) | 12.65 → **4.04** ms | 16.96 → **6.47** ms |

From the traces (`MASKS_DEBUG=1`), on the pressure ramp: the strokes themselves went from ~6 ms to ~3 ms, and the 4 ms full-view composite of the group became a composite of the painted rectangle. The harness paints its own background each frame (~1 ms, in both columns) — the darkroom pays that as its image blit anyway.

**The pixels.** On the corpus's screen renders, before vs after: painted-pixel counts agree within 1–3 %, no pixel differs by more than 51/255 except single end-cap pixels (a one-pixel stub under a node whose flat end is round now; the first pixel of one dash on the self-crossing brush), and **no raster (alpha) baseline moved at all** — the masks' pixels are untouched. The 23 overlay baselines are regenerated in the private bank, uncommitted for your review; the old ones are at `/var/tmp/ansel-overlay-old-baselines`.

Side by side at 2×, cairo left, rasteriser right (path, dashed border, nodes, the square cusp node): indistinguishable — the sheet is what I checked before regenerating anything.

## Verification

- `tests/unittests/test_stroke_raster.c` pins the contract pixel by pixel, 8 cases: the band's width and ramp, a round cap and a flat one, dash gaps, the bright pass over the dark one, refusal of a non-writable surface with the path kept, **a stroke inside a clipped pushed group landing where cairo composites it**, the matrix scaling widths, the touched record.
- Corpus 23/23 against the bank; GCC Release, clang Debug `-Weverything` and nofeatures on every touched file; gates pass.
- **Not verified by me: the live darkroom.** A build is installed at `/var/tmp/ansel-overlay-inst/bin/ansel` for a drag with a real mask group. What to look for: identical appearance (including HiDPI, where the canvas takes the widget's device scale), nothing left behind when a shape moves out of where it was (the dirty rectangle is cleared per frame), and the creation session (multi-shape drawing) still painting from its pattern cache.

## Traps, paid for

- Stamping a **disc per vertex** instead of a capsule per segment scallops thin lines: necks of `s²/8R` between vertices `s` apart, visible at the bright pass's half-width.
- Inside a pushed group, **`cairo_get_target()` is the original target**; the writable surface is `cairo_get_group_target()`, and it carries a device offset (pixel = device + offset). The unit test paints inside a clipped group and checks the composite lands where cairo puts it.
- A widget context has a **device scale**, so an identity matrix is not device pixels; the canvas takes the target's scale and its matrix is `cr`'s followed by a translation in device units divided by that scale.

## What is left on the table

The darkroom repaints the whole widget on every motion (`dt_control_queue_redraw_center()`), so the clip — hence the canvas composite and the image blit — is always the full view even when only the overlay changed. A `queue_draw_area` of the overlay's dirty rectangle for overlay-only changes is the next lever, and a darkroom change rather than a masks one.

## Second commit: the scratch belongs to the surface

`tools/check_statelessness.sh` failed the first push, and it was right: `src/widgets` keeps no state outside its two registries, and the rasteriser held its scratch plane and a mutex in statics. The scratch now lives on the surface it serves, as cairo user data beside the touched record — grown to the largest box that surface asks for, freed with it, no lock. Sonar's findings on the first push (gate passing) went in the same pass: a segment struct instead of eight parameters, one row per helper for the stamp and the composite, the dashed walk and the path gathering as their own functions, and the expose function opening and closing a canvas frame through `_canvas_begin()` / `_canvas_end()`. Same numbers, same pixels: corpus 23/23, unit tests, GCC, clang, and the statelessness gate itself.
A third commit answers the one finding the re-analysis kept — the expose function at complexity 30 — by drawing the form through one helper and deciding the dirty rectangle through another.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Follow-ups after the first review

**HiDPI (reported from a 2x darkroom: every overlay at half size in the top-left quadrant).** Cairo's device space is not the pixel grid: a surface applies its own transform after the CTM (pixel = device × device_scale + device_offset), and `cairo_user_to_device()` stops before it — measured with pycairo: on a surface with device scale 2, (10, 10) maps to (10, 10) and a group pushed under a clip at (20, 20) reports offset (−40, −40), in pixels. The rasteriser and the canvas mapped device units straight to pixels, exact on every 1x screen and in every unit test. Every derived pixel now multiplies by the surface's device scale and adds its offset. `test_stroke_raster` paints on a device-scaled surface, plain and inside a clipped group; the harness renders every case at device scale 2 and compares the painted bounding box with the 1x render's (all ten cases agree within 2 px, the wider line a 2x screen is entitled to). Corpus unchanged at scale 1.

**Bound before draw.** A review flagged `_canvas_acquire()` for reusing a same-size canvas without its position; the mechanism it described cannot ghost (the canvas is cleared after every composite), but the symptom was reachable: a cairo-drawn handle landing outside the dirty estimate stayed on the canvas for the next, panned frame. The bound on what cairo may paint is now computed before anything is drawn and the canvas context is clipped to it. The harness draws a panned frame after every state and fails on any pixel a fresh surface would not show.

**Dashed border gaps (reported from the harness renders of brush-1352 and brush-1313).** Not the rasteriser: the cairo fallback renders the same frame to 18 pixels. 37% of the 1313 brush's border was being skipped by the boundary pass along both long sides, because a border sample sat on the normal of its spine sample while the boundary of discs whose radius varies is their envelope, tilted off the normal by asin(dr/ds); the normal sample is inside the union by ~r′²r/2, invisible to the eye and exactly what the detector rejects. The raster had the same defect from the same samples (a fat node's shoulders painted as a flat shelf). `dt_masks_outline_envelope_offset()` now places every brush and polygon sample; the rate is zero at segment ends so caps and joints are untouched, the tilt is capped at 0.7. Constant-radius corpus cases are bit-identical; 1313 ×8 and 1352 ×2 baselines regenerated in the bank (uncommitted there, for review). The harness now prints the skipped fraction per case and `MASKS_DUMP_SKIPS=<dir>` dumps every spoke.

**A copy of a boundary stretch is not a boundary sample (`_MG_1074.CR2` brush #4, reported as a missing dashed border near node 0).** The walk stamps a full disc at a radius-stepping node in both passes and bridges joints with arcs about the same node, so a flaring node's circle was traced two or three times, each copy dashed from its own phase, and the copies filled each other's gaps into a near-solid line (4,020 kept samples on a 2,114 px circumference). The boundary pass now drops a sample that repeats an earlier one: the same spine point to 0.01 px, a border position within 0.75 px, at least 16 samples earlier along the walk. The other side of the stroke never matches; polygons and constant-radius brushes are bit-identical; the 1313 and 1360 outline baselines were regenerated and the 1074 brush joined the corpus and the harness, which gained `MASKS_OVERLAY_VIEW` to render the darkroom's actual view at any zoom and device scale.

**Dash spacing and the junction at a flaring node.** The rasteriser restarted the dash pattern at every sub-path, one per kept run between skips, so dashes bunched at every run boundary; one dash state now travels across all the sub-paths of a stroke, so a dash is a function of the arc length drawn before it. The copies rule is position-only now: a sample within 0.75 px of an earlier one at least 4 px of walked border behind it is a repeat, whatever discs they belong to, which also takes the stretch where a segment leaves a stamped node within the tolerance of its circle. `MASKS_DUMP_OVERLAY=<dir>` makes the darkroom write each frame's canvas and outlines, for reports the harness cannot reproduce.

**The exact envelope.** The darkroom's frame dump showed the missing top of brush #4: as the user drew it, the flare's radius rate peaks near 1, its union's top is the rear envelope 40 px outside the wide node's circle at a 64° tilt, and the 0.7 tilt cap kept every sample short of it. The cap was reasoned, not measured; at the exact envelope the raster oracle reports no missing pixel on any case, and the top closes. That brush is a corpus and harness case now, and a sample past the frame's edge is reported rather than judged.
