### PR TITLE
darkroom: the centre paints into GTK's buffer, once per source frame, and a mask motion repaints a rectangle (#1198)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1980,6 +1980,38 @@ did not, was correct on every 1x screen and every unit test, and drew the whole 
 size in the top-left quadrant of a HiDPI darkroom; `test_stroke_raster` and the harness's
 `hidpi placement` check now paint on device-scaled surfaces.
 
+### The darkroom centre paints into GTK's buffer, once per source frame, and a mask motion repaints a rectangle
+
+`doc/darkroom-redraw.md` prices every pass of the repaint path with cairo at a 2560x1440
+window at device scale 1 and 2. Before it, every centre repaint allocated and freed a
+full-window surface, filled two full-window backgrounds and blitted the window three times
+through two intermediate surfaces, whatever had changed: about 10 ms at 1x and 59 ms at 2x
+per frame before any overlay, and a zoom or pan while the main pipe caught up scaled the
+preview with cairo's default filter, 262 ms at 2x, because `CAIRO_FILTER_NEAREST` was set on
+the context's default source before the surface replaced it. Four rules now:
+
+- **`dt_control_expose(cr, w, h)` paints into GTK's own `cr`**, which is a double buffer
+  already and arrives clipped to what was invalidated. No intermediate surface, no pixmap.
+  A view that paints every pixel returns `VIEW_FLAGS_PAINTS_WHOLE_AREA` from `flags()` and
+  the toplevel skips its background fill under it.
+- **The darkroom composes `dev->image_surface` once per (source hash, viewport, colours,
+  border, size) key** (`_darkroom_compose_locked()` / `_darkroom_compose_fallback()`), fills
+  the background as the four bands around the image and the ISO 12646 frame as a ring, and
+  sets a scaling filter on the pattern that scales. Set `cairo_pattern_set_filter()` AFTER
+  `cairo_set_source_surface()`, never on the context's default source.
+- **A motion the masks handled invalidates a rectangle**: `dt_masks_overlay_queue_redraw()`
+  asks for the last composited overlay rectangle grown by the pointer's motion, and
+  `_overlay_damage_record()` asks for whatever a frame painted outside the expose's clip, so
+  an under-estimate costs one more small frame and never an unpainted overlay. A module's own
+  overlay knows no rectangle and keeps the full redraw.
+- **The overlay canvas is sized to the view, never to `cr`'s clip**, which a rectangle redraw
+  narrows; and a creation session's frame is bounded to the session's box and the live shape,
+  where it was the whole window before.
+
+The views are plugins: `ninja ansel` does NOT compile `src/views/*.c`. Build every target
+(`ninja`) before trusting a darkroom edit; a use of an undeclared variable in `darkroom.c`
+survived an `ansel` build here.
+
 ### A rotated GtkLabel sizes the column it sits in
 
 A `GtkLabel` with `gtk_label_set_angle()` requests the width of its *slanted* bounding box, so a

--- a/doc/darkroom-redraw.md
+++ b/doc/darkroom-redraw.md
@@ -1,0 +1,107 @@
+# The darkroom repaint: what a frame costs, and what it may not cost
+
+The darkroom's centre is repainted on the GUI thread, on the CPU, and it is repainted often:
+on every pipe frame, on every mask hover and drag motion, on every guide toggle. Whatever a
+frame paints is time the GUI thread cannot give to anything else, so the floor of a frame --
+what it costs when nothing but an overlay has moved -- decides how the darkroom feels under
+a drawing tablet. Issue #1198 measured that floor at about 15.7 ms of the 16.7 ms a 60 fps
+frame allows and listed what it was made of. This is the account of what it was actually made
+of, measured, and of what was done about it.
+
+## The floor, priced
+
+Every number below is a cairo operation timed on this machine at a 2560x1440 window, once at
+device scale 1 and once at 2 (a 5120x2880 buffer of 59 MB), which is a 2x screen. The
+operations are the ones the repaint path performed, in the order it performed them, on every
+frame, whatever had changed.
+
+| operation, per frame | at 1x | at 2x |
+| --- | ---: | ---: |
+| allocate, first-touch and free a full-window ARGB surface | 2.2 ms | 29.5 ms |
+| fill the whole window with a colour | 1.8 ms | 5.9 ms |
+| blit a full-window surface onto another, pixel for pixel | 1.2 ms | 5.8 ms |
+| composite a mostly transparent full-window ARGB canvas | 0.0 ms | 0.0 ms |
+| blit a 400x300 rectangle of it, clipped | 0.03 ms | 0.12 ms |
+| scale a full-window preview by 0.73 with cairo's default filter | 66 ms | 262 ms |
+| the same with the NEAREST filter | 1.0 ms | 3.7 ms |
+| memset a full-window canvas row by row | 1.2 ms | 5.7 ms |
+
+And the path, from the GTK draw signal down, before any overlay was drawn:
+
+1. `dt_control_expose()` allocated a full-window ARGB surface and freed it at the end (row 1).
+2. It filled it with the toplevel background (row 2).
+3. The darkroom composed its image surface: a full-window background fill (row 2) and the
+   image blit from the pipe's cacheline (row 3), on every frame, for an image that had not
+   changed since the last one.
+4. With ISO 12646 on, a white rectangle the size of the image plus its border was filled
+   under the image (row 2 again, nearly).
+5. `_paint_all()` blitted the composed image surface into the throwaway surface (row 3).
+6. `dt_control_expose()` blitted the throwaway surface into a persistent pixmap (row 3).
+7. The draw handler blitted the pixmap into GTK's own double buffer (row 3).
+
+Seven passes over the window: about 10 ms at 1x, about 59 ms at 2x, before the first overlay
+pixel. During a brush creation session the overlay canvas was composited and cleared over the
+whole window as well (rows 3 and 8). And a zoom or a pan, while the main pipe catches up,
+scaled the preview with the default filter (row 6): a third of a second per frame at 2x,
+because the `CAIRO_FILTER_NEAREST` the code set was set on the context's default solid source,
+which the surface then replaced.
+
+Nothing on the request side could narrow any of it. `gtk_widget_queue_draw_area()` appeared
+nowhere in the tree; every redraw invalidated the whole widget, so the clip GTK hands the
+draw signal was always the whole window, and the draw handler discarded even that.
+
+## What was done
+
+**The centre paints into GTK's buffer.** GTK's `cr` is a double buffer already, and it
+arrives clipped to the region that was invalidated. `dt_control_expose(cr, width, height)`
+paints into it directly: rows 1, 6 and 7 are gone, and every remaining pass is clipped to the
+region GTK asked for. The persistent pixmap and its copy on resize are gone with them. A view
+whose expose paints every pixel of the centre says so with `VIEW_FLAGS_PAINTS_WHOLE_AREA`, and
+the toplevel skips its background fill under it (row 2, once): the darkroom does.
+
+**The image is composed once per source frame.** `dev->image_surface` is keyed on everything
+it depends on -- the source frame's hash, the viewport, the colours, the border, the frame size
+-- and an expose that finds the same key repaints from it without composing. A pipe frame
+still costs the compose; a frame that only moved an overlay costs one clipped blit. The
+background is filled where the image will not cover, as the four bands around it in one
+even-odd fill whose hole is a pixel inside the image so no seam shows, and the ISO 12646
+frame is a ring: 1.3 ms against 5.9 at 2x. The preview fallback sets its filter on the pattern
+that scales.
+
+**A motion the masks handled repaints what it touched.** The masks record the rectangle their
+last frame composited, in the view's coordinates (`_overlay_damage`), and the darkroom asks
+`dt_masks_overlay_queue_redraw()` for that rectangle grown by the pointer's motion since --
+a dragged shape moves with the pointer, a hovered one does not move -- when the masks handled
+the motion and nothing else did; a module's own overlay knows no rectangle and keeps the whole
+widget. The invalidation is an estimate made before the frame is drawn: when a frame outgrows
+it, `_overlay_damage_record()` compares the composited rectangle with the clip of the expose
+and asks for the rest, and the next, small expose paints it. At worst that is one extra small
+frame; it can never leave part of an overlay unpainted.
+
+**The overlay canvas is the view, and a session frame is bounded.** The canvas was sized to
+`cr`'s clip, which a rectangle redraw narrows: it would have been reallocated on every such
+frame and held nothing beyond the clip. It covers the view and stays; what reaches the target
+is the composite, and cairo clips that. A creation session's frame took the whole canvas
+before -- a full-window composite and a full-window memset on every frame drawn -- and spans
+the session's box and the live shape's now. The session's box covers the borders and not the
+spines alone, which is also what a brush's dashed border, a radius outside its spine, needed
+from the pattern's clip after a pan.
+
+## What a frame costs now
+
+| frame | before, 2x | after, 2x |
+| --- | ---: | ---: |
+| a mask hover or drag motion, overlay only | ~59 ms + overlay | ~0.2 ms + overlay |
+| a new pipe frame | ~59 ms | ~13 ms: bands 1.3, image 5.8, GTK blit 5.8 |
+| a zoom or pan while the main pipe catches up | ~320 ms | ~10 ms |
+
+The overlay itself -- the outlines rasterised directly, see `doc/overlay-raster.md` -- costs
+1 to 8 ms per shape at fit zoom and is now the largest term of a motion frame, which is where
+the next work belongs.
+
+## Reading it
+
+`-d perf` prints `[darkroom] surface prepared / image painted / overlay predicates / overlays
+drawn / redraw` per expose; `-d perf -d masks` adds `[masks] overlay composited (WxH of WxH)`,
+which now prints a small rectangle of the view on a motion frame and the whole view on a pipe
+frame. `MASKS_DUMP_OVERLAY=<dir>` writes what a frame drew.

--- a/src/control/control.c
+++ b/src/control/control.c
@@ -583,23 +583,23 @@ gboolean dt_control_button_down(int which)
   }
 }
 
-void *dt_control_expose(void *voidptr)
+/* The centre used to be painted three times per frame: into a full-window ARGB surface
+ * allocated and freed on every expose, from there into a persistent pixmap, and from the pixmap
+ * into GTK's own double buffer -- with the pixmap's whole area filled first. Measured at a
+ * 2560x1440 window on a 2x screen (a 59 MB buffer): 29.5 ms to allocate and first-touch the
+ * throwaway surface, 5.9 ms per full fill, 5.8 ms per full blit, around 59 ms a frame before a
+ * single overlay was drawn, against the 16.7 ms a 60 fps frame allows. GTK's cr is already a
+ * double buffer, and it arrives clipped to the region that was invalidated, so painting into it
+ * directly costs one pass over that region and nothing over the rest of the window. */
+void dt_control_expose(cairo_t *cr, const int width, const int height)
 {
+  if(IS_NULL_PTR(cr) || width <= 0 || height <= 0) return;
   int pointerx, pointery;
-  if(IS_NULL_PTR(dt_gui_get_global()->surface)) return NULL;
-  const int width = dt_cairo_image_surface_get_width(dt_gui_get_global()->surface);
-  const int height = dt_cairo_image_surface_get_height(dt_gui_get_global()->surface);
   GtkWidget *widget = dt_gui_center_widget();
   gdk_window_get_device_position(gtk_widget_get_window(widget),
       gdk_seat_get_pointer(gdk_display_get_default_seat(gtk_widget_get_display(widget))),
       &pointerx, &pointery, NULL);
 
-  // create a gtk-independent surface to draw on
-  cairo_surface_t *cst = dt_cairo_image_surface_create(CAIRO_FORMAT_ARGB32, width, height);
-  cairo_t *cr = cairo_create(cst);
-
-  // TODO: control_expose: only redraw the part not overlapped by temporary control panel show!
-  //
   darktable.control->width = width;
   darktable.control->height = height;
 
@@ -608,12 +608,17 @@ void *dt_control_expose(void *voidptr)
   // look up some colors once
   GdkRGBA bg_color = lookup_color(context, "bg_color");
 
-  gdk_cairo_set_source_rgba(cr, &bg_color);
   cairo_save(cr);
   cairo_rectangle(cr, 0, 0, width, height);
-  cairo_paint(cr);
   cairo_clip(cr);
   cairo_new_path(cr);
+  /* the background, only for a view that does not paint every pixel itself: the darkroom
+   * composes its own, and a fill under it was a full pass over the window for nothing */
+  if(!(dt_view_manager_current_flags(darktable.view_manager) & VIEW_FLAGS_PAINTS_WHOLE_AREA))
+  {
+    gdk_cairo_set_source_rgba(cr, &bg_color);
+    cairo_paint(cr);
+  }
   // draw view
   dt_view_manager_expose(darktable.view_manager, cr, width, height, pointerx, pointery);
   cairo_restore(cr);
@@ -642,15 +647,6 @@ void *dt_control_expose(void *voidptr)
     cairo_set_source_rgba(cr, 0., 0., 0., 0.33);
     cairo_fill(cr);
   }
-  cairo_destroy(cr);
-
-  cairo_t *cr_pixmap = cairo_create(dt_gui_get_global()->surface);
-  cairo_set_source_surface(cr_pixmap, cst, 0, 0);
-  cairo_paint(cr_pixmap);
-  cairo_destroy(cr_pixmap);
-
-  cairo_surface_destroy(cst);
-  return NULL;
 }
 
 void dt_control_mouse_leave()

--- a/src/control/control.h
+++ b/src/control/control.h
@@ -89,8 +89,9 @@ typedef struct dt_control_pointer_input_t
   guint32 time_ms;
 } dt_control_pointer_input_t;
 
-// called from gui
-void *dt_control_expose(void *voidptr);
+// called from gui: paint the centre area into @p cr, which is GTK's own double buffer, clipped to
+// the region GTK asked for. Nothing is painted anywhere else and nothing is copied afterwards.
+void dt_control_expose(cairo_t *cr, int width, int height);
 void dt_control_button_pressed(double x, double y, double pressure, int which, int type, uint32_t state);
 
 /** Message painted over the main preview while the pipeline is working. Written by the

--- a/src/darktable.c
+++ b/src/darktable.c
@@ -1908,11 +1908,6 @@ void dt_cleanup()
     if(!IS_NULL_PTR(darktable.gui->ui))
       dt_ui_cleanup_titlebar(darktable.gui->ui);
 
-    if(darktable.gui->surface)
-    {
-      cairo_surface_destroy(darktable.gui->surface);
-      darktable.gui->surface = NULL;
-    }
 
     // hide main window and do rest of the cleanup in the background
     gtk_widget_hide(dt_ui_main_window(darktable.gui->ui));

--- a/src/develop/masks/masks_gui.c
+++ b/src/develop/masks/masks_gui.c
@@ -2767,8 +2767,29 @@ static void _dt_masks_events_set_current_pos(const double x, const double y, dt_
 static int _dt_masks_events_mouse_moved(dt_develop_t *dev, struct dt_iop_module_t *module, double x,
                                        double y, double pressure, int which);
 
+/* How far the pointer moved since the motion before, in the view's coordinates: with the
+ * rectangle the last overlay frame touched, it says which rectangle of the view a motion the
+ * masks handled can have changed. */
+static double _overlay_pointer[2] = { 0.0, 0.0 };
+static double _overlay_pointer_delta[2] = { 0.0, 0.0 };
+static gboolean _overlay_pointer_valid = FALSE;
+
 int dt_masks_events_mouse_moved(dt_develop_t *dev, struct dt_iop_module_t *module, double x, double y, double pressure, int which)
 {
+  if(_overlay_pointer_valid)
+  {
+    _overlay_pointer_delta[0] = x - _overlay_pointer[0];
+    _overlay_pointer_delta[1] = y - _overlay_pointer[1];
+  }
+  else
+  {
+    _overlay_pointer_delta[0] = 0.0;
+    _overlay_pointer_delta[1] = 0.0;
+  }
+  _overlay_pointer[0] = x;
+  _overlay_pointer[1] = y;
+  _overlay_pointer_valid = TRUE;
+
   /* Timed because it is the other thing that scales with the number of shapes and is not part of
    * the expose: hit-testing walks every shape in the group and, for a brush, every point of it.
    * The #1158 logs show the darkroom redraw growing to 400 ms with only 1.5 ms of mask overlay in
@@ -3672,33 +3693,41 @@ static int _session_sigs_take(const dt_masks_form_gui_t *gui, _session_outline_s
 }
 
 /** @brief Union of the cached outlines, or FALSE when there is nothing to bound. */
+static void _bbox_include_array(const float *const array, const int count, double bbox[4], gboolean *any)
+{
+  if(IS_NULL_PTR(array) || count <= 0) return;
+  for(int i = 0; i < count; i++)
+  {
+    const double x = array[2 * i];
+    const double y = array[2 * i + 1];
+    if(!*any)
+    {
+      bbox[0] = x;
+      bbox[2] = x;
+      bbox[1] = y;
+      bbox[3] = y;
+      *any = TRUE;
+      continue;
+    }
+    bbox[0] = fmin(bbox[0], x);
+    bbox[1] = fmin(bbox[1], y);
+    bbox[2] = fmax(bbox[2], x);
+    bbox[3] = fmax(bbox[3], y);
+  }
+}
+
+/* The box of everything the session draws: the spines AND the borders. It held the spines
+ * alone, and a brush's dashed border lies a radius outside its spine, further than the clip's
+ * margin; the pattern was clipped to it on a cache hit after a pan or zoom. */
 static gboolean _session_bbox_from_points(const dt_masks_form_gui_t *gui, double bbox[4])
 {
   gboolean any = FALSE;
   for(const GList *node = gui->points; node; node = g_list_next(node))
   {
     const dt_masks_form_gui_points_t *const pts = (const dt_masks_form_gui_points_t *)node->data;
-    if(IS_NULL_PTR(pts) || IS_NULL_PTR(pts->points) || pts->points_count <= 0) continue;
-
-    for(int i = 0; i < pts->points_count; i++)
-    {
-      const double x = pts->points[2 * i];
-      const double y = pts->points[2 * i + 1];
-
-      if(!any)
-      {
-        bbox[0] = bbox[2] = x;
-        bbox[1] = bbox[3] = y;
-        any = TRUE;
-      }
-      else
-      {
-        bbox[0] = fmin(bbox[0], x);
-        bbox[1] = fmin(bbox[1], y);
-        bbox[2] = fmax(bbox[2], x);
-        bbox[3] = fmax(bbox[3], y);
-      }
-    }
+    if(IS_NULL_PTR(pts)) continue;
+    _bbox_include_array(pts->points, pts->points_count, bbox, &any);
+    _bbox_include_array(pts->border, pts->border_count, bbox, &any);
   }
   return any;
 }
@@ -4141,13 +4170,47 @@ static void _canvas_cairo_bound(cairo_t *canvas_cr, const dt_masks_form_gui_t *g
   rect->height += 2 * margin;
 }
 
-/* Bound what cairo may paint on top of the outlines and clip the canvas context to it. A
- * creation session paints through its own cached pattern and keeps @p bound as the caller set
- * it, the whole canvas, unclipped. Returns whether @p bound holds a rectangle at all. */
-static gboolean _overlay_clip_to_bound(cairo_t *mask_draw, const dt_masks_form_gui_t *gui,
-                                       const _canvas_frame_t *const frame, cairo_rectangle_int_t *bound)
+/* Grow @p rect to the session's box, taken through the canvas context to pixels, with the
+ * margin the session clip uses. */
+static void _session_bound_include(cairo_t *canvas_cr, const float zoom_scale, cairo_rectangle_int_t *rect,
+                                   gboolean *any)
 {
-  if(gui->creation || !IS_NULL_PTR(gui->creation_formids)) return TRUE;
+  if(!_session_bbox_valid) return;
+  const double scale = _canvas_device_scale(canvas_cr);
+  const double margin = (zoom_scale > 1e-6f) ? (16.0 / zoom_scale) : 0.0;
+  const double xs[2] = { _session_bbox[0] - margin, _session_bbox[2] + margin };
+  const double ys[2] = { _session_bbox[1] - margin, _session_bbox[3] + margin };
+  for(int c = 0; c < 4; c++)
+  {
+    double x = xs[c & 1];
+    double y = ys[c >> 1];
+    cairo_user_to_device(canvas_cr, &x, &y);
+    _rect_include(rect, any, x * scale, y * scale, 2);
+  }
+}
+
+/* Bound what cairo may paint on top of the outlines and clip the canvas context to it.
+ *
+ * A creation session is bounded but not clipped: the pattern of the saved strokes is rebuilt
+ * inside a group cairo sizes to the clip, and a group cut to a stale box truncated a new stroke
+ * for the rest of the session. Its bound is the session's box and the live shape's, which is
+ * what the composite and the clear then span. Before, a session took @p bound as the caller
+ * set it, the whole canvas: a full-window composite and a full-window memset on every frame
+ * drawn, 11.6 ms of a frame at a 2560x1440 window on a 2x screen. Returns whether @p bound
+ * holds a rectangle at all. */
+static gboolean _overlay_clip_to_bound(cairo_t *mask_draw, const dt_masks_form_gui_t *gui,
+                                       const _canvas_frame_t *const frame, cairo_rectangle_int_t *bound,
+                                       const float zoom_scale)
+{
+  if(gui->creation || !IS_NULL_PTR(gui->creation_formids))
+  {
+    cairo_rectangle_int_t session = { 0 };
+    gboolean session_bounded = FALSE;
+    _canvas_cairo_bound(mask_draw, gui, &session, &session_bounded);
+    _session_bound_include(mask_draw, zoom_scale, &session, &session_bounded);
+    if(session_bounded) *bound = session;
+    return TRUE;
+  }
   gboolean bounded = FALSE;
   _canvas_cairo_bound(mask_draw, gui, bound, &bounded);
   if(!bounded) return FALSE;
@@ -4162,17 +4225,16 @@ static gboolean _overlay_clip_to_bound(cairo_t *mask_draw, const dt_masks_form_g
 
 /* Open a frame covering cr's clip. Returns FALSE with nothing to draw into when the clip is
  * empty or the canvas cannot be had. */
-static gboolean _canvas_begin(cairo_t *cr, _canvas_frame_t *frame)
+static gboolean _canvas_begin(cairo_t *cr, const int width, const int height, _canvas_frame_t *frame)
 {
-  double clip_x0 = 0.0;
-  double clip_y0 = 0.0;
-  double clip_x1 = 0.0;
-  double clip_y1 = 0.0;
-  cairo_clip_extents(cr, &clip_x0, &clip_y0, &clip_x1, &clip_y1);
-  double device_x0 = clip_x0;
-  double device_y0 = clip_y0;
-  double device_x1 = clip_x1;
-  double device_y1 = clip_y1;
+  /* The frame is the view, not cr's clip. A redraw asked for a rectangle narrows the clip to
+   * what moved, and a canvas sized to the clip would be reallocated on every such frame and
+   * hold nothing beyond it. The canvas covers the view and stays; what reaches the target is
+   * the composite, and cairo clips that. */
+  double device_x0 = 0.0;
+  double device_y0 = 0.0;
+  double device_x1 = width;
+  double device_y1 = height;
   cairo_user_to_device(cr, &device_x0, &device_y0);
   cairo_user_to_device(cr, &device_x1, &device_y1);
 
@@ -4296,6 +4358,59 @@ static void _overlay_dump(const _canvas_frame_t *const frame, const dt_masks_for
   }
 }
 
+/* What the last overlay frame composited onto the view, in the view's coordinates, and how far
+ * the pointer moved since the motion before (see _overlay_pointer_delta): together they say
+ * which rectangle of the view a motion the masks handled can have changed. Every such motion
+ * used to invalidate the whole centre widget, which repainted the whole image under an overlay
+ * that had moved by a few pixels. */
+static cairo_rectangle_int_t _overlay_damage = { 0, 0, 0, 0 };
+static gboolean _overlay_damage_valid = FALSE;
+
+void dt_masks_overlay_queue_redraw(GtkWidget *widget)
+{
+  if(IS_NULL_PTR(widget)) return;
+  if(!_overlay_damage_valid)
+  {
+    gtk_widget_queue_draw(widget);
+    return;
+  }
+  /* the last frame's rectangle, grown by the pointer's motion: a dragged shape moves with the
+   * pointer, a hovered one does not move at all. Where a frame lands outside this,
+   * _overlay_damage_record() asks for the rest. */
+  const int grow_x = (int)ceil(fabs(_overlay_pointer_delta[0])) + 4;
+  const int grow_y = (int)ceil(fabs(_overlay_pointer_delta[1])) + 4;
+  gtk_widget_queue_draw_area(widget, _overlay_damage.x - grow_x, _overlay_damage.y - grow_y,
+                             _overlay_damage.width + 2 * grow_x, _overlay_damage.height + 2 * grow_y);
+}
+
+/* Record the rectangle the frame composited, in the view's coordinates, and ask for whatever
+ * of it the clip of this expose did not cover: the invalidation was an estimate made before the
+ * frame was drawn, and a frame that outgrew it is painted in full by the next, small one. */
+static void _overlay_damage_record(cairo_t *cr, const _canvas_frame_t *const frame, const cairo_rectangle_int_t *dirty)
+{
+  if(IS_NULL_PTR(dirty))
+  {
+    _overlay_damage_valid = FALSE;
+    return;
+  }
+  const double s = frame->device_scale;
+  const cairo_rectangle_int_t damage = { (int)floor(dirty->x / s), (int)floor(dirty->y / s),
+                                         (int)ceil((dirty->x + dirty->width) / s) - (int)floor(dirty->x / s),
+                                         (int)ceil((dirty->y + dirty->height) / s) - (int)floor(dirty->y / s) };
+  _overlay_damage = damage;
+  _overlay_damage_valid = TRUE;
+
+  double clip_x0 = 0.0;
+  double clip_y0 = 0.0;
+  double clip_x1 = 0.0;
+  double clip_y1 = 0.0;
+  cairo_clip_extents(cr, &clip_x0, &clip_y0, &clip_x1, &clip_y1);
+  const gboolean covered = damage.x >= floor(clip_x0) && damage.y >= floor(clip_y0)
+                           && damage.x + damage.width <= ceil(clip_x1) && damage.y + damage.height <= ceil(clip_y1);
+  if(!covered)
+    gtk_widget_queue_draw_area(dt_gui_center_widget(), damage.x, damage.y, damage.width, damage.height);
+}
+
 /* Draw the visible form: a group member by member, anything else through its own drawer. */
 static void _overlay_draw_form(cairo_t *cr, const float zoom_scale, dt_masks_form_t *mask_form,
                                dt_masks_form_gui_t *mask_gui)
@@ -4374,7 +4489,7 @@ void dt_masks_events_post_expose_with(dt_develop_t *dev, struct dt_iop_module_t 
     dt_print(DT_DEBUG_MASKS, "[masks] overlay preamble took %0.04f sec\n", group_start - post_expose_start);
 
   _canvas_frame_t frame = { 0 };
-  if(!_canvas_begin(cr, &frame)) return;
+  if(!_canvas_begin(cr, width, height, &frame)) return;
   cairo_t *const mask_draw = frame.cr;
   if(dt_get_debug_flags() & DT_DEBUG_PERF)
     dt_print(DT_DEBUG_MASKS, "[masks] overlay canvas %dx%d ready in %0.04f sec\n", frame.width, frame.height,
@@ -4409,7 +4524,7 @@ void dt_masks_events_post_expose_with(dt_develop_t *dev, struct dt_iop_module_t 
 
   /* The rectangle cairo may paint in, and the clip that holds it to that. */
   cairo_rectangle_int_t cairo_bound = { 0, 0, frame.width, frame.height };
-  const gboolean cairo_bounded = _overlay_clip_to_bound(mask_draw, mask_gui, &frame, &cairo_bound);
+  const gboolean cairo_bounded = _overlay_clip_to_bound(mask_draw, mask_gui, &frame, &cairo_bound, zoom_scale);
 
   if(dt_get_debug_flags() & DT_DEBUG_MASKS)
     dt_show_times(&rebuild_start, "[masks] overlay outline refresh");
@@ -4439,6 +4554,8 @@ void dt_masks_events_post_expose_with(dt_develop_t *dev, struct dt_iop_module_t 
 
   const double composite_start = dt_get_wtime();
   if(any) _canvas_end(cr, &frame, &dirty);
+  /* the darkroom's own frames only: a headless caller has no widget to invalidate */
+  if(IS_NULL_PTR(transform)) _overlay_damage_record(cr, &frame, any ? &dirty : NULL);
   if(dt_get_debug_flags() & DT_DEBUG_PERF)
     dt_print(DT_DEBUG_MASKS, "[masks] overlay composited (%dx%d of %dx%d) in %0.04f sec\n",
              any ? dirty.width : 0, any ? dirty.height : 0, frame.width, frame.height,

--- a/src/develop/masks/masks_gui.c
+++ b/src/develop/masks/masks_gui.c
@@ -4411,6 +4411,28 @@ static void _overlay_damage_record(cairo_t *cr, const _canvas_frame_t *const fra
     gtk_widget_queue_draw_area(dt_gui_center_widget(), damage.x, damage.y, damage.width, damage.height);
 }
 
+/* Map the canvas context to input space: from the viewport, or from the caller's own mapping
+ * when it supplied one (see dt_masks_overlay_transform_t: the viewport path needs GUI state).
+ * Returns FALSE when the viewport cannot be mapped, in which case nothing can be drawn. */
+static gboolean _overlay_apply_transform(cairo_t *mask_draw, dt_develop_t *develop,
+                                         const dt_masks_overlay_transform_t *transform, const int width,
+                                         const int height)
+{
+  if(IS_NULL_PTR(transform)) return dt_dev_rescale_roi_to_input(develop, mask_draw, width, height) == 0;
+  cairo_translate(mask_draw, transform->offset_x, transform->offset_y);
+  cairo_scale(mask_draw, transform->scale, transform->scale);
+  return TRUE;
+}
+
+/* Composite what the frame painted and remember it; a headless caller has no widget to ask a
+ * redraw of, so only the darkroom's own frames are recorded. */
+static void _overlay_finish(cairo_t *cr, const _canvas_frame_t *const frame, const cairo_rectangle_int_t *dirty,
+                            const gboolean darkroom_frame)
+{
+  if(!IS_NULL_PTR(dirty)) _canvas_end(cr, frame, dirty);
+  if(darkroom_frame) _overlay_damage_record(cr, frame, dirty);
+}
+
 /* Draw the visible form: a group member by member, anything else through its own drawer. */
 static void _overlay_draw_form(cairo_t *cr, const float zoom_scale, dt_masks_form_t *mask_form,
                                dt_masks_form_gui_t *mask_gui)
@@ -4497,21 +4519,11 @@ void dt_masks_events_post_expose_with(dt_develop_t *dev, struct dt_iop_module_t 
 
   cairo_save(mask_draw);
 
-  // We rescale to input space -- from the viewport, or from the caller's own mapping when it
-  // supplied one (see dt_masks_overlay_transform_t: the viewport path needs GUI state).
-  if(IS_NULL_PTR(transform))
+  if(!_overlay_apply_transform(mask_draw, develop, transform, width, height))
   {
-    if(dt_dev_rescale_roi_to_input(develop, mask_draw, width, height))
-    {
-      cairo_restore(mask_draw);
-      cairo_destroy(mask_draw);   // nothing was drawn
-      return;
-    }
-  }
-  else
-  {
-    cairo_translate(mask_draw, transform->offset_x, transform->offset_y);
-    cairo_scale(mask_draw, transform->scale, transform->scale);
+    cairo_restore(mask_draw);
+    cairo_destroy(mask_draw);   // nothing was drawn
+    return;
   }
 
   // We update the form if needed
@@ -4553,9 +4565,7 @@ void dt_masks_events_post_expose_with(dt_develop_t *dev, struct dt_iop_module_t 
     dt_show_times(&draw_start, "[masks] overlay drawn");
 
   const double composite_start = dt_get_wtime();
-  if(any) _canvas_end(cr, &frame, &dirty);
-  /* the darkroom's own frames only: a headless caller has no widget to invalidate */
-  if(IS_NULL_PTR(transform)) _overlay_damage_record(cr, &frame, any ? &dirty : NULL);
+  _overlay_finish(cr, &frame, any ? &dirty : NULL, IS_NULL_PTR(transform));
   if(dt_get_debug_flags() & DT_DEBUG_PERF)
     dt_print(DT_DEBUG_MASKS, "[masks] overlay composited (%dx%d of %dx%d) in %0.04f sec\n",
              any ? dirty.width : 0, any ? dirty.height : 0, frame.width, frame.height,

--- a/src/develop/masks_gui.h
+++ b/src/develop/masks_gui.h
@@ -573,6 +573,11 @@ void dt_masks_events_post_expose_with(dt_develop_t *dev, struct dt_iop_module_t 
                                       int32_t width, int32_t height, int32_t pointerx, int32_t pointery,
                                       const dt_masks_overlay_transform_t *transform);
 
+/** Ask the centre widget for a redraw of what the last overlay frame touched, grown by the
+ * pointer's motion since, instead of the whole widget: for a motion the masks handled and
+ * nothing else did. Falls back to the whole widget when no frame has been recorded. */
+void dt_masks_overlay_queue_redraw(GtkWidget *widget);
+
 void dt_masks_events_post_expose(dt_develop_t *dev, struct dt_iop_module_t *module, cairo_t *cr, int32_t width, int32_t height,
                                  int32_t pointerx, int32_t pointery);
 int dt_masks_events_mouse_leave(struct dt_iop_module_t *module);

--- a/src/gui/application.c
+++ b/src/gui/application.c
@@ -189,12 +189,8 @@ static gboolean _configure(GtkWidget *da, GdkEventConfigure *event, gpointer use
 
 static gboolean _draw(GtkWidget *da, cairo_t *cr, gpointer user_data)
 {
-  dt_control_expose(NULL);
-  if(darktable.gui->surface)
-  {
-    cairo_set_source_surface(cr, darktable.gui->surface, 0, 0);
-    cairo_paint(cr);
-  }
+  /* cr is GTK's double buffer, clipped to what was invalidated; the centre paints into it */
+  dt_control_expose(cr, gtk_widget_get_allocated_width(da), gtk_widget_get_allocated_height(da));
   return TRUE;
 }
 
@@ -331,26 +327,8 @@ static gboolean _configure(GtkWidget *da, GdkEventConfigure *event, gpointer use
 {
   static int oldw = 0;
   static int oldh = 0;
-  // make our selves a properly sized pixmap if our window has been resized
   if(oldw != event->width || oldh != event->height)
   {
-    // create our new pixmap with the correct size.
-    cairo_surface_t *tmpsurface
-        = dt_cairo_image_surface_create(CAIRO_FORMAT_ARGB32, event->width, event->height);
-    // copy the contents of the old pixmap to the new pixmap.  This keeps ugly uninitialized
-    // pixmaps from being painted upon resize
-    //     int minw = oldw, minh = oldh;
-    //     if(event->width  < minw) minw = event->width;
-    //     if(event->height < minh) minh = event->height;
-
-    cairo_t *cr = cairo_create(tmpsurface);
-    cairo_set_source_surface(cr, darktable.gui->surface, 0, 0);
-    cairo_paint(cr);
-    cairo_destroy(cr);
-
-    // we're done with our old pixmap, so we can get rid of it and replace it with our properly-sized one.
-    cairo_surface_destroy(darktable.gui->surface);
-    darktable.gui->surface = tmpsurface;
     // maybe we are on another screen now with > 50% of the area
     _update_display_profile();
   }
@@ -1243,7 +1221,6 @@ int dt_gui_gtk_init(dt_gui_gtk_t *gui)
 
   GtkWidget *widget;
   gui->ui = g_malloc0(sizeof(dt_ui_t));
-  gui->surface = NULL;
   gui->center_tooltip = 0;
   gui->culling_mode = FALSE;
   gui->presets_popup_menu = NULL;
@@ -1441,14 +1418,6 @@ void dt_gui_gtk_run(dt_gui_gtk_t *gui)
   GtkAllocation allocation;
   gtk_widget_get_allocation(widget, &allocation);
 
-  if(darktable.gui->surface)
-  {
-    cairo_surface_destroy(darktable.gui->surface);
-    darktable.gui->surface = NULL;
-  }
-
-  darktable.gui->surface
-      = dt_cairo_image_surface_create(CAIRO_FORMAT_ARGB32, allocation.width, allocation.height);
   /* Pre-configure the views so a draw arriving before the first configure-event has a valid
    * size to work with.
    *
@@ -1475,11 +1444,6 @@ void dt_gui_gtk_run(dt_gui_gtk_t *gui)
   /* start the event loop */
   gtk_main();
 
-  if (darktable.gui->surface)
-  {
-    cairo_surface_destroy(darktable.gui->surface);
-    darktable.gui->surface = NULL;
-  }
   dt_cleanup();
 }
 

--- a/src/gui/application.h
+++ b/src/gui/application.h
@@ -166,7 +166,6 @@ typedef struct dt_gui_gtk_t
 
   dt_gui_widgets_t widgets;
 
-  cairo_surface_t *surface;
   GtkMenu *presets_popup_menu;
   char *last_preset;
 

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -2617,6 +2617,7 @@ void mouse_moved(dt_view_t *self, double x, double y, double pressure, int which
   // change cursor appearance by default
   _darkroom_set_default_cursor(self, x, y);
   gboolean handled = FALSE;
+  gboolean masks_handled = FALSE;
 
   if(picker_active && dt_control_button_down(1))
   {
@@ -2672,6 +2673,7 @@ void mouse_moved(dt_view_t *self, double x, double y, double pressure, int which
   else if(dt_masks_get_visible_form(dev)
           && dt_masks_events_mouse_moved(dev, dev->gui_module, x, y, pressure, which))
   {
+    masks_handled = TRUE;
     // There is no shape dragging in creation mode, so no need to commit history.
     if(!dev->form_gui->creation)
     {
@@ -2756,7 +2758,12 @@ void mouse_moved(dt_view_t *self, double x, double y, double pressure, int which
 
   if(handled)
   {
-    dt_control_queue_redraw_center();
+    /* a motion the masks handled changed the overlay and nothing else: repaint what it touched,
+     * not the image under the whole window */
+    if(masks_handled)
+      dt_masks_overlay_queue_redraw(dt_gui_center_widget());
+    else
+      dt_control_queue_redraw_center();
     return;
   }
 

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -817,33 +817,52 @@ static inline void _darkroom_reset_expose_state(darkroom_expose_state_t *state)
   state->composed_key = 0;
 }
 
+/* One expose's composition: the context of the image surface, the frame and the colours it
+ * is composed for, and the state that remembers what it holds. */
+typedef struct _darkroom_compose_t
+{
+  cairo_t *cr;
+  const dt_develop_t *dev;
+  darkroom_expose_state_t *state;
+  int width;
+  int height;
+  int border;
+  uint64_t zoom_hash;
+  const float *bg_color;
+} _darkroom_compose_t;
+
+static uint64_t _darkroom_compose_key_of(const _darkroom_compose_t *const c, const uint64_t source_hash)
+{
+  return _darkroom_compose_key(source_hash, c->zoom_hash, c->bg_color, c->border, c->dev->iso_12646.enabled,
+                               c->width, c->height);
+}
+
+static gboolean _darkroom_composed_already(const _darkroom_compose_t *const c, const uint64_t key)
+{
+  return c->state->composed_key == key && c->state->image_surface_imgid == c->dev->image_storage.id;
+}
+
 /* Compose @p locked into the image surface unless the frame it would compose is already
  * there. */
-static gboolean _darkroom_compose_locked(cairo_t *cr, const dt_develop_t *dev, dt_dev_locked_surface_t *locked,
-                                         const int width, const int height, const int border,
-                                         const dt_aligned_pixel_t bg_color, darkroom_expose_state_t *state,
-                                         const uint64_t zoom_hash)
+static gboolean _darkroom_compose_locked(const _darkroom_compose_t *const c, dt_dev_locked_surface_t *locked)
 {
   if(IS_NULL_PTR(locked) || IS_NULL_PTR(locked->surface)) return FALSE;
-  const uint64_t key
-      = _darkroom_compose_key(locked->hash, zoom_hash, bg_color, border, dev->iso_12646.enabled, width, height);
-  if(state->composed_key == key && state->image_surface_imgid == dev->image_storage.id) return TRUE;
-  if(!dt_dev_render_locked_surface(cr, dev, locked, width, height, border, bg_color)) return FALSE;
-  state->composed_key = key;
+  const uint64_t key = _darkroom_compose_key_of(c, locked->hash);
+  if(_darkroom_composed_already(c, key)) return TRUE;
+  if(!dt_dev_render_locked_surface(c->cr, c->dev, locked, c->width, c->height, c->border, c->bg_color)) return FALSE;
+  c->state->composed_key = key;
   return TRUE;
 }
 
 /* Copy the cached fallback into the image surface unless it is already the frame there. */
-static gboolean _darkroom_compose_fallback(cairo_t *cr, const dt_develop_t *dev, const int width, const int height,
-                                           const int border, const dt_aligned_pixel_t bg_color,
-                                           darkroom_expose_state_t *state, const uint64_t zoom_hash)
+static gboolean _darkroom_compose_fallback(const _darkroom_compose_t *const c)
 {
   /* salted: a fallback is not the same frame as a main backbuf that happened to hash alike */
-  const uint64_t source = _darkroom_preview_fallback_backbuf_hash ^ 0x9e3779b97f4a7c15ull;
-  const uint64_t key = _darkroom_compose_key(source, zoom_hash, bg_color, border, dev->iso_12646.enabled, width, height);
-  if(state->composed_key == key && state->image_surface_imgid == dev->image_storage.id) return TRUE;
-  if(!_render_preview_fallback_surface(cr)) return FALSE;
-  state->composed_key = key;
+  const uint64_t source = _darkroom_preview_fallback_backbuf_hash ^ 0x9e3779b97f4a7c15ULL;
+  const uint64_t key = _darkroom_compose_key_of(c, source);
+  if(_darkroom_composed_already(c, key)) return TRUE;
+  if(!_render_preview_fallback_surface(c->cr)) return FALSE;
+  c->state->composed_key = key;
   return TRUE;
 }
 
@@ -953,6 +972,9 @@ void expose(
   gboolean drawn_from_main = FALSE;
 
   dt_dev_get_background_color(dev, bg_color);
+  const _darkroom_compose_t compose = { .cr = cr, .dev = dev, .state = &expose_state, .width = width,
+                                        .height = height, .border = border, .zoom_hash = zoom_hash,
+                                        .bg_color = bg_color };
 
   /* Selection policy, kept intentionally linear:
    * 1. Prefer the main pipe whenever it already has the backbuf for the
@@ -981,8 +1003,7 @@ void expose(
   {
     if(dt_dev_lock_pipe_surface(dev, dev->pipe, &_darkroom_main_locked, &_darkroom_main_wait, "darkroom-main", FALSE)
        && _darkroom_main_locked.surface
-       && _darkroom_compose_locked(cr, dev, &_darkroom_main_locked, width, height, border, bg_color, &expose_state,
-                                   zoom_hash))
+       && _darkroom_compose_locked(&compose, &_darkroom_main_locked))
     {
       expose_state.main_zoom_hash = zoom_hash;
       expose_state.image_surface_imgid = dev->image_storage.id;
@@ -1015,8 +1036,7 @@ void expose(
     if(dt_dev_lock_pipe_surface(dev, dev->preview_pipe, &_darkroom_preview_locked, &_darkroom_preview_wait,
                                 "darkroom-preview", FALSE)
        && _darkroom_preview_locked.surface
-       && _darkroom_compose_locked(cr, dev, &_darkroom_preview_locked, width, height, border, bg_color,
-                                   &expose_state, zoom_hash))
+       && _darkroom_compose_locked(&compose, &_darkroom_preview_locked))
     {
       // This frame validates the composed image, not the locked main surface. Keep main_zoom_hash
       // unchanged so the old main backbuffer cannot be reused as if it had been rendered at fit.
@@ -1038,7 +1058,7 @@ void expose(
     if(dt_dev_lock_pipe_surface(dev, dev->preview_pipe, &_darkroom_preview_locked, &_darkroom_preview_wait,
                                 "darkroom-preview", TRUE)
        && _build_preview_fallback_surface(dev, width, height, border, bg_color, zoom_hash)
-       && _darkroom_compose_fallback(cr, dev, width, height, border, bg_color, &expose_state, zoom_hash))
+       && _darkroom_compose_fallback(&compose))
     {
       expose_state.image_surface_imgid = dev->image_storage.id;
       expose_state.image_surface_has_main = FALSE;
@@ -1054,7 +1074,7 @@ void expose(
    * is still catching up. */
   if(!drawn && roi_changed && !full_image_backbuf_ready
      && _darkroom_preview_fallback_valid(dev, width, height, zoom_hash)
-     && _darkroom_compose_fallback(cr, dev, width, height, border, bg_color, &expose_state, zoom_hash))
+     && _darkroom_compose_fallback(&compose))
   {
     expose_state.image_surface_imgid = dev->image_storage.id;
     expose_state.image_surface_has_main = FALSE;
@@ -1068,8 +1088,7 @@ void expose(
    * the same zoom/pan. History-only changes should not glitch to preview or
    * background while the new main backbuf is still being produced. */
   if(!drawn && _darkroom_locked_main_valid_for_zoom(&expose_state, zoom_hash)
-     && _darkroom_compose_locked(cr, dev, &_darkroom_main_locked, width, height, border, bg_color, &expose_state,
-                                 zoom_hash))
+     && _darkroom_compose_locked(&compose, &_darkroom_main_locked))
   {
     expose_state.image_surface_imgid = dev->image_storage.id;
     expose_state.image_surface_has_main = TRUE;

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -238,6 +238,12 @@ uint32_t view(const dt_view_t *self)
   return DT_VIEW_DARKROOM;
 }
 
+uint32_t flags()
+{
+  /* expose() composes background and image over the whole centre itself */
+  return VIEW_FLAGS_PAINTS_WHOLE_AREA;
+}
+
 static void _reset_edge_pan()
 {
   dt_gui_gtk_t *gui = dt_gui_get_global();
@@ -624,7 +630,6 @@ static gboolean _build_preview_fallback_surface(dt_develop_t *dev, const int wid
   }
 
   cairo_t *cr = cairo_create(_darkroom_preview_fallback_surface);
-  cairo_pattern_set_filter(cairo_get_source(cr), CAIRO_FILTER_NEAREST);
 
   cairo_set_source_rgb(cr, bg_color[0], bg_color[1], bg_color[2]);
   cairo_paint(cr);
@@ -672,6 +677,12 @@ static gboolean _build_preview_fallback_surface(dt_develop_t *dev, const int wid
   cairo_scale(cr, preview_scale, preview_scale);
   cairo_rectangle(cr, 0, 0, preview_wd, preview_ht);
   cairo_set_source_surface(cr, _darkroom_preview_locked.surface, 0, 0);
+  /* A placeholder while the main pipe catches up, resampled by the zoom: nearest neighbour,
+   * on the pattern that actually scales. This filter used to be set on the context's default
+   * solid source before the surface replaced it, so the scaling ran with cairo's default GOOD
+   * filter -- measured at a 2560x1440 window on a 2x screen: 262 ms per frame zooming out,
+   * 120 ms zooming in, against 4 and 8 ms with the filter that was meant. */
+  cairo_pattern_set_filter(cairo_get_source(cr), CAIRO_FILTER_NEAREST);
   cairo_fill(cr);
   dt_dev_pixelpipe_cache_rdlock_entry(FALSE, _darkroom_preview_locked.entry);
   cairo_destroy(cr);
@@ -689,6 +700,7 @@ static gboolean _render_preview_fallback_surface(cairo_t *cr)
   cairo_paint(cr);
   return TRUE;
 }
+
 
 static void _paint_all(cairo_t *cri, cairo_t *cr, cairo_surface_t *image_surface)
 {
@@ -712,7 +724,29 @@ typedef struct darkroom_expose_state_t
    * not spin the center redraw at frame-clock rate while we show the preview
    * fallback. Reset whenever a main frame is rendered successfully. */
   uint64_t pending_main_hash;
+  /* What dev->image_surface currently holds: the source frame, the viewport, the colours and
+   * the frame size it was composed for. A frame with the same key is already on it, and an
+   * expose that only moved an overlay repaints from it without composing again -- composing
+   * was a full-window fill and a full-window blit on every frame, for an image that had not
+   * changed. */
+  uint64_t composed_key;
 } darkroom_expose_state_t;
+
+/* Everything the composed image depends on, and nothing else. */
+static uint64_t _darkroom_compose_key(const uint64_t source_hash, const uint64_t zoom_hash,
+                                      const dt_aligned_pixel_t bg_color, const int border, const gboolean iso,
+                                      const int width, const int height)
+{
+  uint64_t key = 5381;
+  key = dt_hash(key, (const char *)&source_hash, sizeof(source_hash));
+  key = dt_hash(key, (const char *)&zoom_hash, sizeof(zoom_hash));
+  key = dt_hash(key, (const char *)bg_color, 3 * sizeof(float));
+  key = dt_hash(key, (const char *)&border, sizeof(border));
+  key = dt_hash(key, (const char *)&iso, sizeof(iso));
+  key = dt_hash(key, (const char *)&width, sizeof(width));
+  key = dt_hash(key, (const char *)&height, sizeof(height));
+  return key;
+}
 
 static inline gboolean _darkroom_preview_fallback_valid(const dt_develop_t *dev, const int width,
                                                         const int height, const uint64_t zoom_hash)
@@ -780,6 +814,37 @@ static inline void _darkroom_reset_expose_state(darkroom_expose_state_t *state)
   state->image_surface_hash = DT_PIXELPIPE_CACHE_HASH_INVALID;
   state->main_zoom_hash = 0;
   state->pending_main_hash = DT_PIXELPIPE_CACHE_HASH_INVALID;
+  state->composed_key = 0;
+}
+
+/* Compose @p locked into the image surface unless the frame it would compose is already
+ * there. */
+static gboolean _darkroom_compose_locked(cairo_t *cr, const dt_develop_t *dev, dt_dev_locked_surface_t *locked,
+                                         const int width, const int height, const int border,
+                                         const dt_aligned_pixel_t bg_color, darkroom_expose_state_t *state,
+                                         const uint64_t zoom_hash)
+{
+  if(IS_NULL_PTR(locked) || IS_NULL_PTR(locked->surface)) return FALSE;
+  const uint64_t key
+      = _darkroom_compose_key(locked->hash, zoom_hash, bg_color, border, dev->iso_12646.enabled, width, height);
+  if(state->composed_key == key && state->image_surface_imgid == dev->image_storage.id) return TRUE;
+  if(!dt_dev_render_locked_surface(cr, dev, locked, width, height, border, bg_color)) return FALSE;
+  state->composed_key = key;
+  return TRUE;
+}
+
+/* Copy the cached fallback into the image surface unless it is already the frame there. */
+static gboolean _darkroom_compose_fallback(cairo_t *cr, const dt_develop_t *dev, const int width, const int height,
+                                           const int border, const dt_aligned_pixel_t bg_color,
+                                           darkroom_expose_state_t *state, const uint64_t zoom_hash)
+{
+  /* salted: a fallback is not the same frame as a main backbuf that happened to hash alike */
+  const uint64_t source = _darkroom_preview_fallback_backbuf_hash ^ 0x9e3779b97f4a7c15ull;
+  const uint64_t key = _darkroom_compose_key(source, zoom_hash, bg_color, border, dev->iso_12646.enabled, width, height);
+  if(state->composed_key == key && state->image_surface_imgid == dev->image_storage.id) return TRUE;
+  if(!_render_preview_fallback_surface(cr)) return FALSE;
+  state->composed_key = key;
+  return TRUE;
 }
 
 static void _darkroom_prepare_image_surface(dt_develop_t *dev, const int width, const int height,
@@ -806,6 +871,7 @@ static void _darkroom_prepare_image_surface(dt_develop_t *dev, const int width, 
   state->image_surface_imgid = UNKNOWN_IMAGE;
   state->image_surface_has_main = FALSE;
   state->image_surface_hash = DT_PIXELPIPE_CACHE_HASH_INVALID;
+  state->composed_key = 0;
   _release_preview_fallback_surface();
 }
 
@@ -842,6 +908,7 @@ void expose(
     .image_surface_hash = DT_PIXELPIPE_CACHE_HASH_INVALID,
     .main_zoom_hash = 0,
     .pending_main_hash = DT_PIXELPIPE_CACHE_HASH_INVALID,
+    .composed_key = 0,
   };
   const uint64_t zoom_hash = _darkroom_zoom_hash(dev);
   const gboolean roi_changed = !_darkroom_locked_main_valid_for_zoom(&expose_state, zoom_hash);
@@ -887,8 +954,6 @@ void expose(
 
   dt_dev_get_background_color(dev, bg_color);
 
-  cairo_pattern_set_filter(cairo_get_source(cr), CAIRO_FILTER_NEAREST);
-
   /* Selection policy, kept intentionally linear:
    * 1. Prefer the main pipe whenever it already has the backbuf for the
    *    current darkroom view. We do not guess that from size. If ROI did not
@@ -916,7 +981,8 @@ void expose(
   {
     if(dt_dev_lock_pipe_surface(dev, dev->pipe, &_darkroom_main_locked, &_darkroom_main_wait, "darkroom-main", FALSE)
        && _darkroom_main_locked.surface
-       && dt_dev_render_locked_surface(cr, dev, &_darkroom_main_locked, width, height, border, bg_color))
+       && _darkroom_compose_locked(cr, dev, &_darkroom_main_locked, width, height, border, bg_color, &expose_state,
+                                   zoom_hash))
     {
       expose_state.main_zoom_hash = zoom_hash;
       expose_state.image_surface_imgid = dev->image_storage.id;
@@ -949,7 +1015,8 @@ void expose(
     if(dt_dev_lock_pipe_surface(dev, dev->preview_pipe, &_darkroom_preview_locked, &_darkroom_preview_wait,
                                 "darkroom-preview", FALSE)
        && _darkroom_preview_locked.surface
-       && dt_dev_render_locked_surface(cr, dev, &_darkroom_preview_locked, width, height, border, bg_color))
+       && _darkroom_compose_locked(cr, dev, &_darkroom_preview_locked, width, height, border, bg_color,
+                                   &expose_state, zoom_hash))
     {
       // This frame validates the composed image, not the locked main surface. Keep main_zoom_hash
       // unchanged so the old main backbuffer cannot be reused as if it had been rendered at fit.
@@ -971,7 +1038,7 @@ void expose(
     if(dt_dev_lock_pipe_surface(dev, dev->preview_pipe, &_darkroom_preview_locked, &_darkroom_preview_wait,
                                 "darkroom-preview", TRUE)
        && _build_preview_fallback_surface(dev, width, height, border, bg_color, zoom_hash)
-       && _render_preview_fallback_surface(cr))
+       && _darkroom_compose_fallback(cr, dev, width, height, border, bg_color, &expose_state, zoom_hash))
     {
       expose_state.image_surface_imgid = dev->image_storage.id;
       expose_state.image_surface_has_main = FALSE;
@@ -987,7 +1054,7 @@ void expose(
    * is still catching up. */
   if(!drawn && roi_changed && !full_image_backbuf_ready
      && _darkroom_preview_fallback_valid(dev, width, height, zoom_hash)
-     && _render_preview_fallback_surface(cr))
+     && _darkroom_compose_fallback(cr, dev, width, height, border, bg_color, &expose_state, zoom_hash))
   {
     expose_state.image_surface_imgid = dev->image_storage.id;
     expose_state.image_surface_has_main = FALSE;
@@ -1001,7 +1068,8 @@ void expose(
    * the same zoom/pan. History-only changes should not glitch to preview or
    * background while the new main backbuf is still being produced. */
   if(!drawn && _darkroom_locked_main_valid_for_zoom(&expose_state, zoom_hash)
-     && dt_dev_render_locked_surface(cr, dev, &_darkroom_main_locked, width, height, border, bg_color))
+     && _darkroom_compose_locked(cr, dev, &_darkroom_main_locked, width, height, border, bg_color, &expose_state,
+                                 zoom_hash))
   {
     expose_state.image_surface_imgid = dev->image_storage.id;
     expose_state.image_surface_has_main = TRUE;
@@ -1039,6 +1107,7 @@ void expose(
     /* Cold-start / no valid frame cached anywhere yet. */
     cairo_set_source_rgb(cr, bg_color[0], bg_color[1], bg_color[2]);
     cairo_paint(cr);
+    expose_state.composed_key = 0;
     _paint_all(cri, cr, dev->image_surface);
     dt_print(DT_DEBUG_DEV, "[darkroom] expose drew %s (backbuf hash=%" PRIu64 ")\n",
              draw_source, draw_hash);

--- a/src/views/dev_backbuf.c
+++ b/src/views/dev_backbuf.c
@@ -55,10 +55,15 @@ void dt_dev_get_background_color(const dt_develop_t *dev, dt_aligned_pixel_t bg_
 
 void dt_dev_draw_iso12646_border(cairo_t *cr, double width, double height, int border)
 {
-  // draw the white frame around picture
+  /* the white frame around the picture: the ring only, the picture is painted over the middle
+   * anyway and the middle is most of the window */
+  cairo_save(cr);
   cairo_rectangle(cr, -border * .5f, -border * .5f, width + border, height + border);
+  cairo_rectangle(cr, 1.0, 1.0, width - 2.0, height - 2.0);
+  cairo_set_fill_rule(cr, CAIRO_FILL_RULE_EVEN_ODD);
   cairo_set_source_rgb(cr, 1., 1., 1.);
   cairo_fill(cr);
+  cairo_restore(cr);
 }
 
 void dt_dev_draw_profile_mode_label(cairo_t *cri, int height)
@@ -224,16 +229,29 @@ gboolean dt_dev_render_locked_surface(cairo_t *cr, const dt_develop_t *dev, dt_d
   if(IS_NULL_PTR(cr) || IS_NULL_PTR(dev) || IS_NULL_PTR(locked) || IS_NULL_PTR(locked->surface)) return FALSE;
   if(IS_NULL_PTR(locked->entry) || locked->hash == DT_PIXELPIPE_CACHE_HASH_INVALID) return FALSE;
 
-  cairo_set_source_rgb(cr, bg_color[0], bg_color[1], bg_color[2]);
-  cairo_paint(cr);
-
   int wd = locked->width;
   int ht = locked->height;
   if(wd <= 0 || ht <= 0) return FALSE;
 
   wd /= dt_gui_get_global()->ppd;
   ht /= dt_gui_get_global()->ppd;
-  cairo_translate(cr, .5f * (width - wd), .5f * (height - ht));
+  const double x0 = .5 * (width - wd);
+  const double y0 = .5 * (height - ht);
+
+  /* The background where the image will not cover: the four bands around it, as one even-odd
+   * fill. The hole is a pixel smaller than the image on every side so the blit overlaps it and
+   * no seam shows between the band and an antialiased image edge. A fill of the whole window
+   * under an image that covers most of it was a full pass for nothing: 5.9 ms of a frame at a
+   * 2560x1440 window on a 2x screen, against 1.3 ms for the bands. */
+  cairo_save(cr);
+  cairo_rectangle(cr, 0, 0, width, height);
+  cairo_rectangle(cr, x0 + 1.0, y0 + 1.0, wd - 2.0, ht - 2.0);
+  cairo_set_fill_rule(cr, CAIRO_FILL_RULE_EVEN_ODD);
+  cairo_set_source_rgb(cr, bg_color[0], bg_color[1], bg_color[2]);
+  cairo_fill(cr);
+  cairo_restore(cr);
+
+  cairo_translate(cr, x0, y0);
 
   if(dev->iso_12646.enabled) dt_dev_draw_iso12646_border(cr, wd, ht, border);
 
@@ -241,6 +259,9 @@ gboolean dt_dev_render_locked_surface(cairo_t *cr, const dt_develop_t *dev, dt_d
   cairo_surface_set_device_scale(locked->surface, dt_gui_get_global()->ppd, dt_gui_get_global()->ppd);
   cairo_rectangle(cr, 0, 0, wd, ht);
   cairo_set_source_surface(cr, locked->surface, 0, 0);
+  /* pixel for pixel on a matching target; say so, rather than leave the default filter to
+   * discover a mismatch the expensive way */
+  cairo_pattern_set_filter(cairo_get_source(cr), CAIRO_FILTER_NEAREST);
   cairo_fill(cr);
   dt_dev_pixelpipe_cache_rdlock_entry(FALSE, locked->entry);
 

--- a/src/views/view.c
+++ b/src/views/view.c
@@ -441,6 +441,12 @@ const char *dt_view_manager_name(dt_view_manager_t *vm)
     return vm->current_view->module_name;
 }
 
+uint32_t dt_view_manager_current_flags(const dt_view_manager_t *vm)
+{
+  if(IS_NULL_PTR(vm) || IS_NULL_PTR(vm->current_view) || IS_NULL_PTR(vm->current_view->flags)) return 0;
+  return vm->current_view->flags();
+}
+
 void dt_view_manager_expose(dt_view_manager_t *vm, cairo_t *cr, int32_t width, int32_t height,
                             int32_t pointerx, int32_t pointery)
 {

--- a/src/views/view.h
+++ b/src/views/view.h
@@ -87,6 +87,7 @@ typedef enum dt_view_flags_t
 {
   VIEW_FLAGS_NONE = 0,
   VIEW_FLAGS_HIDDEN = 1 << 0,       // Hide the view from userinterface
+  VIEW_FLAGS_PAINTS_WHOLE_AREA = 1 << 1,   // its expose paints every pixel of the centre: no background fill needed
 } dt_view_flags_t;
 
 typedef enum dt_darkroom_layout_t
@@ -282,6 +283,9 @@ const char *dt_view_manager_name(dt_view_manager_t *vm);
 int dt_view_manager_switch(dt_view_manager_t *vm, const char *view_name);
 int dt_view_manager_switch_by_view(dt_view_manager_t *vm, const dt_view_t *new_view);
 /** expose current module. */
+/** the current view's flags(), or 0 when there is no view */
+uint32_t dt_view_manager_current_flags(const dt_view_manager_t *vm);
+
 void dt_view_manager_expose(dt_view_manager_t *vm, cairo_t *cr, int32_t width, int32_t height,
                             int32_t pointerx, int32_t pointery);
 /** reset current view. */


### PR DESCRIPTION
Follow-up to #1198 (the darkroom's 60 fps floor), on top of the merged #1387. `doc/darkroom-redraw.md` is the account.

## The floor, priced

Every pass of the repaint path timed with cairo at a 2560x1440 window, at device scale 1 and at 2 (a 59 MB buffer):

| per frame | 1x | 2x |
| --- | ---: | ---: |
| allocate, first-touch, free a full-window ARGB surface | 2.2 ms | 29.5 ms |
| full-window fill | 1.8 ms | 5.9 ms |
| full-window 1:1 blit | 1.2 ms | 5.8 ms |
| clipped 400x300 blit | 0.03 ms | 0.12 ms |
| scaled preview blit, cairo's default filter | 66 ms | 262 ms |
| same, NEAREST | 1.0 ms | 3.7 ms |

Every centre repaint, whatever had changed, allocated and freed the throwaway surface, filled two full-window backgrounds and blitted the window three times through two intermediate surfaces: **about 10 ms at 1x and 59 ms at 2x before the first overlay pixel**. The darkroom recomposed its image surface on every frame for an image that had not changed. Nothing invalidated a rectangle anywhere in the tree, and the draw handler discarded GTK's clip. And a zoom or pan, while the main pipe catches up, scaled the preview with the default filter because `CAIRO_FILTER_NEAREST` was set on the context's solid source before the surface replaced it: a third of a second per frame at 2x.

## What changes

- **`dt_control_expose(cr, w, h)` paints into GTK's own buffer**, which is a double buffer already and arrives clipped to what was invalidated. The throwaway surface, the pixmap and its resize copy are gone. A view that paints every pixel (`VIEW_FLAGS_PAINTS_WHOLE_AREA`, the darkroom) skips the toplevel fill.
- **The darkroom composes its image once per source frame**, keyed on the source hash, viewport, colours, border and size; overlay-only frames repaint from it with one clipped blit. Background as the four bands around the image, ISO 12646 frame as a ring, the fallback's filter on the pattern that scales.
- **A motion the masks handled invalidates a rectangle**: the last composited overlay rectangle grown by the pointer's motion, with an expose-side safety net that asks for whatever a frame painted outside the clip. A module's own overlay keeps the full redraw.
- **The overlay canvas is sized to the view, and a creation session's frame is bounded** to the session's box and the live shape (it was the whole window: a full composite and a full memset per frame).

Expected at 2x: a mask hover or drag frame from ~59 ms + overlay to ~0.2 ms + overlay; a new pipe frame ~13 ms; a zoom/pan frame ~10 ms instead of ~320 ms.

## Verification

GCC, clang and nofeatures build every target; unit tests, the masks corpus and the overlay harness are unchanged. **Not GUI-tested by me: this machine has no display.** Please run with `-d perf -d masks` and read `[darkroom] redraw` and `[masks] overlay composited (WxH of WxH)` on a mask hover, a drag, a pipe frame and a zoom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

