### PR TITLE
masks: a drag's outline rebuild, counted and sampled at the screen's density (#1391 item 2)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1182,6 +1182,37 @@ rules that were each paid for by a reported defect:
   away along it. The other side of the stroke, which the backward pass lays on the same spine
   points, is a diameter away and never matches; `_outline_keep_specks()` keeps a dropped run of
   one or two samples between kept ones, since hiding it changes nothing and cuts the run.
+- **The boundary pass is counted, not computed, and its window is a length of walk.** A disc can
+  hide a border sample only if the two centres are within two radii in the plane, hence within
+  two radii along the spine; the near window is that much WALK either side of the sample's own
+  disc, found by bisection on the walk to each disc's centre. It used to be a count of discs
+  (four times the largest radius, plus eight), which is a different length wherever the radius
+  steps and was ten times too wide once outlines were sampled at the screen's density. The discs
+  are flat arrays (centre x, centre y, squared radius less the tolerance) tested by squared
+  distance in blocks of eight, each block carrying its centres' box and largest radius; the copy
+  test lives in a hash of the samples by pixel cell and reads nine cells, where it used to walk
+  the samples of every disc whose circle passed near the probe, with a hypot per disc. Measured:
+  the same skip ranges to the sample on the whole corpus, 4.5 ns per disc test to 2.5, the pass
+  on the 1313 cusp 19 ms to 7. `-d masks -d perf` prints `[masks] boundary pass: ...` per build.
+- **The GUI outline is sampled at the density the screen shows, not at one image pixel.** The
+  expose reads what one device pixel spans (`dt_draw_min_emit_step()` on the transformed
+  context) and publishes it with `dt_masks_gui_set_outline_density()`; `dt_masks_distort_for_gui()`
+  reads it back through `dt_masks_gui_outline_step(dev)`, so every build -- a drag's, an
+  expose's, the creation session's -- composes at the density in force without its caller
+  knowing it, and `outline_step_built` is part of the outline cache key beside the geometry
+  generation. At fit zoom on a 24 Mpx raw the old fixed step was five samples per device pixel
+  (the recursion stops on integer parts, so it lays several around every integer crossing):
+  53,917 samples for a border 10,000 px long, each paid in the transform, the boundary pass, the
+  stroke and the hit test. The pipe's walk is untouched -- its arcs and stamps stay one sample
+  per pixel through the walk's own `arc_step`, whatever spoke budget it was given -- so no
+  raster changes under a preference; the polygon's pixel threshold stays pinned at 1 for the
+  pipe's scanline fill and follows the density for the GUI. Measured, the first frame after a
+  rebuild of the selected shape: the 1074 flare 103 ms -> 33 at 1:1, 13 at fit, 5 at quarter;
+  a group of 11 members 459 -> 218 / 80 / 30. `MASKS_OUTLINE_STEP=<n>` runs the corpus's band
+  check at that density (0 inside / 0 outside at 3 and 5); the baselines are step-1 pictures
+  and are not compared at any other step. The corpus dev has no expose, so the harness
+  re-applies its density before every build: the overlay it writes beside each case goes
+  through the darkroom's expose at full resolution, which publishes 1.
 - **The dash phase is the arc length along the whole stroke, not along each sub-path.** An
   outline is one cairo path of many sub-paths, one per kept run between skips, and cairo (and
   the rasteriser, at first) restarts the dash pattern at every sub-path, so dashes bunched and

--- a/doc/brush-boundary.md
+++ b/doc/brush-boundary.md
@@ -122,24 +122,41 @@ answer as the skip ranges every consumer of the outline already reads
 and the shared detector is no longer called for a brush.
 
 Two searches, because the discs that can hide a sample come from two places, and what
-separates them is their **index** along the walk, not their position:
+separates them is where they sit **along the walk**, not where they sit in the plane:
 
-- **Near.** A disc within twice the largest radius of the sample's own spine position can
-  contain it and no other can, so a window of discs either side of the sample's own is
-  exhaustive for folds, joints and caps. Consecutive discs move at most a step, so the
-  window is scanned in blocks of eight and a block whose first disc is out of reach is
-  skipped whole.
-- **Far.** A hairpin, a crossing or a spiral brings discs from any distance along the walk
-  to within one radius in the plane. A bucket grid of one reach per cell finds them, and
-  each bucket holds its discs as *runs* of consecutive indices: a run inside the window is
-  the near part, already answered, dismissed in one comparison; only runs from far along
-  the walk are tested disc by disc.
+- **Near.** A disc can contain a border sample only if its centre is within its own radius
+  of it, and the sample is one radius from its own spine point, so the two centres are
+  within two radii of each other in the plane and, the spine being a continuous line,
+  within two radii of each other along it. That much walk either side of the sample's own
+  disc is exhaustive for folds, joints and caps. The window is a *length* of walk, found by
+  bisection on the walk to each disc's centre, never a count of discs: a disc is made
+  wherever the spine moves half a pixel *or the radius steps*, so a count is a different
+  length at every sampling density and at every flare, and the count this used to be —
+  four times the largest radius, plus eight — was ten times too wide once the outline was
+  sampled at the density the screen shows.
+- **Far.** A hairpin, a crossing or a spiral — and the brush's own second pass down the
+  other side — brings discs from any distance along the walk to within one radius in the
+  plane. A bucket grid of one reach per cell finds them, and each bucket holds its discs as
+  *runs* of consecutive indices: a run inside the window is the near part, already
+  answered, dismissed in one comparison; only runs from far along the walk are tested disc
+  by disc.
+
+The test itself is arranged to be counted rather than computed. The discs are flat arrays —
+centre x, centre y, and the squared radius less the tolerance, negative for a disc the
+tolerance leaves nothing of — so a probe is one squared distance against each, no square
+root anywhere, in blocks of eight the compiler can vectorise; and each block carries the
+box its centres span and its largest radius, so a block that cannot reach the probe costs
+four comparisons. The previous test took a hypot per disc for the copy test below, and
+dismissed a block on its first disc's distance against a reach padded by the largest step
+between discs. Measured on the corpus, per probe: 430 disc tests at 4.5 ns each became 126
+to 470 at about 2.5 ns, and the pass on the cusp went from 19 ms to 7.
 
 Cost is bounded by decimation, not by the sample count: consecutive samples closer than
 half a pixel with the same radius are one disc, and a sample is only *probed* when it has
 moved half a pixel from the last probe, the samples between two agreeing probes taking
 their answer. Measured on the corpus, the probed version produces the same skip ranges to
-the sample as probing everything, at a third of the probes.
+the sample as probing everything, at a third of the probes. `-d masks -d perf` prints what
+a pass cost and how many discs it tested.
 
 A first version used a coarse occupancy map of the union for the far part. It was
 conservative, so it left every sample within a few pixels of a far boundary undecided,
@@ -148,21 +165,68 @@ within a few pixels of its *own* stroke's interior. Position cannot tell near fr
 the index can. Measured: 30 ms → 250 ms with the map and its band, back to 3–32 ms with
 the runs.
 
-| case | kept samples | inside the union | outside the permitted region | build |
-|---|---|---|---|---|
-| brush-1313-cusp (5184×3888) | 33,753 | 0 | 0 | 12 ms |
-| brush-cusp | 45,009 | 0 | 0 | 14 ms |
-| brush-hairpin | 41,629 | 0 | 0 | 19 ms |
-| brush-zigzag | 88,011 | 0 | 0 | 24 ms |
-| brush-selfcross | 70,833 | 0 | 0 | 24 ms |
-| brush-concave | 62,264 | 0 | 0 | 18 ms |
-| brush-1360-pressure-ramp | 36,927 | 0 | 0 | 32 ms |
-| brush-1352-radius-step | 18,822 | 0 | 0 | 5 ms |
+| case | kept samples | inside the union | outside the permitted region | build at step 1 | kept at step 3 | build at step 3 |
+|---|---|---|---|---|---|---|
+| brush-1313-cusp (5184×3888) | 44,549 | 0 | 0 | 11 ms | 2,057 | 1.3 ms |
+| brush-cusp | 45,000 | 0 | 0 | 14 ms | 3,989 | 2.3 ms |
+| brush-hairpin | 41,612 | 0 | 0 | 20 ms | 5,584 | 4.0 ms |
+| brush-zigzag | 87,969 | 0 | 0 | 25 ms | 7,172 | 3.6 ms |
+| brush-selfcross | 70,707 | 0 | 0 | 24 ms | 6,217 | 3.7 ms |
+| brush-concave | 62,058 | 0 | 0 | 21 ms | 5,605 | 3.8 ms |
+| brush-1360-pressure-ramp | 36,682 | 0 | 0 | 34 ms | 2,187 | 5.3 ms |
+| brush-1352-radius-step | 20,319 | 0 | 0 | 5 ms | 1,111 | 0.9 ms |
+| brush-1074-flare | 27,432 | 0 | 0 | 26 ms | 2,475 | 4.9 ms |
 
 "Build" is the whole GUI-side call, `dt_masks_get_points_border()`: producer, transform
-and boundary pass. Before the rework, kept outline samples that sat two to five pixels
-inside the union numbered 47 to 206 per case; the old display cut through self-crossings
-without stopping at all.
+and boundary pass; the step is the density the outline is sampled at, see the next section.
+At every step the band check reads the same: zero kept samples inside the union, zero
+outside the permitted region. Before the rework, kept outline samples that sat two to five
+pixels inside the union numbered 47 to 206 per case; the old display cut through
+self-crossings without stopping at all.
+
+## The outline is built at the density the screen shows
+
+The GUI outline used to be sampled at one image pixel whatever the zoom: "pixel-accurate",
+which at fit zoom on a 24 Mpx raw in a 2560 px window is five samples per device pixel —
+and the recursion that places them stops on integer parts, so it lays several samples
+around every integer crossing and a 1313 cusp came to 53,917 samples for a border some
+10,000 px long. Everything downstream is paid per sample: the distortion transform, the
+boundary pass, the stroke, and the hit test that walks every sample on every pointer
+motion.
+
+The step is now the view's. The expose reads what one device pixel spans in image pixels
+from the transformed context (`dt_draw_min_emit_step()`, the same measure the circle already
+decimated its strokes by) and publishes it through `dt_masks_gui_set_outline_density()`;
+`dt_masks_form_gui_t::outline_step` is the density in force and `outline_step_built` the one
+the cached outlines were built at, and a difference between the two is a rebuild, exactly
+like a geometry move. `dt_masks_distort_for_gui()`, the GUI supplier every outline build
+composes through, reads the density back with `dt_masks_gui_outline_step(dev)` — so a
+drag's rebuild, an expose's and the creation session's all sample at the density in force
+without their callers knowing it. The brush and the polygon sample their curves, their arcs
+and their stamps at it; the pipe's walk is untouched,
+its arcs and stamps still one sample per pixel whatever spoke budget it was given (the walk
+carries a separate `arc_step`), so no raster changes under a preference. The polygon used to
+pin its threshold at one pixel for the pipe's scanline fill, which needs every row crossed;
+the GUI fills nothing.
+
+What a step buys, measured with `ansel-test-masks-geometry --time-overlay` on the corpus,
+the first frame after a rebuild of the selected shape:
+
+| view | step | cusp-1313 | flare | pressure ramp | comb (polygon) | group of 11, all |
+|---|---|---|---|---|---|---|
+| 1:1 | 1 | 18 ms | 33 ms | 39 ms | 28 ms | 218 ms |
+| fit, 2560×1440 | 2 | 4.7 ms | 12.9 ms | 13.6 ms | 15.6 ms | 80 ms |
+| quarter | 4 | 2.9 ms | 5.4 ms | 6.2 ms | 6.1 ms | 30 ms |
+
+Before both changes the same first frames read 29, 103, 69, 49 and 459 ms at step 1, which
+was the only step there was. On a HiDPI screen the device pixels are the physical ones, so a
+2x screen at fit zoom sits one step below a 1x one.
+
+The corpus judges pixel-accurate outlines by default and `MASKS_OUTLINE_STEP=<n>` has it
+judge the outline every n pixels against the same full-resolution maps: at 3 and at 5 every
+case still reads zero inside, zero outside. The baselines are step-1 pictures and are not
+compared at any other step; the timing run takes its density from its view
+(`MASKS_OVERLAY_VIEW`), the way the darkroom does.
 
 ## The border sample is on the envelope, not on the normal
 
@@ -229,7 +293,10 @@ dashed border: 4,020 kept samples on a 2,114 px circumference.
 
 `_outline_sample_repeats()` drops a sample within three quarters of a pixel of an earlier one
 that lies at least four pixels of border behind it along the walk, whatever discs the two belong
-to: for drawing, two boundary samples that close are one line. The other side of the stroke,
+to: for drawing, two boundary samples that close are one line. The samples are hashed by pixel
+cell and the test reads the nine cells around the probe; it used to ride inside the disc test,
+walking the samples of every disc whose circle passed near the probe, which is what put a
+square root in that loop. The other side of the stroke,
 which the backward pass lays on the very same spine points, is a diameter away and never
 matches. The same rule takes the stretch where a segment leaves a stamped node, whose envelope
 runs within the boundary tolerance of the node's circle for tens of pixels — a second dash over

--- a/doc/darkroom-redraw.md
+++ b/doc/darkroom-redraw.md
@@ -127,8 +127,27 @@ next item (#1391).
 | a zoom or pan while the main pipe catches up | ~320 ms | ~10 ms |
 
 The overlay itself -- the outlines rasterised directly, see `doc/overlay-raster.md` -- costs
-1 to 8 ms per shape at fit zoom and is now the largest term of a motion frame, which is where
-the next work belongs.
+1 to 8 ms per shape at fit zoom; a group's unselected members live in a static layer (below),
+so a frame strokes one shape.
+
+A drag motion also REBUILDS the dragged shape's outline, throttled to 60 Hz and 2 px: the
+whole walk, its distortion transform and the boundary pass, and on a large brush that was the
+frame, not the drawing. Two changes in `doc/brush-boundary.md`: the boundary pass streams
+sqrt-free disc arrays in bounded blocks and keeps its copy test in a sample hash (2-3x), and
+the outline is sampled at the density the screen shows instead of at one image pixel (another
+2-5x at fit zoom, in the build, the transform, the stroke and the hit test alike). Measured,
+first frame after a rebuild of the selected shape, corpus at 2560x1440:
+
+| shape | before, step 1 | after, 1:1 (step 1) | after, fit (step 2) | after, quarter (step 4) |
+| --- | ---: | ---: | ---: | ---: |
+| brush-1313-cusp | 29 ms | 18 ms | 4.7 ms | 2.9 ms |
+| brush-1074-flare | 103 ms | 33 ms | 12.9 ms | 5.4 ms |
+| brush-1360-pressure-ramp | 69 ms | 39 ms | 13.6 ms | 6.2 ms |
+| polygon-comb | 49 ms | 28 ms | 15.6 ms | 6.1 ms |
+| group of 11, every member | 459 ms | 218 ms | 80 ms | 30 ms |
+
+`-d masks -d perf` prints `[masks] boundary pass: ... probed in N ms` per rebuild, and
+`[masks] outline cache: held for geometry G at step S` says why a frame rebuilt.
 
 ## Reading it
 

--- a/src/develop/masks/brush.c
+++ b/src/develop/masks/brush.c
@@ -526,9 +526,9 @@ static void _brush_init_ctrl_points(dt_masks_form_t *mask_form)
 
 /** fill the gap between 2 points with an arc of circle */
 /** this function is here because we can have gap in border, esp. if the corner is very sharp */
-static void _brush_points_recurs_border_gaps(float *cmax, float *bmin, float *bmin2, float *bmax,
+static void _brush_points_recurs_border_gaps(float *cmax, float *bmin, float *bmax,
                                              dt_masks_dynbuf_t *dpoints, dt_masks_dynbuf_t *dborder,
-                                             gboolean clockwise)
+                                             gboolean clockwise, const int step)
 {
   // we want to find the start and end angles
   float a1 = atan2f(bmin[1] - cmax[1], bmin[0] - cmax[0]);
@@ -550,8 +550,8 @@ static void _brush_points_recurs_border_gaps(float *cmax, float *bmin, float *bm
   float r1 = dt_fast_hypotf(bmin[1] - cmax[1], bmin[0] - cmax[0]);
   float r2 = dt_fast_hypotf(bmax[1] - cmax[1], bmax[0] - cmax[0]);
 
-  // and the max length of the circle arc
-  const int l = fabsf(a2 - a1) * fmaxf(r1, r2);
+  // and the max length of the circle arc, in samples
+  const int l = fabsf(a2 - a1) * fmaxf(r1, r2) / (float)step;
   if(l < 2) return;
 
   // and now we add the points
@@ -592,8 +592,9 @@ static void _brush_points_recurs_border_gaps(float *cmax, float *bmin, float *bm
 /** fill small gap between 2 points with an arc of circle */
 /** in contrast to the previous function it will always run the shortest path (max. PI) and does not consider
  * clock or anti-clockwise action */
-static void _brush_points_recurs_border_small_gaps(float *cmax, float *bmin, float *bmin2, float *bmax,
-                                                   dt_masks_dynbuf_t *dpoints, dt_masks_dynbuf_t *dborder)
+static void _brush_points_recurs_border_small_gaps(float *cmax, float *bmin, float *bmax,
+                                                   dt_masks_dynbuf_t *dpoints, dt_masks_dynbuf_t *dborder,
+                                                   const int step)
 {
   // we want to find the start and end angles
   const float a1 = fmodf(atan2f(bmin[1] - cmax[1], bmin[0] - cmax[0]) + 2.0f * M_PI, 2.0f * M_PI);
@@ -609,8 +610,8 @@ static void _brush_points_recurs_border_small_gaps(float *cmax, float *bmin, flo
   float delta = a2 - a1;
   if(fabsf(delta) > M_PI) delta = delta - copysignf(2.0f * M_PI, delta);
 
-  // get the max length of the circle arc
-  const int l = fabsf(delta) * fmaxf(r1, r2);
+  // get the max length of the circle arc, in samples
+  const int l = fabsf(delta) * fmaxf(r1, r2) / (float)step;
   if(l < 2) return;
 
   // and now we add the points
@@ -662,12 +663,12 @@ static void _brush_points_recurs_border_small_gaps(float *cmax, float *bmin, flo
  * @p from_border only chooses the start angle, so the first sample continues from the border
  * sample the caller just wrote; any angle is geometrically right. */
 static void _brush_points_stamp(const float *const centre, const float *const from_border, const float radius,
-                                dt_masks_dynbuf_t *dpoints, dt_masks_dynbuf_t *dborder)
+                                dt_masks_dynbuf_t *dpoints, dt_masks_dynbuf_t *dborder, const int step)
 {
   const float a1 = atan2f(from_border[1] - centre[1], from_border[0] - centre[0]);
 
-  // determine the max length of the circle arc
-  const int l = 2.0f * M_PI * radius;
+  // determine the max length of the circle arc, in samples
+  const int l = 2.0f * M_PI * radius / (float)step;
   if(l < 2) return;
 
   // and now we add the points
@@ -755,86 +756,6 @@ static inline void _brush_leaf_borrow_border(float *const border_min, float *con
   dt_masks_outline_offset_along(centre, chord[1], -chord[0], radius, border_max);
 }
 
-/** recursive function to get all points of the brush AND all point of the border */
-/** the function takes care to avoid big gaps between points */
-/* @p have_min / @p have_max say whether the caller already evaluated that endpoint, and
- * @p have_border_min / @p have_border_max whether a border point came with it. They used to be
- * read out of the arrays as NaN -- "not computed" and "no border" sharing one representation
- * with each other and with real geometry. Which of the three a NaN meant depended on where you
- * were standing, and the arrays are the same ones that end up in the outline. A leaf always
- * writes a border now (see _brush_leaf_borrow_border()), so @p out_have_border reports TRUE
- * whenever a border is being built at all. */
-static void _brush_points_recurs(float *p1, float *p2, double tmin, double tmax, float *points_min,
-                                 float *points_max, float *border_min, float *border_max, float *rpoints,
-                                 float *rborder, float *rpayload, dt_masks_dynbuf_t *dpoints, dt_masks_dynbuf_t *dborder,
-                                 dt_masks_dynbuf_t *dpayload, const int pixel_threshold,
-                                 const gboolean have_min, const gboolean have_max,
-                                 gboolean have_border_min, gboolean have_border_max,
-                                 gboolean *out_have_border)
-{
-  const gboolean withborder = (!IS_NULL_PTR(dborder));
-
-  // we calculate points if needed
-  if(!have_min)
-    have_border_min = _brush_border_get_XY(p1[0], p1[1], p1[2], p1[3], p2[2], p2[3], p2[0], p2[1], tmin,
-                                           _brush_radius_at(p1[4], p2[4], tmin),
-                                           _brush_radius_rate_at(p1[4], p2[4], tmin), points_min,
-                                           points_min + 1, border_min, border_min + 1);
-  if(!have_max)
-    have_border_max = _brush_border_get_XY(p1[0], p1[1], p1[2], p1[3], p2[2], p2[3], p2[0], p2[1], tmax,
-                                           _brush_radius_at(p1[4], p2[4], tmax),
-                                           _brush_radius_rate_at(p1[4], p2[4], tmax), points_max,
-                                           points_max + 1, border_max, border_max + 1);
-
-  if(!_brush_span_is_leaf(tmin, tmax, points_min, points_max, withborder ? border_min : NULL, border_max,
-                          pixel_threshold))
-  {
-    // we split in two part
-    const double tx = (tmin + tmax) / 2.0;
-    float c[2] = { 0.0f, 0.0f };
-    float b[2] = { 0.0f, 0.0f };
-    float rc[2];
-    float rb[2];
-    float rp[2];
-    /* the left half inherits our min end and computes the midpoint; the right half is then handed
-     * that midpoint already evaluated, and inherits our max end */
-    _brush_points_recurs(p1, p2, tmin, tx, points_min, c, border_min, b, rc, rb, rp, dpoints, dborder, dpayload,
-                         pixel_threshold, have_min, FALSE, have_border_min, FALSE, NULL);
-    _brush_points_recurs(p1, p2, tx, tmax, rc, points_max, rb, border_max, rpoints, rborder, rpayload, dpoints,
-                         dborder, dpayload, pixel_threshold, TRUE, have_max, TRUE, have_border_max,
-                         out_have_border);
-    return;
-  }
-
-  // the leaf: one sample, at the far end of the span
-  rpoints[0] = points_max[0];
-  rpoints[1] = points_max[1];
-  dt_masks_dynbuf_add_2(dpoints, rpoints[0], rpoints[1]);
-
-  if(withborder)
-  {
-    const float radius = _brush_radius_at(p1[4], p2[4], tmax);
-    const float chord[2] = { p2[0] - p1[0], p2[1] - p1[1] };
-    _brush_leaf_borrow_border(border_min, border_max, have_border_min, have_border_max, points_max, chord, radius);
-
-    // we check gaps in the border (sharp edges)
-    if(abs((int)border_max[0] - (int)border_min[0]) > 2 || abs((int)border_max[1] - (int)border_min[1]) > 2)
-      _brush_points_recurs_border_small_gaps(points_max, border_min, NULL, border_max, dpoints, dborder);
-
-    rborder[0] = border_max[0];
-    rborder[1] = border_max[1];
-    if(!IS_NULL_PTR(out_have_border)) *out_have_border = TRUE;
-    dt_masks_dynbuf_add_2(dborder, rborder[0], rborder[1]);
-  }
-
-  if(!IS_NULL_PTR(dpayload))
-  {
-    rpayload[0] = p1[5] + tmax * (p2[5] - p1[5]);
-    rpayload[1] = p1[6] + tmax * (p2[6] - p1[6]);
-    _brush_payload_sync(dpayload, dpoints, rpayload[0], rpayload[1]);
-  }
-}
-
 /* The frame the walk works in: the image size the normalised node coordinates scale to, and
  * the shift that moves a clone source's outline onto its target. */
 typedef struct _brush_frame_t
@@ -844,6 +765,151 @@ typedef struct _brush_frame_t
   float dx;
   float dy;
 } _brush_frame_t;
+
+/* THE WALK.
+ *
+ * A brush is the union of a disc of the local radius over every point of its centreline, and
+ * the rasteriser paints that union as spokes: from every centreline sample out to its border
+ * sample, on both sides. So the centreline is walked twice, forward with the border on the
+ * right and backward with the border on the right again -- the other side -- and the two
+ * sides are joined by a cap at each end. Where the direction, the radius or the payload jumps
+ * at a node, the spokes of the two segments meeting there leave a wedge; a disc or an arc,
+ * centred on that node at that node's radius, fills it.
+ *
+ * Everything a joint or a cap needs is taken from the two segment END SAMPLES that meet
+ * there, and from the node data. Nothing is read back out of the buffers. The previous walk
+ * took "the last centreline sample and the last border sample written" as the centre and
+ * radius of every cap, arc and stamp, on the assumption that they belonged to one spoke; a
+ * degenerate segment broke that assumption once and the damage compounded through every
+ * later joint of the stroke (issue #1360: a circle 2058 px across, centred on the stroke,
+ * grown from a border sample that was the image origin).
+ *
+ * A DEGENERATE segment -- its four control points one point, which is what a pen resting
+ * under rising pressure produces -- has no direction and so no spokes, and contributes
+ * nothing: its disc is the cap of whichever neighbour has a direction. The walk skips it and
+ * joins the segments either side of it as if it were not there, which for the disc union is
+ * exactly right. */
+typedef struct _brush_walk_t
+{
+  dt_masks_node_brush_t **nodes;
+  int node_count;
+  _brush_frame_t frame;
+  int pixel_threshold;
+  /* Image pixels between consecutive samples of an arc or a stamp. The GUI's outline takes the
+   * density it is shown at, like its curves; the pipe keeps one per pixel whatever spoke
+   * budget it was given, so its raster does not change under a preference. */
+  int arc_step;
+  dt_masks_dynbuf_t *dpoints;
+  dt_masks_dynbuf_t *dborder;   /* NULL when no border is wanted */
+  dt_masks_dynbuf_t *dpayload;  /* NULL when no payload is wanted */
+} _brush_walk_t;
+
+/* One span [tmin, tmax] of a segment and what is known at its ends: the spine and border
+ * samples there, whether each end was evaluated already, and whether a border came with it.
+ * Those flags used to be read out of the arrays as NaN -- "not computed" and "no border"
+ * sharing one representation with each other and with real geometry. Which of the three a NaN
+ * meant depended on where you were standing, and the arrays are the same ones that end up in
+ * the outline. A leaf always writes a border now (see _brush_leaf_borrow_border()). */
+typedef struct _brush_span_t
+{
+  double tmin;
+  double tmax;
+  float *points_min;
+  float *points_max;
+  float *border_min;
+  float *border_max;
+  gboolean have_min;
+  gboolean have_max;
+  gboolean have_border_min;
+  gboolean have_border_max;
+} _brush_span_t;
+
+/* The sample a span's far end resolved to: the next span's near end, and the segment's end
+ * sample for the walk. have_border is TRUE whenever a border is being built at all. */
+typedef struct _brush_sample_t
+{
+  float point[2];
+  float border[2];
+  float payload[2];
+  gboolean have_border;
+} _brush_sample_t;
+
+/** recursive function to get all points of the brush AND all point of the border */
+/** the function takes care to avoid big gaps between points */
+static void _brush_points_recurs(const float *const p1, const float *const p2, const _brush_span_t *const span,
+                                 const _brush_walk_t *const w, _brush_sample_t *const out)
+{
+  dt_masks_dynbuf_t *const dpoints = w->dpoints;
+  dt_masks_dynbuf_t *const dborder = w->dborder;
+  dt_masks_dynbuf_t *const dpayload = w->dpayload;
+  const gboolean withborder = (!IS_NULL_PTR(dborder));
+  float *const points_min = span->points_min;
+  float *const points_max = span->points_max;
+  float *const border_min = span->border_min;
+  float *const border_max = span->border_max;
+  gboolean have_border_min = span->have_border_min;
+  gboolean have_border_max = span->have_border_max;
+
+  // we calculate points if needed
+  if(!span->have_min)
+    have_border_min = _brush_border_get_XY(p1[0], p1[1], p1[2], p1[3], p2[2], p2[3], p2[0], p2[1], span->tmin,
+                                           _brush_radius_at(p1[4], p2[4], span->tmin),
+                                           _brush_radius_rate_at(p1[4], p2[4], span->tmin), points_min,
+                                           points_min + 1, border_min, border_min + 1);
+  if(!span->have_max)
+    have_border_max = _brush_border_get_XY(p1[0], p1[1], p1[2], p1[3], p2[2], p2[3], p2[0], p2[1], span->tmax,
+                                           _brush_radius_at(p1[4], p2[4], span->tmax),
+                                           _brush_radius_rate_at(p1[4], p2[4], span->tmax), points_max,
+                                           points_max + 1, border_max, border_max + 1);
+
+  if(!_brush_span_is_leaf(span->tmin, span->tmax, points_min, points_max, withborder ? border_min : NULL,
+                          border_max, w->pixel_threshold))
+  {
+    // we split in two part
+    const double tx = (span->tmin + span->tmax) / 2.0;
+    float c[2] = { 0.0f, 0.0f };
+    float b[2] = { 0.0f, 0.0f };
+    _brush_sample_t mid = { 0 };
+    /* the left half inherits our min end, now evaluated, and computes the midpoint; the right
+     * half is then handed that midpoint already evaluated, and inherits our max end */
+    const _brush_span_t left = { span->tmin, tx, points_min, c, border_min, b, TRUE, FALSE, have_border_min, FALSE };
+    _brush_points_recurs(p1, p2, &left, w, &mid);
+    const _brush_span_t right
+        = { tx, span->tmax, mid.point, points_max, mid.border, border_max, TRUE, TRUE, TRUE, have_border_max };
+    _brush_points_recurs(p1, p2, &right, w, out);
+    return;
+  }
+
+  // the leaf: one sample, at the far end of the span
+  out->point[0] = points_max[0];
+  out->point[1] = points_max[1];
+  out->have_border = FALSE;
+  dt_masks_dynbuf_add_2(dpoints, out->point[0], out->point[1]);
+
+  if(withborder)
+  {
+    const float radius = _brush_radius_at(p1[4], p2[4], span->tmax);
+    const float chord[2] = { p2[0] - p1[0], p2[1] - p1[1] };
+    _brush_leaf_borrow_border(border_min, border_max, have_border_min, have_border_max, points_max, chord, radius);
+
+    // we check gaps in the border (sharp edges), at the density the arc will be sampled at
+    const int gap = 2 * w->arc_step;
+    if(abs((int)border_max[0] - (int)border_min[0]) > gap || abs((int)border_max[1] - (int)border_min[1]) > gap)
+      _brush_points_recurs_border_small_gaps(points_max, border_min, border_max, dpoints, dborder, w->arc_step);
+
+    out->border[0] = border_max[0];
+    out->border[1] = border_max[1];
+    out->have_border = TRUE;
+    dt_masks_dynbuf_add_2(dborder, out->border[0], out->border[1]);
+  }
+
+  if(!IS_NULL_PTR(dpayload))
+  {
+    out->payload[0] = p1[5] + span->tmax * (p2[5] - p1[5]);
+    out->payload[1] = p1[6] + span->tmax * (p2[6] - p1[6]);
+    _brush_payload_sync(dpayload, dpoints, out->payload[0], out->payload[1]);
+  }
+}
 
 /* The two ends of one segment of the walk, in image pixels: node, the control point that
  * faces the other end, radius, fading, density. Travelling forward the segment leaves node
@@ -879,48 +945,15 @@ static void _brush_segment_load(const dt_masks_node_brush_t *const from, const d
 /* The arc that bridges a joint, the short way round; at a cusp the pass's rotation decides
  * (see dt_masks_outline_short_way()). The filler is the brush's own. */
 static void _brush_joint_arc(const float *const centre, const float *const from, const float *const to,
-                             const gboolean forward, dt_masks_dynbuf_t *dpoints, dt_masks_dynbuf_t *dborder)
+                             const gboolean forward, dt_masks_dynbuf_t *dpoints, dt_masks_dynbuf_t *dborder,
+                             const int step)
 {
   const gboolean clockwise = dt_masks_outline_short_way(centre, from, to, forward);
   float f[2] = { from[0], from[1] };
   float t[2] = { to[0], to[1] };
   float c[2] = { centre[0], centre[1] };
-  _brush_points_recurs_border_gaps(c, f, NULL, t, dpoints, dborder, clockwise);
+  _brush_points_recurs_border_gaps(c, f, t, dpoints, dborder, clockwise, step);
 }
-
-/* THE WALK.
- *
- * A brush is the union of a disc of the local radius over every point of its centreline, and
- * the rasteriser paints that union as spokes: from every centreline sample out to its border
- * sample, on both sides. So the centreline is walked twice, forward with the border on the
- * right and backward with the border on the right again -- the other side -- and the two
- * sides are joined by a cap at each end. Where the direction, the radius or the payload jumps
- * at a node, the spokes of the two segments meeting there leave a wedge; a disc or an arc,
- * centred on that node at that node's radius, fills it.
- *
- * Everything a joint or a cap needs is taken from the two segment END SAMPLES that meet
- * there, and from the node data. Nothing is read back out of the buffers. The previous walk
- * took "the last centreline sample and the last border sample written" as the centre and
- * radius of every cap, arc and stamp, on the assumption that they belonged to one spoke; a
- * degenerate segment broke that assumption once and the damage compounded through every
- * later joint of the stroke (issue #1360: a circle 2058 px across, centred on the stroke,
- * grown from a border sample that was the image origin).
- *
- * A DEGENERATE segment -- its four control points one point, which is what a pen resting
- * under rising pressure produces -- has no direction and so no spokes, and contributes
- * nothing: its disc is the cap of whichever neighbour has a direction. The walk skips it and
- * joins the segments either side of it as if it were not there, which for the disc union is
- * exactly right. */
-typedef struct _brush_walk_t
-{
-  dt_masks_node_brush_t **nodes;
-  int node_count;
-  _brush_frame_t frame;
-  int pixel_threshold;
-  dt_masks_dynbuf_t *dpoints;
-  dt_masks_dynbuf_t *dborder;   /* NULL when no border is wanted */
-  dt_masks_dynbuf_t *dpayload;  /* NULL when no payload is wanted */
-} _brush_walk_t;
 
 /* The walk at the node the next segment starts from: the end sample of the previous
  * non-degenerate segment of this pass. */
@@ -955,7 +988,7 @@ static void _brush_walk_node(const _brush_walk_t *const w, const _brush_walk_sta
   const gboolean radius_step = (fabsf(p1[4] - p2[4]) > 0.0001f || fabsf(s->r - p1[4]) > 0.0001f);
   if(payload_step || radius_step)
   {
-    _brush_points_stamp(s->c, s->b, fmaxf(s->r, p1[4]), w->dpoints, w->dborder);
+    _brush_points_stamp(s->c, s->b, fmaxf(s->r, p1[4]), w->dpoints, w->dborder, w->arc_step);
     _brush_walk_sync_payload(w, s->payload);
   }
 
@@ -968,7 +1001,7 @@ static void _brush_walk_node(const _brush_walk_t *const w, const _brush_walk_sta
    * them from the outline. */
   if(fabsf(b0[0] - s->b[0]) > 1.0f || fabsf(b0[1] - s->b[1]) > 1.0f)
   {
-    _brush_joint_arc(c0, s->b, b0, forward, w->dpoints, w->dborder);
+    _brush_joint_arc(c0, s->b, b0, forward, w->dpoints, w->dborder, w->arc_step);
     _brush_walk_sync_payload(w, s->payload);
   }
 }
@@ -997,33 +1030,31 @@ static gboolean _brush_walk_segment(const _brush_walk_t *const w, _brush_walk_st
 
   if(s->have_prev) _brush_walk_node(w, s, p1, p2, c0, b0, forward);
 
-  float rc[2];
-  float rb[2];
-  float rp[2];
   float bmin[2] = { b0[0], b0[1] };
   float bmax[2] = { b1[0], b1[1] };
   float cmin[2] = { c0[0], c0[1] };
   float cmax[2] = { c1[0], c1[1] };
-  gboolean have_rb = FALSE;
-  _brush_points_recurs(p1, p2, 0.0, 1.0, cmin, cmax, bmin, bmax, rc, rb, rp, w->dpoints, w->dborder, w->dpayload,
-                       w->pixel_threshold, TRUE, TRUE, TRUE, TRUE, &have_rb);
+  const _brush_span_t span = { 0.0, 1.0, cmin, cmax, bmin, bmax, TRUE, TRUE, TRUE, TRUE };
+  _brush_sample_t end = { 0 };
+  _brush_points_recurs(p1, p2, &span, w, &end);
 
-  dt_masks_dynbuf_add_2(w->dpoints, rc[0], rc[1]);
-  if(!IS_NULL_PTR(w->dpayload)) dt_masks_dynbuf_add_2(w->dpayload, rp[0], rp[1]);
+  dt_masks_dynbuf_add_2(w->dpoints, end.point[0], end.point[1]);
+  if(!IS_NULL_PTR(w->dpayload)) dt_masks_dynbuf_add_2(w->dpayload, end.payload[0], end.payload[1]);
   if(!IS_NULL_PTR(w->dborder))
   {
-    if(!have_rb) dt_masks_outline_offset_along(rc, b1[0] - c1[0], b1[1] - c1[1], p2[4], rb);
-    dt_masks_dynbuf_add_2(w->dborder, rb[0], rb[1]);
+    if(!end.have_border)
+      dt_masks_outline_offset_along(end.point, b1[0] - c1[0], b1[1] - c1[1], p2[4], end.border);
+    dt_masks_dynbuf_add_2(w->dborder, end.border[0], end.border[1]);
   }
 
-  s->c[0] = rc[0];
-  s->c[1] = rc[1];
-  s->b[0] = rb[0];
-  s->b[1] = rb[1];
+  s->c[0] = end.point[0];
+  s->c[1] = end.point[1];
+  s->b[0] = end.border[0];
+  s->b[1] = end.border[1];
   s->r = p2[4];
 
-  s->payload[0] = rp[0];
-  s->payload[1] = rp[1];
+  s->payload[0] = end.payload[0];
+  s->payload[1] = end.payload[1];
   s->have_prev = TRUE;
   return TRUE;
 }
@@ -1036,7 +1067,7 @@ static void _brush_walk_cap(const _brush_walk_t *const w, const _brush_walk_stat
   float centre[2] = { s->c[0], s->c[1] };
   float from[2] = { s->b[0], s->b[1] };
   float opposite[2] = { 2.0f * s->c[0] - s->b[0], 2.0f * s->c[1] - s->b[1] };
-  _brush_points_recurs_border_gaps(centre, from, NULL, opposite, w->dpoints, w->dborder, TRUE);
+  _brush_points_recurs_border_gaps(centre, from, opposite, w->dpoints, w->dborder, TRUE, w->arc_step);
   _brush_walk_sync_payload(w, s->payload);
 }
 
@@ -1068,7 +1099,7 @@ static void _brush_walk_single_dab(const _brush_walk_t *const w)
   if(!IS_NULL_PTR(w->dborder))
   {
     dt_masks_dynbuf_add_2(w->dborder, from[0], from[1]);
-    _brush_points_stamp(centre, from, radius, w->dpoints, w->dborder);
+    _brush_points_stamp(centre, from, radius, w->dpoints, w->dborder, w->arc_step);
   }
   const float payload[2] = { n0->fading, n0->density };
   _brush_walk_sync_payload(w, payload);
@@ -1247,6 +1278,7 @@ static int _brush_get_pts_border(dt_develop_t *develop, dt_masks_form_t *mask_fo
                                .node_count = (int)node_count,
                                .frame = { iwd, iht, dx, dy },
                                .pixel_threshold = pixel_threshold,
+                               .arc_step = IS_NULL_PTR(dist->pipe) ? pixel_threshold : 1,
                                .dpoints = dpoints,
                                .dborder = dborder,
                                .dpayload = dpayload };

--- a/src/develop/masks/masks_distort.h
+++ b/src/develop/masks/masks_distort.h
@@ -91,17 +91,30 @@ static inline dt_masks_distort_t dt_masks_distort_for_pipe(dt_dev_pixelpipe_t *p
 }
 
 /**
- * @brief The GUI supplier: compose through the geometry service, at full resolution, one pixel
- * at a time.
+ * @brief The density the dev's GUI shows its outlines at, in image pixels between consecutive
+ * samples: what the view published through dt_masks_gui_set_outline_density(), 1 for a dev with
+ * no GUI state. Implemented in masks_gui.c, which owns that state; declared here because the
+ * GUI supplier below is what reads it.
+ */
+int dt_masks_gui_outline_step(const dt_develop_t *dev);
+
+/**
+ * @brief The GUI supplier: compose through the geometry service, at full resolution, sampled
+ * at the density the view shows.
  *
- * @details The step is 1 because that is what the GUI has always had: the pixel-less pipe this
- * replaces was never given a rasterisation step, so it kept the one its init set, and outlines
- * the user drags are drawn pixel-accurate. The size is the raw geometry, which is what that
- * pipe's input was set from.
+ * @details The step is the view's: what one device pixel spans in image pixels, never less than
+ * one (dt_masks_gui_outline_step()). It used to be pinned at 1 because that is what the GUI had
+ * always had -- the pixel-less pipe this replaces was never given a rasterisation step, so it
+ * kept the one its init set -- and at fit zoom on a 24 Mpx raw that sampled the outline five
+ * times per device pixel: five times the build, the transform, the boundary pass and the hit
+ * test, for a line the screen shows at one sample per pixel either way. Read here rather than
+ * passed in, so that every GUI outline build -- a drag's, an expose's, the creation session's --
+ * composes at the density in force without its caller having to know it. The size is the raw
+ * geometry, which is what that pipe's input was set from.
  */
 static inline dt_masks_distort_t dt_masks_distort_for_gui(dt_develop_t *dev)
 {
-  dt_masks_distort_t d = { NULL, dev, 0, 0, 1 };
+  dt_masks_distort_t d = { NULL, dev, 0, 0, dt_masks_gui_outline_step(dev) };
   int32_t raw_width = 0;
   int32_t raw_height = 0;
   if(dt_dev_geometry_get_raw_size(dev, &raw_width, &raw_height))

--- a/src/develop/masks/masks_functions.h
+++ b/src/develop/masks/masks_functions.h
@@ -155,6 +155,10 @@ dt_masks_raster_result_t dt_masks_get_mask_roi(const dt_iop_module_t *const modu
                                                dt_masks_form_t *const form, const dt_iop_roi_t *roi,
                                                float *buffer, dt_iop_roi_t *touched);
 
+/* The outline is sampled at the density the dev's GUI shows -- dt_masks_gui_outline_step(),
+ * read by dt_masks_distort_for_gui() -- so that it is built at the density it is drawn and
+ * hit-tested at. The brush and the polygon sample their curves, arcs and stamps at it; the
+ * circle, the ellipse and the gradient have their own sampling. */
 dt_masks_raster_result_t dt_masks_get_points_border(struct dt_develop_t *dev, dt_masks_form_t *form,
                                float **points, int *points_count,
                                float **border, int *border_count,

--- a/src/develop/masks/masks_gui.c
+++ b/src/develop/masks/masks_gui.c
@@ -38,6 +38,7 @@
 #include "develop/masks_debug.h"
 #include "develop/masks_gui.h"
 #include "develop/masks_group.h"
+#include "develop/masks/masks_distort.h"
 #include "develop/masks/masks_functions.h"
 #include "widgets/stroke_raster.h"
 #include "widgets/bauhaus.h"
@@ -1848,6 +1849,7 @@ void dt_masks_init_form_gui(dt_develop_t *dev, dt_masks_form_gui_t *mask_gui)
   memset(mask_gui, 0, sizeof(dt_masks_form_gui_t));
 
   mask_gui->dev = dev;
+  mask_gui->outline_step = 1;
   mask_gui->pos[0] = mask_gui->pos[1] = -1.0f;
   mask_gui->rel_pos[0] = mask_gui->rel_pos[1] = -1.0f;
   mask_gui->raw_pos[0] = mask_gui->raw_pos[1] = -1.0f;
@@ -1894,6 +1896,19 @@ void dt_masks_soft_reset_form_gui(dt_masks_form_gui_t *mask_gui)
   mask_gui->last_rebuild_pos[0] = mask_gui->last_rebuild_pos[1] = 0.0f;
   mask_gui->rebuild_pending = FALSE;
   mask_gui->last_hit_test_pos[0] = mask_gui->last_hit_test_pos[1] = -1.0f;
+}
+
+void dt_masks_gui_set_outline_density(dt_masks_form_gui_t *mask_gui, const double image_px_per_device_px)
+{
+  if(IS_NULL_PTR(mask_gui)) return;
+  const double span = isfinite(image_px_per_device_px) ? floor(image_px_per_device_px) : 1.0;
+  mask_gui->outline_step = (span > 1.0) ? (int)span : 1;
+}
+
+int dt_masks_gui_outline_step(const dt_develop_t *dev)
+{
+  if(IS_NULL_PTR(dev) || IS_NULL_PTR(dev->form_gui)) return 1;
+  return MAX(1, dev->form_gui->outline_step);
 }
 
 void dt_masks_gui_form_create(dt_masks_form_t *mask_form, dt_masks_form_gui_t *mask_gui,
@@ -1948,6 +1963,7 @@ void dt_masks_gui_form_create(dt_masks_form_t *mask_form, dt_masks_form_gui_t *m
         return;
     }
     mask_gui->geometry_generation = dt_geometry_chain_generation(mask_gui->dev->geometry_chain);
+    mask_gui->outline_step_built = dt_masks_gui_outline_step(mask_gui->dev);
     mask_gui->formid = mask_form->formid;
     mask_gui->type = mask_form->type;
 
@@ -2413,18 +2429,23 @@ void dt_masks_gui_form_remove(dt_masks_form_t *mask_form, dt_masks_form_gui_t *m
 void dt_masks_gui_form_test_create(dt_masks_form_t *mask_form, dt_masks_form_gui_t *mask_gui,
                                    dt_iop_module_t *module)
 {
-  // we test if the geometry the cached outlines were built against has moved
+  // we test if the geometry the cached outlines were built against has moved, or the density
+  // the view shows them at
   const uint64_t live_generation = dt_geometry_chain_generation(mask_gui->dev->geometry_chain);
+  const int live_step = dt_masks_gui_outline_step(mask_gui->dev);
+  const gboolean stale = (mask_gui->geometry_generation != live_generation)
+                         || (mask_gui->outline_step_built != live_step);
   if(dt_get_debug_flags() & DT_DEBUG_MASKS)
-    dt_print(DT_DEBUG_MASKS, "[masks] outline cache: held for geometry %lu, live %lu -> %s\n",
-             (unsigned long)mask_gui->geometry_generation, (unsigned long)live_generation,
+    dt_print(DT_DEBUG_MASKS, "[masks] outline cache: held for geometry %lu at step %d, live %lu at step %d -> %s\n",
+             (unsigned long)mask_gui->geometry_generation, mask_gui->outline_step_built,
+             (unsigned long)live_generation, live_step,
              (mask_gui->geometry_generation == 0)
                  ? "REBUILD (nothing cached)"
-                 : ((mask_gui->geometry_generation != live_generation) ? "REBUILD (geometry moved)" : "reuse"));
+                 : (stale ? "REBUILD (geometry or density moved)" : "reuse"));
 
   if(mask_gui->geometry_generation != 0)
   {
-    if(mask_gui->geometry_generation != live_generation)
+    if(stale)
     {
       mask_gui->geometry_generation = 0;
       mask_gui->formid = 0;
@@ -3837,10 +3858,11 @@ static void _masks_draw_creation_session_forms(dt_develop_t *develop, dt_iop_mod
   _session_gui.edit_mode = creation_gui->edit_mode;
   _session_gui.group_selected = -1;
 
-  /* Rebuild only when the composed geometry moved or the session gained a shape -- the same rule
-   * the mask group's outlines follow. A shape's own content changing commits history, which
-   * rebuilds the chain, which advances the generation. */
-  const gboolean rebuild = (_session_gui_generation != live_generation) || (_session_gui_count != count);
+  /* Rebuild only when the composed geometry moved, the view's density changed or the session
+   * gained a shape -- the same rule the mask group's outlines follow. A shape's own content
+   * changing commits history, which rebuilds the chain, which advances the generation. */
+  const gboolean rebuild = (_session_gui_generation != live_generation) || (_session_gui_count != count)
+                           || (_session_gui.outline_step_built != dt_masks_gui_outline_step(develop));
   if(rebuild)
   {
     g_list_free_full(_session_gui.points, dt_masks_form_gui_points_free);
@@ -4664,6 +4686,10 @@ void dt_masks_events_post_expose_with(dt_develop_t *dev, struct dt_iop_module_t 
     cairo_destroy(mask_draw);   // nothing was drawn
     return;
   }
+  /* The density the outlines are built at is what this context shows: the transform is on,
+   * so one device pixel spans this many image pixels. Read before the cache is tested, since
+   * a change is a rebuild. */
+  dt_masks_gui_set_outline_density(mask_gui, dt_draw_min_emit_step(mask_draw));
 
   // We update the form if needed
   // Add preview when creating a circle, ellipse and gradient

--- a/src/develop/masks/masks_gui.c
+++ b/src/develop/masks/masks_gui.c
@@ -2436,22 +2436,21 @@ void dt_masks_gui_form_test_create(dt_masks_form_t *mask_form, dt_masks_form_gui
   const gboolean stale = (mask_gui->geometry_generation != live_generation)
                          || (mask_gui->outline_step_built != live_step);
   if(dt_get_debug_flags() & DT_DEBUG_MASKS)
+  {
+    const char *verdict = "reuse";
+    if(mask_gui->geometry_generation == 0) verdict = "REBUILD (nothing cached)";
+    else if(stale) verdict = "REBUILD (geometry or density moved)";
     dt_print(DT_DEBUG_MASKS, "[masks] outline cache: held for geometry %lu at step %d, live %lu at step %d -> %s\n",
              (unsigned long)mask_gui->geometry_generation, mask_gui->outline_step_built,
-             (unsigned long)live_generation, live_step,
-             (mask_gui->geometry_generation == 0)
-                 ? "REBUILD (nothing cached)"
-                 : (stale ? "REBUILD (geometry or density moved)" : "reuse"));
+             (unsigned long)live_generation, live_step, verdict);
+  }
 
-  if(mask_gui->geometry_generation != 0)
+  if(mask_gui->geometry_generation != 0 && stale)
   {
-    if(stale)
-    {
-      mask_gui->geometry_generation = 0;
-      mask_gui->formid = 0;
-      g_list_free_full(mask_gui->points, dt_masks_form_gui_points_free);
-      mask_gui->points = NULL;
-    }
+    mask_gui->geometry_generation = 0;
+    mask_gui->formid = 0;
+    g_list_free_full(mask_gui->points, dt_masks_form_gui_points_free);
+    mask_gui->points = NULL;
   }
 
   // we create the form if needed

--- a/src/develop/masks/masks_outline.c
+++ b/src/develop/masks/masks_outline.c
@@ -30,6 +30,8 @@
 #include "caches/pixelpipe_cache_alloc.h"
 #include "system/mem_alloc.h"
 #include "math/math.h"
+#include "common/logging.h"
+#include "common/times.h"
 
 #include <float.h>
 #include <math.h>
@@ -121,35 +123,71 @@ gboolean dt_masks_outline_short_way(const float *const centre, const float *cons
  * chosen between.
  *
  * Two searches, because the discs that can hide a sample come from two places, and what
- * separates them is their INDEX along the walk, not their position. A disc within twice the
- * largest radius of the sample's own spine position can reach it and no other can, so a
- * window of discs either side of the sample's own is exhaustive for folds, joints and caps;
- * consecutive discs move at most a step, so the window is scanned in blocks and a block whose
- * first disc is out of reach is skipped whole. The stroke can also come back on itself -- a
- * hairpin, a crossing, a spiral -- and then the hiding disc is any distance away along the
- * walk but within one radius in the plane. A bucket grid of one reach per cell finds those,
- * and each bucket holds its discs as RUNS of consecutive indices: a run inside the window is
- * the near part, already answered, and is dismissed in one comparison; only runs from far
- * along the walk are tested disc by disc. On a stroke that never revisits its own ground that
- * is nothing at all, and at a crossing it is the discs of the other pass and no more.
+ * separates them is where they sit ALONG THE WALK, not where they sit in the plane. A disc
+ * can contain a border sample only if its centre is within its own radius of it, and the
+ * sample is one radius from its own spine point, so the two centres are within two radii of
+ * each other in the plane and -- the spine being a continuous line -- within two radii of
+ * each other along it: that much walk either side of the sample's own disc is exhaustive for
+ * folds, joints and caps. The window is measured in walk LENGTH, never in discs: a disc is
+ * made wherever the spine moves half a pixel or the radius steps, so a count of discs is a
+ * different length at every sampling density and at every flare, and the count this used to
+ * be (four times the largest radius, plus eight) was ten times too wide once the outline was
+ * sampled at the density the screen shows. The stroke can also come back on itself -- a
+ * hairpin, a crossing, a spiral, and the brush's own second pass down the other side -- and
+ * then the hiding disc is any distance away along the walk but within one radius in the
+ * plane. A bucket grid of one reach per cell finds those, and each bucket holds its discs as
+ * RUNS of consecutive indices: a run inside the window is the near part, already answered,
+ * and is dismissed in one comparison; only runs from far along the walk are tested disc by
+ * disc.
+ *
+ * The test itself is the cost, and it is arranged to be counted rather than computed. The
+ * discs are flat arrays -- centre x, centre y, and the SQUARED radius less the tolerance,
+ * negative for a disc the tolerance leaves nothing of -- so a probe is one squared distance
+ * against each, no square root anywhere, in blocks of eight the compiler can vectorise; and
+ * each block carries the box its centres span and its largest radius, so a block that cannot
+ * reach the probe costs four comparisons. The previous test took a hypot per disc for the
+ * copy test below, and dismissed a block on its first disc's distance against a reach padded
+ * by the largest step between discs: measured on the corpus, 4.5 ns per disc test and half
+ * the blocks tested.
+ *
+ * The copy test is a different question and has its own structure. The walk stamps a full
+ * disc at a node whose radius steps in BOTH passes, and bridges a joint with an arc about
+ * the same node at the same radius; every copy after the first traces a boundary the first
+ * already traces, and drawn on top of it with its own dash phase it fills the gaps of the
+ * dashes -- measured on a flaring brush: 3,171 samples per pass centred on the node to the
+ * float, 4,020 kept on a 2,114 px circumference, drawn as a near-solid line. A copy is not a
+ * boundary sample. Neither is the stretch where a segment leaves such a node: its envelope
+ * runs within the boundary tolerance of the node's circle for tens of pixels. So a sample
+ * that repeats an EARLIER one -- a border position within three quarters of a pixel, at
+ * least OUTLINE_REPEAT_MIN_WALK of border walked between the two -- is dropped. Position
+ * alone decides, whatever discs the two samples belong to: for drawing, two boundary samples
+ * within three quarters of a pixel are one line. The other side of the stroke is a diameter
+ * away and never matches. A sample's own run is excluded by the length of border walked
+ * between the two: an arc filler can sample closer than the tolerance, and the recursion
+ * samples a hundredth of a pixel apart around every integer crossing, so neither a count of
+ * samples nor a predecessor test can tell a run from its copy -- the walk can, a copy being
+ * the other pass or another stamp, thousands of pixels away along it. Keyed on the sample's
+ * disc or its spine point instead, this test missed the copies (a disc's centre is its first
+ * sample's, half a pixel off and differently per pass) or the junctions; each round was
+ * measured on the corpus before the next. The samples are hashed by pixel cell, so the test
+ * reads the nine cells around the probe and nothing else; it used to ride inside the disc
+ * test, walking the samples of every disc whose circle passed near the probe, and was what
+ * put the square root in that loop.
  *
  * A first version used a coarse occupancy map of the union for the far part instead. It was
  * conservative, and so it left every sample within a few pixels of a far boundary undecided;
  * refining those exactly meant refining every sample, because every boundary sample is within
  * a few pixels of its OWN stroke's interior, and the build went from 30 ms to 250 ms on the
- * corpus. Position cannot tell near from far; the index can.
+ * corpus. Position cannot tell near from far; the walk can.
  *
  * Cost is bounded by decimation, not by the sample count: consecutive samples closer than half
  * a pixel with the same radius are one disc, so the window and the grid both see a few
- * thousand discs on a stroke of a hundred thousand samples. */
-typedef struct _outline_disc_t
-{
-  float x;
-  float y;
-  float r;
-  int first;   /* the disc's samples: consecutive along the walk, [first, last] */
-  int last;
-} _outline_disc_t;
+ * thousand discs on a stroke of a hundred thousand samples. `-d masks -d perf' prints what a
+ * pass cost and how many discs it tested. */
+
+/* Discs per block of the containment test; a block is dismissed on its bounds or tested
+ * whole. */
+#define OUTLINE_BLOCK 8
 
 /* The bucket grid over the discs: one reach per cell, each bucket a linked list of RUNS of
  * consecutive disc indices, so that a run inside the walk's window can be dismissed with two
@@ -170,119 +208,176 @@ typedef struct _outline_disc_grid_t
 /* Everything the per-sample test needs. */
 typedef struct _outline_boundary_t
 {
-  const _outline_disc_t *discs;
+  /* the discs, decimated, as the flat arrays the containment test streams through */
+  float *cx;
+  float *cy;
+  float *rin2;          /* (radius - eps)^2, or -1 for a disc the tolerance leaves nothing of */
+  float *dwalk;         /* per disc, the length of spine walked to its centre */
   int ndisc;
-  const int *disc_of;   /* per sample, the disc it belongs to */
+  /* per block of OUTLINE_BLOCK discs: the box its centres span, and how far past it the
+   * largest disc reaches -- zero when none of them can contain anything */
+  float *bminx;
+  float *bmaxx;
+  float *bminy;
+  float *bmaxy;
+  float *breach;
+  int nblock;
+  int *disc_of;         /* per sample, the disc it belongs to */
   const float *border_h;   /* the border samples, past the header */
-  const float *walk;       /* per sample, the length of the border walked to reach it */
-  int window;           /* discs either side of a sample's own that can reach it along the walk */
-  float reach;          /* how far a block's first disc may be for the block to matter */
+  float *walk;          /* per sample, the length of border walked to reach it */
+  float window;         /* walk either side of a sample's own disc that can reach it */
   float eps;            /* boundary tolerance, in pixels */
   _outline_disc_grid_t grid;
   gboolean have_grid;
+  /* the samples hashed by pixel cell, for the copy test */
+  int *cell_head;
+  int *cell_next;
+  unsigned cell_mask;
+  /* what the pass did, for the perf trace */
+  long probes;
+  long disc_tests;
 } _outline_boundary_t;
-
-/* One border sample being probed: its index, its disc and its position. */
-typedef struct _outline_probe_t
-{
-  int i;
-  int own;
-  float bx;
-  float by;
-  float walk;   /* the border length walked to this sample */
-} _outline_probe_t;
 
 /* How far back along the walk a sample may match: closer than this it is the sample's own
  * run. Sixteen samples was the first guess, and the recursion samples a border a hundredth of
  * a pixel apart around every integer crossing, where sixteen samples are less than a pixel. */
 #define OUTLINE_REPEAT_MIN_WALK 4.0f
 
-/* Does the probed sample repeat an earlier sample of disc @p j: a border position within three
- * quarters of a pixel, at least sixteen samples earlier along the walk.
- *
- * The walk stamps a full disc at a node whose radius steps in BOTH passes, and bridges a joint
- * with an arc about the same node at the same radius; every copy after the first traces a
- * boundary the first already traces, and drawn on top of it with its own dash phase it fills
- * the gaps of the dashes -- measured on a flaring brush: 3,171 samples per pass centred on the
- * node to the float, 4,020 kept on a 2,114 px circumference, drawn as a near-solid line. A copy
- * is not a boundary sample. Neither is the stretch where a segment leaves such a node: its
- * envelope runs within the boundary tolerance of the node's circle for tens of pixels, and both
- * were kept, a second dash over the first from a different phase.
- *
- * Position alone decides, whatever discs the two samples belong to: for drawing, two boundary
- * samples within three quarters of a pixel are one line. The other side of the stroke -- the
- * backward pass revisits every spine point of the forward one -- is a diameter away and never
- * matches. A sample's own run is excluded by the length of border walked between the two,
- * OUTLINE_REPEAT_MIN_WALK: an arc filler can sample closer than the tolerance, and the
- * recursion samples a hundredth of a pixel apart around every integer crossing, so neither a
- * count of samples nor a predecessor test can tell a run from its copy -- the walk can, a copy
- * being the other pass or another stamp, thousands of pixels away along it. Keyed on the
- * sample's disc or its spine point instead, this test missed the copies (a disc's centre is
- * its first sample's, half a pixel off and differently per pass) or the junctions; each round
- * was measured on the corpus before the next. The annulus test on the disc is what keeps it
- * cheap: a disc's samples lie a radius from its centre, give or take the half pixel its spine
- * may have moved. */
-static inline gboolean _outline_sample_repeats(const _outline_boundary_t *const b, const int j,
-                                               const _outline_probe_t *const probe)
+static void _outline_boundary_free(_outline_boundary_t *const b)
 {
-  if(j > probe->own) return FALSE;
-  const _outline_disc_t *const d = &b->discs[j];
-  const float cx = d->x - probe->bx;
-  const float cy = d->y - probe->by;
-  const float distance = dt_fast_hypotf(cx, cy);
-  if(fabsf(distance - d->r) > 1.3f) return FALSE;   /* no sample of this disc can be within reach */
-  const float walk_limit = probe->walk - OUTLINE_REPEAT_MIN_WALK;
-  for(int k = d->first; k <= d->last && b->walk[k] <= walk_limit; k++)
+  dt_free_align(b->cx);
+  dt_free_align(b->cy);
+  dt_free_align(b->rin2);
+  dt_free_align(b->dwalk);
+  dt_free_align(b->bminx);
+  dt_free_align(b->bmaxx);
+  dt_free_align(b->bminy);
+  dt_free_align(b->bmaxy);
+  dt_free_align(b->breach);
+  dt_free_align(b->disc_of);
+  dt_free_align(b->walk);
+  dt_free_align(b->grid.bucket_head);
+  dt_free_align(b->grid.run_start);
+  dt_free_align(b->grid.run_end);
+  dt_free_align(b->grid.run_next);
+  dt_free_align(b->cell_head);
+  dt_free_align(b->cell_next);
+  memset(b, 0, sizeof(*b));
+}
+
+/* The arrays a pass over @p n samples needs, all of them, or none. */
+static gboolean _outline_boundary_alloc(_outline_boundary_t *const b, const int n)
+{
+  const int nblock = n / OUTLINE_BLOCK + 1;
+  b->cx = dt_alloc_align((size_t)n * sizeof(float));
+  b->cy = dt_alloc_align((size_t)n * sizeof(float));
+  b->rin2 = dt_alloc_align((size_t)n * sizeof(float));
+  b->dwalk = dt_alloc_align((size_t)n * sizeof(float));
+  b->bminx = dt_alloc_align((size_t)nblock * sizeof(float));
+  b->bmaxx = dt_alloc_align((size_t)nblock * sizeof(float));
+  b->bminy = dt_alloc_align((size_t)nblock * sizeof(float));
+  b->bmaxy = dt_alloc_align((size_t)nblock * sizeof(float));
+  b->breach = dt_alloc_align((size_t)nblock * sizeof(float));
+  b->disc_of = dt_alloc_align((size_t)n * sizeof(int));
+  b->walk = dt_alloc_align((size_t)n * sizeof(float));
+  const gboolean ok = !IS_NULL_PTR(b->cx) && !IS_NULL_PTR(b->cy) && !IS_NULL_PTR(b->rin2)
+                      && !IS_NULL_PTR(b->dwalk) && !IS_NULL_PTR(b->bminx) && !IS_NULL_PTR(b->bmaxx)
+                      && !IS_NULL_PTR(b->bminy) && !IS_NULL_PTR(b->bmaxy) && !IS_NULL_PTR(b->breach)
+                      && !IS_NULL_PTR(b->disc_of) && !IS_NULL_PTR(b->walk);
+  if(!ok) _outline_boundary_free(b);
+  return ok;
+}
+
+static inline unsigned _outline_cell_hash(const int cx, const int cy)
+{
+  return ((unsigned)cx * 73856093u) ^ ((unsigned)cy * 19349663u);
+}
+
+/* Hash every sample by the pixel cell it falls in. Returns FALSE when the table could not be
+ * allocated, in which case the copy test answers "no copy" and the stamps are drawn twice --
+ * the outline of a build under memory pressure, not a wrong one. */
+static gboolean _outline_cells_build(_outline_boundary_t *const b, const int n)
+{
+  unsigned size = 1;
+  while(size < 2u * (unsigned)n) size <<= 1;
+  b->cell_head = dt_alloc_align((size_t)size * sizeof(int));
+  b->cell_next = dt_alloc_align((size_t)n * sizeof(int));
+  if(IS_NULL_PTR(b->cell_head) || IS_NULL_PTR(b->cell_next))
   {
-    const float dx = b->border_h[2 * k] - probe->bx;
-    const float dy = b->border_h[2 * k + 1] - probe->by;
-    if(dx * dx + dy * dy <= 0.5625f) return TRUE;
+    dt_free_align(b->cell_head);
+    dt_free_align(b->cell_next);
+    b->cell_head = NULL;
+    b->cell_next = NULL;
+    return FALSE;
+  }
+  memset(b->cell_head, 0xff, (size_t)size * sizeof(int));   /* every head -1 */
+  b->cell_mask = size - 1;
+  for(int i = 0; i < n; i++)
+  {
+    const int cx = (int)floorf(b->border_h[2 * i]);
+    const int cy = (int)floorf(b->border_h[2 * i + 1]);
+    const unsigned h = _outline_cell_hash(cx, cy) & b->cell_mask;
+    b->cell_next[i] = b->cell_head[h];
+    b->cell_head[h] = i;
+  }
+  return TRUE;
+}
+
+/* Does the sample at (bx, by), reached after @p walk of border, repeat an earlier one: a
+ * border position within three quarters of a pixel, at least OUTLINE_REPEAT_MIN_WALK before
+ * it along the walk. The nine pixel cells around it hold every candidate. */
+static inline gboolean _outline_sample_repeats(const _outline_boundary_t *const b, const float bx, const float by,
+                                               const float walk)
+{
+  if(IS_NULL_PTR(b->cell_head)) return FALSE;
+  const float walk_limit = walk - OUTLINE_REPEAT_MIN_WALK;
+  const int cx = (int)floorf(bx);
+  const int cy = (int)floorf(by);
+  for(int dy = -1; dy <= 1; dy++)
+  {
+    for(int dx = -1; dx <= 1; dx++)
+    {
+      const unsigned h = _outline_cell_hash(cx + dx, cy + dy) & b->cell_mask;
+      for(int k = b->cell_head[h]; k >= 0; k = b->cell_next[k])
+      {
+        if(b->walk[k] > walk_limit) continue;
+        const float ex = b->border_h[2 * k] - bx;
+        const float ey = b->border_h[2 * k + 1] - by;
+        if(ex * ex + ey * ey <= 0.5625f) return TRUE;
+      }
+    }
   }
   return FALSE;
 }
 
-/* is @p b strictly inside disc @p d, by more than the boundary tolerance */
-static inline gboolean _outline_disc_contains(const _outline_disc_t *const d, const float bx, const float by,
-                                            const float eps)
+/* Is (bx, by) strictly inside one of the discs [lo, hi], by more than the tolerance: block by
+ * block, a block dismissed on its bounds or streamed whole. */
+static inline gboolean _outline_discs_contain(_outline_boundary_t *const b, const int lo, const int hi,
+                                              const float bx, const float by)
 {
-  const float jx = d->x - bx;
-  const float jy = d->y - by;
-  const float rin = d->r - eps;
-  return (rin > 0.0f && jx * jx + jy * jy < rin * rin);
-}
-
-/* test the discs [lo, hi] against the probe, in blocks: consecutive discs move at most
- * @p step_max, so a block whose first disc is further than reach + block * step_max away
- * holds nothing that can contain the probe */
-static inline gboolean _outline_discs_contain(const _outline_boundary_t *const b, const int lo, const int hi,
-                                              const _outline_probe_t *const probe)
-{
-  const int block = 8;
-  const float reach2 = b->reach * b->reach;
-  for(int d = lo; d <= hi; d += block)
+  if(lo > hi) return FALSE;
+  const int blk_lo = lo / OUTLINE_BLOCK;
+  const int blk_hi = hi / OUTLINE_BLOCK;
+  for(int blk = blk_lo; blk <= blk_hi; blk++)
   {
-    const float ddx = b->discs[d].x - probe->bx;
-    const float ddy = b->discs[d].y - probe->by;
-    if(ddx * ddx + ddy * ddy > reach2) continue;
-    const int e = MIN(d + block - 1, hi);
-    for(int j = d; j <= e; j++)
-      if(_outline_disc_contains(&b->discs[j], probe->bx, probe->by, b->eps) || _outline_sample_repeats(b, j, probe))
-        return TRUE;
+    const float reach = b->breach[blk];
+    if(reach <= 0.0f) continue;
+    if(bx < b->bminx[blk] - reach || bx > b->bmaxx[blk] + reach || by < b->bminy[blk] - reach
+       || by > b->bmaxy[blk] + reach)
+      continue;
+    const int j0 = MAX(lo, blk * OUTLINE_BLOCK);
+    const int j1 = MIN(hi, blk * OUTLINE_BLOCK + OUTLINE_BLOCK - 1);
+    b->disc_tests += j1 - j0 + 1;
+    int hit = 0;
+    for(int j = j0; j <= j1; j++)
+    {
+      const float ex = b->cx[j] - bx;
+      const float ey = b->cy[j] - by;
+      hit |= (ex * ex + ey * ey < b->rin2[j]);
+    }
+    if(hit) return TRUE;
   }
   return FALSE;
-}
-
-
-static void _outline_grid_free(_outline_disc_grid_t *const g)
-{
-  dt_free_align(g->bucket_head);
-  dt_free_align(g->run_start);
-  dt_free_align(g->run_end);
-  dt_free_align(g->run_next);
-  g->bucket_head = NULL;
-  g->run_start = NULL;
-  g->run_end = NULL;
-  g->run_next = NULL;
 }
 
 static inline int _outline_grid_cell(const _outline_disc_grid_t *const g, const float x, const float y)
@@ -309,17 +404,14 @@ static gboolean _outline_grid_build(_outline_boundary_t *const b, const float *c
   g->run_next = dt_alloc_align((size_t)b->ndisc * sizeof(int));
   if(IS_NULL_PTR(g->bucket_head) || IS_NULL_PTR(g->run_start) || IS_NULL_PTR(g->run_end)
      || IS_NULL_PTR(g->run_next))
-  {
-    _outline_grid_free(g);
     return FALSE;
-  }
 
   for(int cell = 0; cell < g->bw * g->bh; cell++) g->bucket_head[cell] = -1;
   int nruns = 0;
   int last_cell = -1;
   for(int d = 0; d < b->ndisc; d++)
   {
-    const int cell = _outline_grid_cell(g, b->discs[d].x, b->discs[d].y);
+    const int cell = _outline_grid_cell(g, b->cx[d], b->cy[d]);
     if(cell == last_cell)
     {
       g->run_end[nruns - 1] = d;   /* the walk is still in this bucket: extend its latest run */
@@ -337,12 +429,12 @@ static gboolean _outline_grid_build(_outline_boundary_t *const b, const float *c
 
 /* The far test: every run in reach of the probe, but only the parts of it OUTSIDE the walk's
  * window [lo, hi] -- the part inside is the near test's, already answered. */
-static inline gboolean _outline_far_contains(const _outline_boundary_t *const b, const int lo, const int hi,
-                                    const _outline_probe_t *const probe)
+static inline gboolean _outline_far_contains(_outline_boundary_t *const b, const int lo, const int hi,
+                                             const float bx, const float by)
 {
   const _outline_disc_grid_t *const g = &b->grid;
-  const int gx = CLAMP((int)((probe->bx - g->minx) / g->bucket) + 1, 0, g->bw - 1);
-  const int gy = CLAMP((int)((probe->by - g->miny) / g->bucket) + 1, 0, g->bh - 1);
+  const int gx = CLAMP((int)((bx - g->minx) / g->bucket) + 1, 0, g->bw - 1);
+  const int gy = CLAMP((int)((by - g->miny) / g->bucket) + 1, 0, g->bh - 1);
 
   for(int neighbour = 0; neighbour < 9; neighbour++)
   {
@@ -354,38 +446,67 @@ static inline gboolean _outline_far_contains(const _outline_boundary_t *const b,
     {
       const int start = g->run_start[r];
       const int end = g->run_end[r];
-      if(start < lo && _outline_discs_contain(b, start, MIN(end, lo - 1), probe)) return TRUE;
-      if(end > hi && _outline_discs_contain(b, MAX(start, hi + 1), end, probe)) return TRUE;
+      if(start < lo && _outline_discs_contain(b, start, MIN(end, lo - 1), bx, by)) return TRUE;
+      if(end > hi && _outline_discs_contain(b, MAX(start, hi + 1), end, bx, by)) return TRUE;
     }
   }
   return FALSE;
 }
 
-/* Is border sample @p i, at (bx, by), strictly inside some other sample's disc: the window along
- * the walk first, then whatever a far part of the stroke brings within reach. */
-static inline gboolean _outline_sample_inside(const _outline_boundary_t *const b, const int i, const float bx, const float by)
+/* The discs within the window of walk either side of disc @p d0: the walk to a centre is
+ * monotone along the discs, so both ends are a bisection. */
+static inline void _outline_window(const _outline_boundary_t *const b, const int d0, int *const lo, int *const hi)
 {
-  const int d0 = b->disc_of[i];
-  const int lo = MAX(d0 - b->window, 0);
-  const int hi = MIN(d0 + b->window, b->ndisc - 1);
-  const _outline_probe_t probe = { .i = i, .own = d0, .bx = bx, .by = by, .walk = b->walk[i] };
-  if(_outline_discs_contain(b, lo, hi, &probe)) return TRUE;
-  return b->have_grid && _outline_far_contains(b, lo, hi, &probe);
+  const float w0 = b->dwalk[d0];
+  const float w_lo = w0 - b->window;
+  int l = 0;
+  int h = d0;
+  while(l < h)
+  {
+    const int m = (l + h) / 2;
+    if(b->dwalk[m] < w_lo) l = m + 1;
+    else h = m;
+  }
+  *lo = l;
+  const float w_hi = w0 + b->window;
+  l = d0;
+  h = b->ndisc - 1;
+  while(l < h)
+  {
+    const int m = (l + h + 1) / 2;
+    if(b->dwalk[m] > w_hi) h = m - 1;
+    else l = m;
+  }
+  *hi = l;
+}
+
+/* Is border sample @p i, at (bx, by), strictly inside some other sample's disc, or a copy of
+ * an earlier sample: the window along the walk first, then whatever a far part of the stroke
+ * brings within reach, then the cells around it. */
+static inline gboolean _outline_sample_inside(_outline_boundary_t *const b, const int i, const float bx, const float by)
+{
+  int lo = 0;
+  int hi = 0;
+  _outline_window(b, b->disc_of[i], &lo, &hi);
+  b->probes++;
+  if(_outline_discs_contain(b, lo, hi, bx, by)) return TRUE;
+  if(b->have_grid && _outline_far_contains(b, lo, hi, bx, by)) return TRUE;
+  return _outline_sample_repeats(b, bx, by, b->walk[i]);
 }
 
 /* Settle the samples [from, to) between two probes: when both probes agreed, the samples take
  * their answer (@p agreed is 0 or 1); when they disagreed (@p agreed is -1) each sample is
  * asked itself, which is what makes the cut land on the sample it belongs to and not on a
- * neighbour. @p border_h is the border array already offset past the header. Returns how many
- * were dropped. */
-static inline int _outline_settle_span(const _outline_boundary_t *const b, const float *const border_h,
-                              uint8_t *const dropped, const int from, const int to, const int agreed)
+ * neighbour. Returns how many were dropped. */
+static inline int _outline_settle_span(_outline_boundary_t *const b, uint8_t *const dropped, const int from,
+                                       const int to, const int agreed)
 {
   if(agreed == 0) return 0;
   int ndropped = 0;
   for(int j = from; j < to; j++)
   {
-    const gboolean inside = (agreed == 1) || _outline_sample_inside(b, j, border_h[j * 2], border_h[j * 2 + 1]);
+    const gboolean inside
+        = (agreed == 1) || _outline_sample_inside(b, j, b->border_h[j * 2], b->border_h[j * 2 + 1]);
     if(!inside) continue;
     dropped[j] = 1;
     ndropped++;
@@ -394,15 +515,17 @@ static inline int _outline_settle_span(const _outline_boundary_t *const b, const
 }
 
 /* The discs, decimated: consecutive samples closer than half a pixel with the same radius are
- * one disc. Fills @p b's discs/disc_of/ndisc and the sample bbox; returns the largest step
- * between consecutive discs, which bounds how far a block of them can travel. */
+ * one disc. Fills @p b's disc arrays, disc_of, the block bounds and the sample bbox; returns
+ * the largest radius. */
 static float _outline_discs_from_outline(const float *const points_h, const float *const border_h, const int n,
-                                       _outline_disc_t *const discs, int *const disc_of, _outline_boundary_t *const b,
-                                       float *const bbox)
+                                         _outline_boundary_t *const b, float *const bbox)
 {
   int ndisc = 0;
   float r_max = 0.0f;
-  float step_max = 0.0f;
+  float last_x = 0.0f;
+  float last_y = 0.0f;
+  float last_r = 0.0f;
+  float walked = 0.0f;
   bbox[0] = FLT_MAX;
   bbox[1] = -FLT_MAX;
   bbox[2] = FLT_MAX;
@@ -419,33 +542,52 @@ static float _outline_discs_from_outline(const float *const points_h, const floa
     bbox[2] = fminf(bbox[2], fminf(by, py));
     bbox[3] = fmaxf(bbox[3], fmaxf(by, py));
 
+    float moved = 0.0f;
     gboolean new_disc = (ndisc == 0);
     if(!new_disc)
     {
-      const _outline_disc_t *const last = &discs[ndisc - 1];
-      const float moved = dt_fast_hypotf(px - last->x, py - last->y);
-      new_disc = (moved > 0.5f || fabsf(r - last->r) > 0.5f);
-      if(new_disc) step_max = fmaxf(step_max, moved);
+      moved = dt_fast_hypotf(px - last_x, py - last_y);
+      new_disc = (moved > 0.5f || fabsf(r - last_r) > 0.5f);
     }
     if(new_disc)
     {
-      discs[ndisc].x = px;
-      discs[ndisc].y = py;
-      discs[ndisc].r = r;
-      discs[ndisc].first = i;
+      walked += moved;
+      const float rin = r - b->eps;
+      b->cx[ndisc] = px;
+      b->cy[ndisc] = py;
+      b->rin2[ndisc] = (rin > 0.0f) ? rin * rin : -1.0f;
+      b->dwalk[ndisc] = walked;
+      const int blk = ndisc / OUTLINE_BLOCK;
+      if(ndisc % OUTLINE_BLOCK == 0)
+      {
+        b->bminx[blk] = px;
+        b->bmaxx[blk] = px;
+        b->bminy[blk] = py;
+        b->bmaxy[blk] = py;
+        b->breach[blk] = fmaxf(rin, 0.0f);
+      }
+      else
+      {
+        b->bminx[blk] = fminf(b->bminx[blk], px);
+        b->bmaxx[blk] = fmaxf(b->bmaxx[blk], px);
+        b->bminy[blk] = fminf(b->bminy[blk], py);
+        b->bmaxy[blk] = fmaxf(b->bmaxy[blk], py);
+        b->breach[blk] = fmaxf(b->breach[blk], rin);
+      }
       ndisc++;
       r_max = fmaxf(r_max, r);
+      last_x = px;
+      last_y = py;
+      last_r = r;
     }
-    discs[ndisc - 1].last = i;
-    disc_of[i] = ndisc - 1;
+    b->disc_of[i] = ndisc - 1;
   }
-  b->discs = discs;
   b->ndisc = ndisc;
-  b->disc_of = disc_of;
+  b->nblock = (ndisc + OUTLINE_BLOCK - 1) / OUTLINE_BLOCK;
   b->border_h = border_h;
-  b->window = (int)(4.0f * r_max) + 8;
-  b->reach = r_max + 8.0f * fmaxf(step_max, 1.0f);
-  b->eps = 0.5f;
+  /* the sample is one radius from its spine point, the hiding disc's centre one radius from
+   * the sample, and each of them half a pixel from its disc's centre */
+  b->window = 2.0f * r_max + 1.0f;
   return r_max;
 }
 
@@ -527,47 +669,17 @@ static int _outline_skips_from_dropped(const uint8_t *const dropped, const int n
   return nskips;
 }
 
-int dt_masks_outline_boundary_skips(const float *const points, const float *const border,
-                                         const int count, const int header,
-                                         dt_masks_skip_range_t **skips_out)
+/* The probes.
+ *
+ * Not every sample: the border is sampled several times per pixel, and two samples a
+ * quarter of a pixel apart cannot be on different sides of a boundary that is decided to
+ * half a pixel. So a sample is probed when it has moved half a pixel from the last probe,
+ * and the samples between two probes that agree take their answer; only where two probes
+ * disagree is every sample between them probed. Measured on the corpus: the same skip
+ * ranges to the sample, at a third of the probes. Returns how many samples were dropped. */
+static int _outline_probe_samples(_outline_boundary_t *const b, uint8_t *const dropped, const int n)
 {
-  *skips_out = NULL;
-  const int n = count - header;
-  if(IS_NULL_PTR(points) || IS_NULL_PTR(border) || n < 8) return 0;
-  const float *const points_h = points + 2 * header;
-  const float *const border_h = border + 2 * header;
-
-  _outline_disc_t *discs = dt_alloc_align((size_t)n * sizeof(_outline_disc_t));
-  int *disc_of = dt_alloc_align((size_t)n * sizeof(int));
-  uint8_t *dropped = dt_alloc_align((size_t)n);
-  float *walk = dt_alloc_align((size_t)n * sizeof(float));
-  if(IS_NULL_PTR(discs) || IS_NULL_PTR(disc_of) || IS_NULL_PTR(dropped) || IS_NULL_PTR(walk))
-  {
-    dt_free_align(discs);
-    dt_free_align(disc_of);
-    dt_free_align(dropped);
-    dt_free_align(walk);
-    return 0;
-  }
-  memset(dropped, 0, (size_t)n);
-  walk[0] = 0.0f;
-  for(int i = 1; i < n; i++)
-    walk[i] = walk[i - 1] + dt_fast_hypotf(border_h[2 * i] - border_h[2 * i - 2], border_h[2 * i + 1] - border_h[2 * i - 1]);
-
-  _outline_boundary_t b = { 0 };
-  float bbox[4];
-  const float r_max = _outline_discs_from_outline(points_h, border_h, n, discs, disc_of, &b, bbox);
-  b.walk = walk;
-  b.have_grid = _outline_grid_build(&b, bbox, r_max);
-
-  /* The probes.
-   *
-   * Not every sample: the border is sampled several times per pixel, and two samples a
-   * quarter of a pixel apart cannot be on different sides of a boundary that is decided to
-   * half a pixel. So a sample is probed when it has moved half a pixel from the last probe,
-   * and the samples between two probes that agree take their answer; only where two probes
-   * disagree is every sample between them probed. Measured on the corpus: the same skip
-   * ranges to the sample, at a third of the probes. */
+  const float *const border_h = b->border_h;
   int ndropped = 0;
   int last_probe = -1;
   gboolean last_inside = FALSE;
@@ -580,11 +692,11 @@ int dt_masks_outline_boundary_skips(const float *const points, const float *cons
     const gboolean moved = (fabsf(bx - last_bx) > 0.5f || fabsf(by - last_by) > 0.5f);
     if(last_probe >= 0 && i != n - 1 && !moved) continue;
 
-    const gboolean inside = _outline_sample_inside(&b, i, bx, by);
+    const gboolean inside = _outline_sample_inside(b, i, bx, by);
     if(last_probe >= 0 && i > last_probe + 1)
     {
       const int agreed = (inside == last_inside) ? (int)inside : -1;
-      ndropped += _outline_settle_span(&b, border_h, dropped, last_probe + 1, i, agreed);
+      ndropped += _outline_settle_span(b, dropped, last_probe + 1, i, agreed);
     }
     if(inside)
     {
@@ -596,14 +708,51 @@ int dt_masks_outline_boundary_skips(const float *const points, const float *cons
     last_bx = bx;
     last_by = by;
   }
+  return ndropped;
+}
 
-  _outline_grid_free(&b.grid);
-  dt_free_align(discs);
-  dt_free_align(disc_of);
+int dt_masks_outline_boundary_skips(const float *const points, const float *const border,
+                                         const int count, const int header,
+                                         dt_masks_skip_range_t **skips_out)
+{
+  *skips_out = NULL;
+  const int n = count - header;
+  if(IS_NULL_PTR(points) || IS_NULL_PTR(border) || n < 8) return 0;
+  const float *const points_h = points + 2 * header;
+  const float *const border_h = border + 2 * header;
+
+  const double start = dt_get_wtime();
+  _outline_boundary_t b = { 0 };
+  uint8_t *dropped = dt_alloc_align((size_t)n);
+  if(IS_NULL_PTR(dropped) || !_outline_boundary_alloc(&b, n))
+  {
+    dt_free_align(dropped);
+    return 0;
+  }
+  memset(dropped, 0, (size_t)n);
+  b.eps = 0.5f;
+  b.walk[0] = 0.0f;
+  for(int i = 1; i < n; i++)
+    b.walk[i] = b.walk[i - 1]
+                + dt_fast_hypotf(border_h[2 * i] - border_h[2 * i - 2], border_h[2 * i + 1] - border_h[2 * i - 1]);
+
+  float bbox[4];
+  const float r_max = _outline_discs_from_outline(points_h, border_h, n, &b, bbox);
+  b.have_grid = _outline_grid_build(&b, bbox, r_max);
+  _outline_cells_build(&b, n);
+  const double prepared = dt_get_wtime();
+
+  const int ndropped = _outline_probe_samples(&b, dropped, n);
+  if(dt_get_debug_flags() & DT_DEBUG_PERF)
+    dt_print(DT_DEBUG_MASKS,
+             "[masks] boundary pass: %d samples, %d discs, radius %.0f, %ld probes, %ld disc tests, %d dropped;"
+             " prepared in %.1f ms, probed in %.1f ms\n",
+             n, b.ndisc, r_max, b.probes, b.disc_tests, ndropped, 1000.0 * (prepared - start),
+             1000.0 * (dt_get_wtime() - prepared));
+  _outline_boundary_free(&b);
 
   if(ndropped > 0) _outline_keep_specks(dropped, n);
   const int nskips = (ndropped > 0) ? _outline_skips_from_dropped(dropped, n, header, skips_out) : 0;
   dt_free_align(dropped);
-  dt_free_align(walk);
   return nskips;
 }

--- a/src/develop/masks/masks_outline.c
+++ b/src/develop/masks/masks_outline.c
@@ -205,23 +205,41 @@ typedef struct _outline_disc_grid_t
   float miny;
 } _outline_disc_grid_t;
 
-/* Everything the per-sample test needs. */
-typedef struct _outline_boundary_t
+/* The discs, decimated, as the flat arrays the containment test streams through. */
+typedef struct _outline_discs_t
 {
-  /* the discs, decimated, as the flat arrays the containment test streams through */
   float *cx;
   float *cy;
   float *rin2;          /* (radius - eps)^2, or -1 for a disc the tolerance leaves nothing of */
   float *dwalk;         /* per disc, the length of spine walked to its centre */
-  int ndisc;
-  /* per block of OUTLINE_BLOCK discs: the box its centres span, and how far past it the
-   * largest disc reaches -- zero when none of them can contain anything */
-  float *bminx;
-  float *bmaxx;
-  float *bminy;
-  float *bmaxy;
-  float *breach;
-  int nblock;
+  int count;
+} _outline_discs_t;
+
+/* Per block of OUTLINE_BLOCK discs: the box its centres span, and how far past it the largest
+ * disc reaches -- zero when none of them can contain anything. */
+typedef struct _outline_blocks_t
+{
+  float *minx;
+  float *maxx;
+  float *miny;
+  float *maxy;
+  float *reach;
+  int count;
+} _outline_blocks_t;
+
+/* The samples hashed by pixel cell, for the copy test. */
+typedef struct _outline_cells_t
+{
+  int *head;
+  int *next;
+  unsigned mask;
+} _outline_cells_t;
+
+/* Everything the per-sample test needs. */
+typedef struct _outline_boundary_t
+{
+  _outline_discs_t discs;
+  _outline_blocks_t blocks;
   int *disc_of;         /* per sample, the disc it belongs to */
   const float *border_h;   /* the border samples, past the header */
   float *walk;          /* per sample, the length of border walked to reach it */
@@ -229,10 +247,7 @@ typedef struct _outline_boundary_t
   float eps;            /* boundary tolerance, in pixels */
   _outline_disc_grid_t grid;
   gboolean have_grid;
-  /* the samples hashed by pixel cell, for the copy test */
-  int *cell_head;
-  int *cell_next;
-  unsigned cell_mask;
+  _outline_cells_t cells;
   /* what the pass did, for the perf trace */
   long probes;
   long disc_tests;
@@ -245,23 +260,23 @@ typedef struct _outline_boundary_t
 
 static void _outline_boundary_free(_outline_boundary_t *const b)
 {
-  dt_free_align(b->cx);
-  dt_free_align(b->cy);
-  dt_free_align(b->rin2);
-  dt_free_align(b->dwalk);
-  dt_free_align(b->bminx);
-  dt_free_align(b->bmaxx);
-  dt_free_align(b->bminy);
-  dt_free_align(b->bmaxy);
-  dt_free_align(b->breach);
+  dt_free_align(b->discs.cx);
+  dt_free_align(b->discs.cy);
+  dt_free_align(b->discs.rin2);
+  dt_free_align(b->discs.dwalk);
+  dt_free_align(b->blocks.minx);
+  dt_free_align(b->blocks.maxx);
+  dt_free_align(b->blocks.miny);
+  dt_free_align(b->blocks.maxy);
+  dt_free_align(b->blocks.reach);
   dt_free_align(b->disc_of);
   dt_free_align(b->walk);
   dt_free_align(b->grid.bucket_head);
   dt_free_align(b->grid.run_start);
   dt_free_align(b->grid.run_end);
   dt_free_align(b->grid.run_next);
-  dt_free_align(b->cell_head);
-  dt_free_align(b->cell_next);
+  dt_free_align(b->cells.head);
+  dt_free_align(b->cells.next);
   memset(b, 0, sizeof(*b));
 }
 
@@ -269,20 +284,20 @@ static void _outline_boundary_free(_outline_boundary_t *const b)
 static gboolean _outline_boundary_alloc(_outline_boundary_t *const b, const int n)
 {
   const int nblock = n / OUTLINE_BLOCK + 1;
-  b->cx = dt_alloc_align((size_t)n * sizeof(float));
-  b->cy = dt_alloc_align((size_t)n * sizeof(float));
-  b->rin2 = dt_alloc_align((size_t)n * sizeof(float));
-  b->dwalk = dt_alloc_align((size_t)n * sizeof(float));
-  b->bminx = dt_alloc_align((size_t)nblock * sizeof(float));
-  b->bmaxx = dt_alloc_align((size_t)nblock * sizeof(float));
-  b->bminy = dt_alloc_align((size_t)nblock * sizeof(float));
-  b->bmaxy = dt_alloc_align((size_t)nblock * sizeof(float));
-  b->breach = dt_alloc_align((size_t)nblock * sizeof(float));
+  b->discs.cx = dt_alloc_align((size_t)n * sizeof(float));
+  b->discs.cy = dt_alloc_align((size_t)n * sizeof(float));
+  b->discs.rin2 = dt_alloc_align((size_t)n * sizeof(float));
+  b->discs.dwalk = dt_alloc_align((size_t)n * sizeof(float));
+  b->blocks.minx = dt_alloc_align((size_t)nblock * sizeof(float));
+  b->blocks.maxx = dt_alloc_align((size_t)nblock * sizeof(float));
+  b->blocks.miny = dt_alloc_align((size_t)nblock * sizeof(float));
+  b->blocks.maxy = dt_alloc_align((size_t)nblock * sizeof(float));
+  b->blocks.reach = dt_alloc_align((size_t)nblock * sizeof(float));
   b->disc_of = dt_alloc_align((size_t)n * sizeof(int));
   b->walk = dt_alloc_align((size_t)n * sizeof(float));
-  const gboolean ok = !IS_NULL_PTR(b->cx) && !IS_NULL_PTR(b->cy) && !IS_NULL_PTR(b->rin2)
-                      && !IS_NULL_PTR(b->dwalk) && !IS_NULL_PTR(b->bminx) && !IS_NULL_PTR(b->bmaxx)
-                      && !IS_NULL_PTR(b->bminy) && !IS_NULL_PTR(b->bmaxy) && !IS_NULL_PTR(b->breach)
+  const gboolean ok = !IS_NULL_PTR(b->discs.cx) && !IS_NULL_PTR(b->discs.cy) && !IS_NULL_PTR(b->discs.rin2)
+                      && !IS_NULL_PTR(b->discs.dwalk) && !IS_NULL_PTR(b->blocks.minx) && !IS_NULL_PTR(b->blocks.maxx)
+                      && !IS_NULL_PTR(b->blocks.miny) && !IS_NULL_PTR(b->blocks.maxy) && !IS_NULL_PTR(b->blocks.reach)
                       && !IS_NULL_PTR(b->disc_of) && !IS_NULL_PTR(b->walk);
   if(!ok) _outline_boundary_free(b);
   return ok;
@@ -300,27 +315,42 @@ static gboolean _outline_cells_build(_outline_boundary_t *const b, const int n)
 {
   unsigned size = 1;
   while(size < 2u * (unsigned)n) size <<= 1;
-  b->cell_head = dt_alloc_align((size_t)size * sizeof(int));
-  b->cell_next = dt_alloc_align((size_t)n * sizeof(int));
-  if(IS_NULL_PTR(b->cell_head) || IS_NULL_PTR(b->cell_next))
+  b->cells.head = dt_alloc_align((size_t)size * sizeof(int));
+  b->cells.next = dt_alloc_align((size_t)n * sizeof(int));
+  if(IS_NULL_PTR(b->cells.head) || IS_NULL_PTR(b->cells.next))
   {
-    dt_free_align(b->cell_head);
-    dt_free_align(b->cell_next);
-    b->cell_head = NULL;
-    b->cell_next = NULL;
+    dt_free_align(b->cells.head);
+    dt_free_align(b->cells.next);
+    b->cells.head = NULL;
+    b->cells.next = NULL;
     return FALSE;
   }
-  memset(b->cell_head, 0xff, (size_t)size * sizeof(int));   /* every head -1 */
-  b->cell_mask = size - 1;
+  memset(b->cells.head, 0xff, (size_t)size * sizeof(int));   /* every head -1 */
+  b->cells.mask = size - 1;
   for(int i = 0; i < n; i++)
   {
     const int cx = (int)floorf(b->border_h[2 * i]);
     const int cy = (int)floorf(b->border_h[2 * i + 1]);
-    const unsigned h = _outline_cell_hash(cx, cy) & b->cell_mask;
-    b->cell_next[i] = b->cell_head[h];
-    b->cell_head[h] = i;
+    const unsigned h = _outline_cell_hash(cx, cy) & b->cells.mask;
+    b->cells.next[i] = b->cells.head[h];
+    b->cells.head[h] = i;
   }
   return TRUE;
+}
+
+/* Is there, in the hashed cell @p h, a sample within three quarters of a pixel of (bx, by) that
+ * lies at least OUTLINE_REPEAT_MIN_WALK before the probe along the border (@p walk_limit). */
+static inline gboolean _outline_cell_repeats(const _outline_boundary_t *const b, const unsigned h, const float bx,
+                                             const float by, const float walk_limit)
+{
+  for(int k = b->cells.head[h]; k >= 0; k = b->cells.next[k])
+  {
+    if(b->walk[k] > walk_limit) continue;
+    const float ex = b->border_h[2 * k] - bx;
+    const float ey = b->border_h[2 * k + 1] - by;
+    if(ex * ex + ey * ey <= 0.5625f) return TRUE;
+  }
+  return FALSE;
 }
 
 /* Does the sample at (bx, by), reached after @p walk of border, repeat an earlier one: a
@@ -329,23 +359,14 @@ static gboolean _outline_cells_build(_outline_boundary_t *const b, const int n)
 static inline gboolean _outline_sample_repeats(const _outline_boundary_t *const b, const float bx, const float by,
                                                const float walk)
 {
-  if(IS_NULL_PTR(b->cell_head)) return FALSE;
+  if(IS_NULL_PTR(b->cells.head)) return FALSE;
   const float walk_limit = walk - OUTLINE_REPEAT_MIN_WALK;
   const int cx = (int)floorf(bx);
   const int cy = (int)floorf(by);
-  for(int dy = -1; dy <= 1; dy++)
+  for(int neighbour = 0; neighbour < 9; neighbour++)
   {
-    for(int dx = -1; dx <= 1; dx++)
-    {
-      const unsigned h = _outline_cell_hash(cx + dx, cy + dy) & b->cell_mask;
-      for(int k = b->cell_head[h]; k >= 0; k = b->cell_next[k])
-      {
-        if(b->walk[k] > walk_limit) continue;
-        const float ex = b->border_h[2 * k] - bx;
-        const float ey = b->border_h[2 * k + 1] - by;
-        if(ex * ex + ey * ey <= 0.5625f) return TRUE;
-      }
-    }
+    const unsigned h = _outline_cell_hash(cx - 1 + neighbour % 3, cy - 1 + neighbour / 3) & b->cells.mask;
+    if(_outline_cell_repeats(b, h, bx, by, walk_limit)) return TRUE;
   }
   return FALSE;
 }
@@ -360,10 +381,10 @@ static inline gboolean _outline_discs_contain(_outline_boundary_t *const b, cons
   const int blk_hi = hi / OUTLINE_BLOCK;
   for(int blk = blk_lo; blk <= blk_hi; blk++)
   {
-    const float reach = b->breach[blk];
+    const float reach = b->blocks.reach[blk];
     if(reach <= 0.0f) continue;
-    if(bx < b->bminx[blk] - reach || bx > b->bmaxx[blk] + reach || by < b->bminy[blk] - reach
-       || by > b->bmaxy[blk] + reach)
+    if(bx < b->blocks.minx[blk] - reach || bx > b->blocks.maxx[blk] + reach || by < b->blocks.miny[blk] - reach
+       || by > b->blocks.maxy[blk] + reach)
       continue;
     const int j0 = MAX(lo, blk * OUTLINE_BLOCK);
     const int j1 = MIN(hi, blk * OUTLINE_BLOCK + OUTLINE_BLOCK - 1);
@@ -371,9 +392,9 @@ static inline gboolean _outline_discs_contain(_outline_boundary_t *const b, cons
     int hit = 0;
     for(int j = j0; j <= j1; j++)
     {
-      const float ex = b->cx[j] - bx;
-      const float ey = b->cy[j] - by;
-      hit |= (ex * ex + ey * ey < b->rin2[j]);
+      const float ex = b->discs.cx[j] - bx;
+      const float ey = b->discs.cy[j] - by;
+      hit |= (ex * ex + ey * ey < b->discs.rin2[j]);
     }
     if(hit) return TRUE;
   }
@@ -399,9 +420,9 @@ static gboolean _outline_grid_build(_outline_boundary_t *const b, const float *c
   g->bw = (int)((bbox[1] - bbox[0]) / g->bucket) + 3;
   g->bh = (int)((bbox[3] - bbox[2]) / g->bucket) + 3;
   g->bucket_head = dt_alloc_align((size_t)g->bw * g->bh * sizeof(int));
-  g->run_start = dt_alloc_align((size_t)b->ndisc * sizeof(int));
-  g->run_end = dt_alloc_align((size_t)b->ndisc * sizeof(int));
-  g->run_next = dt_alloc_align((size_t)b->ndisc * sizeof(int));
+  g->run_start = dt_alloc_align((size_t)b->discs.count * sizeof(int));
+  g->run_end = dt_alloc_align((size_t)b->discs.count * sizeof(int));
+  g->run_next = dt_alloc_align((size_t)b->discs.count * sizeof(int));
   if(IS_NULL_PTR(g->bucket_head) || IS_NULL_PTR(g->run_start) || IS_NULL_PTR(g->run_end)
      || IS_NULL_PTR(g->run_next))
     return FALSE;
@@ -409,9 +430,9 @@ static gboolean _outline_grid_build(_outline_boundary_t *const b, const float *c
   for(int cell = 0; cell < g->bw * g->bh; cell++) g->bucket_head[cell] = -1;
   int nruns = 0;
   int last_cell = -1;
-  for(int d = 0; d < b->ndisc; d++)
+  for(int d = 0; d < b->discs.count; d++)
   {
-    const int cell = _outline_grid_cell(g, b->cx[d], b->cy[d]);
+    const int cell = _outline_grid_cell(g, b->discs.cx[d], b->discs.cy[d]);
     if(cell == last_cell)
     {
       g->run_end[nruns - 1] = d;   /* the walk is still in this bucket: extend its latest run */
@@ -457,24 +478,24 @@ static inline gboolean _outline_far_contains(_outline_boundary_t *const b, const
  * monotone along the discs, so both ends are a bisection. */
 static inline void _outline_window(const _outline_boundary_t *const b, const int d0, int *const lo, int *const hi)
 {
-  const float w0 = b->dwalk[d0];
+  const float w0 = b->discs.dwalk[d0];
   const float w_lo = w0 - b->window;
   int l = 0;
   int h = d0;
   while(l < h)
   {
     const int m = (l + h) / 2;
-    if(b->dwalk[m] < w_lo) l = m + 1;
+    if(b->discs.dwalk[m] < w_lo) l = m + 1;
     else h = m;
   }
   *lo = l;
   const float w_hi = w0 + b->window;
   l = d0;
-  h = b->ndisc - 1;
+  h = b->discs.count - 1;
   while(l < h)
   {
     const int m = (l + h + 1) / 2;
-    if(b->dwalk[m] > w_hi) h = m - 1;
+    if(b->discs.dwalk[m] > w_hi) h = m - 1;
     else l = m;
   }
   *hi = l;
@@ -553,26 +574,26 @@ static float _outline_discs_from_outline(const float *const points_h, const floa
     {
       walked += moved;
       const float rin = r - b->eps;
-      b->cx[ndisc] = px;
-      b->cy[ndisc] = py;
-      b->rin2[ndisc] = (rin > 0.0f) ? rin * rin : -1.0f;
-      b->dwalk[ndisc] = walked;
+      b->discs.cx[ndisc] = px;
+      b->discs.cy[ndisc] = py;
+      b->discs.rin2[ndisc] = (rin > 0.0f) ? rin * rin : -1.0f;
+      b->discs.dwalk[ndisc] = walked;
       const int blk = ndisc / OUTLINE_BLOCK;
       if(ndisc % OUTLINE_BLOCK == 0)
       {
-        b->bminx[blk] = px;
-        b->bmaxx[blk] = px;
-        b->bminy[blk] = py;
-        b->bmaxy[blk] = py;
-        b->breach[blk] = fmaxf(rin, 0.0f);
+        b->blocks.minx[blk] = px;
+        b->blocks.maxx[blk] = px;
+        b->blocks.miny[blk] = py;
+        b->blocks.maxy[blk] = py;
+        b->blocks.reach[blk] = fmaxf(rin, 0.0f);
       }
       else
       {
-        b->bminx[blk] = fminf(b->bminx[blk], px);
-        b->bmaxx[blk] = fmaxf(b->bmaxx[blk], px);
-        b->bminy[blk] = fminf(b->bminy[blk], py);
-        b->bmaxy[blk] = fmaxf(b->bmaxy[blk], py);
-        b->breach[blk] = fmaxf(b->breach[blk], rin);
+        b->blocks.minx[blk] = fminf(b->blocks.minx[blk], px);
+        b->blocks.maxx[blk] = fmaxf(b->blocks.maxx[blk], px);
+        b->blocks.miny[blk] = fminf(b->blocks.miny[blk], py);
+        b->blocks.maxy[blk] = fmaxf(b->blocks.maxy[blk], py);
+        b->blocks.reach[blk] = fmaxf(b->blocks.reach[blk], rin);
       }
       ndisc++;
       r_max = fmaxf(r_max, r);
@@ -582,8 +603,8 @@ static float _outline_discs_from_outline(const float *const points_h, const floa
     }
     b->disc_of[i] = ndisc - 1;
   }
-  b->ndisc = ndisc;
-  b->nblock = (ndisc + OUTLINE_BLOCK - 1) / OUTLINE_BLOCK;
+  b->discs.count = ndisc;
+  b->blocks.count = (ndisc + OUTLINE_BLOCK - 1) / OUTLINE_BLOCK;
   b->border_h = border_h;
   /* the sample is one radius from its spine point, the hiding disc's centre one radius from
    * the sample, and each of them half a pixel from its disc's centre */
@@ -747,7 +768,7 @@ int dt_masks_outline_boundary_skips(const float *const points, const float *cons
     dt_print(DT_DEBUG_MASKS,
              "[masks] boundary pass: %d samples, %d discs, radius %.0f, %ld probes, %ld disc tests, %d dropped;"
              " prepared in %.1f ms, probed in %.1f ms\n",
-             n, b.ndisc, r_max, b.probes, b.disc_tests, ndropped, 1000.0 * (prepared - start),
+             n, b.discs.count, r_max, b.probes, b.disc_tests, ndropped, 1000.0 * (prepared - start),
              1000.0 * (dt_get_wtime() - prepared));
   _outline_boundary_free(&b);
 

--- a/src/develop/masks/polygon.c
+++ b/src/develop/masks/polygon.c
@@ -339,7 +339,7 @@ static gboolean _polygon_is_clockwise(dt_masks_form_t *mask_form)
 static void _polygon_points_recurs_border_gaps(const float *const center_max, const float *const border_min,
                                                const float *const border_max, dt_masks_dynbuf_t *draw_points,
                                                dt_masks_dynbuf_t *draw_border,
-                                               gboolean clockwise)
+                                               gboolean clockwise, const int step)
 {
   // we want to find the start and end angles
   double angle_start = atan2f(border_min[1] - center_max[1], border_min[0] - center_max[0]);
@@ -362,12 +362,12 @@ static void _polygon_points_recurs_border_gaps(const float *const center_max, co
   const float radius_end = sqrtf((border_max[1] - center_max[1]) * (border_max[1] - center_max[1])
                                  + (border_max[0] - center_max[0]) * (border_max[0] - center_max[0]));
 
-  // and the max length of the circle arc
+  // and the max length of the circle arc, in samples
   int step_count = 0;
   if(angle_end > angle_start)
-    step_count = (angle_end - angle_start) * fmaxf(radius_start, radius_end);
+    step_count = (angle_end - angle_start) * fmaxf(radius_start, radius_end) / (float)step;
   else
-    step_count = (angle_start - angle_end) * fmaxf(radius_start, radius_end);
+    step_count = (angle_start - angle_end) * fmaxf(radius_start, radius_end) / (float)step;
   if(step_count < 2) return;
 
   // and now we add the points
@@ -587,7 +587,7 @@ static void _polygon_joint_arc(const _polygon_walk_t *const w, const float *cons
 {
   if(fabsf(to[0] - from[0]) <= 1.0f && fabsf(to[1] - from[1]) <= 1.0f) return;
   const gboolean clockwise = dt_masks_outline_short_way(centre, from, to, w->clockwise);
-  _polygon_points_recurs_border_gaps(centre, from, to, w->dpoints, w->dborder, clockwise);
+  _polygon_points_recurs_border_gaps(centre, from, to, w->dpoints, w->dborder, clockwise, w->pixel_threshold);
 }
 
 /* One segment of the walk: the joint at its start node, then every sample within a pixel of
@@ -689,10 +689,10 @@ static int _polygon_get_pts_border(dt_develop_t *develop, dt_masks_form_t *mask_
   const float input_width = dist->iwidth;
   const float input_height = dist->iheight;
 
-  /* Fixed at one pixel: the interior fill is a scanline over these samples and needs every
-   * row crossed; the pipe's mask_rasterization_step is a spoke-spacing budget, not a
-   * scanline one. */
-  const int pixel_threshold = 1;
+  /* The pipe's is fixed at one pixel: its interior fill is a scanline over these samples and
+   * needs every row crossed, and its mask_rasterization_step is a spoke-spacing budget, not a
+   * scanline one. The GUI fills nothing and samples at the density it shows. */
+  const int pixel_threshold = IS_NULL_PTR(dist->pipe) ? dist->rasterization_step : 1;
   const int node_count = (int)g_list_length(mask_form->points);
 
   dt_masks_dynbuf_t *dpoints = dt_masks_dynbuf_init(1000000, "polygon dpoints");

--- a/src/develop/masks_gui.h
+++ b/src/develop/masks_gui.h
@@ -182,10 +182,26 @@ typedef struct dt_masks_form_gui_t
    * the outlines of every shape in the group rebuilt on every mouse move, and the 1/60 s throttle
    * in dt_masks_gui_form_create_throttled() bypassed by its own force_rebuild clause. */
   uint64_t geometry_generation;
+  /* The sampling density of the outlines, in image pixels between consecutive samples. The
+   * expose publishes the density the view shows, from what one device pixel spans, into the
+   * dev's own GUI state (dt_masks_gui_set_outline_density()), and every build reads it from
+   * there through dt_masks_gui_outline_step() -- so on any other GUI state, the creation
+   * session's for one, ::outline_step is not consulted. ::outline_step_built is the density the
+   * outlines in ::points were built at, on every state that holds outlines; a difference from
+   * the density in force is a rebuild, like a geometry move. An outline sampled finer than the
+   * screen can show costs its whole build, its transform, its boundary pass and its hit test for
+   * nothing: at fit zoom on a 24 Mpx raw that was five samples per device pixel. */
+  int outline_step;
+  int outline_step_built;
 } dt_masks_form_gui_t;
 
 /** Reset a form GUI state and bind it to its owning develop instance (gui->dev). */
 void dt_masks_init_form_gui(dt_develop_t *dev, dt_masks_form_gui_t *gui);
+/** Publish the density the view shows into the dev's GUI state: @p image_px_per_device_px is
+ * what one device pixel spans in image pixels (dt_draw_min_emit_step() on the transformed
+ * context). The outlines are sampled at whole image pixels, never finer than one.
+ * dt_masks_gui_outline_step() (masks/masks_distort.h) reads it back. */
+void dt_masks_gui_set_outline_density(dt_masks_form_gui_t *gui, double image_px_per_device_px);
 dt_masks_form_t *dt_masks_get_visible_form(const struct dt_develop_t *dev);
 void dt_masks_set_visible_form(struct dt_develop_t *dev, dt_masks_form_t *form);
 void dt_masks_gui_init(struct dt_develop_t *dev);

--- a/tests/masks/masks_geometry.c
+++ b/tests/masks/masks_geometry.c
@@ -42,6 +42,7 @@
 #include "develop/masks.h"
 #include "develop/masks_debug.h"
 #include "develop/masks/masks_functions.h"
+#include "develop/masks/masks_distort.h"
 #include "math/math.h"
 #include "system/mem_alloc.h"
 
@@ -681,6 +682,31 @@ static void _surface_diff(cairo_surface_t *const a, cairo_surface_t *const b,
 }
 
 static const char *baseline_dir = NULL;
+
+/* MASKS_OUTLINE_STEP=<n> has the corpus build every GUI outline every n image pixels -- the
+ * density the darkroom shows a zoomed-out image at -- so the band check judges what a user sees
+ * at fit zoom; unset, the corpus judges pixel-accurate outlines. The baselines are step-1
+ * pictures and are not compared at any other step. --time-overlay takes its density from its
+ * view (MASKS_OVERLAY_VIEW), the way the darkroom does: the expose publishes it from the
+ * transformed context, which is also why the corpus re-applies its own before every build --
+ * the overlay it writes beside each case is drawn at full resolution and publishes 1. */
+static int _outline_step_override = 0;
+
+/* Give @p dev a GUI state with the density its outlines are built at: the override when set,
+ * else @p image_px_per_device_px. */
+static void _outline_density_apply(dt_develop_t *dev, const double image_px_per_device_px)
+{
+  if(IS_NULL_PTR(dev->form_gui))
+  {
+    dev->form_gui = (dt_masks_form_gui_t *)calloc(1, sizeof(dt_masks_form_gui_t));
+    if(IS_NULL_PTR(dev->form_gui)) return;
+    dt_masks_init_form_gui(dev, dev->form_gui);
+  }
+  dt_masks_gui_set_outline_density(dev->form_gui, (_outline_step_override > 0) ? (double)_outline_step_override
+                                                                                 : image_px_per_device_px);
+}
+
+
 static gboolean baseline_update = FALSE;
 static gboolean time_overlay = FALSE;
 static int time_overlay_frames = 30;
@@ -691,6 +717,11 @@ static int baseline_missing = 0;
 static gboolean _baseline_check(const char *path, const char *name)
 {
   if(IS_NULL_PTR(baseline_dir)) return TRUE;
+  if(_outline_step_override > 1)
+  {
+    printf("      baseline: not compared, the outline is sampled every %d px\n", _outline_step_override);
+    return TRUE;
+  }
 
   char *base = g_strdup_printf("%s/%s.png", baseline_dir, name);
 
@@ -849,6 +880,7 @@ static _band_t _outline_band_check(dt_develop_t *dev, dt_masks_form_t *form, con
   int skip_count = 0;
   dt_masks_skip_range_t *skips = NULL;
 
+  _outline_density_apply(dev, 1.0);
   const double t0 = dt_get_wtime();
   const dt_masks_raster_result_t st = dt_masks_get_points_border(dev, form, &points, &points_count, &border,
                                                                  &border_count, &skips, &skip_count, 0, NULL);
@@ -1443,10 +1475,10 @@ static void _overlay_report(dt_develop_t *dev, const char *name, const int img_w
     _overlay_skipped(gp, &skipped, &skip_ranges);
     if(selected) _overlay_dump_skips(gp, name, transform);
   }
-  printf("[TIME] %-26s %5dx%-4d %-8s %7.2f ms/frame  (first frame incl. build %7.2f ms;"
+  printf("[TIME] %-26s %5dx%-4d %-8s %7.2f ms/frame  (first frame incl. build %7.2f ms at step %d;"
          " %d outline samples, %d border samples, %d skipped in %d ranges)\n",
-         name, img_w, img_h, selected ? "selected" : "member", timing->per_frame_ms, timing->build_ms, points, border,
-         skipped, skip_ranges);
+         name, img_w, img_h, selected ? "selected" : "member", timing->per_frame_ms, timing->build_ms,
+         dt_masks_gui_outline_step(dev), points, border, skipped, skip_ranges);
 }
 
 static void _time_overlay_form(dt_develop_t *dev, dt_masks_form_t *form, const char *name, const char *dir,
@@ -1890,6 +1922,11 @@ int main(int argc, char *argv[])
   dt_geometry_chain_rebuild(&dev);
   printf("geometry chain authoritative: %s\n",
          dt_geometry_chain_authoritative(dev.geometry_chain) ? "yes" : "NO -- outlines will be empty");
+
+  const char *step_env = g_getenv("MASKS_OUTLINE_STEP");
+  if(!IS_NULL_PTR(step_env)) _outline_step_override = MAX(0, atoi(step_env));
+  if(!time_overlay && _outline_step_override > 0)
+    printf("GUI outlines sampled every %d px\n", _outline_step_override);
 
   if(time_overlay)
   {


### PR DESCRIPTION
Item 2 of #1391: a dragged shape's outline is rebuilt on every motion, and on a large brush the rebuild, not the drawing, was the frame. Two changes, each measured with `ansel-test-masks-geometry` before and after.

## The boundary pass counts its discs

Instrumented, 70–90% of a rebuild was the boundary pass (17.7 of a 1313 cusp's 20 ms, ~100 of the 1074 flare's 107): 430 disc tests per probe at 4.5 ns each, a `hypot` in every one for the copy test, and half the far tests re-testing the other pass's mirror discs.

- The near window is a **length of walk** (bisection on the walk to each disc's centre): a disc can hide a sample only if the two centres are within two radii in the plane, hence within two radii along the spine. It used to be a count of discs, which is a different length wherever the radius steps and ten times too wide at the screen's density.
- The discs are flat arrays (centre x, centre y, squared radius less the tolerance) tested by squared distance in blocks of eight, each block carrying its centres' box and largest radius. No square root in the loop.
- The copy test lives in a hash of the samples by pixel cell and reads the nine cells around the probe.

Same skip ranges to the sample on the whole corpus, baselines bit-identical. Per probe: 126–470 tests at ~2.5 ns; the pass on the cusp 19 → 7 ms, on the flare ~100 → ~25 ms.

## The GUI outline is sampled at the density the screen shows

It was sampled at one image pixel whatever the zoom: at fit zoom on a 24 Mpx raw that is five samples per device pixel, and the recursion stops on integer parts, so it lays several around every integer crossing (53,917 samples for a border ~10,000 px long). Everything downstream is paid per sample: the distortion transform, the boundary pass, the stroke and the hit test.

The expose now publishes what one device pixel spans (`dt_draw_min_emit_step()` on the transformed context, the measure the circle already decimated by) into the dev's GUI state; `dt_masks_distort_for_gui()` reads it back through `dt_masks_gui_outline_step(dev)`, so a drag's rebuild, an expose's and the creation session's all compose at the density in force without their callers knowing it. `outline_step_built` joins the geometry generation in the cache key. The pipe's walk is untouched (its arcs and stamps keep one sample per pixel through the walk's own `arc_step`), so no raster changes under a preference; the polygon's threshold stays pinned at 1 for the pipe's scanline fill.

First frame after a rebuild of the selected shape, corpus at 2560×1440:

| shape | before (step 1) | 1:1, step 1 | fit, step 2 | quarter, step 4 |
| --- | ---: | ---: | ---: | ---: |
| brush-1313-cusp | 29 ms | 18 | 4.7 | 2.9 |
| brush-1074-flare | 103 ms | 33 | 12.9 | 5.4 |
| brush-1360-pressure-ramp | 69 ms | 39 | 13.6 | 6.2 |
| polygon-comb | 49 ms | 28 | 15.6 | 6.1 |
| group of 11, every member | 459 ms | 218 | 80 | 30 |

Per-frame stroking drops with it (cusp 4.0 → 1.4 ms/frame at fit), and so will the hit test (item 3), which walks the same samples.

## Validation

- Corpus at step 1: every baseline bit-identical, band check 0 inside / 0 outside everywhere.
- `MASKS_OUTLINE_STEP=3` and `=5`: the coarser outlines judged against the same full-resolution maps, 0 inside / 0 outside on every case (the harness gained that knob; the baselines are step-1 pictures and are skipped at any other step).
- `--time-overlay` at fit, 1:1 and quarter views: hidpi placement and leftover checks pass; the fit-view PNGs of the cusp, the flare, the pressure ramp and the comb inspected.
- Unit tests, GCC RelWithDebInfo, clang `build-warnsweep`, `build-nofeatures`, and the `tools/check_*` gates.
- Not verifiable here: the darkroom itself (no display). What to look at: drag a large brush at fit zoom and at 100%, zoom in and out across a step boundary (the outline rebuilds once per step change, `-d masks` prints `outline cache: ... at step N`), and the creation session while zoomed out.

Docs: `doc/brush-boundary.md` (walk-length window, flat arrays, sample hash, the density section with the corpus at three steps), `doc/darkroom-redraw.md` (the rebuild priced per view), CLAUDE.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
