### PR TITLE
Implement Wayland color management.

### DIFF
--- a/cmake/modules/FindWayland.cmake
+++ b/cmake/modules/FindWayland.cmake
@@ -1,0 +1,139 @@
+# SPDX-FileCopyrightText: 2014 Alex Merry <alex.merry@kde.org>
+# SPDX-FileCopyrightText: 2014 Martin Gräßlin <mgraesslin@kde.org>
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+#[=======================================================================[.rst:
+FindWayland
+-----------
+
+Try to find Wayland.
+
+This is a component-based find module, which makes use of the COMPONENTS
+and OPTIONAL_COMPONENTS arguments to find_module.  The following components
+are available::
+
+  Client  Server  Cursor  Egl
+
+If no components are specified, this module will act as though all components
+were passed to OPTIONAL_COMPONENTS.
+
+This module will define the following variables, independently of the
+components searched for or found:
+
+``Wayland_FOUND``
+    TRUE if (the requested version of) Wayland is available
+``Wayland_VERSION``
+    Found Wayland version
+``Wayland_TARGETS``
+    A list of all targets imported by this module (note that there may be more
+    than the components that were requested)
+``Wayland_LIBRARIES``
+    This can be passed to target_link_libraries() instead of the imported
+    targets
+``Wayland_INCLUDE_DIRS``
+    This should be passed to target_include_directories() if the targets are
+    not used for linking
+``Wayland_DEFINITIONS``
+    This should be passed to target_compile_options() if the targets are not
+    used for linking
+``Wayland_DATADIR``
+    The core wayland protocols data directory
+    Since 5.73.0
+
+For each searched-for components, ``Wayland_<component>_FOUND`` will be set to
+TRUE if the corresponding Wayland library was found, and FALSE otherwise.  If
+``Wayland_<component>_FOUND`` is TRUE, the imported target
+``Wayland::<component>`` will be defined.  This module will also attempt to
+determine ``Wayland_*_VERSION`` variables for each imported target, although
+``Wayland_VERSION`` should normally be sufficient.
+
+In general we recommend using the imported targets, as they are easier to use
+and provide more control.  Bear in mind, however, that if any target is in the
+link interface of an exported library, it must be made available by the
+package config file.
+
+Since pre-1.0.0.
+#]=======================================================================]
+
+cmake_policy(VERSION 3.16)
+
+include(${CMAKE_CURRENT_LIST_DIR}/ECMFindModuleHelpersStub.cmake)
+
+ecm_find_package_version_check(Wayland)
+
+set(Wayland_known_components
+    Client
+    Server
+    Cursor
+    Egl
+)
+foreach(_comp ${Wayland_known_components})
+    string(TOLOWER "${_comp}" _lc_comp)
+    set(Wayland_${_comp}_component_deps)
+    set(Wayland_${_comp}_pkg_config "wayland-${_lc_comp}")
+    set(Wayland_${_comp}_lib "wayland-${_lc_comp}")
+    set(Wayland_${_comp}_header "wayland-${_lc_comp}.h")
+endforeach()
+set(Wayland_Egl_component_deps Client)
+
+ecm_find_package_parse_components(Wayland
+    RESULT_VAR Wayland_components
+    KNOWN_COMPONENTS ${Wayland_known_components}
+)
+ecm_find_package_handle_library_components(Wayland
+    COMPONENTS ${Wayland_components}
+)
+
+# If pkg-config didn't provide us with version information,
+# try to extract it from wayland-version.h
+# (Note that the version from wayland-egl.pc will probably be
+# the Mesa version, rather than the Wayland version, but that
+# version will be ignored as we always find wayland-client.pc
+# first).
+if(NOT Wayland_VERSION)
+    find_file(Wayland_VERSION_HEADER
+        NAMES wayland-version.h
+        HINTS ${Wayland_INCLUDE_DIRS}
+    )
+    mark_as_advanced(Wayland_VERSION_HEADER)
+    if(Wayland_VERSION_HEADER)
+        file(READ ${Wayland_VERSION_HEADER} _wayland_version_header_contents)
+        string(REGEX REPLACE
+            "^.*[ \t]+WAYLAND_VERSION[ \t]+\"([0-9.]*)\".*$"
+            "\\1"
+            Wayland_VERSION
+            "${_wayland_version_header_contents}"
+        )
+        unset(_wayland_version_header_contents)
+    endif()
+endif()
+
+find_package_handle_standard_args(Wayland
+    FOUND_VAR
+        Wayland_FOUND
+    REQUIRED_VARS
+        Wayland_LIBRARIES
+    VERSION_VAR
+        Wayland_VERSION
+    HANDLE_COMPONENTS
+)
+
+pkg_get_variable(Wayland_DATADIR wayland-scanner pkgdatadir)
+if (CMAKE_CROSSCOMPILING AND (NOT EXISTS "${Wayland_DATADIR}/wayland.xml"))
+    # PKG_CONFIG_SYSROOT_DIR only applies to -I and -L flags, so pkg-config
+    # does not prepend CMAKE_SYSROOT when cross-compiling unless you pass
+    # --define-prefix explicitly. Therefore we have to  manually do prepend
+    # it here when cross-compiling.
+    # See https://gitlab.kitware.com/cmake/cmake/-/issues/16647#note_844761
+    set(Wayland_DATADIR ${CMAKE_SYSROOT}${Wayland_DATADIR})
+endif()
+if (NOT EXISTS "${Wayland_DATADIR}/wayland.xml")
+    message(WARNING "Could not find wayland.xml in ${Wayland_DATADIR}")
+endif()
+
+include(FeatureSummary)
+set_package_properties(Wayland PROPERTIES
+    URL "https://wayland.freedesktop.org/"
+    DESCRIPTION "C library implementation of the Wayland protocol: a protocol for a compositor to talk to its clients"
+)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -352,6 +352,7 @@ pkg_check_modules(GMODULE REQUIRED IMPORTED_TARGET gmodule-2.0)
 pkg_check_modules(RSVG2 REQUIRED IMPORTED_TARGET librsvg-2.0)
 pkg_check_modules(JSONGLIB REQUIRED IMPORTED_TARGET json-glib-1.0)
 pkg_check_modules(LIBXML2 REQUIRED IMPORTED_TARGET libxml-2.0)
+pkg_check_modules(Wayland IMPORTED_TARGET wayland-client)
 
 # TODO: the following find_package() need to be replaced by pkg_check_modules()
 # like above as soon as they will get supported by PkgConfig,
@@ -371,14 +372,14 @@ if(NOT USE_BUNDLED_EXIV2)
 endif()
 find_package(Pugixml 1.2 REQUIRED)
 
-# CMake provides a `FindCURL.cmake` module, which will set `CURL_LIBRARIES`, 
-# however if cURL is built with CMake, it will generate a `CURLConfig.cmake` 
-# config, which will not set `CURL_LIBRARIES`. 
-# 
-# MSYS2 currently build cURL with CMake, and if we do `find_package(CURL)` 
-# directly, config will be used, so we need to keep compatibility。 
-# 
-# See <https://cmake.org/cmake/help/latest/module/FindCURL.html#curl-cmake>. 
+# CMake provides a `FindCURL.cmake` module, which will set `CURL_LIBRARIES`,
+# however if cURL is built with CMake, it will generate a `CURLConfig.cmake`
+# config, which will not set `CURL_LIBRARIES`.
+#
+# MSYS2 currently build cURL with CMake, and if we do `find_package(CURL)`
+# directly, config will be used, so we need to keep compatibility。
+#
+# See <https://cmake.org/cmake/help/latest/module/FindCURL.html#curl-cmake>.
 # See <https://github.com/msys2/MINGW-packages/issues/21028>.
 find_package(CURL REQUIRED)
 
@@ -630,6 +631,48 @@ if(WIN32)
   )
 endif()
 
+if(Wayland_FOUND)
+  pkg_get_variable(WAYLAND_PROTOCOLS_DATADIR wayland-protocols pkgdatadir)
+
+  find_program(WAYLAND_SCANNER wayland-scanner)
+
+  set(COLOR_MANAGEMENT_XML
+    ${WAYLAND_PROTOCOLS_DATADIR}/staging/color-management/color-management-v1.xml
+  )
+
+  set(COLOR_MANAGEMENT_CODE ${CMAKE_CURRENT_BINARY_DIR}/color-management-v1-protocol.c)
+  set(COLOR_MANAGEMENT_HEADER ${CMAKE_CURRENT_BINARY_DIR}/color-management-v1-client-protocol.h)
+
+  add_custom_command(
+      OUTPUT ${COLOR_MANAGEMENT_CODE}
+      COMMAND ${WAYLAND_SCANNER} private-code ${COLOR_MANAGEMENT_XML} ${COLOR_MANAGEMENT_CODE}
+      DEPENDS ${COLOR_MANAGEMENT_XML}
+      COMMENT "Generating color management c file."
+      VERBATIM
+  )
+
+  add_custom_command(
+      OUTPUT ${COLOR_MANAGEMENT_HEADER}
+      COMMAND ${WAYLAND_SCANNER} client-header ${COLOR_MANAGEMENT_XML} ${COLOR_MANAGEMENT_HEADER}
+      DEPENDS ${COLOR_MANAGEMENT_XML}
+      COMMENT "Generating color management h file."
+      VERBATIM
+  )
+
+  add_custom_target(
+    generate_wayland_protocols_h ALL
+    DEPENDS ${COLOR_MANAGEMENT_HEADER}
+  )
+
+  add_custom_target(
+    generate_wayland_protocols_c ALL
+    DEPENDS ${COLOR_MANAGEMENT_CODE}
+  )
+
+  # Wayland color management source files
+  list(APPEND SOURCES "color-management-v1-protocol.c")
+endif()
+
 #
 # Generate config.h
 #
@@ -837,6 +880,11 @@ add_dependencies(lib_ansel generate_conf)
 add_dependencies(lib_ansel generate_version)
 add_dependencies(lib_ansel generate_preferences)
 add_dependencies(lib_ansel generate_authors_h)
+
+if(Wayland_FOUND)
+  add_dependencies(lib_ansel generate_wayland_protocols_h)
+  add_dependencies(lib_ansel generate_wayland_protocols_c)
+endif()
 
 if(APPLE)
   set_target_properties(lib_ansel PROPERTIES MACOSX_RPATH TRUE)

--- a/src/colorprofiles/colorspaces.c
+++ b/src/colorprofiles/colorspaces.c
@@ -35,17 +35,17 @@
     Copyright (C) 2022 Martin Bařinka.
     Copyright (C) 2023 Alynx Zhou.
     Copyright (C) 2023 Luca Zulberti.
-    
+
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation, either version 3 of the License, or
     (at your option) any later version.
-    
+
     darktable is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
-    
+
     You should have received a copy of the GNU General Public License
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
@@ -1804,7 +1804,7 @@ static GList *load_profile_from_dir(const char *subdir)
           dt_colorspaces_get_profile_name(tmpprof, lang, lang + 3, prof->name, sizeof(prof->name));
           if(prof->name[0] == '\0')
             g_strlcpy(prof->name, _("(unknown name)"), sizeof(prof->name));
-            
+
           g_strlcpy(prof->filename, filename, sizeof(prof->filename));
           prof->type = DT_COLORSPACE_FILE;
           prof->profile = tmpprof;

--- a/src/system/display_profile.c
+++ b/src/system/display_profile.c
@@ -34,8 +34,9 @@
 #include <gdk/gdkwin32.h>
 #endif
 
-#ifdef GDK_WINDOWING_WAYLAND
+#if defined GDK_WINDOWING_WAYLAND
 #include <sys/mman.h>
+#include <lcms2.h>
 #include <gtk-3.0/gdk/gdkwayland.h>
 #include "color-management-v1-client-protocol.h"
 #endif
@@ -72,13 +73,32 @@ typedef struct {
   struct wp_image_description_info_v1 *color_image_description_info;
   guint8 *icc_buffer;
   gint icc_buffer_size;
+  gint r_x;
+  gint r_y;
+  gint g_x;
+  gint g_y;
+  gint b_x;
+  gint b_y;
+  gint w_x;
+  gint w_y;
+  guint tf_power;
   gboolean have_registry;
   gboolean have_color_manager;
+  gboolean have_icc;
+  gboolean have_primaries;
+  gboolean have_transfer_function;
 } wayland_color_management_struct;
 
 wayland_color_management_struct wayland_color_management = {0};
 
-void noop(){return;}
+void handle_wp_image_description_info_done(void *data,
+		                                       struct wp_image_description_info_v1 *wp_image_description_info_v1)
+{
+  wayland_color_management_struct *wcm = data;
+
+  wp_image_description_info_v1_destroy(wcm->color_image_description_info);
+  wcm->color_image_description_info = NULL;
+}
 
 void handle_wp_image_description_info_icc_file(void *data,
 			                                         struct wp_image_description_info_v1 *wp_image_description_info_v1,
@@ -90,27 +110,166 @@ void handle_wp_image_description_info_icc_file(void *data,
   wcm->icc_buffer = mmap(NULL, icc_size, PROT_READ, MAP_PRIVATE, icc, 0);
   wcm->icc_buffer_size = icc_size;
   close(icc);
+
+  if (wcm->icc_buffer && wcm->icc_buffer_size > 0)
+  {
+    wcm->have_icc = TRUE;
+  }
+}
+
+void handle_wp_image_description_info_primaries(void *data,
+			                                          struct wp_image_description_info_v1 *wp_image_description_info_v1,
+																								int32_t r_x,
+																						    int32_t r_y,
+																								int32_t g_x,
+																						    int32_t g_y,
+																								int32_t b_x,
+																						    int32_t b_y,
+																								int32_t w_x,
+																						    int32_t w_y)
+{
+  wayland_color_management_struct *wcm = data;
+
+  wcm->r_x = r_x;
+  wcm->r_y = r_y;
+  wcm->g_x = g_x;
+  wcm->g_y = g_y;
+  wcm->b_x = b_x;
+  wcm->b_y = b_y;
+  wcm->w_x = w_x;
+  wcm->w_y = w_y;
+
+  wcm->have_primaries = TRUE;
+}
+
+void handle_wp_image_description_info_primaries_named(void *data,
+				                                              struct wp_image_description_info_v1 *wp_image_description_info_v1,
+																											uint32_t primaries)
+{
+  // Unused.
+}
+
+void handle_wp_image_description_info_tf_power(void *data,
+                                               struct wp_image_description_info_v1 *wp_image_description_info_v1,
+                                               uint32_t eexp)
+{
+  wayland_color_management_struct *wcm = data;
+
+  wcm->tf_power = eexp;
+
+  wcm->have_transfer_function = TRUE;
+}
+
+void handle_wp_image_description_info_tf_named(void *data,
+			                                         struct wp_image_description_info_v1 *wp_image_description_info_v1,
+																							 uint32_t tf)
+{
+  wayland_color_management_struct *wcm = data;
+
+  switch (tf)
+  {
+    case WP_COLOR_MANAGER_V1_TRANSFER_FUNCTION_GAMMA22:
+    {
+      wcm->tf_power = 22000;
+    } break;
+  }
+
+  wcm->have_transfer_function = TRUE;
+}
+
+void handle_wp_image_description_info_luminances(void *data,
+			                                           struct wp_image_description_info_v1 *wp_image_description_info_v1,
+																								 uint32_t min_lum,
+																						     uint32_t max_lum,
+																								 uint32_t reference_lum)
+{
+  // Unused.
+}
+
+void handle_wp_image_description_info_target_primaries(void *data,
+				                                               struct wp_image_description_info_v1 *wp_image_description_info_v1,
+																											 int32_t r_x,
+																											 int32_t r_y,
+																											 int32_t g_x,
+																											 int32_t g_y,
+																											 int32_t b_x,
+																											 int32_t b_y,
+																											 int32_t w_x,
+																											 int32_t w_y)
+{
+  // Unused.
+}
+
+void handle_wp_image_description_info_target_luminance(void *data,
+				                                               struct wp_image_description_info_v1 *wp_image_description_info_v1,
+																											 uint32_t min_lum,
+																											 uint32_t max_lum)
+{
+  // Unused.
+}
+
+void handle_wp_image_description_info_target_max_cll(void *data,
+			                                               struct wp_image_description_info_v1 *wp_image_description_info_v1,
+																										 uint32_t max_cll)
+{
+  // Unused.
+}
+
+void handle_wp_image_description_info_target_max_fall(void *data,
+				                                              struct wp_image_description_info_v1 *wp_image_description_info_v1,
+																											uint32_t max_fall)
+{
+  // Unused.
 }
 
 struct wp_image_description_info_v1_listener wp_image_description_info_v1_listener = {
-  .done = noop,
+  .done = handle_wp_image_description_info_done,
 	.icc_file = handle_wp_image_description_info_icc_file,
-	.primaries = noop,
-	.primaries_named = noop,
-	.tf_power = noop,
-	.tf_named = noop,
-	.luminances = noop,
-	.target_primaries = noop,
-	.target_luminance = noop,
-	.target_max_cll = noop,
-	.target_max_fall = noop,
+	.primaries = handle_wp_image_description_info_primaries,
+	.primaries_named = handle_wp_image_description_info_primaries_named,
+	.tf_power = handle_wp_image_description_info_tf_power,
+	.tf_named = handle_wp_image_description_info_tf_named,
+	.luminances = handle_wp_image_description_info_luminances,
+	.target_primaries = handle_wp_image_description_info_target_primaries,
+	.target_luminance = handle_wp_image_description_info_target_luminance,
+	.target_max_cll = handle_wp_image_description_info_target_max_cll,
+	.target_max_fall = handle_wp_image_description_info_target_max_fall,
 };
 
-void handle_wp_image_decription_ready(void *data,
-		                                  struct wp_image_description_v1 *wp_image_description_v1,
-																			uint32_t identity)
+void handle_wp_image_description_failed(void *data,
+		                                    struct wp_image_description_v1 *wp_image_description_v1,
+																				uint32_t cause,
+													              const char *msg)
+{
+  // Unused, could be useful for debugging.
+}
+
+void handle_wp_image_description_ready(void *data,
+		                                   struct wp_image_description_v1 *wp_image_description_v1,
+																			 uint32_t identity)
 {
   wayland_color_management_struct *wcm = data;
+
+  // Reset old image description color state.
+  if (wcm->icc_buffer && wcm->icc_buffer_size > 0)
+  {
+    munmap(wcm->icc_buffer, wcm->icc_buffer_size);
+    wcm->icc_buffer_size = 0;
+  }
+
+  wcm->r_x = 0;
+  wcm->r_y = 0;
+  wcm->g_x = 0;
+  wcm->g_y = 0;
+  wcm->b_x = 0;
+  wcm->b_y = 0;
+  wcm->w_x = 0;
+  wcm->w_y = 0;
+  wcm->tf_power = 0;
+
+  wcm->have_icc = FALSE;
+  wcm->have_primaries = FALSE;
+  wcm->have_transfer_function = FALSE;
 
   wcm->color_image_description_info = wp_image_description_v1_get_information(wcm->color_image_description);
   wp_image_description_info_v1_add_listener(wcm->color_image_description_info, &wp_image_description_info_v1_listener, &wayland_color_management);
@@ -122,8 +281,8 @@ void handle_wp_image_decription_ready(void *data,
 }
 
 struct wp_image_description_v1_listener wp_image_description_v1_listener = {
-  .failed = noop,
-	.ready = handle_wp_image_decription_ready,
+  .failed = handle_wp_image_description_failed,
+	.ready = handle_wp_image_description_ready,
 };
 
 void handle_wp_color_management_surface_feedback_preferred_changed(void *data,
@@ -138,8 +297,8 @@ void handle_wp_color_management_surface_feedback_preferred_changed(void *data,
     wcm->color_image_description = NULL;
   }
 
-  wayland_color_management.color_image_description = wp_color_management_surface_feedback_v1_get_preferred(wayland_color_management.color_surface_feedback);
-  wp_image_description_v1_add_listener(wayland_color_management.color_image_description, &wp_image_description_v1_listener, &wayland_color_management);
+  wcm->color_image_description = wp_color_management_surface_feedback_v1_get_preferred(wcm->color_surface_feedback);
+  wp_image_description_v1_add_listener(wcm->color_image_description, &wp_image_description_v1_listener, &wayland_color_management);
 }
 
 struct wp_color_management_surface_feedback_v1_listener wp_color_management_surface_feedback_v1_listener = {
@@ -154,7 +313,8 @@ void handle_wl_registry_global(void *data,
 {
   wayland_color_management_struct *wcm = data;
 
-  if (strcmp(interface, wp_color_manager_v1_interface.name) == 0) {
+  if (strcmp(interface, wp_color_manager_v1_interface.name) == 0)
+  {
     wcm->color_manager = wl_registry_bind(wl_registry, name, &wp_color_manager_v1_interface, 1);
 
     if (wcm->color_manager)
@@ -164,9 +324,16 @@ void handle_wl_registry_global(void *data,
   }
 }
 
+void handle_wl_registry_global_remove(void *data,
+			                                struct wl_registry *wl_registry,
+																			uint32_t name)
+{
+  // Unused, compositor will not send global remove events.
+}
+
 struct wl_registry_listener wl_registry_listener = {
 	.global = handle_wl_registry_global,
-	.global_remove = noop,
+	.global_remove = handle_wl_registry_global_remove,
 };
 #endif
 
@@ -242,12 +409,64 @@ void dt_display_profile_read(GtkWidget *widget, guint8 **buffer, gint *buffer_si
       }
     }
 
-    if (wayland_color_management.color_manager && wayland_color_management.icc_buffer && wayland_color_management.icc_buffer_size > 0)
+    if (wayland_color_management.color_manager && wayland_color_management.have_icc)
     {
-      buffer = &wayland_color_management.icc_buffer;
-      buffer_size = &wayland_color_management.icc_buffer_size;
+      *buffer = wayland_color_management.icc_buffer;
+      *buffer_size = wayland_color_management.icc_buffer_size;
       *source = g_strdup("Wayland color profile api");
+      return;
     }
+
+    if (wayland_color_management.color_manager && wayland_color_management.have_primaries && wayland_color_management.have_transfer_function)
+    {
+      cmsCIExyY white_point;
+      cmsCIExyYTRIPLE primaries;
+      cmsToneCurve *curve[3];
+      cmsHPROFILE lcms_profile;
+
+      primaries.Red.x = wayland_color_management.r_x / 1000000.0;
+      primaries.Red.y = wayland_color_management.r_y / 1000000.0;
+      primaries.Red.Y = 1.0;
+      primaries.Green.x = wayland_color_management.g_x / 1000000.0;
+      primaries.Green.y = wayland_color_management.g_y / 1000000.0;
+      primaries.Green.Y = 1.0;
+      primaries.Blue.x = wayland_color_management.b_x / 1000000.0;
+      primaries.Blue.y = wayland_color_management.b_y / 1000000.0;
+      primaries.Blue.Y = 1.0;
+
+      white_point.x = wayland_color_management.w_x / 1000000.0;
+      white_point.y = wayland_color_management.w_y / 1000000.0;
+      white_point.Y = 1.0;
+
+      curve[0] = curve[1] = curve[2] = cmsBuildGamma(NULL, wayland_color_management.tf_power / 10000.0);
+
+      if (curve[0])
+      {
+        lcms_profile = cmsCreateRGBProfile(&white_point, &primaries, curve);
+
+        if (lcms_profile)
+        {
+          cmsUInt32Number size = 0;
+
+          if (cmsSaveProfileToMem(lcms_profile, NULL, &size) && size > 0)
+          {
+            guint8 *data = g_malloc(size);
+
+            if (cmsSaveProfileToMem(lcms_profile, data, &size))
+            {
+              *buffer = data;
+              *buffer_size = size;
+              *source = g_strdup("Wayland color profile api");
+            }
+          }
+        }
+        cmsCloseProfile(lcms_profile);
+      }
+      cmsFreeToneCurve(curve[0]);
+
+      return;
+    }
+
   }
 
 #elif defined GDK_WINDOWING_QUARTZ

--- a/src/system/display_profile.c
+++ b/src/system/display_profile.c
@@ -464,28 +464,37 @@ void dt_display_profile_read(GtkWidget *widget, guint8 **buffer, gint *buffer_si
 
       curve[0] = curve[1] = curve[2] = cmsBuildGamma(NULL, wayland_color_management.tf_power / 10000.0);
 
-      if (curve[0])
+      if (!curve[0])
       {
-        lcms_profile = cmsCreateRGBProfile(&white_point, &primaries, curve);
-
-        if (lcms_profile)
-        {
-          cmsUInt32Number size = 0;
-
-          if (cmsSaveProfileToMem(lcms_profile, NULL, &size) && size > 0)
-          {
-            guint8 *data = g_malloc(size);
-
-            if (cmsSaveProfileToMem(lcms_profile, data, &size))
-            {
-              *buffer = data;
-              *buffer_size = size;
-              *source = g_strdup("Wayland color profile api");
-            }
-          }
-        }
-        cmsCloseProfile(lcms_profile);
+        cmsFreeToneCurve(curve[0]);
+        return;
       }
+
+      lcms_profile = cmsCreateRGBProfile(&white_point, &primaries, curve);
+
+      if (!lcms_profile)
+      {
+        cmsCloseProfile(lcms_profile);
+        return;
+      }
+
+      cmsUInt32Number size = 0;
+
+      if (!cmsSaveProfileToMem(lcms_profile, NULL, &size) && size == 0)
+      {
+        return;
+      }
+
+      guint8 *data = g_malloc(size);
+
+      if (cmsSaveProfileToMem(lcms_profile, data, &size))
+      {
+        *buffer = data;
+        *buffer_size = size;
+        *source = g_strdup("Wayland color profile api");
+      }
+
+      cmsCloseProfile(lcms_profile);
       cmsFreeToneCurve(curve[0]);
 
       return;

--- a/src/system/display_profile.c
+++ b/src/system/display_profile.c
@@ -462,41 +462,50 @@ void dt_display_profile_read(GtkWidget *widget, guint8 **buffer, gint *buffer_si
       white_point.y = wayland_color_management.w_y / 1000000.0;
       white_point.Y = 1.0;
 
-      curve[0] = curve[1] = curve[2] = cmsBuildGamma(NULL, wayland_color_management.tf_power / 10000.0);
-
-      if (!curve[0])
+      cmsToneCurve *single_curve = cmsBuildGamma(NULL, wayland_color_management.tf_power / 10000.0);
+      if (!single_curve)
       {
-        cmsFreeToneCurve(curve[0]);
         return;
       }
 
+      curve[0] = curve[1] = curve[2] = single_curve;
+
       lcms_profile = cmsCreateRGBProfile(&white_point, &primaries, curve);
+
+      cmsFreeToneCurve(single_curve);
 
       if (!lcms_profile)
       {
-        cmsCloseProfile(lcms_profile);
         return;
       }
 
       cmsUInt32Number size = 0;
 
-      if (!cmsSaveProfileToMem(lcms_profile, NULL, &size) && size == 0)
+      if (!cmsSaveProfileToMem(lcms_profile, NULL, &size) || size == 0)
       {
+        cmsCloseProfile(lcms_profile);
         return;
       }
 
       guint8 *data = g_malloc(size);
+      if (!data)
+      {
+        cmsCloseProfile(lcms_profile);
+        return;
+      }
 
       if (cmsSaveProfileToMem(lcms_profile, data, &size))
       {
         *buffer = data;
-        *buffer_size = size;
+        *buffer_size = (gint)size;
         *source = g_strdup("Wayland color profile api");
+      }
+      else
+      {
+        g_free(data);
       }
 
       cmsCloseProfile(lcms_profile);
-      cmsFreeToneCurve(curve[0]);
-
       return;
     }
 

--- a/src/system/display_profile.c
+++ b/src/system/display_profile.c
@@ -34,6 +34,12 @@
 #include <gdk/gdkwin32.h>
 #endif
 
+#ifdef GDK_WINDOWING_WAYLAND
+#include <sys/mman.h>
+#include <gtk-3.0/gdk/gdkwayland.h>
+#include "color-management-v1-client-protocol.h"
+#endif
+
 #if 0
 #include <ApplicationServices/ApplicationServices.h>
 #include <Carbon/Carbon.h>
@@ -54,6 +60,114 @@ static int _monitor_index(GdkMonitor *monitor)
 
   return -1;
 }
+#endif
+
+#if defined GDK_WINDOWING_WAYLAND
+typedef struct {
+  struct wl_surface *color_wl_surface;
+  struct wp_color_manager_v1 *color_manager;
+  struct wp_color_management_surface_v1 *color_surface;
+  struct wp_color_management_surface_feedback_v1 *color_surface_feedback;
+  struct wp_image_description_v1 *color_image_description;
+  struct wp_image_description_info_v1 *color_image_description_info;
+  guint8 *icc_buffer;
+  gint icc_buffer_size;
+  gboolean have_registry;
+  gboolean have_color_manager;
+} wayland_color_management_struct;
+
+wayland_color_management_struct wayland_color_management = {0};
+
+void noop(){return;}
+
+void handle_wp_image_description_info_icc_file(void *data,
+			                                         struct wp_image_description_info_v1 *wp_image_description_info_v1,
+																							 int32_t icc,
+																							 uint32_t icc_size)
+{
+  wayland_color_management_struct *wcm = data;
+
+  wcm->icc_buffer = mmap(NULL, icc_size, PROT_READ, MAP_PRIVATE, icc, 0);
+  wcm->icc_buffer_size = icc_size;
+  close(icc);
+}
+
+struct wp_image_description_info_v1_listener wp_image_description_info_v1_listener = {
+  .done = noop,
+	.icc_file = handle_wp_image_description_info_icc_file,
+	.primaries = noop,
+	.primaries_named = noop,
+	.tf_power = noop,
+	.tf_named = noop,
+	.luminances = noop,
+	.target_primaries = noop,
+	.target_luminance = noop,
+	.target_max_cll = noop,
+	.target_max_fall = noop,
+};
+
+void handle_wp_image_decription_ready(void *data,
+		                                  struct wp_image_description_v1 *wp_image_description_v1,
+																			uint32_t identity)
+{
+  wayland_color_management_struct *wcm = data;
+
+  wcm->color_image_description_info = wp_image_description_v1_get_information(wcm->color_image_description);
+  wp_image_description_info_v1_add_listener(wcm->color_image_description_info, &wp_image_description_info_v1_listener, &wayland_color_management);
+
+  // Set image description on surface to tell compositor in which colorspace window is in.
+  wp_color_management_surface_v1_set_image_description(wcm->color_surface, wcm->color_image_description, WP_COLOR_MANAGER_V1_RENDER_INTENT_PERCEPTUAL);
+
+  wl_surface_commit(wcm->color_wl_surface);
+}
+
+struct wp_image_description_v1_listener wp_image_description_v1_listener = {
+  .failed = noop,
+	.ready = handle_wp_image_decription_ready,
+};
+
+void handle_wp_color_management_surface_feedback_preferred_changed(void *data,
+				                                                           struct wp_color_management_surface_feedback_v1 *wp_color_management_surface_feedback_v1,
+																																	 uint32_t identity)
+{
+  wayland_color_management_struct *wcm = data;
+
+  if (wcm->color_image_description)
+  {
+    wp_image_description_v1_destroy(wcm->color_image_description);
+    wcm->color_image_description = NULL;
+  }
+
+  wayland_color_management.color_image_description = wp_color_management_surface_feedback_v1_get_preferred(wayland_color_management.color_surface_feedback);
+  wp_image_description_v1_add_listener(wayland_color_management.color_image_description, &wp_image_description_v1_listener, &wayland_color_management);
+}
+
+struct wp_color_management_surface_feedback_v1_listener wp_color_management_surface_feedback_v1_listener = {
+  .preferred_changed = handle_wp_color_management_surface_feedback_preferred_changed,
+};
+
+void handle_wl_registry_global(void *data,
+		                           struct wl_registry *wl_registry,
+															 uint32_t name,
+									             const char *interface,
+															 uint32_t version)
+{
+  wayland_color_management_struct *wcm = data;
+
+  if (strcmp(interface, wp_color_manager_v1_interface.name) == 0) {
+    wcm->color_manager = wl_registry_bind(wl_registry, name, &wp_color_manager_v1_interface, 1);
+
+    if (wcm->color_manager)
+    {
+      wcm->have_color_manager = TRUE;
+    }
+  }
+}
+
+struct wl_registry_listener wl_registry_listener = {
+	.global = handle_wl_registry_global,
+	.global_remove = noop,
+};
 #endif
 
 void dt_display_profile_read(GtkWidget *widget, guint8 **buffer, gint *buffer_size, gchar **source)
@@ -82,6 +196,63 @@ void dt_display_profile_read(GtkWidget *widget, guint8 **buffer, gint *buffer_si
   gdk_property_get(gdk_screen_get_root_window(screen), gdk_atom_intern(atom_name, FALSE), GDK_NONE, 0,
                    64 * 1024 * 1024, FALSE, &type, &format, buffer_size, buffer);
   dt_free(atom_name);
+
+#endif
+
+#if defined GDK_WINDOWING_WAYLAND
+  GdkDisplay *wayland_gdk_display = gtk_widget_get_display(widget);
+  GdkWindow *wayland_gdk_window = gtk_widget_get_window(widget);
+
+  if (GDK_IS_WAYLAND_DISPLAY(wayland_gdk_display))
+  {
+    printf("help\n");
+    if (!wayland_color_management.color_manager)
+    {
+      struct wl_display *wl_display = gdk_wayland_display_get_wl_display(wayland_gdk_display);
+
+      if (!wayland_color_management.have_registry)
+      {
+        struct wl_registry *wl_registry = wl_display_get_registry(wl_display);
+        wl_registry_add_listener(wl_registry, &wl_registry_listener, &wayland_color_management);
+
+        // Initial roundtrip for wl_registry events
+        wl_display_roundtrip(wl_display);
+        wayland_color_management.have_registry = TRUE;
+      }
+
+      if (wayland_color_management.have_color_manager)
+      {
+        // Initial roundtrip for wp_color_manager events.
+        wl_display_roundtrip(wl_display);
+
+        wayland_color_management.color_wl_surface = gdk_wayland_window_get_wl_surface(wayland_gdk_window);
+
+        wayland_color_management.color_surface = wp_color_manager_v1_get_surface(wayland_color_management.color_manager, wayland_color_management.color_wl_surface);
+
+        wayland_color_management.color_surface_feedback = wp_color_manager_v1_get_surface_feedback(wayland_color_management.color_manager, wayland_color_management.color_wl_surface);
+        wp_color_management_surface_feedback_v1_add_listener(wayland_color_management.color_surface_feedback, &wp_color_management_surface_feedback_v1_listener, &wayland_color_management);
+
+        wayland_color_management.color_image_description = wp_color_management_surface_feedback_v1_get_preferred(wayland_color_management.color_surface_feedback);
+        wp_image_description_v1_add_listener(wayland_color_management.color_image_description, &wp_image_description_v1_listener, &wayland_color_management);
+
+        // Initial roundtrip for wp_image_description events
+        wl_display_roundtrip(wl_display);
+
+        // Initial roundtrip for wp_image_description_info events
+        wl_display_roundtrip(wl_display);
+      }
+    }
+
+    if (wayland_color_management.color_manager && wayland_color_management.icc_buffer && wayland_color_management.icc_buffer_size > 0)
+    {
+      buffer = &wayland_color_management.icc_buffer;
+      buffer_size = &wayland_color_management.icc_buffer_size;
+      *source = g_strdup("Wayland color profile api");
+    }
+    printf("%p\n", buffer);
+    printf("%i\n", *buffer_size);
+    printf("%s\n", *source);
+  }
 
 #elif defined GDK_WINDOWING_QUARTZ
 #if 0

--- a/src/system/display_profile.c
+++ b/src/system/display_profile.c
@@ -425,9 +425,19 @@ void dt_display_profile_read(GtkWidget *widget, guint8 **buffer, gint *buffer_si
 
     if (wayland_color_management.color_manager && wayland_color_management.have_icc)
     {
-      *buffer = wayland_color_management.icc_buffer;
+      *buffer = g_malloc(wayland_color_management.icc_buffer_size);
       *buffer_size = wayland_color_management.icc_buffer_size;
       *source = g_strdup("Wayland color profile api");
+
+      if (*buffer == NULL)
+      {
+        g_free(*source);
+        *source = NULL;
+        *buffer_size = 0;
+        return;
+      }
+
+      memcpy(*buffer, wayland_color_management.icc_buffer, wayland_color_management.icc_buffer_size);
       return;
     }
 

--- a/src/system/display_profile.c
+++ b/src/system/display_profile.c
@@ -107,14 +107,28 @@ void handle_wp_image_description_info_icc_file(void *data,
 {
   wayland_color_management_struct *wcm = data;
 
+  if (icc_size == 0)
+  {
+    close(icc);
+    wcm->icc_buffer = NULL;
+    wcm->icc_buffer_size = 0;
+    return;
+  }
+
   wcm->icc_buffer = mmap(NULL, icc_size, PROT_READ, MAP_PRIVATE, icc, 0);
   wcm->icc_buffer_size = icc_size;
+
+  if (wcm->icc_buffer == MAP_FAILED)
+  {
+    close(icc);
+    wcm->icc_buffer = NULL;
+    wcm->icc_buffer_size = 0;
+    return;
+  }
+
   close(icc);
 
-  if (wcm->icc_buffer && wcm->icc_buffer_size > 0)
-  {
-    wcm->have_icc = TRUE;
-  }
+  wcm->have_icc = TRUE;
 }
 
 void handle_wp_image_description_info_primaries(void *data,

--- a/src/system/display_profile.c
+++ b/src/system/display_profile.c
@@ -205,7 +205,6 @@ void dt_display_profile_read(GtkWidget *widget, guint8 **buffer, gint *buffer_si
 
   if (GDK_IS_WAYLAND_DISPLAY(wayland_gdk_display))
   {
-    printf("help\n");
     if (!wayland_color_management.color_manager)
     {
       struct wl_display *wl_display = gdk_wayland_display_get_wl_display(wayland_gdk_display);
@@ -249,9 +248,6 @@ void dt_display_profile_read(GtkWidget *widget, guint8 **buffer, gint *buffer_si
       buffer_size = &wayland_color_management.icc_buffer_size;
       *source = g_strdup("Wayland color profile api");
     }
-    printf("%p\n", buffer);
-    printf("%i\n", *buffer_size);
-    printf("%s\n", *source);
   }
 
 #elif defined GDK_WINDOWING_QUARTZ


### PR DESCRIPTION
Hello. This MR implements wayland color management in Ansel by providing image description which is set on surface with perceptual render intent to nominate surface colorspace.

After that image description can provide image description info which contains for now, icc profile (if compositor sends it) or primaries, named primaries and transfer function (gamma).

If compositor provides icc, then buffer will have icc buffer and if alternative compositor provides primaries and transfer function then  lcms will create rgb profile and then convert to readable buffer.

Because wayland is asynchronous, color information could already be saved by moving from one monitor to another or changing monitor's icc profile, buffer, buffer_size and source is only provided by dt_display_profile_read callback.

Thanks for reading. 