### PR TITLE
navigation, darkroom: the thumbnail composes once per state, a same-size configure does nothing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2053,6 +2053,30 @@ The views are plugins: `ninja ansel` does NOT compile `src/views/*.c`. Build eve
 (`ninja`) before trusting a darkroom edit; a use of an undeclared variable in `darkroom.c`
 survived an `ansel` build here.
 
+### A widget under a translucent overlay is repainted whenever the overlay is, so its draw must be cheap
+
+The resize grips (`widgets/resize_handle.c`) are GtkEventBox overlay children floating over
+the area they resize, invisible until hovered. GTK3 composites overlay children over the main
+child, so invalidating the grip -- its `:hover` state, its cursor, its redraw on enter and
+leave -- exposes the main child under it with a clip of the grip's strip, and the main child's
+`draw` handler runs. The navigation thumbnail answered every such expose with a fresh full-size
+surface, a background render, the thumbnail copy and a pango layout (`libs/navigation.c`); it
+now composes once per state (`_lib_navigation_picture_key()`: preview hash, size, image,
+viewport, preview plan) and blits the composed surface on any expose with an equal key. Any
+draw handler placed under an overlay owes the same: paint from a cache keyed on its inputs,
+never re-derive per expose. `-d perf` prints the clip with each navigation redraw, which is
+how a grip's expose is told from a request of the module's own.
+
+The other way a hover reaches every widget is a layout pass: the theme gives every hovered
+tab and button `font-weight: 500`, which changes the widget's size request, and GTK then
+allocates the whole window again. The centre's `configure-event` used to re-plan both pipes,
+recompute the thumbnail size and raise `DT_SIGNAL_CONTROL_REDRAW_ALL` on every allocation;
+`dt_dev_configure_real()` now returns when the viewport box it publishes comes back unchanged
+(`dt_dev_viewport_set_box()` reports it), so only the first configure and a real size, border
+or zoom change do any of that. `ansel -d signal --d-signal-act raise,print-trace --d-signal
+DT_SIGNAL_CONTROL_REDRAW_ALL` backtraces every raise, which is the tool for the next report of
+"X redraws when I hover Y".
+
 ### A rotated GtkLabel sizes the column it sits in
 
 A `GtkLabel` with `gtk_label_set_angle()` requests the width of its *slanted* bounding box, so a

--- a/doc/darkroom-redraw.md
+++ b/doc/darkroom-redraw.md
@@ -149,6 +149,37 @@ first frame after a rebuild of the selected shape, corpus at 2560x1440:
 `-d masks -d perf` prints `[masks] boundary pass: ... probed in N ms` per rebuild, and
 `[masks] outline cache: held for geometry G at step S` says why a frame rebuilt.
 
+## The navigation thumbnail, and a configure that changes nothing
+
+Two more sources of GUI-thread work that a pointer motion over an unrelated widget could
+reach, found when the navigation thumbnail was seen repainting on every hover over a
+notebook tab or a panel edge:
+
+- **The navigation composes its picture once per state.** `libs/navigation.c` used to answer
+  every expose with a fresh full-size surface, a background render, the thumbnail copy, a
+  pango layout for the zoom label and the arrow, then a blit. Exposes it did not ask for are
+  the rule: the resize grip floating over the area is a translucent overlay, so GTK repaints
+  what lies under it every time the grip is hovered (the clip is then a strip along the edge),
+  and a whole-window redraw reaches it like any other widget. The picture is now keyed on
+  everything it depends on -- the preview frame's hash, the widget's size, the image, the
+  viewport state and the preview's plan -- and an expose with an equal key is one blit.
+  `-d perf` prints `[navigation] redraw: cached|composed, clip WxH at x,y of WxH`, which also
+  says who asked: the whole widget is a request of the module's own, a strip is the grip.
+- **A configure that changes nothing does nothing.** `dt_dev_configure_real()` used to re-plan
+  both pipes, recompute the thumbnail size and raise `DT_SIGNAL_CONTROL_REDRAW_ALL` -- every
+  panel, the navigation, the scopes -- on every configure-event of the centre. GTK allocates
+  the centre again whenever a layout pass runs, and the theme gives every hovered tab and
+  button a heavier font weight (`font-weight: 500` under `:hover`), so a layout pass is every
+  hover; when the allocation comes back unchanged the box the pipes plan from is unchanged too,
+  and the setter already says so. Only the first configure and a real size, border or zoom
+  change get past it. `-d dev` prints the request either way, `unchanged` appended when it was.
+
+To find out who asked for a redraw, the signal layer traces its raisers:
+`ansel -d signal --d-signal-act raise,print-trace --d-signal <name>` prints a backtrace for
+every raise of that signal (`DT_SIGNAL_CONTROL_REDRAW_ALL`, `DT_SIGNAL_CONTROL_NAVIGATION_REDRAW`,
+`DT_SIGNAL_HISTORY_RESYNC` are the ones that reach the navigation). A redraw with no signal
+behind it is GTK's own: an overlay exposed, or an allocation that moved.
+
 ## Reading it
 
 `-d perf` prints `[darkroom] surface prepared / image painted / overlay predicates / overlays

--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -1040,7 +1040,20 @@ void dt_dev_configure_real(dt_develop_t *dev, int wd, int ht)
   const dt_iop_roi_t gui_roi = { .x = 0, .y = 0, .width = wd, .height = ht, .scale = 1.0f };
   dt_iop_roi_t pipe_roi = { 0 };
   dt_dev_convert_roi(dev, &gui_roi, &pipe_roi, DT_DEV_ROI_GUI_LOGICAL, DT_DEV_ROI_PIPELINE);
-  dt_dev_viewport_set_box(dev, pipe_roi.width, pipe_roi.height);
+
+  /* A configure that changes nothing does nothing. GTK delivers a configure-event to the centre
+   * whenever its window is allocated again, and a layout pass runs whenever any widget's size
+   * request changes -- the theme gives every hovered tab and button a heavier font weight, so
+   * that is every hover. The box is what the pipes plan from; when it comes back the same as
+   * the one already published there is nothing to re-plan, no thumbnail size to recompute, and
+   * no reason to redraw the whole window (every panel, the navigation, the scopes). Only the
+   * first configure and a real size, border or zoom change get past this. */
+  if(!dt_dev_viewport_set_box(dev, pipe_roi.width, pipe_roi.height))
+  {
+    dt_print(DT_DEBUG_DEV, "[pixelpipe] Darkroom requested a %i×%i px widget -> %i×%i px raster preview, unchanged\n",
+             wd, ht, dt_dev_viewport_box_width(dev), dt_dev_viewport_box_height(dev));
+    return;
+  }
 
   dt_print(DT_DEBUG_DEV,
            "[pixelpipe] Darkroom requested a %i×%i px widget -> %i×%i px raster preview\n",

--- a/src/libs/navigation.c
+++ b/src/libs/navigation.c
@@ -47,6 +47,7 @@
 #include "system/macros.h"
 #include "common/module_versioning.h"
 #include "common/times.h"
+#include "common/hash.h"
 #include "control/control.h"
 #include "caches/pixelpipe_cache.h"
 #include "develop/dev_pixelpipe.h"
@@ -69,7 +70,18 @@ typedef struct dt_lib_navigation_t
   GtkWidget *area;    // the drawing area (self->widget is the resizable wrapper around it)
   int dragging;
   int zoom_w, zoom_h; // size of the zoom button
-  cairo_surface_t *image_surface;
+  cairo_surface_t *image_surface;   // the preview frame, scaled to the widget
+  /* The whole picture this widget shows -- background, thumbnail, viewport box, zoom label,
+   * arrow -- composed once per state and blitted on every later expose. Keyed on everything it
+   * depends on (_lib_navigation_picture_key()): an expose that changes none of it costs one
+   * blit, where it used to cost a fresh full-size surface, a background render, a pango layout
+   * and the thumbnail copy. Such exposes are the rule, not the exception: the resize grip
+   * floating over this area is translucent, so GTK repaints what lies under it every time the
+   * grip is hovered, and a panel that moved redraws the whole window with it. */
+  cairo_surface_t *composed;
+  uint64_t composed_key;
+  int composed_width;
+  int composed_height;
   dt_dev_pixelpipe_cache_wait_t preview_wait;
 } dt_lib_navigation_t;
 
@@ -217,6 +229,8 @@ void gui_cleanup(dt_lib_module_t *self)
 
   if(!IS_NULL_PTR(d->image_surface)) cairo_surface_destroy(d->image_surface);
   d->image_surface = NULL;
+  if(!IS_NULL_PTR(d->composed)) cairo_surface_destroy(d->composed);
+  d->composed = NULL;
 
   dt_free(self->data);
 }
@@ -228,16 +242,37 @@ void gui_reset(dt_lib_module_t *self)
   d->image_surface = NULL;
 }
 
-static gboolean _lib_navigation_draw_callback(GtkWidget *widget, cairo_t *crf, gpointer user_data)
+/* Everything the picture this widget shows depends on, folded into one key: the preview frame,
+ * the widget's size, the image, the viewport (zoom, pan, box, border) and the preview's plan.
+ * Equal keys are equal pictures. */
+static uint64_t _lib_navigation_picture_key(dt_develop_t *dev, const int width, const int height,
+                                            const gboolean has_preview_image)
 {
-  dt_times_t start;
-  dt_get_times(&start);
+  uint64_t key = has_preview_image ? dt_dev_backbuf_get_hash(&dev->preview_pipe->backbuf) : 0;
+  key = dt_hash(key, (const char *)&width, sizeof(width));
+  key = dt_hash(key, (const char *)&height, sizeof(height));
+  key = dt_hash(key, (const char *)&has_preview_image, sizeof(has_preview_image));
+  const int32_t imgid = dev->image_storage.id;
+  key = dt_hash(key, (const char *)&imgid, sizeof(imgid));
+  // padding-free, hashed whole the way the darkroom keys its own composition
+  const dt_dev_viewport_state_t viewport = dt_dev_viewport_get(dev);
+  key = dt_hash(key, (const char *)&viewport, sizeof(viewport));
+  const float natural_scale = dt_dev_roi_request_natural_scale(dev);
+  key = dt_hash(key, (const char *)&natural_scale, sizeof(natural_scale));
+  const int preview_width = dt_dev_roi_request_preview_width(dev);
+  const int preview_height = dt_dev_roi_request_preview_height(dev);
+  key = dt_hash(key, (const char *)&preview_width, sizeof(preview_width));
+  key = dt_hash(key, (const char *)&preview_height, sizeof(preview_height));
+  return key;
+}
 
-  dt_develop_t *dev = dt_dev_get_global();
-  dt_lib_module_t *self = (dt_lib_module_t *)user_data;
+/* Compose the picture for @p key into a fresh surface and make it the current one. Returns
+ * FALSE, leaving the previous picture in place, when the preview frame cannot be read yet. */
+static gboolean _lib_navigation_compose(GtkWidget *widget, dt_lib_module_t *self, dt_develop_t *dev,
+                                        const int width, const int height, const gboolean has_preview_image,
+                                        const uint64_t key)
+{
   dt_lib_navigation_t *d = (dt_lib_navigation_t *)self->data;
-
-  const gboolean has_preview_image = dt_dev_pixelpipe_is_backbufer_valid(dev->preview_pipe);
 
   static uint64_t image_hash = -1;
   static int wd = 0;
@@ -245,18 +280,12 @@ static gboolean _lib_navigation_draw_callback(GtkWidget *widget, cairo_t *crf, g
   static float scale = 1.f;
   static int32_t imgid = UNKNOWN_IMAGE;
 
-  GtkAllocation allocation;
-  gtk_widget_get_allocation(widget, &allocation);
-  static int width = 0;
-  static int height = 0;
-  gboolean changed = (width != allocation.width) || (height != allocation.height);
-  width = allocation.width;
-  height = allocation.height;
+  const gboolean changed = (d->composed_width != width) || (d->composed_height != height);
 
-  cairo_surface_t *cst = dt_cairo_image_surface_create(CAIRO_FORMAT_ARGB32, width, height);
-  cairo_t *cr = cairo_create(cst);
+  cairo_surface_t *target = dt_cairo_image_surface_create(CAIRO_FORMAT_ARGB32, width, height);
+  cairo_t *cr = cairo_create(target);
   GtkStyleContext *context = gtk_widget_get_style_context(widget);
-  gtk_render_background(context, cr, 0, 0, allocation.width, allocation.height);
+  gtk_render_background(context, cr, 0, 0, width, height);
   cairo_save(cr);
   
   if(has_preview_image
@@ -272,7 +301,13 @@ static gboolean _lib_navigation_draw_callback(GtkWidget *widget, cairo_t *crf, g
     dt_dev_pixelpipe_cache_wait_set_owner(&d->preview_wait, "navigation-preview", self);
     if(!dt_dev_pixelpipe_cache_peek_gui(dev->preview_pipe, NULL, &data, &cache_entry, &d->preview_wait,
                                         _lib_navigation_restart_cache_wait, self))
-      return TRUE;
+    {
+      /* the frame is not published yet: the wait above redraws when it is, and until then the
+       * previous picture stands (this used to return with the surface and its context leaked) */
+      cairo_destroy(cr);
+      cairo_surface_destroy(target);
+      return FALSE;
+    }
 
     dt_dev_pixelpipe_cache_rdlock_entry(TRUE, cache_entry);
 
@@ -301,7 +336,9 @@ static gboolean _lib_navigation_draw_callback(GtkWidget *widget, cairo_t *crf, g
        || dt_pixel_cache_entry_get_data(cache_entry) != data)
     {
       dt_dev_pixelpipe_cache_rdlock_entry(FALSE, cache_entry);
-      return TRUE;
+      cairo_destroy(cr);
+      cairo_surface_destroy(target);
+      return FALSE;
     }
 
     scale = fminf(width / (float)wd, height / (float)ht);
@@ -463,13 +500,56 @@ static gboolean _lib_navigation_draw_callback(GtkWidget *widget, cairo_t *crf, g
   cairo_line_to(cr, width - 0.5 * arrow_h, -0.1 * arrow_h - 2);
   cairo_fill(cr);
 
-  /* blit memsurface into widget */
-  cairo_destroy(cr);
-  cairo_set_source_surface(crf, cst, 0, 0);
-  cairo_paint(crf);
-  cairo_surface_destroy(cst);
 
-  dt_show_times_f(&start, "[navigation]", "redraw");
+  cairo_destroy(cr);
+  if(!IS_NULL_PTR(d->composed)) cairo_surface_destroy(d->composed);
+  d->composed = target;
+  d->composed_key = key;
+  d->composed_width = width;
+  d->composed_height = height;
+  return TRUE;
+}
+
+static gboolean _lib_navigation_draw_callback(GtkWidget *widget, cairo_t *crf, gpointer user_data)
+{
+  dt_times_t start;
+  dt_get_times(&start);
+
+  dt_develop_t *dev = dt_dev_get_global();
+  dt_lib_module_t *self = (dt_lib_module_t *)user_data;
+  dt_lib_navigation_t *d = (dt_lib_navigation_t *)self->data;
+
+  GtkAllocation allocation;
+  gtk_widget_get_allocation(widget, &allocation);
+  const int width = allocation.width;
+  const int height = allocation.height;
+
+  const gboolean has_preview_image = dt_dev_pixelpipe_is_backbufer_valid(dev->preview_pipe);
+  const uint64_t key = _lib_navigation_picture_key(dev, width, height, has_preview_image);
+
+  gboolean composed = FALSE;
+  if(IS_NULL_PTR(d->composed) || d->composed_key != key || d->composed_width != width
+     || d->composed_height != height)
+    composed = _lib_navigation_compose(widget, self, dev, width, height, has_preview_image, key);
+
+  if(!IS_NULL_PTR(d->composed))
+  {
+    cairo_set_source_surface(crf, d->composed, 0, 0);
+    cairo_paint(crf);
+  }
+
+  /* The clip says who asked: the whole widget is a request of this module's own, a strip along
+   * an edge is the grip floating over it, hovered. */
+  if(dt_get_debug_flags() & DT_DEBUG_PERF)
+  {
+    double x1 = 0.0;
+    double y1 = 0.0;
+    double x2 = 0.0;
+    double y2 = 0.0;
+    cairo_clip_extents(crf, &x1, &y1, &x2, &y2);
+    dt_show_times_f(&start, "[navigation]", "redraw: %s, clip %.0fx%.0f at %.0f,%.0f of %dx%d",
+                    composed ? "composed" : "cached", x2 - x1, y2 - y1, x1, y1, width, height);
+  }
 
   return TRUE;
 }

--- a/src/libs/navigation.c
+++ b/src/libs/navigation.c
@@ -245,7 +245,7 @@ void gui_reset(dt_lib_module_t *self)
 /* Everything the picture this widget shows depends on, folded into one key: the preview frame,
  * the widget's size, the image, the viewport (zoom, pan, box, border) and the preview's plan.
  * Equal keys are equal pictures. */
-static uint64_t _lib_navigation_picture_key(dt_develop_t *dev, const int width, const int height,
+static uint64_t _lib_navigation_picture_key(const dt_develop_t *dev, const int width, const int height,
                                             const gboolean has_preview_image)
 {
   uint64_t key = has_preview_image ? dt_dev_backbuf_get_hash(&dev->preview_pipe->backbuf) : 0;


### PR DESCRIPTION
Reported after #1394: the navigation thumbnail repaints on every pointer hover over a notebook tab or a panel edge. Two ways a hover over an unrelated widget reaches it, both closed; the darkroom cannot be driven here, so which of the two fires on which widget is for the tester to read off the trace below.

## The grip over the navigation area

The resize grips are translucent GtkEventBox overlay children floating over the area they resize. GTK3 composites overlay children over the main child, so invalidating the grip (its `:hover` state, its cursor, its own redraw on enter and leave) exposes the navigation area under it with a clip of the grip's strip, and the area's draw handler runs. It answered every expose with a fresh full-size surface, a background render, the thumbnail copy, a pango layout for the zoom label and a blit.

The picture is now composed once per state, keyed on the preview frame's hash, the widget's size, the image, the viewport state and the preview's plan, and an expose with an equal key is one blit. A miss on the preview cacheline keeps the previous picture instead of leaking the surface and its context, as the early return used to.

## A configure that changes nothing

A layout pass allocates the centre again and GTK delivers it a configure-event; `dt_dev_configure_real()` re-planned both pipes, recomputed the thumbnail size and raised `DT_SIGNAL_CONTROL_REDRAW_ALL` (every panel, the navigation, the scopes) whether or not anything changed. The theme gives every hovered tab and button `font-weight: 500`, which changes the widget's size request, so a layout pass is every hover. The viewport box the pipes plan from is published by a setter that already reports whether it changed; when it did not, the configure returns. Only the first configure and a real size, border or zoom change get past it.

## What to look at

- `-d perf`: `[navigation] redraw: cached|composed, clip WxH at x,y of WxH` on every expose. Hovering a grip should print `cached` with a strip-shaped clip; a tab hover should print nothing at all now. If it still prints, the clip says whether it is an overlay expose (strip) or a request of the module's own (whole widget).
- `-d dev`: `[pixelpipe] Darkroom requested … unchanged` on a same-size configure; a hover that used to re-plan the pipes shows up here.
- `ansel -d signal --d-signal-act raise,print-trace --d-signal DT_SIGNAL_CONTROL_REDRAW_ALL` backtraces every whole-window redraw request, for whatever remains.
- Behaviour to re-check, since the configure no-op is on the darkroom's entry path: enter and leave the darkroom, switch images of different sizes, resize the window, toggle ISO 12646, move the border-size slider, zoom. Each must still re-plan the pipes and repaint.

## Validation

GCC, clang `build-warnsweep` and `build-nofeatures`; the `tools/check_*` gates; the unit tests (the six LensSerious tests report "Not Run" in this tree, as before, their binaries are not built here); the image smoke test. The GUI itself is not verifiable here.

Docs: `doc/darkroom-redraw.md` (a new section on both), CLAUDE.md (the overlay rule and the trace).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
