### PR TITLE
masks overlay: a group's unselected members live in a static layer (#1391)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2007,6 +2007,16 @@ the context's default source before the surface replaced it. Four rules now:
 - **The overlay canvas is sized to the view, never to `cr`'s clip**, which a rectangle redraw
   narrows; and a creation session's frame is bounded to the session's box and the live shape,
   where it was the whole window before.
+- **A group's unselected members live in the static layer** (`_static_layer_ensure()`,
+  `masks_gui.c`): stroked once into a view-sized surface, composited under the live canvas with
+  one clipped blit, keyed on the view matrix, the group, the selection, the overlay colours and
+  every other member's outline signature (counts plus every 32nd sample). Only the selected member
+  is stroked per frame. A rebuild marks the whole frame dirty, so a selection change under a small
+  invalidation gets its one full repaint. Cairo's bound covers the selected member's header alone,
+  since that is all cairo draws for a group. Measured on the harness's 11-member group: 14.1 → 4.0
+  ms a full frame with nothing selected, 16.4 → 5.7 with one selected. The harness's `group-11`
+  case is the regression check; its "build" column, 340 ms, is the outline rebuild and is #1391's
+  next item.
 
 The views are plugins: `ninja ansel` does NOT compile `src/views/*.c`. Build every target
 (`ninja`) before trusting a darkroom edit; a use of an undeclared variable in `darkroom.c`

--- a/doc/darkroom-redraw.md
+++ b/doc/darkroom-redraw.md
@@ -87,6 +87,37 @@ the session's box and the live shape's now. The session's box covers the borders
 spines alone, which is also what a brush's dashed border, a radius outside its spine, needed
 from the pattern's clip after a pan.
 
+## The static layer: the members that did not change are not stroked again
+
+After the four rules a pipe frame still re-stroked every member of the visible group: 1 to
+8 ms a shape at fit zoom, and a drag makes a pipe frame per motion, so a mask-heavy edit paid
+tens of milliseconds of GUI thread per motion for shapes that had not moved. The members that
+are not the selected one are now stroked once into a view-sized surface, `_static_layer` in
+`masks_gui.c`, and composited under the live canvas with one blit, clipped to what the redraw
+asked for. Its key is the view matrix, the group, the selection, the overlay colours and a
+signature of every other member's outline -- its counts and every 32nd sample -- so a member
+an undo moved is caught, while the selected member, which a drag rebuilds on every motion, is
+not in it at all. A pan, a zoom or a change of selection pays one full stroke of the others,
+which is what every frame paid before; a rebuild also marks the whole frame dirty, so a
+selection change under a small invalidation gets its one full repaint.
+
+With it, cairo's own drawing -- nodes, handles, arrows -- is bounded to the selected member's
+header alone, which is all cairo draws for a group: bounding every member's header had made
+a spread-out group's dirty rectangle the whole window on every frame, and with it the
+composite, the clear and the rectangle a motion asks a redraw of.
+
+Measured by the harness's `group-11` case, every brush and polygon of the corpus in one group
+at fit zoom on a 2560x1440 surface, RelWithDebInfo, per frame, of which about 1.8 ms is the
+harness's own background paint:
+
+| group of 11, per full frame | before | after |
+| --- | ---: | ---: |
+| nothing selected | 14.1 ms | 4.0 ms |
+| one member selected | 16.4 ms | 5.7 ms |
+
+The first frame of that group, 340 ms, is the rebuild of every member's outline and is the
+next item (#1391).
+
 ## What a frame costs now
 
 | frame | before, 2x | after, 2x |

--- a/src/develop/masks/group.c
+++ b/src/develop/masks/group.c
@@ -161,6 +161,21 @@ static void _group_events_post_expose_draw(cairo_t *cr, float zoom_scale, dt_mas
   }
 }
 
+void dt_group_events_post_expose_except(cairo_t *cr, float zoom_scale, dt_masks_form_t *form,
+                                        dt_masks_form_gui_t *gui, const int except_pos)
+{
+  int pos = 0;
+  for(GList *fpts = form->points; fpts; fpts = g_list_next(fpts), pos++)
+    if(pos != except_pos) _group_events_post_expose_draw(cr, zoom_scale, form, gui, pos);
+}
+
+void dt_group_events_post_expose_only(cairo_t *cr, float zoom_scale, dt_masks_form_t *form,
+                                      dt_masks_form_gui_t *gui, const int pos)
+{
+  if(pos < 0 || pos >= (int)g_list_length(form->points)) return;
+  _group_events_post_expose_draw(cr, zoom_scale, form, gui, pos);
+}
+
 void dt_group_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks_form_t *form,
                                  dt_masks_form_gui_t *gui)
 {

--- a/src/develop/masks/masks_gui.c
+++ b/src/develop/masks/masks_gui.c
@@ -4023,8 +4023,8 @@ static void _canvas_clear(cairo_surface_t *canvas, const cairo_rectangle_int_t *
   const int stride = cairo_image_surface_get_stride(canvas);
   const int x0 = MAX(rect->x, 0);
   const int y0 = MAX(rect->y, 0);
-  const int x1 = MIN(rect->x + rect->width, _canvas_width);
-  const int y1 = MIN(rect->y + rect->height, _canvas_height);
+  const int x1 = MIN(rect->x + rect->width, cairo_image_surface_get_width(canvas));
+  const int y1 = MIN(rect->y + rect->height, cairo_image_surface_get_height(canvas));
   if(x1 <= x0 || y1 <= y0) return;
   for(int y = y0; y < y1; y++) memset(data + (size_t)y * stride + (size_t)x0 * 4, 0, (size_t)(x1 - x0) * 4);
   cairo_surface_mark_dirty_rectangle(canvas, x0, y0, x1 - x0, y1 - y0);
@@ -4148,17 +4148,37 @@ static double _bound_header_reach(cairo_t *canvas_cr, const dt_masks_form_gui_po
   return reach;
 }
 
+/* The node count of the outline at @p index of the visible form: a group's member's own, a
+ * single form's. The header of an outline is three points per node. */
+static int _outline_nodes(dt_develop_t *dev, const dt_masks_form_t *form, const int index)
+{
+  if(IS_NULL_PTR(form)) return 0;
+  if(!(form->type & DT_MASKS_GROUP)) return (int)g_list_length(form->points);
+  const dt_masks_form_group_t *entry = (const dt_masks_form_group_t *)g_list_nth_data(form->points, index);
+  if(IS_NULL_PTR(entry)) return 0;
+  const dt_masks_form_t *member = dt_masks_get_from_id(dev, entry->formid);
+  return IS_NULL_PTR(member) ? 0 : (int)g_list_length(member->points);
+}
+
+/* Cairo draws nodes, handles and arrows for the selected member of a group and for a single
+ * form, and for no other member: the other members are their rasterised paths and nothing
+ * else. Bounding every member's header made a spread-out group's dirty rectangle the whole
+ * window on every frame, and with it the composite, the clear and the rectangle a motion asks
+ * a redraw of. */
 static void _canvas_cairo_bound(cairo_t *canvas_cr, const dt_masks_form_gui_t *gui, cairo_rectangle_int_t *rect,
                                 gboolean *any)
 {
   const dt_masks_form_t *form = dt_masks_get_visible_form(gui->dev);
-  const int nodes = IS_NULL_PTR(form) ? 0 : (int)g_list_length(form->points);
+  const gboolean group = !IS_NULL_PTR(form) && (form->type & DT_MASKS_GROUP);
   const double scale = _canvas_device_scale(canvas_cr);
   double reach = 0.0;
-  for(const GList *node = gui->points; node; node = g_list_next(node))
+  int index = 0;
+  for(const GList *node = gui->points; node; node = g_list_next(node), index++)
   {
+    if(group && index != gui->group_selected) continue;
     const dt_masks_form_gui_points_t *const pts = (const dt_masks_form_gui_points_t *)node->data;
     if(IS_NULL_PTR(pts)) continue;
+    const int nodes = _outline_nodes(gui->dev, form, index);
     _bound_include_headers(canvas_cr, pts, nodes, scale, rect, any);
     reach = MAX(reach, _bound_header_reach(canvas_cr, pts, nodes, scale));
   }
@@ -4277,8 +4297,30 @@ static gboolean _canvas_begin(cairo_t *cr, const int width, const int height, _c
   return TRUE;
 }
 
-/* Composite @p dirty of the frame's canvas onto @p cr, one pixel to one device pixel, then
- * clear it so the next frame starts from transparency there. */
+/* Composite the pixels [x0, x1) x [y0, y1) of a view-sized @p surface onto @p cr, one pixel
+ * to one device pixel. With the identity matrix a user unit is one device unit, and the target
+ * maps those to pixels through its device scale and offset; the surface, carrying the same
+ * device scale, then lands pixel on pixel. cr's clip bounds it: a redraw asked for a rectangle
+ * pays for that rectangle. */
+static void _canvas_composite(cairo_t *cr, const _canvas_frame_t *frame, cairo_surface_t *surface, const int x0,
+                              const int y0, const int x1, const int y1)
+{
+  const double s = frame->device_scale;
+  double offset_x = 0.0;
+  double offset_y = 0.0;
+  cairo_surface_get_device_offset(cairo_get_target(cr), &offset_x, &offset_y);
+  cairo_surface_flush(surface);
+  cairo_save(cr);
+  cairo_identity_matrix(cr);
+  cairo_set_source_surface(cr, surface, (frame->x - offset_x) / s, (frame->y - offset_y) / s);
+  cairo_rectangle(cr, (frame->x + x0 - offset_x) / s, (frame->y + y0 - offset_y) / s, (x1 - x0) / s,
+                  (y1 - y0) / s);
+  cairo_fill(cr);
+  cairo_restore(cr);
+}
+
+/* Composite @p dirty of the frame's canvas onto @p cr, then clear it so the next frame starts
+ * from transparency there. */
 static void _canvas_end(cairo_t *cr, const _canvas_frame_t *frame, const cairo_rectangle_int_t *dirty)
 {
   const int x0 = CLAMP(dirty->x, 0, frame->width);
@@ -4286,23 +4328,114 @@ static void _canvas_end(cairo_t *cr, const _canvas_frame_t *frame, const cairo_r
   const int x1 = CLAMP(dirty->x + dirty->width, 0, frame->width);
   const int y1 = CLAMP(dirty->y + dirty->height, 0, frame->height);
   if(x1 <= x0 || y1 <= y0) return;
-  /* With the identity matrix a user unit is one device unit, and the target maps those to
-   * pixels through its device scale and offset; the canvas, carrying the same device scale,
-   * then lands pixel on pixel. */
-  const double s = frame->device_scale;
-  double offset_x = 0.0;
-  double offset_y = 0.0;
-  cairo_surface_get_device_offset(cairo_get_target(cr), &offset_x, &offset_y);
-  cairo_surface_flush(frame->canvas);
-  cairo_save(cr);
-  cairo_identity_matrix(cr);
-  cairo_set_source_surface(cr, frame->canvas, (frame->x - offset_x) / s, (frame->y - offset_y) / s);
-  cairo_rectangle(cr, (frame->x + x0 - offset_x) / s, (frame->y + y0 - offset_y) / s, (x1 - x0) / s,
-                  (y1 - y0) / s);
-  cairo_fill(cr);
-  cairo_restore(cr);
+  _canvas_composite(cr, frame, frame->canvas, x0, y0, x1, y1);
   const cairo_rectangle_int_t painted = { x0, y0, x1 - x0, y1 - y0 };
   _canvas_clear(frame->canvas, &painted);
+}
+
+/* ---------------------------------------------------------------------------------------------
+ * The static layer.
+ *
+ * A pipe frame redraws the whole centre, and the overlay stroked every member of the visible
+ * group on it: 1 to 8 ms a shape at fit zoom, 50 to 100 ms of GUI thread for a 26-shape edit,
+ * on every pipe frame -- and a drag makes a pipe frame per motion. The members that are not the
+ * selected one do not change between those frames: they are stroked once into this view-sized
+ * surface and composited under the live canvas with one blit, clipped to what the redraw asked
+ * for, until the key changes. The key is the view matrix, the group, the selection, and a
+ * signature of every other member's outline -- its counts and every 32nd sample -- so a member
+ * an undo moved is caught, while the selected member, which a drag rebuilds on every motion,
+ * is not in it at all. A pan, a zoom or a change of selection pays one full stroke of the
+ * others, which is what every frame paid before. */
+static cairo_surface_t *_static_layer = NULL;
+static int _static_layer_width = 0;
+static int _static_layer_height = 0;
+static uint64_t _static_layer_key = 0;   /* 0: holds nothing */
+
+static uint64_t _static_layer_hash_samples(uint64_t hash, const float *const array, const int count)
+{
+  if(IS_NULL_PTR(array) || count <= 0) return hash;
+  hash = dt_hash(hash, (const char *)&count, sizeof(count));
+  for(int i = 0; i < count; i += 32) hash = dt_hash(hash, (const char *)&array[2 * i], 2 * sizeof(float));
+  hash = dt_hash(hash, (const char *)&array[2 * (count - 1)], 2 * sizeof(float));
+  return hash;
+}
+
+static uint64_t _static_layer_key_compute(cairo_t *canvas_cr, const float zoom_scale, const dt_masks_form_t *form,
+                                          const dt_masks_form_gui_t *gui)
+{
+  cairo_matrix_t matrix;
+  cairo_get_matrix(canvas_cr, &matrix);
+  const dt_widget_overlay_color_t *overlay = dt_widget_overlay_color();
+  uint64_t hash = 5381;
+  hash = dt_hash(hash, (const char *)&matrix, sizeof(matrix));
+  hash = dt_hash(hash, (const char *)&zoom_scale, sizeof(zoom_scale));
+  hash = dt_hash(hash, (const char *)&form->formid, sizeof(form->formid));
+  hash = dt_hash(hash, (const char *)&gui->group_selected, sizeof(gui->group_selected));
+  hash = dt_hash(hash, (const char *)overlay, sizeof(*overlay));
+  int index = 0;
+  for(const GList *node = gui->points; node; node = g_list_next(node), index++)
+  {
+    if(index == gui->group_selected) continue;
+    const dt_masks_form_gui_points_t *const pts = (const dt_masks_form_gui_points_t *)node->data;
+    if(IS_NULL_PTR(pts)) continue;
+    hash = dt_hash(hash, (const char *)&index, sizeof(index));
+    hash = _static_layer_hash_samples(hash, pts->points, pts->points_count);
+    hash = _static_layer_hash_samples(hash, pts->border, pts->border_count);
+    hash = dt_hash(hash, (const char *)&pts->border_skip_count, sizeof(int));
+  }
+  return hash ? hash : 1;
+}
+
+/* Bring the layer up to date with the members other than the selected one, stroking them only
+ * when the key moved; @p rebuilt says whether it did, in which case the whole frame is dirty:
+ * a member that left the selection lost its handles in the layer, and wherever a redraw asked
+ * for less than the window the rest is stale until the next, full one, which the dirty
+ * rectangle then asks for. Returns FALSE when there is no layer to composite. */
+static gboolean _static_layer_ensure(const _canvas_frame_t *frame, cairo_t *canvas_cr, const float zoom_scale,
+                                     dt_masks_form_t *form, dt_masks_form_gui_t *gui, gboolean *rebuilt)
+{
+  *rebuilt = FALSE;
+  const uint64_t key = _static_layer_key_compute(canvas_cr, zoom_scale, form, gui);
+  const gboolean same_size = (_static_layer_width == frame->width && _static_layer_height == frame->height);
+  if(!IS_NULL_PTR(_static_layer) && same_size && _static_layer_key == key) return TRUE;
+  *rebuilt = TRUE;
+
+  if(IS_NULL_PTR(_static_layer) || !same_size)
+  {
+    if(!IS_NULL_PTR(_static_layer)) cairo_surface_destroy(_static_layer);
+    _static_layer = cairo_image_surface_create(CAIRO_FORMAT_ARGB32, frame->width, frame->height);
+    if(cairo_surface_status(_static_layer) != CAIRO_STATUS_SUCCESS)
+    {
+      cairo_surface_destroy(_static_layer);
+      _static_layer = NULL;
+      _static_layer_key = 0;
+      return FALSE;
+    }
+    cairo_surface_set_device_scale(_static_layer, frame->device_scale, frame->device_scale);
+    _static_layer_width = frame->width;
+    _static_layer_height = frame->height;
+  }
+  else
+  {
+    const cairo_rectangle_int_t whole = { 0, 0, frame->width, frame->height };
+    _canvas_clear(_static_layer, &whole);
+  }
+
+  /* the same mapping as the canvas, so the two land pixel on pixel */
+  cairo_matrix_t matrix;
+  cairo_get_matrix(canvas_cr, &matrix);
+  cairo_t *layer_cr = cairo_create(_static_layer);
+  cairo_set_matrix(layer_cr, &matrix);
+  dt_group_events_post_expose_except(layer_cr, zoom_scale, form, gui, gui->group_selected);
+  cairo_destroy(layer_cr);
+  _static_layer_key = key;
+  return TRUE;
+}
+
+/* A group being edited, outside a creation session, has a layer; anything else is drawn whole. */
+static gboolean _static_layer_applies(const dt_masks_form_t *form, const dt_masks_form_gui_t *gui)
+{
+  return !IS_NULL_PTR(form) && (form->type & DT_MASKS_GROUP) && !gui->creation && IS_NULL_PTR(gui->creation_formids);
 }
 
 /* The skip range that hides border sample @p i of @p pts, or -1. */
@@ -4427,19 +4560,25 @@ static gboolean _overlay_apply_transform(cairo_t *mask_draw, dt_develop_t *devel
 /* Composite what the frame painted and remember it; a headless caller has no widget to ask a
  * redraw of, so only the darkroom's own frames are recorded. */
 static void _overlay_finish(cairo_t *cr, const _canvas_frame_t *const frame, const cairo_rectangle_int_t *dirty,
-                            const gboolean darkroom_frame)
+                            const gboolean darkroom_frame, const gboolean layered)
 {
+  /* the static members first, under the live shape; cr's clip keeps it to what was asked */
+  if(layered && !IS_NULL_PTR(_static_layer)) _canvas_composite(cr, frame, _static_layer, 0, 0, frame->width, frame->height);
   if(!IS_NULL_PTR(dirty)) _canvas_end(cr, frame, dirty);
   if(darkroom_frame) _overlay_damage_record(cr, frame, dirty);
 }
 
-/* Draw the visible form: a group member by member, anything else through its own drawer. */
+/* Draw the visible form: a group member by member -- the selected member alone when the static
+ * layer holds the others -- anything else through its own drawer. */
 static void _overlay_draw_form(cairo_t *cr, const float zoom_scale, dt_masks_form_t *mask_form,
-                               dt_masks_form_gui_t *mask_gui)
+                               dt_masks_form_gui_t *mask_gui, const gboolean layered)
 {
   if(mask_form->type & DT_MASKS_GROUP)
   {
-    dt_group_events_post_expose(cr, zoom_scale, mask_form, mask_gui);
+    if(layered)
+      dt_group_events_post_expose_only(cr, zoom_scale, mask_form, mask_gui, mask_gui->group_selected);
+    else
+      dt_group_events_post_expose(cr, zoom_scale, mask_form, mask_gui);
     return;
   }
   if(mask_form->functions && mask_form->functions->post_expose)
@@ -4551,7 +4690,10 @@ void dt_masks_events_post_expose_with(dt_develop_t *dev, struct dt_iop_module_t 
   const dt_times_t draw_start = { 0 };
   dt_get_times((dt_times_t *)&draw_start);
 
-  _overlay_draw_form(mask_draw, zoom_scale, mask_form, mask_gui);
+  gboolean layer_rebuilt = FALSE;
+  const gboolean layered = _static_layer_applies(mask_form, mask_gui)
+                           && _static_layer_ensure(&frame, mask_draw, zoom_scale, mask_form, mask_gui, &layer_rebuilt);
+  _overlay_draw_form(mask_draw, zoom_scale, mask_form, mask_gui, layered);
   /* What was painted: the rasteriser's own record, and the bounds of what cairo drew on top.
    * The transform is still in effect here, which is what the header bounds need; a creation
    * session paints through its own cached pattern and takes the whole canvas. */
@@ -4565,7 +4707,15 @@ void dt_masks_events_post_expose_with(dt_develop_t *dev, struct dt_iop_module_t 
     dt_show_times(&draw_start, "[masks] overlay drawn");
 
   const double composite_start = dt_get_wtime();
-  _overlay_finish(cr, &frame, any ? &dirty : NULL, IS_NULL_PTR(transform));
+  if(layer_rebuilt)
+  {
+    /* the layer changed under the whole view: everything is dirty this frame */
+    dirty.x = 0;
+    dirty.y = 0;
+    dirty.width = frame.width;
+    dirty.height = frame.height;
+  }
+  _overlay_finish(cr, &frame, (any || layered) ? &dirty : NULL, IS_NULL_PTR(transform), layered);
   if(dt_get_debug_flags() & DT_DEBUG_PERF)
     dt_print(DT_DEBUG_MASKS, "[masks] overlay composited (%dx%d of %dx%d) in %0.04f sec\n",
              any ? dirty.width : 0, any ? dirty.height : 0, frame.width, frame.height,

--- a/src/develop/masks_gui.h
+++ b/src/develop/masks_gui.h
@@ -841,6 +841,12 @@ float dt_masks_apply_increment(float current, float amount, dt_masks_increment_t
 float dt_masks_apply_increment_precomputed(float current, float amount, float scale_amount, float offset_amount,
                                             dt_masks_increment_t increment);
 
+/** Draw every member of @p form but the one at @p except_pos, in the group's order. */
+void dt_group_events_post_expose_except(cairo_t *cr, float zoom_scale, dt_masks_form_t *form,
+                                        dt_masks_form_gui_t *gui, int except_pos);
+/** Draw the member of @p form at @p pos alone; nothing for a position the group has not. */
+void dt_group_events_post_expose_only(cairo_t *cr, float zoom_scale, dt_masks_form_t *form,
+                                      dt_masks_form_gui_t *gui, int pos);
 void dt_group_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks_form_t *form,
                                  dt_masks_form_gui_t *gui);
 

--- a/tests/masks/masks_geometry.c
+++ b/tests/masks/masks_geometry.c
@@ -1621,6 +1621,107 @@ static void _time_overlay_brush(dt_develop_t *dev, GList *nodes, const char *nam
   g_list_free_full(form.points, free);
 }
 
+/* A refcounted form the group can find in dev->forms, from a node list the harness built. */
+static dt_masks_form_t *_group_member(dt_develop_t *dev, const dt_masks_type_t type,
+                                      const dt_masks_functions_t *functions, GList *nodes, const int formid,
+                                      const char *name)
+{
+  dt_masks_form_t *form = dt_masks_create(type);
+  if(IS_NULL_PTR(form)) return NULL;
+  form->functions = functions;
+  form->version = 6;
+  form->formid = formid;
+  g_strlcpy(form->name, name, sizeof(form->name));
+  form->points = nodes;
+  dt_masks_append_form(dev, form);
+  return form;
+}
+
+/* The darkroom's actual frame: a group of many members, one of them selected, every one of
+ * them stroked on every full frame. The single-shape cases price a shape; this prices what a
+ * pipe frame pays for a mask-heavy edit, and what a static layer for the members that did not
+ * change saves. Eleven members: every brush and polygon of the corpus in one group. */
+static void _time_overlay_group(dt_develop_t *dev, const char *dir, const int frames)
+{
+  GList *members = NULL;
+  int id = 1000;
+  members = g_list_append(members, _group_member(dev, DT_MASKS_BRUSH, &dt_masks_functions_brush,
+                                                 _brush_from_table(_brush_1313, 11), id++, "brush-1313-cusp"));
+  members = g_list_append(members, _group_member(dev, DT_MASKS_BRUSH, &dt_masks_functions_brush,
+                                                 _brush_from_table(_brush_cusp_tbl, 3), id++, "brush-cusp"));
+  members = g_list_append(members, _group_member(dev, DT_MASKS_BRUSH, &dt_masks_functions_brush,
+                                                 _brush_from_table(_brush_hairpin_tbl, 3), id++, "brush-hairpin"));
+  members = g_list_append(members, _group_member(dev, DT_MASKS_BRUSH, &dt_masks_functions_brush,
+                                                 _brush_from_table(_brush_zigzag_tbl, 6), id++, "brush-zigzag"));
+  members = g_list_append(members, _group_member(dev, DT_MASKS_BRUSH, &dt_masks_functions_brush,
+                                                 _brush_from_table(_brush_selfcross_tbl, 5), id++, "brush-selfcross"));
+  members = g_list_append(members, _group_member(dev, DT_MASKS_BRUSH, &dt_masks_functions_brush,
+                                                 _brush_from_table(_brush_concave_tbl, 5), id++, "brush-concave"));
+  members = g_list_append(members, _group_member(dev, DT_MASKS_BRUSH, &dt_masks_functions_brush,
+                                                 _brush_from_table11(_brush_1360, 43), id++, "brush-1360"));
+  members = g_list_append(members, _group_member(dev, DT_MASKS_BRUSH, &dt_masks_functions_brush,
+                                                 _brush_from_table11(_brush_1352, 7), id++, "brush-1352"));
+  members = g_list_append(members, _group_member(dev, DT_MASKS_BRUSH, &dt_masks_functions_brush,
+                                                 _brush_from_table11(_brush_1074b, 8), id++, "brush-1074b"));
+  {
+    GList *nodes = NULL;
+    for(int i = 0; i < 15; i++)
+    {
+      const float *r = _polygon_1788045925[i];
+      nodes = g_list_append(nodes, _polygon_node(r[0], r[1], r[2], r[3], r[4], r[5], r[6]));
+    }
+    members = g_list_append(members, _group_member(dev, DT_MASKS_POLYGON, &dt_masks_functions_polygon, nodes, id++,
+                                                   "polygon-1788045925"));
+  }
+  {
+    GList *nodes = NULL;
+    const float radius = 0.028f;
+    for(int i = 0; i < 5; i++)
+    {
+      const float x = 0.20f + 0.13f * i;
+      nodes = g_list_append(nodes, _polygon_node(x, 0.35f, x, 0.35f, x, 0.35f, radius));
+      nodes = g_list_append(nodes, _polygon_node(x + 0.05f, 0.62f, x + 0.05f, 0.62f, x + 0.05f, 0.62f, radius));
+    }
+    nodes = g_list_append(nodes, _polygon_node(0.80f, 0.78f, 0.80f, 0.78f, 0.80f, 0.78f, radius));
+    nodes = g_list_append(nodes, _polygon_node(0.20f, 0.78f, 0.20f, 0.78f, 0.20f, 0.78f, radius));
+    members = g_list_append(members, _group_member(dev, DT_MASKS_POLYGON, &dt_masks_functions_polygon, nodes, id++,
+                                                   "polygon-comb"));
+  }
+
+  dt_masks_form_t *group = dt_masks_create(DT_MASKS_GROUP);
+  if(IS_NULL_PTR(group)) return;
+  group->formid = 999;
+  g_strlcpy(group->name, "group-11", sizeof(group->name));
+  int count = 0;
+  for(const GList *node = members; node; node = g_list_next(node))
+  {
+    const dt_masks_form_t *member = (const dt_masks_form_t *)node->data;
+    if(IS_NULL_PTR(member)) continue;
+    dt_masks_form_group_t *entry = (dt_masks_form_group_t *)calloc(1, sizeof(dt_masks_form_group_t));
+    entry->formid = member->formid;
+    entry->parentid = group->formid;
+    entry->state = DT_MASKS_STATE_USE | DT_MASKS_STATE_SHOW;
+    entry->opacity = 1.0f;
+    group->points = g_list_append(group->points, entry);
+    count++;
+  }
+  char name[64];
+  g_snprintf(name, sizeof(name), "group-%d", count);
+  _time_overlay_form(dev, group, name, dir, IMG_W, IMG_H, frames);
+
+  /* the members leave dev->forms with the list's own references; the harness's follow */
+  for(const GList *node = members; node; node = g_list_next(node))
+  {
+    dt_masks_form_t *member = (dt_masks_form_t *)node->data;
+    if(IS_NULL_PTR(member)) continue;
+    dev->forms = g_list_remove(dev->forms, member);
+    dt_masks_form_unref(member);   /* dev->forms's claim */
+    dt_masks_form_unref(member);   /* the harness's */
+  }
+  g_list_free(members);
+  dt_masks_form_unref(group);
+}
+
 static void _time_overlay_all(dt_develop_t *dev, const char *dir, const int frames)
 {
   printf("overlay timing: %dx%d screen, fit zoom, %d frames per measurement\n", OVERLAY_SCREEN_W,
@@ -1673,6 +1774,7 @@ static void _time_overlay_all(dt_develop_t *dev, const char *dir, const int fram
     _check_hidpi_placement(dev, &form, "polygon-comb", IMG_W, IMG_H);
     g_list_free_full(form.points, free);
   }
+  _time_overlay_group(dev, dir, frames);
 }
 
 int main(int argc, char *argv[])


### PR DESCRIPTION
Item 1 of #1391, on top of the merged #1390. `doc/darkroom-redraw.md` has the section.

A pipe frame redraws the whole centre, and the overlay stroked every member of the visible group on it: 1 to 8 ms a shape at fit zoom after #1387, so a mask-heavy edit paid tens of milliseconds of GUI thread per pipe frame for shapes that had not moved, and a drag makes a pipe frame per motion.

**The static layer.** The members that are not the selected one are stroked once into a view-sized surface and composited under the live canvas with one blit, clipped to what the redraw asked for, until the key changes: the view matrix, the group, the selection, the overlay colours and a signature of every other member's outline (counts plus every 32nd sample), so a member an undo moved is caught while the selected member, which a drag rebuilds per motion, is not in the key. A pan, a zoom or a selection change pays one full stroke of the others and marks the whole frame dirty, so a selection change under a small invalidation gets its one full repaint.

**Cairo's bound is the selected member's header alone**, which is all cairo draws for a group; bounding every member's header had made a spread-out group's dirty rectangle the whole window on every frame.

**Measured** on the new harness case `group-11`, every brush and polygon of the corpus in one group, RelWithDebInfo at fit zoom on 2560x1440, per full frame (about 1.8 ms of each is the harness's own background paint):

| group of 11 | before | after |
| --- | ---: | ---: |
| nothing selected | 14.1 ms | 4.0 ms |
| one member selected | 16.4 ms | 5.7 ms |

No frame leaves pixels behind (the leftover check runs on the group too), the HiDPI checks pass, the single-form corpus and the unit tests are unchanged; GCC, clang and nofeatures build every target. Not GUI-tested by me: this machine has no display.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
