### PR TITLE
masks: a hit test asks the shape's box before walking a sample (#1391 item 3)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1213,6 +1213,20 @@ rules that were each paid for by a reported defect:
   and are not compared at any other step. The corpus dev has no expose, so the harness
   re-applies its density before every build: the overlay it writes beside each case goes
   through the darkroom's expose at full resolution, which publishes 1.
+- **A hit test asks the shape's box before walking a sample.** A motion hit-tests the SELECTED
+  member only (nodes, handles, then every sample through `get_distance`), throttled to half a
+  cursor radius; a press hit-tests every member to choose one. #1391's "a million distance tests
+  per motion" was a press at the raw density; measured with `--time-overlay`'s `[HIT]` sweep
+  (20x20 positions), a motion after the density change is 0.01-0.8 ms and a press on 11 members
+  0.6-3.6 ms. `dt_masks_form_gui_points_t::bbox` spans points, border and source, filled by
+  `dt_masks_gui_points_update_bbox()` when `dt_masks_gui_form_create()` builds the entry and
+  emptied by `dt_masks_gui_form_remove()`; the four sample-walking hit tests (brush, polygon,
+  circle, ellipse) return their initialised "nothing" answers when `dt_masks_gui_points_reach()`
+  says the cursor, grown by twice its radius, cannot touch the box -- twice because the ellipse
+  tests its border at 1.5 radii. Those answers are exactly the walk's for such a cursor, which
+  is why every consumer reads the flags and none the distance. The gradient walks no samples and
+  has no box test. Measured: a motion 0.003-0.5 ms, a press on the group 0.26 ms at fit and
+  1.6 at 1:1, the same hits at every position.
 - **The dash phase is the arc length along the whole stroke, not along each sub-path.** An
   outline is one cairo path of many sub-paths, one per kept run between skips, and cairo (and
   the rasteriser, at first) restarts the dash pattern at every sub-path, so dashes bunched and

--- a/doc/darkroom-redraw.md
+++ b/doc/darkroom-redraw.md
@@ -149,6 +149,28 @@ first frame after a rebuild of the selected shape, corpus at 2560x1440:
 `-d masks -d perf` prints `[masks] boundary pass: ... probed in N ms` per rebuild, and
 `[masks] outline cache: held for geometry G at step S` says why a frame rebuilt.
 
+A pointer motion also HIT-TESTS the selected shape -- its nodes and handles, then every sample
+through the shape's `get_distance` -- and a button press hit-tests every member of the group
+to choose one. #1391's third item put that at a million distance tests per motion; measured
+with `ansel-test-masks-geometry --time-overlay`, which sweeps a 20x20 grid of positions over
+the image and times both events (`[HIT]` lines), that was a PRESS at the old raw density. After
+the density change a motion cost 0.01-0.17 ms at fit and 0.09-0.78 ms at 1:1 (the comb
+polygon), a press on the 11-member group 0.56 and 3.6 ms. Each cache entry now carries the box
+its samples span (`dt_masks_form_gui_points_t::bbox`, filled with the outline), and every
+sample-walking hit test asks it first (`dt_masks_gui_points_reach()`, the cursor grown by twice
+its radius): four comparisons answer "nothing here" for a shape the cursor is not near, which
+on a press is most of the group.
+
+| event | before, fit | after, fit | before, 1:1 | after, 1:1 |
+| --- | ---: | ---: | ---: | ---: |
+| motion, 1313 cusp selected | 0.017 ms | 0.003 ms | 0.166 ms | 0.029 ms |
+| motion, comb polygon selected | 0.165 ms | 0.099 ms | 0.78 ms | 0.51 ms |
+| press, group of 11 | 0.56 ms | 0.26 ms | 3.6 ms | 1.6 ms |
+
+The same positions hit the same shapes before and after. What remains is the shape the cursor
+IS near, walked at the screen's density; the comb spans most of the frame, so its box prunes
+little.
+
 ## Reading it
 
 `-d perf` prints `[darkroom] surface prepared / image painted / overlay predicates / overlays

--- a/src/develop/masks/brush.c
+++ b/src/develop/masks/brush.c
@@ -1369,6 +1369,10 @@ static void _brush_get_distance(float point_x, float point_y, float radius,
   dt_masks_form_gui_points_t *gui_points
       = (dt_masks_form_gui_points_t *)g_list_nth_data(mask_gui->points, form_index);
   if(IS_NULL_PTR(gui_points)) return;
+  /* Nothing to walk when the cursor cannot reach a sample: the box every sample spans, grown by
+   * the cursor's reach, answers for the whole shape in four comparisons, and every answer
+   * initialised above is what the walk would have given -- nothing inside, nothing near. */
+  if(!dt_masks_gui_points_reach(gui_points, point_x, point_y, 2.0f * radius)) return;
 
   float min_dist = FLT_MAX;
 

--- a/src/develop/masks/circle.c
+++ b/src/develop/masks/circle.c
@@ -66,6 +66,10 @@ static void _circle_get_distance(float x, float y, float as, dt_masks_form_gui_t
 
   dt_masks_form_gui_points_t *gpt = (dt_masks_form_gui_points_t *)g_list_nth_data(gui->points, index);
   if(IS_NULL_PTR(gpt)) return;
+  /* Nothing to walk when the cursor cannot reach a sample: the box every sample spans, grown by
+   * the cursor's reach, answers for the whole shape in four comparisons, and every answer
+   * initialised above is what the walk would have given -- nothing inside, nothing near. */
+  if(!dt_masks_gui_points_reach(gpt, x, y, 2.0f * as)) return;
 
   // we first check if we are inside the source form
   const float pt[2] = { x, y };

--- a/src/develop/masks/ellipse.c
+++ b/src/develop/masks/ellipse.c
@@ -194,6 +194,10 @@ static void _ellipse_get_distance(float x, float y, float mouse_radius, dt_masks
 
   dt_masks_form_gui_points_t *gpt = (dt_masks_form_gui_points_t *)g_list_nth_data(gui->points, index);
   if(IS_NULL_PTR(gpt)) return;
+  /* Nothing to walk when the cursor cannot reach a sample: the box every sample spans, grown by
+   * the cursor's reach, answers for the whole shape in four comparisons, and every answer
+   * initialised above is what the walk would have given -- nothing inside, nothing near. */
+  if(!dt_masks_gui_points_reach(gpt, x, y, 2.0f * mouse_radius)) return;
 
   const float pt[2] = { x, y };
 

--- a/src/develop/masks/masks_gui.c
+++ b/src/develop/masks/masks_gui.c
@@ -1962,6 +1962,7 @@ void dt_masks_gui_form_create(dt_masks_form_t *mask_form, dt_masks_form_gui_t *m
          != DT_MASKS_RASTER_OK)
         return;
     }
+    dt_masks_gui_points_update_bbox(gui_points);
     mask_gui->geometry_generation = dt_geometry_chain_generation(mask_gui->dev->geometry_chain);
     mask_gui->outline_step_built = dt_masks_gui_outline_step(mask_gui->dev);
     mask_gui->formid = mask_form->formid;
@@ -2404,6 +2405,31 @@ gboolean dt_masks_gui_remove(struct dt_iop_module_t *module, dt_masks_form_t *ma
   return FALSE;
 }
 
+static void _gui_points_bbox_extend(float *const bbox, const float *const samples, const int count)
+{
+  for(int i = 0; i < count; i++)
+  {
+    const float x = samples[2 * i];
+    const float y = samples[2 * i + 1];
+    bbox[0] = fminf(bbox[0], x);
+    bbox[1] = fmaxf(bbox[1], x);
+    bbox[2] = fminf(bbox[2], y);
+    bbox[3] = fmaxf(bbox[3], y);
+  }
+}
+
+void dt_masks_gui_points_update_bbox(dt_masks_form_gui_points_t *gp)
+{
+  if(IS_NULL_PTR(gp)) return;
+  gp->bbox[0] = FLT_MAX;
+  gp->bbox[1] = -FLT_MAX;
+  gp->bbox[2] = FLT_MAX;
+  gp->bbox[3] = -FLT_MAX;
+  if(!IS_NULL_PTR(gp->points)) _gui_points_bbox_extend(gp->bbox, gp->points, gp->points_count);
+  if(!IS_NULL_PTR(gp->border)) _gui_points_bbox_extend(gp->bbox, gp->border, gp->border_count);
+  if(!IS_NULL_PTR(gp->source)) _gui_points_bbox_extend(gp->bbox, gp->source, gp->source_count);
+}
+
 void dt_masks_gui_form_remove(dt_masks_form_t *mask_form, dt_masks_form_gui_t *mask_gui, int form_index)
 {
   dt_masks_form_gui_points_t *gui_points
@@ -2423,6 +2449,7 @@ void dt_masks_gui_form_remove(dt_masks_form_t *mask_form, dt_masks_form_gui_t *m
     gui_points->border_skips = NULL;
     dt_pixelpipe_cache_free_align(gui_points->source);
     gui_points->source = NULL;
+    dt_masks_gui_points_update_bbox(gui_points);   /* empty */
   }
 }
 

--- a/src/develop/masks/polygon.c
+++ b/src/develop/masks/polygon.c
@@ -1171,6 +1171,10 @@ static void _polygon_get_distance(float point_x, float point_y, float radius,
   dt_masks_form_gui_points_t *gui_points
       = (dt_masks_form_gui_points_t *)g_list_nth_data(mask_gui->points, form_index);
   if(IS_NULL_PTR(gui_points)) return;
+  /* Nothing to walk when the cursor cannot reach a sample: the box every sample spans, grown by
+   * the cursor's reach, answers for the whole shape in four comparisons, and every answer
+   * initialised above is what the walk would have given -- nothing inside, nothing near. */
+  if(!dt_masks_gui_points_reach(gui_points, point_x, point_y, 2.0f * radius)) return;
 
   float min_dist_pixel = FLT_MAX;
 

--- a/src/develop/masks_gui.h
+++ b/src/develop/masks_gui.h
@@ -72,7 +72,23 @@ typedef struct dt_masks_form_gui_points_t
   float *source;   // source point in absolute coordinates in output image space
   int source_count;
   gboolean clockwise;
+  /* The box every sample above spans -- points, border and source alike, in the same space --
+   * so a hit test can answer "nothing here" without walking them: minx, maxx, miny, maxy; empty
+   * (min above max) when there is no sample. dt_masks_gui_points_update_bbox() fills it. */
+  float bbox[4];
 } dt_masks_form_gui_points_t;
+
+/** Can a cursor at (x, y), reaching @p reach around itself, touch a sample of @p gp at all:
+ * the box test every hit test runs before walking the samples. An empty box reaches nothing. */
+static inline gboolean dt_masks_gui_points_reach(const dt_masks_form_gui_points_t *gp, const float x,
+                                                 const float y, const float reach)
+{
+  return x >= gp->bbox[0] - reach && x <= gp->bbox[1] + reach && y >= gp->bbox[2] - reach
+         && y <= gp->bbox[3] + reach;
+}
+
+/** Recompute ::bbox from the samples @p gp holds. */
+void dt_masks_gui_points_update_bbox(dt_masks_form_gui_points_t *gp);
 
 
 /** structure used to display a form */

--- a/tests/masks/masks_geometry.c
+++ b/tests/masks/masks_geometry.c
@@ -43,6 +43,7 @@
 #include "develop/masks_debug.h"
 #include "develop/masks/masks_functions.h"
 #include "develop/masks/masks_distort.h"
+#include "widgets/widget_settings.h"
 #include "math/math.h"
 #include "system/mem_alloc.h"
 
@@ -1481,6 +1482,75 @@ static void _overlay_report(dt_develop_t *dev, const char *name, const int img_w
          dt_masks_gui_outline_step(dev), points, border, skipped, skip_ranges);
 }
 
+/* THE HIT TEST, timed. A pointer motion hit-tests the selected member only -- its nodes and
+ * handles, then its samples through get_distance -- and a button press hit-tests every member
+ * to choose one; both walk the outlines at the density they were built at. A grid of positions
+ * over the whole image says what each costs per event, and how many positions find a shape. */
+static void _time_hit_test(dt_develop_t *dev, dt_masks_form_t *form, const char *name, const int img_w,
+                           const int img_h)
+{
+  dt_masks_form_gui_t *gui = dev->form_gui;
+  const int per_axis = 20;
+  const float radius = 10.0f;
+  dt_widget_set_mouse_radius(radius, radius);
+  gui->group_selected = 0;
+  /* nothing is being dragged: a drag index of 0 would answer every motion with "node 0" */
+  dt_masks_gui_reset_dragging(gui);
+
+  GList *members = NULL;
+  if(form->type & DT_MASKS_GROUP)
+  {
+    for(const GList *node = form->points; node; node = g_list_next(node))
+    {
+      const dt_masks_form_group_t *entry = (const dt_masks_form_group_t *)node->data;
+      dt_masks_form_t *member = dt_masks_get_from_id(dev, entry->formid);
+      if(!IS_NULL_PTR(member)) members = g_list_append(members, member);
+    }
+  }
+  else
+    members = g_list_append(members, form);
+  if(IS_NULL_PTR(members)) return;
+  dt_masks_form_t *selected = (dt_masks_form_t *)members->data;
+
+  double hover_seconds = 0.0;
+  double press_seconds = 0.0;
+  int hits = 0;
+  const int positions = per_axis * per_axis;
+  for(int p = 0; p < positions; p++)
+  {
+    gui->pos[0] = (float)img_w * ((float)(p % per_axis) + 0.5f) / (float)per_axis;
+    gui->pos[1] = (float)img_h * ((float)(p / per_axis) + 0.5f) / (float)per_axis;
+    gui->raw_pos[0] = gui->pos[0];
+    gui->raw_pos[1] = gui->pos[1];
+
+    double t0 = dt_get_wtime();
+    if(!IS_NULL_PTR(selected->functions->update_hover)) selected->functions->update_hover(selected, gui, 0);
+    hover_seconds += dt_get_wtime() - t0;
+
+    t0 = dt_get_wtime();
+    int index = 0;
+    for(const GList *node = members; node; node = g_list_next(node), index++)
+    {
+      dt_masks_form_t *member = (dt_masks_form_t *)node->data;
+      if(IS_NULL_PTR(member->functions->get_distance)) continue;
+      int inside = 0;
+      int inside_border = 0;
+      int near_handle = -1;
+      int inside_source = 0;
+      float dist = FLT_MAX;
+      member->functions->get_distance(gui->pos[0], gui->pos[1], radius, gui, index, g_list_length(member->points),
+                                      &inside, &inside_border, &near_handle, &inside_source, &dist);
+      if(inside || inside_border || near_handle >= 0 || inside_source) hits++;
+    }
+    press_seconds += dt_get_wtime() - t0;
+  }
+  printf("[HIT]  %-26s hover %.3f ms/motion (%s), press %.3f ms/click (%d members), %d hits over %d positions,"
+         " at step %d\n",
+         name, 1000.0 * hover_seconds / positions, selected->name, 1000.0 * press_seconds / positions,
+         g_list_length(members), hits, positions, dt_masks_gui_outline_step(dev));
+  g_list_free(members);
+}
+
 static void _time_overlay_form(dt_develop_t *dev, dt_masks_form_t *form, const char *name, const char *dir,
                                const int img_w, const int img_h, const int frames)
 {
@@ -1560,6 +1630,7 @@ static void _time_overlay_form(dt_develop_t *dev, dt_masks_form_t *form, const c
       failures++;
     }
   }
+  _time_hit_test(dev, form, name, img_w, img_h);
   cairo_surface_destroy(surface);
 }
 


### PR DESCRIPTION
Item 3 of #1391, measured before it was built.

## What a motion actually costs

The item said hover walks every shape and every sample, a million distance tests per pointer event on a 26-brush group. `ansel-test-masks-geometry --time-overlay` now sweeps a 20×20 grid of positions over every case and times both events (`[HIT]` lines): a **motion** hit-tests the selected member only (nodes and handles, then its samples through `get_distance`, throttled to half a cursor radius); it is a **press** that hit-tests every member to choose one. The million was a press at the old raw density. After #1393 a motion costs 0.01–0.17 ms at fit and 0.09–0.78 ms at 1:1 (the comb polygon), a press on the 11-member group 0.56 / 3.6 ms.

## The box

Each outline cache entry (`dt_masks_form_gui_points_t`) now carries the box its samples span — points, border and source — filled with the outline and emptied with it. The four hit tests that walk samples (brush, polygon, circle, ellipse) ask `dt_masks_gui_points_reach()` first: a cursor grown by twice its radius that cannot touch the box gets the answers the walk would have given, nothing inside and nothing near, in four comparisons. Twice the radius because the ellipse tests its border at 1.5 radii; the gradient walks no samples and has no box test. Every consumer reads the flags and none the distance, which is what makes the early answers exact.

| event | before, fit | after, fit | before, 1:1 | after, 1:1 |
| --- | ---: | ---: | ---: | ---: |
| motion, 1313 cusp selected | 0.017 ms | 0.003 ms | 0.166 ms | 0.029 ms |
| motion, comb polygon selected | 0.165 ms | 0.099 ms | 0.78 ms | 0.51 ms |
| press, group of 11 | 0.56 ms | 0.26 ms | 3.6 ms | 1.6 ms |

The same positions hit the same shapes before and after. What remains is the shape the cursor is near, walked at the screen's density; the comb spans most of the frame, so its box prunes little.

## Validation

- Corpus and baselines unchanged (the hit test is not on the raster path); unit tests; GCC, clang `build-warnsweep`, `build-nofeatures`; the `tools/check_*` gates; the pre-commit image smoke test.
- Not verifiable here: the darkroom. Hovering and clicking on a group should select and highlight exactly as before; the only observable change is speed.

Docs: `doc/darkroom-redraw.md` (the hit test priced), CLAUDE.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
